### PR TITLE
Fix: Production white screen - DevTools components should not block rendering

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,13 +18,14 @@ export default function RootLayout({ children }: RootLayoutProps) {
     <html lang="en" className="antialiased">
       <body className="font-sans m-0 p-0">
         <DevToolsProvider>
-          {/* Add DevMockState to initialize development data */}
-          <DevMockState />
+          {/* Only render DevMockState in development */}
+          {process.env.NODE_ENV === 'development' && <DevMockState />}
           <Navigation />
           <div className="min-h-screen pb-12 md:pb-14">
             {children}
           </div>
-          <DevToolsPanel />
+          {/* Only render DevToolsPanel in development */}
+          {process.env.NODE_ENV === 'development' && <DevToolsPanel />}
         </DevToolsProvider>
       </body>
     </html>

--- a/src/components/devtools/DevToolsContext/DevToolsContext.tsx
+++ b/src/components/devtools/DevToolsContext/DevToolsContext.tsx
@@ -63,13 +63,9 @@ export const DevToolsProvider = ({
   const isDevToolsTest = typeof window !== 'undefined' && 
     window.location.pathname.includes('/dev/devtools-test');
 
-  // Skip rendering in production (but always render in test page)
-  if (isClient && !isDev && !isDevToolsTest) {
-    return null;
-  }
-
+  // Always render children, but only provide DevTools functionality in dev
   return (
-    <DevToolsContext.Provider value={{ isOpen, toggleDevTools }}>
+    <DevToolsContext.Provider value={{ isOpen: isDev ? isOpen : false, toggleDevTools }}>
       {children}
     </DevToolsContext.Provider>
   );


### PR DESCRIPTION
## Description
Fixes the white screen issue in production deployment where DevToolsProvider was returning null and removing all children from the DOM.

## Changes
- DevToolsProvider now always renders its children in all environments
- DevMockState and DevToolsPanel are conditionally rendered only in development
- This ensures the app renders in production while keeping dev tools hidden

## Issue
- Production deployment was showing a white screen
- Console error: `TypeError: a.default.detectStore(...) is undefined`

## Solution
The DevToolsProvider was returning `null` in production which removed the entire app from the DOM. Now it always renders children but only provides DevTools functionality in development.

## Testing
- ✅ Development mode: DevTools work as expected
- ✅ Production mode: App renders without DevTools visible
- ✅ No console errors in production

## Deployment
Once merged, this will fix the production deployment at https://narraitor-six.vercel.app/