### PR TITLE
Add onRehydrateStorage to goal and lore stores — keep entities in sync after hydration

### DIFF
--- a/src/state/goalStore.ts
+++ b/src/state/goalStore.ts
@@ -371,6 +371,12 @@ export const useGoalStore = create<GoalStore>()(
         sessionGoals: state.sessionGoals,
         activeGoalIds: state.activeGoalIds,
       }),
+      onRehydrateStorage: () => (state) => {
+        // Ensure entities is always in sync with goals after hydration
+        if (state && state.goals) {
+          state.entities = { ...state.goals };
+        }
+      },
       migrate: (persistedState: unknown) => {
         if (persistedState && typeof persistedState === 'object' && 'goals' in persistedState) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/state/loreStore.ts
+++ b/src/state/loreStore.ts
@@ -548,6 +548,12 @@ export const useLoreStore = create<LoreStore>()(
         facts: state.facts,
         factHistory: state.factHistory,
       }),
+      onRehydrateStorage: () => (state) => {
+        // Ensure entities is always in sync with facts after hydration
+        if (state && state.facts) {
+          state.entities = { ...state.facts };
+        }
+      },
       migrate: (persistedState: unknown) => {
         if (persistedState && typeof persistedState === 'object' && 'facts' in persistedState) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Title: Add onRehydrateStorage to goal and lore stores — keep entities in sync after hydration

## Description
This implements a small but important persistence-safety fix for the goal and lore Zustand stores. When persisted state is rehydrated, the `entities` map could be empty or out-of-sync even though `goals` / `facts` exist; that mismatch was causing occasional runtime lookups to fail after reloads or migrations. The change adds `onRehydrateStorage` handlers to both `useGoalStore` and `useLoreStore` to reconstruct `entities` from the persisted `goals` / `facts`.

## Related Issue
Closes #164

## Type of Change
- [x] New feature (keeps rehydrated state consistent)
- [ ] Bug fix
- [x] Refactoring (bring these stores in line with others that already use `onRehydrateStorage`)

## Why this matters
From a developer POV, this avoids hard-to-reproduce runtime errors where components expect an `entities` map that wasn't rebuilt after persistence hydration. In practice, it makes the stores more robust across migrations and browser reloads, and keeps their behavior consistent with other stores that already include rehydrate hooks.

## Implementation details
- `src/state/goalStore.ts`: added an `onRehydrateStorage` handler that sets `state.entities = { ...state.goals }` when `goals` are present on hydration.
- `src/state/loreStore.ts`: added an `onRehydrateStorage` handler that sets `state.entities = { ...state.facts }` when `facts` are present on hydration.
- No public APIs changed; `migrate` logic remains intact.

## Trade-offs / alternatives
This is a small, low-risk change that mirrors the pattern used elsewhere. An alternative would be to add more defensive checks across consumers, but rebuilding `entities` at rehydrate time keeps the logic centralized and easier to reason about.

## Testing notes
Manually verified in the local worktree:
1. Added a few goals/facts, reloaded the app, and confirmed `entities` are populated after rehydrate.
2. Verified no console errors from missing entities.

If preferred, a Jest test can be added to simulate the `persist` rehydrate lifecycle and assert `entities` is populated — happy to add this in a follow-up.

## Next steps
- Merge after review.
- Optionally add a unit test to cover the rehydrate behavior if maintainers want explicit coverage.

---

(Edits applied using the project's voice profile — kept this conversational, context-first, and third-person: "This implements...".)
