### PR TITLE
Refactor template loader to use store methods

### DIFF
--- a/src/lib/templates/__tests__/templateLoader.test.ts
+++ b/src/lib/templates/__tests__/templateLoader.test.ts
@@ -1,24 +1,28 @@
 import { applyWorldTemplate } from '../templateLoader';
 import { templates } from '../worldTemplates';
-import { useWorldStore } from '../../../state/worldStore';
-
-// Get the mocked functions
-const mockSetState = useWorldStore.setState as jest.MockedFunction<typeof useWorldStore.setState>;
+import { useWorldStore } from '@/state/worldStore';
 
 // Mock the generateUniqueId function
 jest.mock('../../utils/generateId', () => ({
   generateUniqueId: jest.fn().mockImplementation((prefix) => {
     if (prefix === 'world') return 'world-123';
-    if (prefix === 'attribute') return 'attr-123';
-    if (prefix === 'skill') return 'skill-123';
+    if (prefix === 'attribute') return `attr-${Math.random().toString(36).substr(2, 9)}`;
+    if (prefix === 'skill') return `skill-${Math.random().toString(36).substr(2, 9)}`;
     return `${prefix}-123`;
   }),
 }));
 
-jest.mock('../../../state/worldStore', () => ({
+// Mock store functions
+const mockCreateWorld = jest.fn(() => 'world-123');
+const mockUpdateWorld = jest.fn();
+
+jest.mock('@/state/worldStore', () => ({
   useWorldStore: {
-    setState: jest.fn(),
-    getState: jest.fn(() => ({ worlds: {} }))
+    getState: jest.fn(() => ({
+      createWorld: mockCreateWorld,
+      updateWorld: mockUpdateWorld,
+      worlds: {}
+    }))
   }
 }));
 
@@ -30,106 +34,130 @@ describe('Template Loader', () => {
   test('applyWorldTemplate creates a world', () => {
     // Get the first template for the test
     const template = templates[0];
-    
+
     // Apply template
     const worldId = applyWorldTemplate(template, 'Test World Name');
-    
+
     // Check if the ID matches
     expect(worldId).toBe('world-123');
-    
-    // Check that setState was called
-    expect(useWorldStore.setState).toHaveBeenCalled();
+
+    // Check that createWorld was called with base data
+    expect(mockCreateWorld).toHaveBeenCalledWith({
+      name: 'Test World Name',
+      description: template.description,
+      genre: template.genre,
+      attributes: [],
+      skills: [],
+      settings: {
+        maxAttributes: 6,
+        maxSkills: 12,
+        attributePointPool: 30,
+        skillPointPool: 36
+      }
+    });
+
+    // Check that updateWorld was called with attributes and skills
+    expect(mockUpdateWorld).toHaveBeenCalledWith('world-123', {
+      attributes: expect.arrayContaining([
+        expect.objectContaining({
+          worldId: 'world-123',
+          name: expect.any(String),
+          description: expect.any(String)
+        })
+      ]),
+      skills: expect.arrayContaining([
+        expect.objectContaining({
+          worldId: 'world-123',
+          name: expect.any(String),
+          description: expect.any(String)
+        })
+      ])
+    });
   });
 
   test('applyWorldTemplate uses template name when no world name provided', () => {
     // Get the first template for the test
     const template = templates[0];
-    
+
     // Apply template without providing a name
     applyWorldTemplate(template);
-    
-    // Extract the updater function from the first setState call
-    const setStateCall = mockSetState.mock.calls[0][0];
-    
-    // Call the updater function with an empty state
-    const testState = { worlds: {} };
-    const result = setStateCall(testState);
-    
-    // Check that the world name is set to the template name
-    const world = result.worlds['world-123'];
-    expect(world.name).toBe(template.name);
+
+    // Check that createWorld was called with template name
+    expect(mockCreateWorld).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: template.name
+      })
+    );
   });
 
   test('applyWorldTemplate creates world with template attributes and skills', () => {
     // Get the template for the test
     const template = templates[0]; // Western template
-    
+
     // Apply template
     applyWorldTemplate(template);
-    
-    // Extract the updater function from the setState call
-    const setStateCall = mockSetState.mock.calls[0][0];
-    
-    // Call the updater function with an empty state
-    const testState = { worlds: {} };
-    const result = setStateCall(testState);
-    
-    // Get the created world
-    const world = result.worlds['world-123'];
-    
-    // Check that attributes were applied from the template
-    expect(world.attributes.length).toBe(template.attributes.length);
-    expect(world.attributes[0].name).toBe(template.attributes[0].name);
-    expect(world.attributes[0].description).toBe(template.attributes[0].description);
-    
-    // Check that skills were applied from the template
-    expect(world.skills.length).toBe(template.skills.length);
-    expect(world.skills[0].name).toBe(template.skills[0].name);
-    expect(world.skills[0].description).toBe(template.skills[0].description);
-    
-    // Check that skills have a difficulty property
-    expect(world.skills[0].difficulty).toBe('medium');
-    
-    // The attributeIds might be undefined initially since it depends on matching attribute names
-    // Just verify it's the correct type (array or undefined)
-    expect(Array.isArray(world.skills[0].attributeIds) || 
-           typeof world.skills[0].attributeIds === 'undefined').toBeTruthy();
+
+    // Check that updateWorld was called with correct number of attributes and skills
+    const updateCall = mockUpdateWorld.mock.calls[0];
+    expect(updateCall).toBeDefined();
+
+    const [worldId, updates] = updateCall;
+    expect(worldId).toBe('world-123');
+
+    // Check attributes
+    expect(updates.attributes).toHaveLength(template.attributes.length);
+    expect(updates.attributes[0]).toEqual(
+      expect.objectContaining({
+        name: template.attributes[0].name,
+        description: template.attributes[0].description,
+        worldId: 'world-123'
+      })
+    );
+
+    // Check skills
+    expect(updates.skills).toHaveLength(template.skills.length);
+    expect(updates.skills[0]).toEqual(
+      expect.objectContaining({
+        name: template.skills[0].name,
+        description: template.skills[0].description,
+        worldId: 'world-123',
+        difficulty: 'medium'
+      })
+    );
+
+    // Verify attributeIds is array or undefined
+    expect(Array.isArray(updates.skills[0].attributeIds) ||
+           typeof updates.skills[0].attributeIds === 'undefined').toBeTruthy();
   });
 
   test('applyWorldTemplate accepts a template ID string', () => {
     // Apply template using a string ID
     const templateId = 'western';
     const worldId = applyWorldTemplate(templateId);
-    
+
     // Check if the ID matches
     expect(worldId).toBe('world-123');
-    
-    // Extract the updater function from the setState call
-    const setStateCall = mockSetState.mock.calls[0][0];
-    
-    // Call the updater function with an empty state
-    const testState = { worlds: {} };
-    const result = setStateCall(testState);
-    
-    // Get the created world
-    const world = result.worlds['world-123'];
-    
+
     // Check that world has correct name and description based on the template
     const westernTemplate = templates.find(t => t.id === 'western');
-    expect(world.name).toBe(westernTemplate?.name);
-    expect(world.description).toBe(westernTemplate?.description);
+    expect(mockCreateWorld).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: westernTemplate?.name,
+        description: westernTemplate?.description
+      })
+    );
   });
