### PR TITLE
Fix #118: Add physical appearance field to character creation

### DIFF
--- a/src/components/CharacterCreationWizard/steps/BackgroundStep.tsx
+++ b/src/components/CharacterCreationWizard/steps/BackgroundStep.tsx
@@ -53,6 +53,15 @@ export const BackgroundStep: React.FC<BackgroundStepProps> = ({
     });
   };
 
+  const handlePhysicalDescriptionChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    onUpdate({
+      background: {
+        ...data.characterData.background,
+        physicalDescription: e.target.value,
+      },
+    });
+  };
+
   const validation = data.validation[3];
   const showErrors = validation?.touched && !validation?.valid;
 
@@ -98,6 +107,22 @@ export const BackgroundStep: React.FC<BackgroundStepProps> = ({
         />
         <p className="text-gray-500 text-sm mt-1">
           {data.characterData.background.personality.length} / 30 characters minimum
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="character-physical-description">
+          Physical Appearance (Optional)
+        </Label>
+        <Textarea
+          id="character-physical-description"
+          value={data.characterData.background.physicalDescription || ''}
+          onChange={handlePhysicalDescriptionChange}
+          rows={4}
+          placeholder="Describe your character's physical appearance... (optional)"
+        />
+        <p className="text-gray-500 text-sm mt-1">
+          Optional field to describe how your character looks
         </p>
       </div>
 

--- a/src/components/CharacterCreationWizard/steps/__tests__/BackgroundStep.physicalDescription.test.tsx
+++ b/src/components/CharacterCreationWizard/steps/__tests__/BackgroundStep.physicalDescription.test.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BackgroundStep } from '../BackgroundStep';
+
+describe('BackgroundStep - Physical Description', () => {
+  const mockData = {
+    characterData: {
+      background: {
+        history: 'A detailed character history that meets minimum requirements.',
+        personality: 'A brave and cheerful adventurer',
+        motivation: 'To protect the innocent',
+        goals: ['Save the world'],
+        physicalDescription: ''
+      }
+    },
+    validation: {
+      3: { valid: true, errors: [], touched: false }
+    }
+  };
+
+  const mockOnUpdate = jest.fn();
+  const mockOnValidation = jest.fn();
+  const mockWorldConfig = {};
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders physical description field', () => {
+    render(
+      <BackgroundStep
+        data={mockData}
+        onUpdate={mockOnUpdate}
+        onValidation={mockOnValidation}
+        worldConfig={mockWorldConfig}
+      />
+    );
+
+    const physicalDescriptionField = screen.getByLabelText('Physical Appearance (Optional)');
+    expect(physicalDescriptionField).toBeInTheDocument();
+    expect(physicalDescriptionField).toHaveAttribute('placeholder', 'Describe your character\'s physical appearance... (optional)');
+  });
+
+  it('displays current physical description value', () => {
+    const dataWithDescription = {
+      ...mockData,
+      characterData: {
+        ...mockData.characterData,
+        background: {
+          ...mockData.characterData.background,
+          physicalDescription: 'Tall with dark hair and piercing blue eyes'
+        }
+      }
+    };
+
+    render(
+      <BackgroundStep
+        data={dataWithDescription}
+        onUpdate={mockOnUpdate}
+        onValidation={mockOnValidation}
+        worldConfig={mockWorldConfig}
+      />
+    );
+
+    const physicalDescriptionField = screen.getByLabelText('Physical Appearance (Optional)');
+    expect(physicalDescriptionField).toHaveValue('Tall with dark hair and piercing blue eyes');
+  });
+
+  it('calls onUpdate when physical description changes', () => {
+    render(
+      <BackgroundStep
+        data={mockData}
+        onUpdate={mockOnUpdate}
+        onValidation={mockOnValidation}
+        worldConfig={mockWorldConfig}
+      />
+    );
+
+    const physicalDescriptionField = screen.getByLabelText('Physical Appearance (Optional)');
+    fireEvent.change(physicalDescriptionField, {
+      target: { value: 'A mysterious figure with a hooded cloak' }
+    });
+
+    expect(mockOnUpdate).toHaveBeenCalledWith({
+      background: {
+        ...mockData.characterData.background,
+        physicalDescription: 'A mysterious figure with a hooded cloak'
+      }
+    });
+  });
+
+  it('handles multiline physical description input', () => {
+    render(
+      <BackgroundStep
+        data={mockData}
+        onUpdate={mockOnUpdate}
+        onValidation={mockOnValidation}
+        worldConfig={mockWorldConfig}
+      />
+    );
+
+    const physicalDescriptionField = screen.getByLabelText('Physical Appearance (Optional)');
+    const multilineDescription = 'Tall and lean with weathered hands.\nScar across the left cheek from an old battle.\nEyes that seem to hold ancient wisdom.';
+    
+    fireEvent.change(physicalDescriptionField, {
+      target: { value: multilineDescription }
+    });
+
+    expect(mockOnUpdate).toHaveBeenCalledWith({
+      background: {
+        ...mockData.characterData.background,
+        physicalDescription: multilineDescription
+      }
+    });
+  });
+
+  it('physical description field is optional (no validation errors)', () => {
+    render(
+      <BackgroundStep
+        data={mockData}
+        onUpdate={mockOnUpdate}
+        onValidation={mockOnValidation}
+        worldConfig={mockWorldConfig}
+      />
+    );
+
+    const physicalDescriptionField = screen.getByLabelText('Physical Appearance (Optional)');
+    
+    // Field should not have required attribute
+    expect(physicalDescriptionField).not.toHaveAttribute('required');
+    
+    // No asterisk (*) should be present for required field indicator (already handled by "(Optional)" suffix)
+    expect(screen.queryByText('Physical Appearance *')).not.toBeInTheDocument();
+  });
+
+  it('renders field in correct position between personality and motivation', () => {
+    render(
+      <BackgroundStep
+        data={mockData}
+        onUpdate={mockOnUpdate}
+        onValidation={mockOnValidation}
+        worldConfig={mockWorldConfig}
+      />
+    );
+
+    const personalityField = screen.getByLabelText(/Personality/);
+    const physicalDescriptionField = screen.getByLabelText('Physical Appearance (Optional)');
+    const motivationField = screen.getByLabelText('Motivation (optional)');
+
+    // Check that physical description comes after personality in DOM order
+    expect(personalityField.compareDocumentPosition(physicalDescriptionField) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    
+    // Check that motivation comes after physical description in DOM order
+    expect(physicalDescriptionField.compareDocumentPosition(motivationField) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Description
Complete implementation of issue #118 by adding the missing Physical Appearance input field to the character creation BackgroundStep component. This was the only gap in an otherwise fully-implemented feature (95% complete - just missing the UI input field).

## Related Issue
Closes #118

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (addresses missing UI functionality)

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested  
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
- As a player, I want to enter physical appearance details during character creation so that my character feels more complete and personalized
- As a player, I want my character's physical description to be saved and displayed on the character sheet
- As a developer, I want the UI to match the type system capabilities for consistent user experience

## Implementation Notes

### Clean Commit History ✅
This PR contains **only** the Issue #118 implementation - no June 2025 commits or unrelated changes. Clean branch created from the commit before the original Issue #118 work (c624202) and built up with only the necessary changes.

### What Was Missing ❌ → ✅ 
- **Before**: BackgroundStep had History, Personality, Motivation, Goals - but no Physical Appearance input
- **After**: BackgroundStep now includes Physical Appearance textarea between Personality and Motivation

### Technical Details
- **File Modified**: `src/components/CharacterCreationWizard/steps/BackgroundStep.tsx:56-63,113-127`
- **Added**: `handlePhysicalDescriptionChange` handler following existing patterns  
- **UI**: shadcn/ui Textarea component with 4 rows, optional field styling
- **Integration**: Connects to existing `physicalDescription` field in character types
- **Display**: Already working in `CharacterBackgroundDisplay` component

### Design Decisions
- **Positioning**: Placed between Personality and Motivation for logical flow
- **Optional Field**: No validation requirements, marked as "(Optional)" in label
- **Styling**: Uses shadcn/ui components (Textarea, Label) for consistent form appearance
- **Behavior**: Multi-paragraph support via textarea (4 rows default)

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

### Stage 1: Unit Testing
```bash
npm test -- --testPathPattern="BackgroundStep.physicalDescription"
# Should show 6 passing tests
```

### Stage 2: Integration Testing  
```bash
npm run dev
# Navigate to character creation → Background step
# Verify Physical Appearance field appears between Personality and Motivation
# Test entering multi-paragraph text and verify it saves correctly
```

### Stage 3: Full Character Creation Flow
1. Create a new character with physical appearance description
2. Complete character creation process  
3. View character sheet and verify physical description displays correctly
4. Test that the field is truly optional (can be left empty)

## Acceptance Criteria Status ✅
- [x] Physical Appearance text input field provided (textarea with 4 rows)
- [x] Multi-paragraph entries supported (textarea supports line breaks)
- [x] Properly formatted and displayed on character sheet (existing display logic works)
- [x] Field validation appropriate (optional field, no validation needed)
- [x] Text appears in readable format in final character sheet

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic (none needed - simple handler)
- [x] Documentation updated (issue updated with completion status)
- [x] No new warnings generated
- [x] Accessibility considerations addressed (proper labels and semantic HTML)

## Commit History Verification
This PR contains exactly **1 commit** with only the Issue #118 changes:
- `50eb611` feat(issue-118): Add physical appearance field to character creation

No historical commits, no June 2025 commits, no unrelated changes.