-  
+
   test('applyWorldTemplate throws error for invalid template ID', () => {
     // Apply template using an invalid string ID
     const invalidTemplateId = 'non-existent-template';
-    
+
     // Should throw an error
     expect(() => {
       applyWorldTemplate(invalidTemplateId);
     }).toThrow(`Template with ID "${invalidTemplateId}" not found`);
-    
-    // Check that setState was not called
-    expect(useWorldStore.setState).not.toHaveBeenCalled();
+
+    // Check that createWorld was not called
+    expect(mockCreateWorld).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/templates/__tests__/templateLoader.test.ts
+++ b/src/lib/templates/__tests__/templateLoader.test.ts
@@ -1,6 +1,5 @@
 import { applyWorldTemplate } from '../templateLoader';
 import { templates } from '../worldTemplates';
-import { useWorldStore } from '@/state/worldStore';
 
 // Mock the generateUniqueId function
 jest.mock('../../utils/generateId', () => ({

--- a/src/lib/templates/templateLoader.ts
+++ b/src/lib/templates/templateLoader.ts
@@ -1,7 +1,6 @@
 import { WorldTemplate, templates } from './worldTemplates';
-import { useWorldStore } from '../../state/worldStore';
+import { useWorldStore } from '@/state/worldStore';
 import { generateUniqueId } from '../utils/generateId';
-import { getTimestamp } from '@/lib/utils';
 import { WorldAttribute, WorldSkill } from '../../types/world.types';
 
 /**
@@ -13,7 +12,7 @@ import { WorldAttribute, WorldSkill } from '../../types/world.types';
 export const applyWorldTemplate = (templateOrId: WorldTemplate | string, worldName?: string): string => {
   // Determine if we were passed a template ID or template object
   let template: WorldTemplate;
-  
+
   if (typeof templateOrId === 'string') {
     // Find the template by ID
     const foundTemplate = templates.find(t => t.id === templateOrId);
@@ -24,11 +23,24 @@ export const applyWorldTemplate = (templateOrId: WorldTemplate | string, worldNa
   } else {
     template = templateOrId;
   }
-  
-  // Generate a worldId
-  const worldId = generateUniqueId('world');
-  
-  // Create world attributes from template
+
+  // Step 1: Create world shell with base data, get worldId from store
+  const { createWorld, updateWorld } = useWorldStore.getState();
+  const worldId = createWorld({
+    name: worldName || template.name,
+    description: template.description,
+    genre: template.genre,
+    attributes: [], // Will be populated in step 2
+    skills: [],     // Will be populated in step 2
+    settings: {
+      maxAttributes: 6,
+      maxSkills: 12,
+      attributePointPool: 30,
+      skillPointPool: 36
+    }
+  });
+
+  // Step 2: Build attributes and skills with the store-generated worldId
   const attributes: WorldAttribute[] = template.attributes.map(attr => ({
     id: generateUniqueId('attribute'),
     name: attr.name,
@@ -38,8 +50,7 @@ export const applyWorldTemplate = (templateOrId: WorldTemplate | string, worldNa
     minValue: attr.minValue,
     maxValue: attr.maxValue
   }));
-  
-  // Create world skills from template
+
   const skills: WorldSkill[] = template.skills.map(skill => ({
     id: generateUniqueId('skill'),
     name: skill.name,
@@ -47,7 +58,7 @@ export const applyWorldTemplate = (templateOrId: WorldTemplate | string, worldNa
     worldId,
     // Convert linkedAttributes array to attributeIds array
     // For now, just use the first attribute in the list if available
-    attributeIds: skill.linkedAttributes?.length > 0 
+    attributeIds: skill.linkedAttributes?.length > 0
       ? [attributes.find(a => a.name === skill.linkedAttributes[0])?.id].filter(Boolean) as string[]
       : undefined,
     difficulty: 'medium', // Default difficulty level
@@ -56,46 +67,9 @@ export const applyWorldTemplate = (templateOrId: WorldTemplate | string, worldNa
     maxValue: 10, // Fixed max value for MVP
     category: skill.category || 'General' // Use provided category or default to 'General'
   }));
-  
-  // Update the world store with the new world
-  useWorldStore.setState(state => {
-    // Create a copy of the existing state
-    const newState = { ...state };
-    
-    // If worlds object doesn't exist, create it
-    if (!newState.worlds) {
-      newState.worlds = {};
-    }
 
-    if (!newState.entities) {
-      newState.entities = {};
-    }
-    
-    // Add the new world to the state
-    const now = getTimestamp();
-    const world = {
-      id: worldId,
-      name: worldName || template.name,
-      description: template.description,
-      genre: template.genre,
-      attributes,
-      skills,
-      settings: {
-        maxAttributes: 6,
-        maxSkills: 12,
-        attributePointPool: 30,
-        skillPointPool: 36
-      },
-      createdAt: now,
-      updatedAt: now
-    };
-    newState.worlds[worldId] = world;
-    newState.entities[worldId] = world;
-    
-    return newState;
-  });
+  // Step 3: Update the world with populated attributes and skills
+  updateWorld(worldId, { attributes, skills });
 
-  // Template applied successfully
-  
   return worldId;
 };


### PR DESCRIPTION
## Description
Refactored the template loader to use the store's `createWorld` and `updateWorld` methods instead of directly manipulating state with `setState`. This keeps template creation aligned with how the rest of the codebase handles world creation - same validation, normalization, and error handling.

The approach uses a two-step pattern: create the world shell first to get the store-generated ID, then build attributes/skills with that ID and update the world. This matches the pattern used in `worldCreationService`.

Also cleaned up import paths to use the `@/` alias consistently.

## Related Issue
Part of broader refactoring discussion around eliminating duplicate world creation logic.

## Type of Change
- [x] Refactoring (code improvements without changing functionality)

## TDD Compliance
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## Implementation Notes
The key change is moving from manual state manipulation to using store methods:
- `createWorld()` generates the world ID and handles validation/normalization
- `updateWorld()` populates attributes/skills after they're built with the correct worldId
- Template-specific settings are preserved in the initial `createWorld()` call
- No breaking changes - function signature and behavior remain the same

Tests were updated to verify both store method calls instead of checking `setState` internals.

## Testing Instructions
Run template loader tests to verify functionality:
```bash
npm test -- src/lib/templates/__tests__/templateLoader.test.ts
```

All five tests pass, covering:
- Basic world creation
- Template name defaulting
- Attributes and skills mapping
- Template ID string lookup
- Error handling for invalid templates

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Documentation updated (if required)
- [x] No new warnings generated