### PR TITLE
Gate player decisions behind required inventory items (#756)

### DIFF
--- a/src/components/GameSession/ActiveGameSession.tsx
+++ b/src/components/GameSession/ActiveGameSession.tsx
@@ -23,6 +23,7 @@ import { GameSessionSkeleton } from './GameSessionSkeleton';
 import { SaveIndicator } from '@/components/ui/SaveIndicator';
 import { useAutoSave } from '@/hooks/useAutoSave';
 import { InventoryList } from '@/components/inventory/InventoryList';
+import { useInventoryStore, type InventoryStore } from '@/state/inventoryStore';
 
 const INITIAL_GENERATION_MAX_WAIT_MS = 20000;
 
@@ -95,6 +96,13 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
   const character = isTestMode 
     ? Object.values(testCharacters || {}).find((char: Character) => char.worldId === worldId)
     : storeCharacter;
+  
+  const selectInventoryItems = React.useCallback(
+    (state: InventoryStore) => (characterId ? state.getCharacterItems(characterId) : []),
+    [characterId]
+  );
+  const inventoryItems = useInventoryStore(selectInventoryItems);
+  const characterSkills = character?.skills ?? [];
   
   // Get narrative store for ending functionality
   const { currentEnding, isGeneratingEnding, generateEnding, isSessionEnded } = useNarrativeStore();
@@ -814,6 +822,8 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
                 enableCustomInput={true}
                 isDisabled={status !== 'active' || isGenerating || isSessionEnded(sessionId)}
                 worldSkills={world?.skills || []}
+                characterSkills={characterSkills}
+                inventoryItems={inventoryItems}
               />
             ) : (
               <div className="space-y-4 p-4">

--- a/src/components/GameSession/ActiveGameSession.tsx
+++ b/src/components/GameSession/ActiveGameSession.tsx
@@ -23,7 +23,7 @@ import { GameSessionSkeleton } from './GameSessionSkeleton';
 import { SaveIndicator } from '@/components/ui/SaveIndicator';
 import { useAutoSave } from '@/hooks/useAutoSave';
 import { InventoryList } from '@/components/inventory/InventoryList';
-import { useInventoryStore, type InventoryStore } from '@/state/inventoryStore';
+import { useInventoryStore } from '@/state/inventoryStore';
 
 const INITIAL_GENERATION_MAX_WAIT_MS = 20000;
 
@@ -97,11 +97,11 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
     ? Object.values(testCharacters || {}).find((char: Character) => char.worldId === worldId)
     : storeCharacter;
   
-  const selectInventoryItems = React.useCallback(
-    (state: InventoryStore) => (characterId ? state.getCharacterItems(characterId) : []),
-    [characterId]
+  const getInventoryItems = useInventoryStore((state) => state.getCharacterItems);
+  const inventoryItems = React.useMemo(
+    () => (characterId ? getInventoryItems(characterId) : []),
+    [characterId, getInventoryItems]
   );
-  const inventoryItems = useInventoryStore(selectInventoryItems);
   const characterSkills = character?.skills ?? [];
   
   // Get narrative store for ending functionality

--- a/src/components/GameSession/hooks/useGameSessionState.ts
+++ b/src/components/GameSession/hooks/useGameSessionState.ts
@@ -237,7 +237,8 @@ export const useGameSessionState = ({
     const currentStoreState = useSessionStore.getState();
     
     // If store already has an active session that matches our requirements, don't initialize
-    if (currentStoreState.status === 'active' && 
+    if (!disableAutoResume &&
+        currentStoreState.status === 'active' && 
         currentStoreState.worldId === worldId && 
         currentStoreState.characterId === sessionCharacterId) {
       logger.debug('[useGameSessionState] Store already has active session for this world/character, skipping initialization');

--- a/src/components/shared/ChoiceSelector/ChoiceSelector.tsx
+++ b/src/components/shared/ChoiceSelector/ChoiceSelector.tsx
@@ -1,25 +1,17 @@
 'use client';
 
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { Scale, Flame, ChevronRight } from 'lucide-react';
-import {
-  Decision,
-  ChoiceAlignment,
-  DecisionWeight,
-  DecisionRequirement,
-  DecisionItemRequirementGroup,
-  DecisionItemRequirements,
-  RequirementLogic,
-} from '@/types/narrative.types';
+import { ChevronRight } from 'lucide-react';
+import { Decision } from '@/types/narrative.types';
 import { WorldSkill } from '@/types/world.types';
 import { InventoryItem } from '@/types/inventory.types';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
-import { resolveSkillData } from '@/lib/utils/gameDataResolver';
 import { CollapsibleSection } from '@/components/ui/CollapsibleSection';
 import { safeTrim } from '@/lib/utils';
-import { evaluateRequirement } from '@/lib/utils/requirementEvaluator';
+import { normalizeDecisionOptions, normalizeSimpleChoices } from './optionNormalizer';
+import { SkillRequirementBadges, ItemRequirementBadges } from './RequirementBadges';
+import { getAlignmentIcon, getAlignmentClasses, getDecisionWeightStyling } from './choiceStyling';
 
 // Simple choice interface for backwards compatibility
 export interface SimpleChoice {
@@ -61,137 +53,6 @@ interface ChoiceSelectorProps {
 }
 
 /**
- * Get icon for choice alignment
- */
-const getAlignmentIcon = (alignment?: ChoiceAlignment): React.ReactNode => {
-  switch (alignment) {
-    case 'lawful':
-      return <Scale className="w-4 h-4" aria-hidden="true" />; // Scales of justice for lawful
-    case 'chaotic':
-      return <Flame className="w-4 h-4" aria-hidden="true" />; // Fire for chaotic/unpredictable
-    case 'neutral':
-    default:
-      return null; // No icon for neutral
-  }
-};
-
-/**
- * Get CSS classes for alignment-based styling
- */
-const getAlignmentClasses = (alignment?: ChoiceAlignment, isDisabled?: boolean): string => {
-  const baseClasses = {
-    lawful: 'bg-blue-50 border-blue-300',
-    chaotic: 'bg-red-200 border-red-300',
-    neutral: 'bg-white border-gray-200'
-  };
-  
-  const hoverClasses = {
-    lawful: 'hover:bg-blue-100',
-    chaotic: 'hover:bg-red-100', 
-    neutral: 'hover:bg-gray-100'
-  };
-  
-  const alignmentKey = alignment || 'neutral';
-  const base = baseClasses[alignmentKey];
-  const hover = isDisabled ? '' : hoverClasses[alignmentKey];
-  
-  return `${base} ${hover}`;
-};
-
-/**
- * Get styling for decision weight using border thickness and strategic colors
- * Critical decisions use bright red, while choice alignments use muted red
- */
-const getDecisionWeightStyling = (weight?: DecisionWeight) => {
-  switch (weight) {
-    case 'critical':
-      return {
-        container: 'border-4 border-red-500 bg-red-200/50 shadow-lg shadow-red-200',
-        dot: 'bg-red-500',
-        label: 'text-red-700'
-      };
-    case 'major':
-      return {
-        container: 'border-2 border-amber-500 bg-amber-50/60 shadow-md shadow-amber-200',
-        dot: 'bg-amber-500',
-        label: 'text-amber-700'
-      };
-    case 'minor':
-    default:
-      return {
-        container: 'border-0 bg-gray-100/5',
-        dot: 'bg-gray-700',
-        label: 'text-gray-900'
-      };
-  }
-};
-
-const DEFAULT_REQUIREMENT_LOGIC: RequirementLogic = 'all';
-
-const isDecisionItemRequirementGroup = (
-  value: unknown
-): value is DecisionItemRequirementGroup => {
-  return Boolean(
-    value &&
-      typeof value === 'object' &&
-      'requirements' in value &&
-      Array.isArray((value as DecisionItemRequirementGroup).requirements)
-  );
-};
-
-const ensureItemRequirementGroup = (
-  requirements: DecisionRequirement[] | undefined,
-  logic?: RequirementLogic
-): DecisionItemRequirementGroup | null => {
-  const filtered = (requirements || []).filter((req) => req.type === 'item');
-  if (filtered.length === 0) {
-    return null;
-  }
-
-  return {
-    logic: logic ?? DEFAULT_REQUIREMENT_LOGIC,
-    requirements: filtered,
-  };
-};
-
-const getNormalizedItemRequirementGroups = (
-  requiredItems: DecisionItemRequirements | undefined,
-  fallbackRequirements: DecisionRequirement[] | undefined
-): DecisionItemRequirementGroup[] => {
-  if (!requiredItems) {
-    const fallbackGroup = ensureItemRequirementGroup(fallbackRequirements);
-    return fallbackGroup ? [fallbackGroup] : [];
-  }
-
-  if (Array.isArray(requiredItems)) {
-    if (requiredItems.length === 0) {
-      return [];
-    }
-
-    const first = requiredItems[0] as DecisionRequirement | DecisionItemRequirementGroup;
-    if (isDecisionItemRequirementGroup(first)) {
-      return (requiredItems as DecisionItemRequirementGroup[])
-        .map((group) => ensureItemRequirementGroup(group.requirements, group.logic))
-        .filter((group): group is DecisionItemRequirementGroup => Boolean(group));
-    }
-
-    const fallbackGroup = ensureItemRequirementGroup(requiredItems as DecisionRequirement[]);
-    return fallbackGroup ? [fallbackGroup] : [];
-  }
-
-  if (isDecisionItemRequirementGroup(requiredItems)) {
-    const group = ensureItemRequirementGroup(
-      requiredItems.requirements,
-      requiredItems.logic
-    );
-    return group ? [group] : [];
-  }
-
-  const fallbackGroup = ensureItemRequirementGroup(fallbackRequirements);
-  return fallbackGroup ? [fallbackGroup] : [];
-};
-
-/**
  * Unified choice selector component that handles both simple choices and complex decisions
  */
 const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
@@ -229,132 +90,9 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
   };
 
   // Normalize the data into a common format
-  const normalizedOptions: Array<{
-    id: string;
-    text: string;
-    hint?: string;
-    isSelected?: boolean;
-    alignment?: ChoiceAlignment;
-    isDisabledByRequirements?: boolean;
-    disabledReason?: string;
-    skillRequirements?: Array<{
-      requirement: DecisionRequirement;
-      skillName?: string;
-      met: boolean;
-    }>;
-    itemRequirementGroups?: Array<{
-      logic: RequirementLogic;
-      met: boolean;
-      requirements: Array<{
-        requirement: DecisionRequirement;
-        itemName: string;
-        met: boolean;
-        current: number;
-        required: number;
-      }>;
-    }>;
-  }> = isDecisionMode
-    ? (decision.options || []).map(opt => {
-        // Process skill requirements
-        const skillRequirements = opt.requirements?.filter(req => req.type === 'skill').map(req => {
-          const skillData = resolveSkillData(req.targetId, worldSkills);
-          const evaluation = evaluateRequirement(req, requirementEvaluationContext);
-
-          return {
-            requirement: req,
-            skillName: skillData?.name || 'Unknown Skill',
-            met: evaluation.success
-          };
-        }) || [];
-
-        // Process item requirements (normalized groups)
-        const normalizedGroups = getNormalizedItemRequirementGroups(
-          opt.requiredItems,
-          opt.requirements
-        );
-        const itemRequirementGroups = normalizedGroups.map(group => {
-          const logic: RequirementLogic = group.logic ?? DEFAULT_REQUIREMENT_LOGIC;
-          const evaluatedRequirements = group.requirements.map(req => {
-          const evaluation = evaluateRequirement(req, requirementEvaluationContext);
-
-            return {
-              requirement: req,
-              itemName: evaluation.itemName || req.targetId,
-              met: evaluation.success,
-              current: evaluation.current,
-              required: typeof evaluation.required === 'number' ? evaluation.required : 0
-            };
-          });
-
-          const groupMet = logic === 'any'
-            ? evaluatedRequirements.some(req => req.met)
-            : evaluatedRequirements.every(req => req.met);
-
-          return {
-            logic,
-            met: groupMet,
-            requirements: evaluatedRequirements
-          };
-        });
-
-        const allSkillRequirementsMet = skillRequirements.every(r => r.met);
-        const allItemGroupsMet =
-          itemRequirementGroups.length === 0 ||
-          itemRequirementGroups.every(group => group.met);
-
-        const disabledReasonParts: string[] = [];
-        if (!allSkillRequirementsMet) {
-          const missingSkills = skillRequirements
-            .filter(req => !req.met)
-            .map(req => req.skillName || 'Required skill');
-          if (missingSkills.length > 0) {
-            disabledReasonParts.push(`Skills: ${missingSkills.join(', ')}`);
-          }
-        }
-
-        if (!allItemGroupsMet) {
-          const missingItems = itemRequirementGroups
-            .filter(group => !group.met)
-            .flatMap(group =>
-              group.requirements.map(req => {
-                if (req.met) {
-                  return null;
-                }
-                const requiredAmount = req.required > 0 ? `${req.current}/${req.required}` : `${req.current}`;
-                return `${req.itemName}${req.required > 0 ? ` (${requiredAmount})` : ''}`;
-              }).filter((value): value is string => Boolean(value))
-            );
-          if (missingItems.length > 0) {
-            disabledReasonParts.push(`Items: ${missingItems.join(', ')}`);
-          }
-        }
-
-        const disabledReason = disabledReasonParts.length > 0
-          ? `Requires ${disabledReasonParts.join(' | ')}`
-          : undefined;
-
-        return {
-          id: opt.id,
-          text: opt.text,
-          hint: opt.hint,
-          isSelected: opt.id === decision.selectedOptionId || opt.id === selectedOptionId,
-          alignment: opt.alignment,
-          isDisabledByRequirements: !(allSkillRequirementsMet && allItemGroupsMet),
-          disabledReason,
-          skillRequirements,
-          itemRequirementGroups
-        };
-      })
-    : (choices || []).map(choice => ({
-        id: choice.id,
-        text: choice.text,
-        isSelected: choice.isSelected || choice.id === selectedOptionId,
-        alignment: 'neutral' as ChoiceAlignment, // Default for simple choices
-        isDisabledByRequirements: false,
-        disabledReason: undefined,
-        skillRequirements: [],
-        itemRequirementGroups: []
-      }));
+  const normalizedOptions = isDecisionMode
+    ? normalizeDecisionOptions(decision, selectedOptionId, worldSkills, requirementEvaluationContext)
+    : normalizeSimpleChoices(choices || [], selectedOptionId);
 
   // Use normalized options without custom input option
   const allOptions = normalizedOptions;
@@ -518,50 +256,14 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
                   {showHints && option.hint && (
                     <div className="text-sm text-gray-500 mt-1">{option.hint}</div>
                   )}
-                  {option.skillRequirements && option.skillRequirements.length > 0 && (
-                    <div className="flex flex-wrap gap-1 mt-2">
-                      {option.skillRequirements.map((skillReq, index) => {
-                        const label = `${skillReq.skillName}`;
-
-                        return (
-                          <Badge
-                            key={`${option.id}-skill-${index}`}
-                            variant="skill-requirement"
-                          >
-                            {label}
-                          </Badge>
-                        );
-                      })}
-                    </div>
-                  )}
-                  {option.itemRequirementGroups && option.itemRequirementGroups.length > 0 && (
-                    <div className="mt-2 space-y-2">
-                      {option.itemRequirementGroups.map((group, groupIndex) => (
-                        <div key={`${option.id}-item-group-${groupIndex}`}>
-                          <p className="text-xs font-medium text-muted-foreground">
-                            {group.logic === 'any' ? 'Requires any of:' : 'Requires all:'}
-                          </p>
-                          <div className="flex flex-wrap gap-1 mt-1">
-                            {group.requirements.map((itemReq, reqIndex) => {
-                              const label = itemReq.met
-                                ? itemReq.itemName
-                                : `${itemReq.itemName} (${itemReq.current}/${itemReq.required})`;
-
-                              return (
-                                <Badge
-                                  key={`${option.id}-item-${groupIndex}-${reqIndex}`}
-                                  variant={itemReq.met ? 'success' : 'destructive'}
-                                >
-                                  {label}
-                                  {!itemReq.met && <span className="sr-only"> - missing</span>}
-                                </Badge>
-                              );
-                            })}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  )}
+                  <SkillRequirementBadges
+                    requirements={option.skillRequirements || []}
+                    optionId={option.id}
+                  />
+                  <ItemRequirementBadges
+                    groups={option.itemRequirementGroups || []}
+                    optionId={option.id}
+                  />
                 </Button>
               );
             })}

--- a/src/components/shared/ChoiceSelector/ChoiceSelector.tsx
+++ b/src/components/shared/ChoiceSelector/ChoiceSelector.tsx
@@ -4,12 +4,14 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Scale, Flame, ChevronRight } from 'lucide-react';
 import { Decision, ChoiceAlignment, DecisionWeight, DecisionRequirement } from '@/types/narrative.types';
 import { WorldSkill } from '@/types/world.types';
+import { InventoryItem } from '@/types/inventory.types';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { resolveSkillData } from '@/lib/utils/gameDataResolver';
 import { CollapsibleSection } from '@/components/ui/CollapsibleSection';
 import { safeTrim } from '@/lib/utils';
+import { evaluateRequirement } from '@/lib/utils/requirementEvaluator';
 
 // Simple choice interface for backwards compatibility
 export interface SimpleChoice {
@@ -37,8 +39,17 @@ interface ChoiceSelectorProps {
   customInputPlaceholder?: string;
   maxCustomLength?: number;
 
-  // Skill requirement props
+  // Requirement evaluation props
   worldSkills?: WorldSkill[];
+  characterSkills?: Array<{
+    id: string;
+    characterId: string;
+    worldSkillId?: string;
+    name: string;
+    level: number;
+    category?: string;
+  }>;
+  inventoryItems?: InventoryItem[];
 }
 
 /**
@@ -123,6 +134,8 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
   customInputPlaceholder = 'Type your custom response...',
   maxCustomLength = 250,
   worldSkills = [],
+  characterSkills = [],
+  inventoryItems = [],
 }) => {
   // Custom input state
   const [customInputText, setCustomInputText] = useState('');
@@ -133,7 +146,15 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
 
   // Determine what data we're working with
   const isDecisionMode = !!decision;
-  
+
+  // Create character object for requirement evaluation
+  const mockCharacter = {
+    skills: characterSkills,
+    inventory: {
+      items: inventoryItems
+    }
+  };
+
   // Normalize the data into a common format
   const normalizedOptions: Array<{
     id: string;
@@ -141,20 +162,50 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
     hint?: string;
     isSelected?: boolean;
     alignment?: ChoiceAlignment;
+    isDisabledByRequirements?: boolean;
     skillRequirements?: Array<{
       requirement: DecisionRequirement;
       skillName?: string;
+      met: boolean;
+    }>;
+    itemRequirements?: Array<{
+      requirement: DecisionRequirement;
+      itemName: string;
+      met: boolean;
+      current: number;
+      required: number;
     }>;
   }> = isDecisionMode
     ? (decision.options || []).map(opt => {
+        // Process skill requirements
         const skillRequirements = opt.requirements?.filter(req => req.type === 'skill').map(req => {
           const skillData = resolveSkillData(req.targetId, worldSkills);
+          const evaluation = evaluateRequirement(req, mockCharacter);
 
           return {
             requirement: req,
-            skillName: skillData?.name || 'Unknown Skill'
+            skillName: skillData?.name || 'Unknown Skill',
+            met: evaluation.success
           };
         }) || [];
+
+        // Process item requirements
+        const itemRequirements = opt.requirements?.filter(req => req.type === 'item').map(req => {
+          const evaluation = evaluateRequirement(req, mockCharacter);
+
+          return {
+            requirement: req,
+            itemName: evaluation.itemName || req.targetId,
+            met: evaluation.success,
+            current: evaluation.current,
+            required: typeof evaluation.required === 'number' ? evaluation.required : 0
+          };
+        }) || [];
+
+        // Option is disabled if ANY requirement is not met (AND logic)
+        const allRequirementsMet =
+          skillRequirements.every(r => r.met) &&
+          itemRequirements.every(r => r.met);
 
         return {
           id: opt.id,
@@ -162,7 +213,9 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
           hint: opt.hint,
           isSelected: opt.id === decision.selectedOptionId || opt.id === selectedOptionId,
           alignment: opt.alignment,
-          skillRequirements
+          isDisabledByRequirements: !allRequirementsMet,
+          skillRequirements,
+          itemRequirements
         };
       })
     : (choices || []).map(choice => ({
@@ -170,7 +223,9 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
         text: choice.text,
         isSelected: choice.isSelected || choice.id === selectedOptionId,
         alignment: 'neutral' as ChoiceAlignment, // Default for simple choices
-        skillRequirements: []
+        isDisabledByRequirements: false,
+        skillRequirements: [],
+        itemRequirements: []
       }));
 
   // Use normalized options without custom input option
@@ -187,7 +242,11 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
   }, [enableCustomInput]);
 
   // Handle option selection
-  const handleOptionSelect = useCallback((optionId: string) => {
+  const handleOptionSelect = useCallback((optionId: string, isDisabledByReqs: boolean) => {
+    // Don't allow selection if option is disabled by requirements
+    if (isDisabledByReqs) {
+      return;
+    }
     setSelectedOptionId(optionId);
     onSelect(optionId);
   }, [onSelect]);
@@ -301,49 +360,72 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
             role="radiogroup" 
             aria-labelledby="choices-heading"
           >
-            {allOptions.map((option) => (
-              <Button
-                key={option.id}
-                data-testid={`choice-option-${option.id}`}
-                variant="ghost"
-                className={`block w-full text-left p-3 border rounded transition-colors h-auto whitespace-normal ${
-                  option.isSelected
-                    ? 'bg-blue-100 border-blue-500 font-bold'
-                    : getAlignmentClasses(option.alignment, isDisabled)
-                } ${isDisabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
-                onClick={() => handleOptionSelect(option.id)}
-                disabled={isDisabled}
-                aria-checked={option.isSelected}
-                role="radio"
-              >
-                <div className="flex items-start gap-2">
-                  {option.isSelected && <ChevronRight className="w-4 h-4 flex-shrink-0 mt-0.5" aria-hidden="true" />}
-                  {!option.isSelected && getAlignmentIcon(option.alignment) && (
-                    <span className="flex-shrink-0 mt-0.5">{getAlignmentIcon(option.alignment)}</span>
-                  )}
-                  <span className="flex-1">{option.text}</span>
-                </div>
-                {showHints && option.hint && (
-                  <div className="text-sm text-gray-500 mt-1">{option.hint}</div>
-                )}
-                {option.skillRequirements && option.skillRequirements.length > 0 && (
-                  <div className="flex flex-wrap gap-1 mt-2">
-                    {option.skillRequirements.map((skillReq, index) => {
-                      const label = `${skillReq.skillName}`;
+            {allOptions.map((option) => {
+              const isOptionDisabled = isDisabled || (option.isDisabledByRequirements ?? false);
 
-                      return (
-                        <Badge
-                          key={`${option.id}-skill-${index}`}
-                          variant="skill-requirement"
-                        >
-                          {label}
-                        </Badge>
-                      );
-                    })}
+              return (
+                <Button
+                  key={option.id}
+                  data-testid={`choice-option-${option.id}`}
+                  variant="ghost"
+                  className={`block w-full text-left p-3 border rounded transition-colors h-auto whitespace-normal ${
+                    option.isSelected
+                      ? 'bg-blue-100 border-blue-500 font-bold'
+                      : getAlignmentClasses(option.alignment, isOptionDisabled)
+                  } ${isOptionDisabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+                  onClick={() => handleOptionSelect(option.id, option.isDisabledByRequirements ?? false)}
+                  disabled={isOptionDisabled}
+                  aria-checked={option.isSelected}
+                  role="radio"
+                >
+                  <div className="flex items-start gap-2">
+                    {option.isSelected && <ChevronRight className="w-4 h-4 flex-shrink-0 mt-0.5" aria-hidden="true" />}
+                    {!option.isSelected && getAlignmentIcon(option.alignment) && (
+                      <span className="flex-shrink-0 mt-0.5">{getAlignmentIcon(option.alignment)}</span>
+                    )}
+                    <span className="flex-1">{option.text}</span>
                   </div>
-                )}
-              </Button>
-            ))}
+                  {showHints && option.hint && (
+                    <div className="text-sm text-gray-500 mt-1">{option.hint}</div>
+                  )}
+                  {option.skillRequirements && option.skillRequirements.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-2">
+                      {option.skillRequirements.map((skillReq, index) => {
+                        const label = `${skillReq.skillName}`;
+
+                        return (
+                          <Badge
+                            key={`${option.id}-skill-${index}`}
+                            variant="skill-requirement"
+                          >
+                            {label}
+                          </Badge>
+                        );
+                      })}
+                    </div>
+                  )}
+                  {option.itemRequirements && option.itemRequirements.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-2">
+                      {option.itemRequirements.map((itemReq, index) => {
+                        const label = itemReq.met
+                          ? itemReq.itemName
+                          : `${itemReq.itemName} (${itemReq.current}/${itemReq.required})`;
+                        const variant = itemReq.met ? 'default' : 'destructive';
+
+                        return (
+                          <Badge
+                            key={`${option.id}-item-${index}`}
+                            variant={variant}
+                          >
+                            {label} {!itemReq.met && '- missing'}
+                          </Badge>
+                        );
+                      })}
+                    </div>
+                  )}
+                </Button>
+              );
+            })}
           </div>
         </CollapsibleSection>
       )}

--- a/src/components/shared/ChoiceSelector/ChoiceSelector.tsx
+++ b/src/components/shared/ChoiceSelector/ChoiceSelector.tsx
@@ -2,7 +2,15 @@
 
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Scale, Flame, ChevronRight } from 'lucide-react';
-import { Decision, ChoiceAlignment, DecisionWeight, DecisionRequirement } from '@/types/narrative.types';
+import {
+  Decision,
+  ChoiceAlignment,
+  DecisionWeight,
+  DecisionRequirement,
+  DecisionItemRequirementGroup,
+  DecisionItemRequirements,
+  RequirementLogic,
+} from '@/types/narrative.types';
 import { WorldSkill } from '@/types/world.types';
 import { InventoryItem } from '@/types/inventory.types';
 import { Badge } from '@/components/ui/badge';
@@ -118,6 +126,71 @@ const getDecisionWeightStyling = (weight?: DecisionWeight) => {
   }
 };
 
+const DEFAULT_REQUIREMENT_LOGIC: RequirementLogic = 'all';
+
+const isDecisionItemRequirementGroup = (
+  value: unknown
+): value is DecisionItemRequirementGroup => {
+  return Boolean(
+    value &&
+      typeof value === 'object' &&
+      'requirements' in value &&
+      Array.isArray((value as DecisionItemRequirementGroup).requirements)
+  );
+};
+
+const ensureItemRequirementGroup = (
+  requirements: DecisionRequirement[] | undefined,
+  logic?: RequirementLogic
+): DecisionItemRequirementGroup | null => {
+  const filtered = (requirements || []).filter((req) => req.type === 'item');
+  if (filtered.length === 0) {
+    return null;
+  }
+
+  return {
+    logic: logic ?? DEFAULT_REQUIREMENT_LOGIC,
+    requirements: filtered,
+  };
+};
+
+const getNormalizedItemRequirementGroups = (
+  requiredItems: DecisionItemRequirements | undefined,
+  fallbackRequirements: DecisionRequirement[] | undefined
+): DecisionItemRequirementGroup[] => {
+  if (!requiredItems) {
+    const fallbackGroup = ensureItemRequirementGroup(fallbackRequirements);
+    return fallbackGroup ? [fallbackGroup] : [];
+  }
+
+  if (Array.isArray(requiredItems)) {
+    if (requiredItems.length === 0) {
+      return [];
+    }
+
+    const first = requiredItems[0] as DecisionRequirement | DecisionItemRequirementGroup;
+    if (isDecisionItemRequirementGroup(first)) {
+      return (requiredItems as DecisionItemRequirementGroup[])
+        .map((group) => ensureItemRequirementGroup(group.requirements, group.logic))
+        .filter((group): group is DecisionItemRequirementGroup => Boolean(group));
+    }
+
+    const fallbackGroup = ensureItemRequirementGroup(requiredItems as DecisionRequirement[]);
+    return fallbackGroup ? [fallbackGroup] : [];
+  }
+
+  if (isDecisionItemRequirementGroup(requiredItems)) {
+    const group = ensureItemRequirementGroup(
+      requiredItems.requirements,
+      requiredItems.logic
+    );
+    return group ? [group] : [];
+  }
+
+  const fallbackGroup = ensureItemRequirementGroup(fallbackRequirements);
+  return fallbackGroup ? [fallbackGroup] : [];
+};
+
 /**
  * Unified choice selector component that handles both simple choices and complex decisions
  */
@@ -163,17 +236,22 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
     isSelected?: boolean;
     alignment?: ChoiceAlignment;
     isDisabledByRequirements?: boolean;
+    disabledReason?: string;
     skillRequirements?: Array<{
       requirement: DecisionRequirement;
       skillName?: string;
       met: boolean;
     }>;
-    itemRequirements?: Array<{
-      requirement: DecisionRequirement;
-      itemName: string;
+    itemRequirementGroups?: Array<{
+      logic: RequirementLogic;
       met: boolean;
-      current: number;
-      required: number;
+      requirements: Array<{
+        requirement: DecisionRequirement;
+        itemName: string;
+        met: boolean;
+        current: number;
+        required: number;
+      }>;
     }>;
   }> = isDecisionMode
     ? (decision.options || []).map(opt => {
@@ -189,23 +267,71 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
           };
         }) || [];
 
-        // Process item requirements
-        const itemRequirements = opt.requirements?.filter(req => req.type === 'item').map(req => {
-          const evaluation = evaluateRequirement(req, mockCharacter);
+        // Process item requirements (normalized groups)
+        const normalizedGroups = getNormalizedItemRequirementGroups(
+          opt.requiredItems,
+          opt.requirements
+        );
+        const itemRequirementGroups = normalizedGroups.map(group => {
+          const logic: RequirementLogic = group.logic ?? DEFAULT_REQUIREMENT_LOGIC;
+          const evaluatedRequirements = group.requirements.map(req => {
+            const evaluation = evaluateRequirement(req, mockCharacter);
+
+            return {
+              requirement: req,
+              itemName: evaluation.itemName || req.targetId,
+              met: evaluation.success,
+              current: evaluation.current,
+              required: typeof evaluation.required === 'number' ? evaluation.required : 0
+            };
+          });
+
+          const groupMet = logic === 'any'
+            ? evaluatedRequirements.some(req => req.met)
+            : evaluatedRequirements.every(req => req.met);
 
           return {
-            requirement: req,
-            itemName: evaluation.itemName || req.targetId,
-            met: evaluation.success,
-            current: evaluation.current,
-            required: typeof evaluation.required === 'number' ? evaluation.required : 0
+            logic,
+            met: groupMet,
+            requirements: evaluatedRequirements
           };
-        }) || [];
+        });
 
-        // Option is disabled if ANY requirement is not met (AND logic)
-        const allRequirementsMet =
-          skillRequirements.every(r => r.met) &&
-          itemRequirements.every(r => r.met);
+        const allSkillRequirementsMet = skillRequirements.every(r => r.met);
+        const allItemGroupsMet =
+          itemRequirementGroups.length === 0 ||
+          itemRequirementGroups.every(group => group.met);
+
+        const disabledReasonParts: string[] = [];
+        if (!allSkillRequirementsMet) {
+          const missingSkills = skillRequirements
+            .filter(req => !req.met)
+            .map(req => req.skillName || 'Required skill');
+          if (missingSkills.length > 0) {
+            disabledReasonParts.push(`Skills: ${missingSkills.join(', ')}`);
+          }
+        }
+
+        if (!allItemGroupsMet) {
+          const missingItems = itemRequirementGroups
+            .filter(group => !group.met)
+            .flatMap(group =>
+              group.requirements.map(req => {
+                if (req.met) {
+                  return null;
+                }
+                const requiredAmount = req.required > 0 ? `${req.current}/${req.required}` : `${req.current}`;
+                return `${req.itemName}${req.required > 0 ? ` (${requiredAmount})` : ''}`;
+              }).filter((value): value is string => Boolean(value))
+            );
+          if (missingItems.length > 0) {
+            disabledReasonParts.push(`Items: ${missingItems.join(', ')}`);
+          }
+        }
+
+        const disabledReason = disabledReasonParts.length > 0
+          ? `Requires ${disabledReasonParts.join(' | ')}`
+          : undefined;
 
         return {
           id: opt.id,
@@ -213,9 +339,10 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
           hint: opt.hint,
           isSelected: opt.id === decision.selectedOptionId || opt.id === selectedOptionId,
           alignment: opt.alignment,
-          isDisabledByRequirements: !allRequirementsMet,
+          isDisabledByRequirements: !(allSkillRequirementsMet && allItemGroupsMet),
+          disabledReason,
           skillRequirements,
-          itemRequirements
+          itemRequirementGroups
         };
       })
     : (choices || []).map(choice => ({
@@ -224,8 +351,9 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
         isSelected: choice.isSelected || choice.id === selectedOptionId,
         alignment: 'neutral' as ChoiceAlignment, // Default for simple choices
         isDisabledByRequirements: false,
+        disabledReason: undefined,
         skillRequirements: [],
-        itemRequirements: []
+        itemRequirementGroups: []
       }));
 
   // Use normalized options without custom input option
@@ -368,6 +496,8 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
                   key={option.id}
                   data-testid={`choice-option-${option.id}`}
                   variant="ghost"
+                  title={isOptionDisabled ? option.disabledReason : undefined}
+                  data-disabled-reason={isOptionDisabled ? option.disabledReason : undefined}
                   className={`block w-full text-left p-3 border rounded transition-colors h-auto whitespace-normal ${
                     option.isSelected
                       ? 'bg-blue-100 border-blue-500 font-bold'
@@ -404,23 +534,32 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
                       })}
                     </div>
                   )}
-                  {option.itemRequirements && option.itemRequirements.length > 0 && (
-                    <div className="flex flex-wrap gap-1 mt-2">
-                      {option.itemRequirements.map((itemReq, index) => {
-                        const label = itemReq.met
-                          ? itemReq.itemName
-                          : `${itemReq.itemName} (${itemReq.current}/${itemReq.required})`;
-                        const variant = itemReq.met ? 'default' : 'destructive';
+                  {option.itemRequirementGroups && option.itemRequirementGroups.length > 0 && (
+                    <div className="mt-2 space-y-2">
+                      {option.itemRequirementGroups.map((group, groupIndex) => (
+                        <div key={`${option.id}-item-group-${groupIndex}`}>
+                          <p className="text-xs font-medium text-muted-foreground">
+                            {group.logic === 'any' ? 'Requires any of:' : 'Requires all:'}
+                          </p>
+                          <div className="flex flex-wrap gap-1 mt-1">
+                            {group.requirements.map((itemReq, reqIndex) => {
+                              const label = itemReq.met
+                                ? itemReq.itemName
+                                : `${itemReq.itemName} (${itemReq.current}/${itemReq.required})`;
 
-                        return (
-                          <Badge
-                            key={`${option.id}-item-${index}`}
-                            variant={variant}
-                          >
-                            {label} {!itemReq.met && '- missing'}
-                          </Badge>
-                        );
-                      })}
+                              return (
+                                <Badge
+                                  key={`${option.id}-item-${groupIndex}-${reqIndex}`}
+                                  variant={itemReq.met ? 'success' : 'destructive'}
+                                >
+                                  {label}
+                                  {!itemReq.met && <span className="sr-only"> - missing</span>}
+                                </Badge>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      ))}
                     </div>
                   )}
                 </Button>

--- a/src/components/shared/ChoiceSelector/ChoiceSelector.tsx
+++ b/src/components/shared/ChoiceSelector/ChoiceSelector.tsx
@@ -221,7 +221,7 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
   const isDecisionMode = !!decision;
 
   // Create character object for requirement evaluation
-  const mockCharacter = {
+  const requirementEvaluationContext = {
     skills: characterSkills,
     inventory: {
       items: inventoryItems
@@ -258,7 +258,7 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
         // Process skill requirements
         const skillRequirements = opt.requirements?.filter(req => req.type === 'skill').map(req => {
           const skillData = resolveSkillData(req.targetId, worldSkills);
-          const evaluation = evaluateRequirement(req, mockCharacter);
+          const evaluation = evaluateRequirement(req, requirementEvaluationContext);
 
           return {
             requirement: req,
@@ -275,7 +275,7 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
         const itemRequirementGroups = normalizedGroups.map(group => {
           const logic: RequirementLogic = group.logic ?? DEFAULT_REQUIREMENT_LOGIC;
           const evaluatedRequirements = group.requirements.map(req => {
-            const evaluation = evaluateRequirement(req, mockCharacter);
+          const evaluation = evaluateRequirement(req, requirementEvaluationContext);
 
             return {
               requirement: req,

--- a/src/components/shared/ChoiceSelector/README.md
+++ b/src/components/shared/ChoiceSelector/README.md
@@ -6,6 +6,8 @@ This handles player choice selection in all its forms - from simple "go left or 
 
 **Multiple choice types** - Works with simple choice lists ("Go north", "Go south") and complex decision objects with hints and requirements.
 
+**Inventory-aware gating** - Surfaces required items and disables locked choices with clear feedback about missing gear.
+
 **Custom player input** - Optional text area where players can type their own creative responses instead of picking from suggested options.
 
 **Smart visual hierarchy** - Custom input gets prominent placement at the top, suggested choices appear below with less visual weight.
@@ -98,6 +100,13 @@ const decision = {
 | `customInputPlaceholder` | `string` | `'Type your custom response...'` | Placeholder text |
 | `maxCustomLength` | `number` | `250` | Maximum character limit |
 
+### Requirement Context Props
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `worldSkills` | `WorldSkill[]` | `[]` | Skill definitions used to label and interpret skill-based requirements. |
+| `characterSkills` | `CharacterSkill[]` | `[]` | Player character skills used to evaluate skill requirements. |
+| `inventoryItems` | `InventoryItem[]` | `[]` | Inventory snapshot used to evaluate item requirements and quantities. |
+
 ## Types
 
 ### SimpleChoice
@@ -123,9 +132,12 @@ interface DecisionOption {
   text: string;
   hint?: string;
   requirements?: DecisionRequirement[];
+  requiredItems?: DecisionItemRequirements;
   isCustomInput?: boolean;  // Added for custom input support
   customText?: string;      // Added for custom input support
 }
+
+`DecisionItemRequirements` supports straightforward arrays (defaults to "all" logic) or grouped objects where you can specify `logic: 'any' | 'all'` for more complex inventory gating.
 ```
 
 ## Visual Design

--- a/src/components/shared/ChoiceSelector/RequirementBadges.tsx
+++ b/src/components/shared/ChoiceSelector/RequirementBadges.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { RequirementLogic } from '@/types/narrative.types';
+
+interface SkillRequirement {
+  skillName?: string;
+}
+
+interface ItemRequirement {
+  itemName: string;
+  met: boolean;
+  current: number;
+  required: number;
+}
+
+interface ItemRequirementGroup {
+  logic: RequirementLogic;
+  requirements: ItemRequirement[];
+}
+
+interface SkillRequirementBadgesProps {
+  requirements: SkillRequirement[];
+  optionId: string;
+}
+
+interface ItemRequirementBadgesProps {
+  groups: ItemRequirementGroup[];
+  optionId: string;
+}
+
+/**
+ * Renders skill requirement badges
+ */
+export const SkillRequirementBadges: React.FC<SkillRequirementBadgesProps> = ({
+  requirements,
+  optionId,
+}) => {
+  if (!requirements || requirements.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1 mt-2">
+      {requirements.map((skillReq, index) => {
+        const label = `${skillReq.skillName}`;
+
+        return (
+          <Badge
+            key={`${optionId}-skill-${index}`}
+            variant="skill-requirement"
+          >
+            {label}
+          </Badge>
+        );
+      })}
+    </div>
+  );
+};
+
+/**
+ * Renders item requirement badges organized by groups
+ */
+export const ItemRequirementBadges: React.FC<ItemRequirementBadgesProps> = ({
+  groups,
+  optionId,
+}) => {
+  if (!groups || groups.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-2 space-y-2">
+      {groups.map((group, groupIndex) => (
+        <div key={`${optionId}-item-group-${groupIndex}`}>
+          <p className="text-xs font-medium text-muted-foreground">
+            {group.logic === 'any' ? 'Requires any of:' : 'Requires all:'}
+          </p>
+          <div className="flex flex-wrap gap-1 mt-1">
+            {group.requirements.map((itemReq, reqIndex) => {
+              const label = itemReq.met
+                ? itemReq.itemName
+                : `${itemReq.itemName} (${itemReq.current}/${itemReq.required})`;
+
+              return (
+                <Badge
+                  key={`${optionId}-item-${groupIndex}-${reqIndex}`}
+                  variant={itemReq.met ? 'success' : 'destructive'}
+                >
+                  {label}
+                  {!itemReq.met && <span className="sr-only"> - missing</span>}
+                </Badge>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/shared/ChoiceSelector/__tests__/ChoiceSelector.inventoryRequirements.test.tsx
+++ b/src/components/shared/ChoiceSelector/__tests__/ChoiceSelector.inventoryRequirements.test.tsx
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import ChoiceSelector from '../ChoiceSelector';
 import { Decision, DecisionRequirement } from '@/types/narrative.types';
-import { InventoryItem } from '@/types/inventory.types';
 
 // Mock the character store to provide inventory data
 jest.mock('@/state/characterStore', () => ({

--- a/src/components/shared/ChoiceSelector/__tests__/ChoiceSelector.inventoryRequirements.test.tsx
+++ b/src/components/shared/ChoiceSelector/__tests__/ChoiceSelector.inventoryRequirements.test.tsx
@@ -5,30 +5,42 @@ import '@testing-library/jest-dom';
 import ChoiceSelector from '../ChoiceSelector';
 import { Decision, DecisionRequirement } from '@/types/narrative.types';
 
-// Mock the character store to provide inventory data
-jest.mock('@/state/characterStore', () => ({
-  useCharacterStore: jest.fn(() => ({
-    getCurrentCharacter: jest.fn(() => ({
-      id: 'char-1',
-      inventory: {
-        items: [
-          {
-            id: 'item-lockpick',
-            name: 'Lockpick',
-            quantity: 1,
-          },
-          {
-            id: 'item-potion',
-            name: 'Healing Potion',
-            quantity: 3,
-          },
-        ],
-      },
-    })),
-  })),
-}));
-
 describe('ChoiceSelector - Inventory Requirements', () => {
+  const mockInventoryItems = [
+    {
+      id: 'item-lockpick',
+      name: 'Lockpick',
+      description: '',
+      quantity: 1,
+      stackable: false,
+      categoryId: 'equipment',
+      acquisitionHistory: [],
+      categorization: {
+        categoryId: 'equipment',
+        source: 'manual' as const,
+        classifiedAt: new Date().toISOString(),
+      },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    {
+      id: 'item-potion',
+      name: 'Healing Potion',
+      description: '',
+      quantity: 3,
+      stackable: true,
+      categoryId: 'consumables',
+      acquisitionHistory: [],
+      categorization: {
+        categoryId: 'consumables',
+        source: 'manual' as const,
+        classifiedAt: new Date().toISOString(),
+      },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+  ];
+
   const createMockDecision = (
     options: Array<{
       id: string;
@@ -66,7 +78,7 @@ describe('ChoiceSelector - Inventory Requirements', () => {
     ]);
 
     const handleSelect = jest.fn();
-    render(<ChoiceSelector decision={decision} onSelect={handleSelect} />);
+    render(<ChoiceSelector decision={decision} onSelect={handleSelect} inventoryItems={mockInventoryItems} />);
 
     const lockpickOption = screen.getByText('Pick the lock');
     expect(lockpickOption).not.toHaveAttribute('disabled');
@@ -93,10 +105,11 @@ describe('ChoiceSelector - Inventory Requirements', () => {
     ]);
 
     const handleSelect = jest.fn();
-    render(<ChoiceSelector decision={decision} onSelect={handleSelect} />);
+    render(<ChoiceSelector decision={decision} onSelect={handleSelect} inventoryItems={mockInventoryItems} />);
 
     const magicKeyOption = screen.getByText('Use the magic key');
-    expect(magicKeyOption).toHaveAttribute('disabled');
+    const button = screen.getByTestId('choice-option-opt-1');
+    expect(button).toHaveAttribute('disabled');
   });
 
   it('should disable option when character has insufficient quantity', () => {
@@ -116,7 +129,7 @@ describe('ChoiceSelector - Inventory Requirements', () => {
     ]);
 
     const handleSelect = jest.fn();
-    render(<ChoiceSelector decision={decision} onSelect={handleSelect} />);
+    render(<ChoiceSelector decision={decision} onSelect={handleSelect} inventoryItems={mockInventoryItems} />);
 
     const bribeOption = screen.getByText('Bribe with 10 gold coins');
     expect(bribeOption).toHaveAttribute('disabled');
@@ -139,7 +152,7 @@ describe('ChoiceSelector - Inventory Requirements', () => {
     ]);
 
     const handleSelect = jest.fn();
-    render(<ChoiceSelector decision={decision} onSelect={handleSelect} showHints={true} />);
+    render(<ChoiceSelector decision={decision} onSelect={handleSelect} showHints={true} inventoryItems={mockInventoryItems} />);
 
     // Should show indicator that item is missing
     expect(screen.getByText(/Magic Key/i)).toBeInTheDocument();
@@ -163,7 +176,7 @@ describe('ChoiceSelector - Inventory Requirements', () => {
     ]);
 
     const handleSelect = jest.fn();
-    render(<ChoiceSelector decision={decision} onSelect={handleSelect} showHints={true} />);
+    render(<ChoiceSelector decision={decision} onSelect={handleSelect} showHints={true} inventoryItems={mockInventoryItems} />);
 
     // Should show current quantity vs required
     expect(screen.getByText(/Healing Potion/i)).toBeInTheDocument();
@@ -193,7 +206,7 @@ describe('ChoiceSelector - Inventory Requirements', () => {
     ]);
 
     const handleSelect = jest.fn();
-    render(<ChoiceSelector decision={decision} onSelect={handleSelect} />);
+    render(<ChoiceSelector decision={decision} onSelect={handleSelect} inventoryItems={mockInventoryItems} />);
 
     // Should be enabled because character has both items in required quantities
     const craftOption = screen.getByText('Craft a healing salve');
@@ -223,7 +236,7 @@ describe('ChoiceSelector - Inventory Requirements', () => {
     ]);
 
     const handleSelect = jest.fn();
-    render(<ChoiceSelector decision={decision} onSelect={handleSelect} />);
+    render(<ChoiceSelector decision={decision} onSelect={handleSelect} inventoryItems={mockInventoryItems} />);
 
     // Should be disabled because character lacks Magic Scroll
     const ritualOption = screen.getByText('Perform complex ritual');
@@ -247,7 +260,7 @@ describe('ChoiceSelector - Inventory Requirements', () => {
     ]);
 
     const handleSelect = jest.fn();
-    render(<ChoiceSelector decision={decision} onSelect={handleSelect} />);
+    render(<ChoiceSelector decision={decision} onSelect={handleSelect} inventoryItems={mockInventoryItems} />);
 
     const magicKeyOption = screen.getByText('Use the magic key');
 
@@ -274,12 +287,12 @@ describe('ChoiceSelector - Inventory Requirements', () => {
     ]);
 
     const handleSelect = jest.fn();
-    render(<ChoiceSelector decision={decision} onSelect={handleSelect} />);
+    render(<ChoiceSelector decision={decision} onSelect={handleSelect} inventoryItems={mockInventoryItems} />);
 
-    const magicKeyOption = screen.getByText('Use the magic key');
+    const magicKeyButton = screen.getByTestId('choice-option-opt-1');
 
     // Should have visual indicator of being disabled
-    expect(magicKeyOption).toHaveClass('opacity-50');
-    expect(magicKeyOption).toHaveClass('cursor-not-allowed');
+    expect(magicKeyButton).toHaveClass('opacity-50');
+    expect(magicKeyButton).toHaveClass('cursor-not-allowed');
   });
 });

--- a/src/components/shared/ChoiceSelector/__tests__/ChoiceSelector.inventoryRequirements.test.tsx
+++ b/src/components/shared/ChoiceSelector/__tests__/ChoiceSelector.inventoryRequirements.test.tsx
@@ -1,0 +1,286 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import ChoiceSelector from '../ChoiceSelector';
+import { Decision, DecisionRequirement } from '@/types/narrative.types';
+import { InventoryItem } from '@/types/inventory.types';
+
+// Mock the character store to provide inventory data
+jest.mock('@/state/characterStore', () => ({
+  useCharacterStore: jest.fn(() => ({
+    getCurrentCharacter: jest.fn(() => ({
+      id: 'char-1',
+      inventory: {
+        items: [
+          {
+            id: 'item-lockpick',
+            name: 'Lockpick',
+            quantity: 1,
+          },
+          {
+            id: 'item-potion',
+            name: 'Healing Potion',
+            quantity: 3,
+          },
+        ],
+      },
+    })),
+  })),
+}));
+
+describe('ChoiceSelector - Inventory Requirements', () => {
+  const createMockDecision = (
+    options: Array<{
+      id: string;
+      text: string;
+      requirements?: DecisionRequirement[];
+    }>
+  ): Decision => ({
+    id: 'decision-1',
+    prompt: 'What do you do?',
+    options: options.map((opt) => ({
+      id: opt.id,
+      text: opt.text,
+      requirements: opt.requirements || [],
+    })),
+  });
+
+  it('should enable option when character has required item', () => {
+    const decision = createMockDecision([
+      {
+        id: 'opt-1',
+        text: 'Pick the lock',
+        requirements: [
+          {
+            type: 'item',
+            targetId: 'Lockpick',
+            operator: 'gte',
+            value: 1,
+          },
+        ],
+      },
+      {
+        id: 'opt-2',
+        text: 'Break down the door',
+      },
+    ]);
+
+    const handleSelect = jest.fn();
+    render(<ChoiceSelector decision={decision} onSelect={handleSelect} />);
+
+    const lockpickOption = screen.getByText('Pick the lock');
+    expect(lockpickOption).not.toHaveAttribute('disabled');
+  });
+
+  it('should disable option when character lacks required item', () => {
+    const decision = createMockDecision([
+      {
+        id: 'opt-1',
+        text: 'Use the magic key',
+        requirements: [
+          {
+            type: 'item',
+            targetId: 'Magic Key',
+            operator: 'gte',
+            value: 1,
+          },
+        ],
+      },
+      {
+        id: 'opt-2',
+        text: 'Look for another way',
+      },
+    ]);
+
+    const handleSelect = jest.fn();
+    render(<ChoiceSelector decision={decision} onSelect={handleSelect} />);
+
+    const magicKeyOption = screen.getByText('Use the magic key');
+    expect(magicKeyOption).toHaveAttribute('disabled');
+  });
+
+  it('should disable option when character has insufficient quantity', () => {
+    const decision = createMockDecision([
+      {
+        id: 'opt-1',
+        text: 'Bribe with 10 gold coins',
+        requirements: [
+          {
+            type: 'item',
+            targetId: 'Gold Coins',
+            operator: 'gte',
+            value: 10,
+          },
+        ],
+      },
+    ]);
+
+    const handleSelect = jest.fn();
+    render(<ChoiceSelector decision={decision} onSelect={handleSelect} />);
+
+    const bribeOption = screen.getByText('Bribe with 10 gold coins');
+    expect(bribeOption).toHaveAttribute('disabled');
+  });
+
+  it('should show feedback about missing items', () => {
+    const decision = createMockDecision([
+      {
+        id: 'opt-1',
+        text: 'Use the magic key',
+        requirements: [
+          {
+            type: 'item',
+            targetId: 'Magic Key',
+            operator: 'gte',
+            value: 1,
+          },
+        ],
+      },
+    ]);
+
+    const handleSelect = jest.fn();
+    render(<ChoiceSelector decision={decision} onSelect={handleSelect} showHints={true} />);
+
+    // Should show indicator that item is missing
+    expect(screen.getByText(/Magic Key/i)).toBeInTheDocument();
+    expect(screen.getByText(/missing/i)).toBeInTheDocument();
+  });
+
+  it('should show feedback about insufficient quantity', () => {
+    const decision = createMockDecision([
+      {
+        id: 'opt-1',
+        text: 'Heal multiple allies',
+        requirements: [
+          {
+            type: 'item',
+            targetId: 'Healing Potion',
+            operator: 'gte',
+            value: 5,
+          },
+        ],
+      },
+    ]);
+
+    const handleSelect = jest.fn();
+    render(<ChoiceSelector decision={decision} onSelect={handleSelect} showHints={true} />);
+
+    // Should show current quantity vs required
+    expect(screen.getByText(/Healing Potion/i)).toBeInTheDocument();
+    expect(screen.getByText(/3\/5/i)).toBeInTheDocument();
+  });
+
+  it('should handle multiple item requirements with AND logic', () => {
+    const decision = createMockDecision([
+      {
+        id: 'opt-1',
+        text: 'Craft a healing salve',
+        requirements: [
+          {
+            type: 'item',
+            targetId: 'Healing Potion',
+            operator: 'gte',
+            value: 2,
+          },
+          {
+            type: 'item',
+            targetId: 'Lockpick',
+            operator: 'gte',
+            value: 1,
+          },
+        ],
+      },
+    ]);
+
+    const handleSelect = jest.fn();
+    render(<ChoiceSelector decision={decision} onSelect={handleSelect} />);
+
+    // Should be enabled because character has both items in required quantities
+    const craftOption = screen.getByText('Craft a healing salve');
+    expect(craftOption).not.toHaveAttribute('disabled');
+  });
+
+  it('should disable option if ANY requirement in AND logic fails', () => {
+    const decision = createMockDecision([
+      {
+        id: 'opt-1',
+        text: 'Perform complex ritual',
+        requirements: [
+          {
+            type: 'item',
+            targetId: 'Healing Potion',
+            operator: 'gte',
+            value: 2,
+          },
+          {
+            type: 'item',
+            targetId: 'Magic Scroll',
+            operator: 'gte',
+            value: 1,
+          },
+        ],
+      },
+    ]);
+
+    const handleSelect = jest.fn();
+    render(<ChoiceSelector decision={decision} onSelect={handleSelect} />);
+
+    // Should be disabled because character lacks Magic Scroll
+    const ritualOption = screen.getByText('Perform complex ritual');
+    expect(ritualOption).toHaveAttribute('disabled');
+  });
+
+  it('should prevent selection of disabled options', async () => {
+    const decision = createMockDecision([
+      {
+        id: 'opt-1',
+        text: 'Use the magic key',
+        requirements: [
+          {
+            type: 'item',
+            targetId: 'Magic Key',
+            operator: 'gte',
+            value: 1,
+          },
+        ],
+      },
+    ]);
+
+    const handleSelect = jest.fn();
+    render(<ChoiceSelector decision={decision} onSelect={handleSelect} />);
+
+    const magicKeyOption = screen.getByText('Use the magic key');
+
+    await userEvent.click(magicKeyOption);
+
+    // Should not call onSelect for disabled option
+    expect(handleSelect).not.toHaveBeenCalled();
+  });
+
+  it('should show visual distinction for disabled options', () => {
+    const decision = createMockDecision([
+      {
+        id: 'opt-1',
+        text: 'Use the magic key',
+        requirements: [
+          {
+            type: 'item',
+            targetId: 'Magic Key',
+            operator: 'gte',
+            value: 1,
+          },
+        ],
+      },
+    ]);
+
+    const handleSelect = jest.fn();
+    render(<ChoiceSelector decision={decision} onSelect={handleSelect} />);
+
+    const magicKeyOption = screen.getByText('Use the magic key');
+
+    // Should have visual indicator of being disabled
+    expect(magicKeyOption).toHaveClass('opacity-50');
+    expect(magicKeyOption).toHaveClass('cursor-not-allowed');
+  });
+});

--- a/src/components/shared/ChoiceSelector/__tests__/ChoiceSelector.inventoryRequirements.test.tsx
+++ b/src/components/shared/ChoiceSelector/__tests__/ChoiceSelector.inventoryRequirements.test.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import ChoiceSelector from '../ChoiceSelector';
-import { Decision, DecisionRequirement } from '@/types/narrative.types';
+import {
+  Decision,
+  DecisionRequirement,
+  DecisionItemRequirements,
+} from '@/types/narrative.types';
 
 describe('ChoiceSelector - Inventory Requirements', () => {
   const mockInventoryItems = [
@@ -46,6 +50,7 @@ describe('ChoiceSelector - Inventory Requirements', () => {
       id: string;
       text: string;
       requirements?: DecisionRequirement[];
+      requiredItems?: DecisionItemRequirements;
     }>
   ): Decision => ({
     id: 'decision-1',
@@ -54,7 +59,15 @@ describe('ChoiceSelector - Inventory Requirements', () => {
       id: opt.id,
       text: opt.text,
       requirements: opt.requirements || [],
+      requiredItems: opt.requiredItems,
     })),
+  });
+
+  const itemRequirement = (targetId: string, value: number): DecisionRequirement => ({
+    type: 'item',
+    targetId,
+    operator: 'gte',
+    value,
   });
 
   it('should enable option when character has required item', () => {
@@ -62,14 +75,7 @@ describe('ChoiceSelector - Inventory Requirements', () => {
       {
         id: 'opt-1',
         text: 'Pick the lock',
-        requirements: [
-          {
-            type: 'item',
-            targetId: 'Lockpick',
-            operator: 'gte',
-            value: 1,
-          },
-        ],
+        requiredItems: [itemRequirement('Lockpick', 1)],
       },
       {
         id: 'opt-2',
@@ -80,8 +86,9 @@ describe('ChoiceSelector - Inventory Requirements', () => {
     const handleSelect = jest.fn();
     render(<ChoiceSelector decision={decision} onSelect={handleSelect} inventoryItems={mockInventoryItems} />);
 
-    const lockpickOption = screen.getByText('Pick the lock');
-    expect(lockpickOption).not.toHaveAttribute('disabled');
+    const lockpickButton = screen.getByTestId('choice-option-opt-1');
+    expect(lockpickButton).not.toBeDisabled();
+    expect(lockpickButton).not.toHaveAttribute('data-disabled-reason');
   });
 
   it('should disable option when character lacks required item', () => {
@@ -89,14 +96,7 @@ describe('ChoiceSelector - Inventory Requirements', () => {
       {
         id: 'opt-1',
         text: 'Use the magic key',
-        requirements: [
-          {
-            type: 'item',
-            targetId: 'Magic Key',
-            operator: 'gte',
-            value: 1,
-          },
-        ],
+        requiredItems: [itemRequirement('Magic Key', 1)],
       },
       {
         id: 'opt-2',
@@ -107,9 +107,10 @@ describe('ChoiceSelector - Inventory Requirements', () => {
     const handleSelect = jest.fn();
     render(<ChoiceSelector decision={decision} onSelect={handleSelect} inventoryItems={mockInventoryItems} />);
 
-    const magicKeyOption = screen.getByText('Use the magic key');
     const button = screen.getByTestId('choice-option-opt-1');
-    expect(button).toHaveAttribute('disabled');
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('data-disabled-reason');
+    expect(button.getAttribute('data-disabled-reason')).toContain('Magic Key');
   });
 
   it('should disable option when character has insufficient quantity', () => {
@@ -117,22 +118,16 @@ describe('ChoiceSelector - Inventory Requirements', () => {
       {
         id: 'opt-1',
         text: 'Bribe with 10 gold coins',
-        requirements: [
-          {
-            type: 'item',
-            targetId: 'Gold Coins',
-            operator: 'gte',
-            value: 10,
-          },
-        ],
+        requiredItems: [itemRequirement('Gold Coins', 10)],
       },
     ]);
 
     const handleSelect = jest.fn();
     render(<ChoiceSelector decision={decision} onSelect={handleSelect} inventoryItems={mockInventoryItems} />);
 
-    const bribeOption = screen.getByText('Bribe with 10 gold coins');
-    expect(bribeOption).toHaveAttribute('disabled');
+    const bribeButton = screen.getByTestId('choice-option-opt-1');
+    expect(bribeButton).toBeDisabled();
+    expect(bribeButton?.getAttribute('data-disabled-reason')).toContain('Gold Coins');
   });
 
   it('should show feedback about missing items', () => {
@@ -140,23 +135,17 @@ describe('ChoiceSelector - Inventory Requirements', () => {
       {
         id: 'opt-1',
         text: 'Use the magic key',
-        requirements: [
-          {
-            type: 'item',
-            targetId: 'Magic Key',
-            operator: 'gte',
-            value: 1,
-          },
-        ],
+        requiredItems: [itemRequirement('Magic Key', 1)],
       },
     ]);
 
     const handleSelect = jest.fn();
     render(<ChoiceSelector decision={decision} onSelect={handleSelect} showHints={true} inventoryItems={mockInventoryItems} />);
 
-    // Should show indicator that item is missing
-    expect(screen.getByText(/Magic Key/i)).toBeInTheDocument();
-    expect(screen.getByText(/missing/i)).toBeInTheDocument();
+    expect(screen.getByText(/Requires all:/i)).toBeInTheDocument();
+    const optionButton = screen.getByTestId('choice-option-opt-1');
+    const requirementBadge = within(optionButton).getByText(/Magic Key\s*\(0\/1\)/i);
+    expect(requirementBadge).toBeInTheDocument();
   });
 
   it('should show feedback about insufficient quantity', () => {
@@ -164,14 +153,7 @@ describe('ChoiceSelector - Inventory Requirements', () => {
       {
         id: 'opt-1',
         text: 'Heal multiple allies',
-        requirements: [
-          {
-            type: 'item',
-            targetId: 'Healing Potion',
-            operator: 'gte',
-            value: 5,
-          },
-        ],
+        requiredItems: [itemRequirement('Healing Potion', 5)],
       },
     ]);
 
@@ -179,8 +161,10 @@ describe('ChoiceSelector - Inventory Requirements', () => {
     render(<ChoiceSelector decision={decision} onSelect={handleSelect} showHints={true} inventoryItems={mockInventoryItems} />);
 
     // Should show current quantity vs required
-    expect(screen.getByText(/Healing Potion/i)).toBeInTheDocument();
-    expect(screen.getByText(/3\/5/i)).toBeInTheDocument();
+    expect(screen.getByText(/Requires all:/i)).toBeInTheDocument();
+    const optionButton = screen.getByTestId('choice-option-opt-1');
+    const requirementBadge = within(optionButton).getByText(/Healing Potion\s*\(3\/5\)/i);
+    expect(requirementBadge).toBeInTheDocument();
   });
 
   it('should handle multiple item requirements with AND logic', () => {
@@ -188,19 +172,9 @@ describe('ChoiceSelector - Inventory Requirements', () => {
       {
         id: 'opt-1',
         text: 'Craft a healing salve',
-        requirements: [
-          {
-            type: 'item',
-            targetId: 'Healing Potion',
-            operator: 'gte',
-            value: 2,
-          },
-          {
-            type: 'item',
-            targetId: 'Lockpick',
-            operator: 'gte',
-            value: 1,
-          },
+        requiredItems: [
+          itemRequirement('Healing Potion', 2),
+          itemRequirement('Lockpick', 1),
         ],
       },
     ]);
@@ -209,8 +183,8 @@ describe('ChoiceSelector - Inventory Requirements', () => {
     render(<ChoiceSelector decision={decision} onSelect={handleSelect} inventoryItems={mockInventoryItems} />);
 
     // Should be enabled because character has both items in required quantities
-    const craftOption = screen.getByText('Craft a healing salve');
-    expect(craftOption).not.toHaveAttribute('disabled');
+    const craftButton = screen.getByTestId('choice-option-opt-1');
+    expect(craftButton).not.toBeDisabled();
   });
 
   it('should disable option if ANY requirement in AND logic fails', () => {
@@ -218,19 +192,9 @@ describe('ChoiceSelector - Inventory Requirements', () => {
       {
         id: 'opt-1',
         text: 'Perform complex ritual',
-        requirements: [
-          {
-            type: 'item',
-            targetId: 'Healing Potion',
-            operator: 'gte',
-            value: 2,
-          },
-          {
-            type: 'item',
-            targetId: 'Magic Scroll',
-            operator: 'gte',
-            value: 1,
-          },
+        requiredItems: [
+          itemRequirement('Healing Potion', 2),
+          itemRequirement('Magic Scroll', 1),
         ],
       },
     ]);
@@ -239,8 +203,34 @@ describe('ChoiceSelector - Inventory Requirements', () => {
     render(<ChoiceSelector decision={decision} onSelect={handleSelect} inventoryItems={mockInventoryItems} />);
 
     // Should be disabled because character lacks Magic Scroll
-    const ritualOption = screen.getByText('Perform complex ritual');
-    expect(ritualOption).toHaveAttribute('disabled');
+    const ritualButton = screen.getByTestId('choice-option-opt-1');
+    expect(ritualButton).toBeDisabled();
+  });
+
+  it('should support OR logic for item requirements', () => {
+    const decision = createMockDecision([
+      {
+        id: 'opt-1',
+        text: 'Open the sealed door',
+        requiredItems: {
+          logic: 'any',
+          requirements: [
+            itemRequirement('Lockpick', 1),
+            itemRequirement('Magic Key', 1),
+          ],
+        },
+      },
+    ]);
+
+    const handleSelect = jest.fn();
+    render(<ChoiceSelector decision={decision} onSelect={handleSelect} inventoryItems={mockInventoryItems} />);
+
+    const doorButton = screen.getByTestId('choice-option-opt-1');
+    expect(doorButton).not.toBeDisabled();
+    expect(screen.getByText(/Requires any of:/i)).toBeInTheDocument();
+    const optionButton = screen.getByTestId('choice-option-opt-1');
+    expect(within(optionButton).getByText(/^Lockpick$/i)).toBeInTheDocument();
+    expect(within(optionButton).getByText(/Magic Key\s*\(0\/1\)/i)).toBeInTheDocument();
   });
 
   it('should prevent selection of disabled options', async () => {
@@ -248,23 +238,16 @@ describe('ChoiceSelector - Inventory Requirements', () => {
       {
         id: 'opt-1',
         text: 'Use the magic key',
-        requirements: [
-          {
-            type: 'item',
-            targetId: 'Magic Key',
-            operator: 'gte',
-            value: 1,
-          },
-        ],
+        requiredItems: [itemRequirement('Magic Key', 1)],
       },
     ]);
 
     const handleSelect = jest.fn();
     render(<ChoiceSelector decision={decision} onSelect={handleSelect} inventoryItems={mockInventoryItems} />);
 
-    const magicKeyOption = screen.getByText('Use the magic key');
+    const magicKeyButton = screen.getByTestId('choice-option-opt-1');
 
-    await userEvent.click(magicKeyOption);
+    await userEvent.click(magicKeyButton);
 
     // Should not call onSelect for disabled option
     expect(handleSelect).not.toHaveBeenCalled();
@@ -275,14 +258,7 @@ describe('ChoiceSelector - Inventory Requirements', () => {
       {
         id: 'opt-1',
         text: 'Use the magic key',
-        requirements: [
-          {
-            type: 'item',
-            targetId: 'Magic Key',
-            operator: 'gte',
-            value: 1,
-          },
-        ],
+        requiredItems: [itemRequirement('Magic Key', 1)],
       },
     ]);
 

--- a/src/components/shared/ChoiceSelector/__tests__/ChoiceSelector.test.tsx
+++ b/src/components/shared/ChoiceSelector/__tests__/ChoiceSelector.test.tsx
@@ -162,20 +162,37 @@ describe('ChoiceSelector', () => {
       expect(screen.getByText('Intimidation')).toBeInTheDocument();
     });
 
-    it('allows selection of any skill-based choice (no client-side gating)', async () => {
+    it('disables options when character lacks required skills', async () => {
       const user = userEvent.setup();
+      // Character with low skills that don't meet requirements
+      const characterSkills = [
+        { id: 'skill-1', characterId: 'char-1', worldSkillId: 'stealth-skill', name: 'Stealth', level: 2, category: 'Physical' },
+        { id: 'skill-2', characterId: 'char-1', worldSkillId: 'intimidation-skill', name: 'Intimidation', level: 3, category: 'Social' },
+      ];
+
       render(
         <ChoiceSelector
           decision={decisionWithSkillRequirements}
           onSelect={mockOnSelect}
           worldSkills={mockWorldSkills}
+          characterSkills={characterSkills}
+          inventoryItems={[]}
         />
       );
       expandSuggestions();
 
-      // Should be able to select any option regardless of requirements
+      // Options with unmet requirements should be disabled
+      const sneakOption = screen.getByText('Sneak past').closest('button');
+      const intimidateOption = screen.getByText('Intimidate the guard').closest('button');
+      const directOption = screen.getByText('Walk directly').closest('button');
+
+      expect(sneakOption).toBeDisabled();
+      expect(intimidateOption).toBeDisabled();
+      expect(directOption).not.toBeDisabled(); // No requirements
+
+      // Should not trigger onSelect when clicking disabled options
       await user.click(screen.getByText('Sneak past'));
-      expect(mockOnSelect).toHaveBeenCalledWith('stealth-opt');
+      expect(mockOnSelect).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/shared/ChoiceSelector/__tests__/ChoiceSelector.test.tsx
+++ b/src/components/shared/ChoiceSelector/__tests__/ChoiceSelector.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ChoiceSelector, { SimpleChoice } from '../ChoiceSelector';
 import { Decision } from '@/types/narrative.types';
+import { InventoryItem } from '@/types/inventory.types';
 
 
 describe('ChoiceSelector', () => {
@@ -54,6 +55,20 @@ describe('ChoiceSelector', () => {
     ],
   };
 
+  const combinedRequirementDecision: Decision = {
+    id: 'decision-3',
+    prompt: 'Slip past the lock without raising alarms',
+    options: [
+      {
+        id: 'combined-opt',
+        text: 'Use stealth and a lockpick to bypass the door',
+        requirements: [{ type: 'skill', targetId: 'stealth-skill', operator: 'gte', value: 5 }],
+        requiredItems: [{ type: 'item', targetId: 'Lockpick', operator: 'gte', value: 1 }],
+      },
+      { id: 'fallback-opt', text: 'Knock and hope someone answers' },
+    ],
+  };
+
   const mockWorldSkills = [
     {
       id: 'stealth-skill',
@@ -78,6 +93,35 @@ describe('ChoiceSelector', () => {
       difficulty: 'medium' as const,
     },
   ];
+
+  const createInventoryItem = (
+    name: string,
+    quantity: number,
+    options: { stackable?: boolean; categoryId?: InventoryItem['categoryId'] } = {}
+  ): InventoryItem => {
+    const now = new Date().toISOString();
+    const {
+      stackable = quantity > 1,
+      categoryId = 'equipment',
+    } = options;
+
+    return {
+      id: `item-${name.toLowerCase().replace(/\s+/g, '-')}`,
+      name,
+      description: '',
+      quantity,
+      stackable,
+      categoryId,
+      acquisitionHistory: [],
+      categorization: {
+        categoryId,
+        source: 'manual',
+        classifiedAt: now,
+      },
+      createdAt: now,
+      updatedAt: now,
+    };
+  };
 
   describe('Basic Choice Selection', () => {
     it('displays all choices and handles selection', async () => {
@@ -193,6 +237,76 @@ describe('ChoiceSelector', () => {
       // Should not trigger onSelect when clicking disabled options
       await user.click(screen.getByText('Sneak past'));
       expect(mockOnSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Skill and Item Requirement Interplay', () => {
+    const proficientSkills = [
+      {
+        id: 'skill-1',
+        characterId: 'char-1',
+        worldSkillId: 'stealth-skill',
+        name: 'Stealth',
+        level: 6,
+        category: 'Physical',
+      },
+    ];
+
+    const insufficientSkills = [
+      {
+        id: 'skill-1',
+        characterId: 'char-1',
+        worldSkillId: 'stealth-skill',
+        name: 'Stealth',
+        level: 2,
+        category: 'Physical',
+      },
+    ];
+
+    const renderCombinedOption = (
+      skills: typeof proficientSkills,
+      items: InventoryItem[]
+    ) => {
+      render(
+        <ChoiceSelector
+          decision={combinedRequirementDecision}
+          onSelect={mockOnSelect}
+          worldSkills={mockWorldSkills}
+          characterSkills={skills}
+          inventoryItems={items}
+        />
+      );
+      expandSuggestions();
+      return screen.getByTestId('choice-option-combined-opt');
+    };
+
+    it('disables when skill requirement is met but item requirement is missing', () => {
+      const button = renderCombinedOption(proficientSkills, []);
+      expect(button).toBeDisabled();
+      expect(button?.getAttribute('data-disabled-reason')).toMatch(/Items/i);
+    });
+
+    it('disables when item requirement is met but skill requirement is missing', () => {
+      const button = renderCombinedOption(insufficientSkills, [
+        createInventoryItem('Lockpick', 1, { stackable: false }),
+      ]);
+      expect(button).toBeDisabled();
+      expect(button?.getAttribute('data-disabled-reason')).toMatch(/Skills/i);
+    });
+
+    it('disables when both requirements are unmet', () => {
+      const button = renderCombinedOption([], []);
+      expect(button).toBeDisabled();
+      const reason = button?.getAttribute('data-disabled-reason') ?? '';
+      expect(reason).toMatch(/Skills/i);
+      expect(reason).toMatch(/Items/i);
+    });
+
+    it('enables when both requirements are satisfied', () => {
+      const button = renderCombinedOption(proficientSkills, [
+        createInventoryItem('Lockpick', 1, { stackable: false }),
+      ]);
+      expect(button).not.toBeDisabled();
     });
   });
 

--- a/src/components/shared/ChoiceSelector/choiceStyling.tsx
+++ b/src/components/shared/ChoiceSelector/choiceStyling.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Scale, Flame } from 'lucide-react';
+import { ChoiceAlignment, DecisionWeight } from '@/types/narrative.types';
+
+/**
+ * Get icon for choice alignment
+ */
+export const getAlignmentIcon = (alignment?: ChoiceAlignment): React.ReactNode => {
+  switch (alignment) {
+    case 'lawful':
+      return <Scale className="w-4 h-4" aria-hidden="true" />;
+    case 'chaotic':
+      return <Flame className="w-4 h-4" aria-hidden="true" />;
+    case 'neutral':
+    default:
+      return null;
+  }
+};
+
+/**
+ * Get CSS classes for alignment-based styling
+ */
+export const getAlignmentClasses = (alignment?: ChoiceAlignment, isDisabled?: boolean): string => {
+  const baseClasses = {
+    lawful: 'bg-blue-50 border-blue-300',
+    chaotic: 'bg-red-200 border-red-300',
+    neutral: 'bg-white border-gray-200'
+  };
+
+  const hoverClasses = {
+    lawful: 'hover:bg-blue-100',
+    chaotic: 'hover:bg-red-100',
+    neutral: 'hover:bg-gray-100'
+  };
+
+  const alignmentKey = alignment || 'neutral';
+  const base = baseClasses[alignmentKey];
+  const hover = isDisabled ? '' : hoverClasses[alignmentKey];
+
+  return `${base} ${hover}`;
+};
+
+/**
+ * Get styling for decision weight using border thickness and strategic colors
+ * Critical decisions use bright red, while choice alignments use muted red
+ */
+export const getDecisionWeightStyling = (weight?: DecisionWeight) => {
+  switch (weight) {
+    case 'critical':
+      return {
+        container: 'border-4 border-red-500 bg-red-200/50 shadow-lg shadow-red-200',
+        dot: 'bg-red-500',
+        label: 'text-red-700'
+      };
+    case 'major':
+      return {
+        container: 'border-2 border-amber-500 bg-amber-50/60 shadow-md shadow-amber-200',
+        dot: 'bg-amber-500',
+        label: 'text-amber-700'
+      };
+    case 'minor':
+    default:
+      return {
+        container: 'border-0 bg-gray-100/5',
+        dot: 'bg-gray-700',
+        label: 'text-gray-900'
+      };
+  }
+};

--- a/src/components/shared/ChoiceSelector/optionNormalizer.ts
+++ b/src/components/shared/ChoiceSelector/optionNormalizer.ts
@@ -1,0 +1,173 @@
+import {
+  Decision,
+  ChoiceAlignment,
+  DecisionRequirement,
+  RequirementLogic,
+} from '@/types/narrative.types';
+import { WorldSkill } from '@/types/world.types';
+import { InventoryItem } from '@/types/inventory.types';
+import { resolveSkillData } from '@/lib/utils/gameDataResolver';
+import { evaluateRequirement } from '@/lib/utils/requirementEvaluator';
+import { getNormalizedItemRequirementGroups } from '@/lib/utils/requirementNormalizer';
+import { SimpleChoice } from './ChoiceSelector';
+
+export interface NormalizedOption {
+  id: string;
+  text: string;
+  hint?: string;
+  isSelected?: boolean;
+  alignment?: ChoiceAlignment;
+  isDisabledByRequirements?: boolean;
+  disabledReason?: string;
+  skillRequirements?: Array<{
+    requirement: DecisionRequirement;
+    skillName?: string;
+    met: boolean;
+  }>;
+  itemRequirementGroups?: Array<{
+    logic: RequirementLogic;
+    met: boolean;
+    requirements: Array<{
+      requirement: DecisionRequirement;
+      itemName: string;
+      met: boolean;
+      current: number;
+      required: number;
+    }>;
+  }>;
+}
+
+interface RequirementEvaluationContext {
+  skills: Array<{
+    id: string;
+    characterId: string;
+    worldSkillId?: string;
+    name: string;
+    level: number;
+    category?: string;
+  }>;
+  inventory: {
+    items: InventoryItem[];
+  };
+}
+
+/**
+ * Normalizes decision options into a common format with evaluated requirements
+ */
+export function normalizeDecisionOptions(
+  decision: Decision,
+  selectedOptionId: string | null,
+  worldSkills: WorldSkill[],
+  evaluationContext: RequirementEvaluationContext
+): NormalizedOption[] {
+  return (decision.options || []).map(opt => {
+    // Process skill requirements
+    const skillRequirements = opt.requirements?.filter(req => req.type === 'skill').map(req => {
+      const skillData = resolveSkillData(req.targetId, worldSkills);
+      const evaluation = evaluateRequirement(req, evaluationContext);
+
+      return {
+        requirement: req,
+        skillName: skillData?.name || 'Unknown Skill',
+        met: evaluation.success
+      };
+    }) || [];
+
+    // Process item requirements (normalized groups)
+    const normalizedGroups = getNormalizedItemRequirementGroups(
+      opt.requiredItems,
+      opt.requirements
+    );
+    const itemRequirementGroups = normalizedGroups.map(group => {
+      const logic: RequirementLogic = group.logic ?? 'all';
+      const evaluatedRequirements = group.requirements.map(req => {
+      const evaluation = evaluateRequirement(req, evaluationContext);
+
+        return {
+          requirement: req,
+          itemName: evaluation.itemName || req.targetId,
+          met: evaluation.success,
+          current: evaluation.current,
+          required: typeof evaluation.required === 'number' ? evaluation.required : 0
+        };
+      });
+
+      const groupMet = logic === 'any'
+        ? evaluatedRequirements.some(req => req.met)
+        : evaluatedRequirements.every(req => req.met);
+
+      return {
+        logic,
+        met: groupMet,
+        requirements: evaluatedRequirements
+      };
+    });
+
+    const allSkillRequirementsMet = skillRequirements.every(r => r.met);
+    const allItemGroupsMet =
+      itemRequirementGroups.length === 0 ||
+      itemRequirementGroups.every(group => group.met);
+
+    const disabledReasonParts: string[] = [];
+    if (!allSkillRequirementsMet) {
+      const missingSkills = skillRequirements
+        .filter(req => !req.met)
+        .map(req => req.skillName || 'Required skill');
+      if (missingSkills.length > 0) {
+        disabledReasonParts.push(`Skills: ${missingSkills.join(', ')}`);
+      }
+    }
+
+    if (!allItemGroupsMet) {
+      const missingItems = itemRequirementGroups
+        .filter(group => !group.met)
+        .flatMap(group =>
+          group.requirements.map(req => {
+            if (req.met) {
+              return null;
+            }
+            const requiredAmount = req.required > 0 ? `${req.current}/${req.required}` : `${req.current}`;
+            return `${req.itemName}${req.required > 0 ? ` (${requiredAmount})` : ''}`;
+          }).filter((value): value is string => Boolean(value))
+        );
+      if (missingItems.length > 0) {
+        disabledReasonParts.push(`Items: ${missingItems.join(', ')}`);
+      }
+    }
+
+    const disabledReason = disabledReasonParts.length > 0
+      ? `Requires ${disabledReasonParts.join(' | ')}`
+      : undefined;
+
+    return {
+      id: opt.id,
+      text: opt.text,
+      hint: opt.hint,
+      isSelected: opt.id === decision.selectedOptionId || opt.id === selectedOptionId,
+      alignment: opt.alignment,
+      isDisabledByRequirements: !(allSkillRequirementsMet && allItemGroupsMet),
+      disabledReason,
+      skillRequirements,
+      itemRequirementGroups
+    };
+  });
+}
+
+/**
+ * Normalizes simple choices into the common format (no requirements)
+ */
+export function normalizeSimpleChoices(
+  choices: SimpleChoice[],
+  selectedOptionId: string | null
+): NormalizedOption[] {
+  return choices.map(choice => ({
+    id: choice.id,
+    text: choice.text,
+    isSelected: choice.isSelected || choice.id === selectedOptionId,
+    alignment: 'neutral' as ChoiceAlignment,
+    isDisabledByRequirements: false,
+    disabledReason: undefined,
+    skillRequirements: [],
+    itemRequirementGroups: []
+  }));
+}

--- a/src/lib/__mocks__/mockAiClient.ts
+++ b/src/lib/__mocks__/mockAiClient.ts
@@ -5,7 +5,7 @@
 import { AIClient, AIResponse } from '../ai/types';
 
 export class MockAIClient implements AIClient {
-  private lastPrompt: string = '';
+  private prompts: string[] = [];
   private mockResponse: AIResponse = {
     content: 'Generated narrative content with decision references',
     finishReason: 'STOP',
@@ -14,12 +14,16 @@ export class MockAIClient implements AIClient {
   };
 
   async generateContent(prompt: string): Promise<AIResponse> {
-    this.lastPrompt = prompt;
+    this.prompts.push(prompt);
     return Promise.resolve(this.mockResponse);
   }
 
   getLastPrompt(): string {
-    return this.lastPrompt;
+    return this.prompts[this.prompts.length - 1] || '';
+  }
+
+  getPrompts(): string[] {
+    return this.prompts;
   }
 
   setMockResponse(response: Partial<AIResponse>): void {
@@ -30,7 +34,7 @@ export class MockAIClient implements AIClient {
   }
 
   reset(): void {
-    this.lastPrompt = '';
+    this.prompts = [];
     this.mockResponse = {
       content: 'Generated narrative content with decision references',
       finishReason: 'STOP',

--- a/src/lib/ai/__tests__/narrativeGenerator.decision-consequences.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.decision-consequences.test.ts
@@ -178,227 +178,452 @@ describe('NarrativeGenerator - Decision Consequences (Issue #210)', () => {
 
       await narrativeGenerator.generateSegment(request);
 
-      // Verify that the AI prompt includes specific decision context
-      const lastPrompt = mockAiClient.getLastPrompt();
+            // Verify that the AI prompt includes specific decision context
+
+            const narrativePrompt = mockAiClient.getPrompts()[0];
+
+            
+
+            // Should mention specific past choices by name
+
+            expect(narrativePrompt).toContain('Help the injured merchant');
+
+            expect(narrativePrompt).toContain('Negotiate instead of fighting');
+
+            
+
+            // Should include decision context section
+
+            expect(narrativePrompt).toMatch(/RECENT PLAYER DECISIONS?:/i);
+
+            
+
+            // Should include any contextual information from decisions (flexible)
+
+            const hasContextualInfo = narrativePrompt.includes('moral dilemma') || 
+
+                                     narrativePrompt.includes('merchant') || 
+
+                                     narrativePrompt.includes('compassionate') ||
+
+                                     narrativePrompt.includes('diplomatic');
+
+            expect(hasContextualInfo).toBe(true);
+
+          });
+
       
-      // Should mention specific past choices by name
-      expect(lastPrompt).toContain('Help the injured merchant');
-      expect(lastPrompt).toContain('Negotiate instead of fighting');
+
+          test('should instruct AI to reference past decisions in narrative', async () => {
+
+            // ACCEPTANCE CRITERIA: AI must be explicitly instructed to use past decisions
+
+            const request: NarrativeGenerationRequest = {
+
+              worldId: 'world-1',
+
+              characterIds: ['char-1'],
+
+              sessionId: 'session-1'
+
+            };
+
       
-      // Should include decision context section
-      expect(lastPrompt).toMatch(/RECENT PLAYER DECISIONS?:/i);
+
+            await narrativeGenerator.generateSegment(request);
+
       
-      // Should include any contextual information from decisions (flexible)
-      const hasContextualInfo = lastPrompt.includes('moral dilemma') || 
-                               lastPrompt.includes('merchant') || 
-                               lastPrompt.includes('compassionate') ||
-                               lastPrompt.includes('diplomatic');
-      expect(hasContextualInfo).toBe(true);
-    });
 
-    test('should instruct AI to reference past decisions in narrative', async () => {
-      // ACCEPTANCE CRITERIA: AI must be explicitly instructed to use past decisions
-      const request: NarrativeGenerationRequest = {
-        worldId: 'world-1',
-        characterIds: ['char-1'],
-        sessionId: 'session-1'
-      };
+            const narrativePrompt = mockAiClient.getPrompts()[0];
 
-      await narrativeGenerator.generateSegment(request);
+            
 
-      const lastPrompt = mockAiClient.getLastPrompt();
+            // Simple instruction to adapt narrative (flexible matching)
+
+            const hasAdaptInstruction = narrativePrompt.toLowerCase().includes('adapt') &&
+
+                                        narrativePrompt.toLowerCase().includes('narrative');
+
+            expect(hasAdaptInstruction).toBe(true);
+
       
-      // Simple instruction to adapt narrative (flexible matching)
-      const hasAdaptInstruction = lastPrompt.toLowerCase().includes('adapt') &&
-                                  lastPrompt.toLowerCase().includes('narrative');
-      expect(hasAdaptInstruction).toBe(true);
 
-      const hasReferenceInstruction = lastPrompt.toLowerCase().includes('reference') &&
-                                      lastPrompt.toLowerCase().includes('choices');
-      expect(hasReferenceInstruction).toBe(true);
-    });
+            const hasReferenceInstruction = narrativePrompt.toLowerCase().includes('reference') &&
 
-    test('should include decision impact instructions for NPCs', async () => {
-      // ACCEPTANCE CRITERIA: NPCs should react based on past player interactions
-      const request: NarrativeGenerationRequest = {
-        worldId: 'world-1', 
-        characterIds: ['char-1'],
-        sessionId: 'session-1'
-      };
+                                            narrativePrompt.toLowerCase().includes('choices');
 
-      await narrativeGenerator.generateSegment(request);
+            expect(hasReferenceInstruction).toBe(true);
 
-      const lastPrompt = mockAiClient.getLastPrompt();
+          });
+
       
-      // Just check that NPC names are included (LLM will handle the rest)
-      expect(lastPrompt).toContain('merchant'); // Should reference the specific NPC from test data
 
-      // Should have basic instruction about adapting to player style
-      const hasAdaptInstruction = lastPrompt.toLowerCase().includes('adapt') ||
-                                  lastPrompt.toLowerCase().includes('based on');
-      expect(hasAdaptInstruction).toBe(true);
+          test('should include decision impact instructions for NPCs', async () => {
+
+            // ACCEPTANCE CRITERIA: NPCs should react based on past player interactions
+
+            const request: NarrativeGenerationRequest = {
+
+              worldId: 'world-1', 
+
+              characterIds: ['char-1'],
+
+              sessionId: 'session-1'
+
+            };
+
       
-      // Should reference the help decision in some way (flexible)
-      const hasHelpReference = lastPrompt.toLowerCase().includes('help') || 
-                              lastPrompt.toLowerCase().includes('assist') ||
-                              lastPrompt.toLowerCase().includes('merchant'); // NPC name implies the help context
-      expect(hasHelpReference).toBe(true);
-    });
-  });
 
-  describe('Decision Consequence Mapping', () => {
-    test('should map compassionate decisions to trust-building consequences', async () => {
-      // ACCEPTANCE CRITERIA: Compassionate choices should build trust and reputation
-      const request: NarrativeGenerationRequest = {
-        worldId: 'world-1',
-        characterIds: ['char-1'], 
-        sessionId: 'session-1'
-      };
+            await narrativeGenerator.generateSegment(request);
 
-      await narrativeGenerator.generateSegment(request);
-
-      const lastPrompt = mockAiClient.getLastPrompt();
       
-      // Check that decision data is included (LLM will infer compassionate consequences)
-      const hasDecisionData = lastPrompt.includes('Help the injured merchant') &&
-                             lastPrompt.includes('[helpful]');
-      expect(hasDecisionData).toBe(true);
 
-      // Should have instruction to adapt narrative
-      const hasAdaptInstruction = lastPrompt.toLowerCase().includes('adapt') ||
-                                 lastPrompt.toLowerCase().includes('based on');
-      expect(hasAdaptInstruction).toBe(true);
-    });
+            const narrativePrompt = mockAiClient.getPrompts()[0];
 
-    test('should map diplomatic decisions to peaceful resolution options', async () => {
-      // ACCEPTANCE CRITERIA: Diplomatic choices should create peaceful alternatives
-      const request: NarrativeGenerationRequest = {
-        worldId: 'world-1',
-        characterIds: ['char-1'],
-        sessionId: 'session-1'
-      };
+            
 
-      await narrativeGenerator.generateSegment(request);
+            // Just check that NPC names are included (LLM will handle the rest)
 
-      const lastPrompt = mockAiClient.getLastPrompt();
+            expect(narrativePrompt).toContain('merchant'); // Should reference the specific NPC from test data
+
       
-      // Check that decision data is included (LLM will infer diplomatic consequences)
-      const hasDecisionData = lastPrompt.includes('Negotiate instead of fighting') &&
-                             lastPrompt.includes('[diplomatic]');
-      expect(hasDecisionData).toBe(true);
 
-      // Should have instruction to adapt narrative
-      const hasAdaptInstruction = lastPrompt.toLowerCase().includes('adapt') ||
-                                 lastPrompt.toLowerCase().includes('based on');
-      expect(hasAdaptInstruction).toBe(true);
-    });
-  });
+            // Should have basic instruction about adapting to player style
 
-  describe('Long-term Consequence Building', () => {
-    test('should create narrative threads that span multiple decisions', async () => {
-      // ACCEPTANCE CRITERIA: Multiple related decisions should build coherent consequences
-      const request: NarrativeGenerationRequest = {
-        worldId: 'world-1',
-        characterIds: ['char-1'],
-        sessionId: 'session-1'
-      };
+            const hasAdaptInstruction = narrativePrompt.toLowerCase().includes('adapt') ||
 
-      await narrativeGenerator.generateSegment(request);
+                                        narrativePrompt.toLowerCase().includes('based on');
 
-      const lastPrompt = mockAiClient.getLastPrompt();
+            expect(hasAdaptInstruction).toBe(true);
+
+            
+
+            // Should reference the help decision in some way (flexible)
+
+            const hasHelpReference = narrativePrompt.toLowerCase().includes('help') || 
+
+                                    narrativePrompt.toLowerCase().includes('assist') ||
+
+                                    narrativePrompt.toLowerCase().includes('merchant'); // NPC name implies the help context
+
+            expect(hasHelpReference).toBe(true);
+
+          });
+
+        });
+
       
-      // Check that multiple decisions are included (LLM will infer patterns)
-      const hasMultipleDecisions = lastPrompt.includes('Help the injured merchant') &&
-                                  lastPrompt.includes('Negotiate instead of fighting');
-      expect(hasMultipleDecisions).toBe(true);
 
-      // Check that choice types are tagged for pattern recognition
-      const hasChoiceTypes = lastPrompt.includes('[helpful]') &&
-                            lastPrompt.includes('[diplomatic]');
-      expect(hasChoiceTypes).toBe(true);
-    });
+        describe('Decision Consequence Mapping', () => {
 
-    test('should provide decision-informed story options', async () => {
-      // ACCEPTANCE CRITERIA: Narrative should suggest options that reflect past decision patterns
-      const request: NarrativeGenerationRequest = {
-        worldId: 'world-1',
-        characterIds: ['char-1'],
-        sessionId: 'session-1'
-      };
+          test('should map compassionate decisions to trust-building consequences', async () => {
 
-      await narrativeGenerator.generateSegment(request);
+            // ACCEPTANCE CRITERIA: Compassionate choices should build trust and reputation
 
-      const lastPrompt = mockAiClient.getLastPrompt();
+            const request: NarrativeGenerationRequest = {
+
+              worldId: 'world-1',
+
+              characterIds: ['char-1'], 
+
+              sessionId: 'session-1'
+
+            };
+
       
-      // Should include guidance about choice options that reflect past patterns
-      const hasChoiceGuidance = lastPrompt.toLowerCase().includes('choice') ||
-                               lastPrompt.toLowerCase().includes('options') ||
-                               lastPrompt.toLowerCase().includes('decision') ||
-                               lastPrompt.toLowerCase().includes('consequences');
-      expect(hasChoiceGuidance).toBe(true);
+
+            await narrativeGenerator.generateSegment(request);
+
       
-      // Should reference past decision types that could inform future choices
-      const hasDecisionTypeReferences = lastPrompt.toLowerCase().includes('compassionate') ||
-                                       lastPrompt.toLowerCase().includes('diplomatic') ||
-                                       lastPrompt.toLowerCase().includes('reputation') ||
-                                       lastPrompt.toLowerCase().includes('trust');
-      expect(hasDecisionTypeReferences).toBe(true);
-    });
-  });
 
-  describe('Error Handling and Edge Cases', () => {
-    test('should handle empty decision history gracefully', async () => {
-      // When no past decisions exist, should not break
-      mockPlayerDecisionTracker.getWorldDecisions.mockReturnValue([]);
+            const narrativePrompt = mockAiClient.getPrompts()[0];
+
+            
+
+            // Check that decision data is included (LLM will infer compassionate consequences)
+
+            const hasDecisionData = narrativePrompt.includes('Help the injured merchant') &&
+
+                                   narrativePrompt.includes('[helpful]');
+
+            expect(hasDecisionData).toBe(true);
+
       
-      const request: NarrativeGenerationRequest = {
-        worldId: 'world-1',
-        characterIds: ['char-1'],
-        sessionId: 'session-1'
-      };
 
-      await expect(narrativeGenerator.generateSegment(request)).resolves.toBeDefined();
-    });
+            // Should have instruction to adapt narrative
 
-    test('should limit decision history to prevent prompt overflow', async () => {
-      // Create many past decisions with deterministic timestamps
-      const manyDecisions = Array.from({ length: 20 }, (_, i) => {
-        // Set time to i seconds ago
-        const timeAgo = new Date('2025-01-15T12:00:00Z');
-        timeAgo.setSeconds(timeAgo.getSeconds() - i);
-        jest.setSystemTime(timeAgo);
-        const timestamp = getTimestamp();
+            const hasAdaptInstruction = narrativePrompt.toLowerCase().includes('adapt') ||
 
-        return {
-          id: `decision-${i}`,
-          prompt: `What will you do next? (Decision ${i})`,
-          sessionId: 'session-1',
-          worldId: 'world-1',
-          choiceText: `Choice ${i}`,
-          choiceType: 'neutral' as const,
-          timestamp,
-          context: { situation: 'generic' }
-        };
+                                       narrativePrompt.toLowerCase().includes('based on');
+
+            expect(hasAdaptInstruction).toBe(true);
+
+          });
+
+      
+
+          test('should map diplomatic decisions to peaceful resolution options', async () => {
+
+            // ACCEPTANCE CRITERIA: Diplomatic choices should create peaceful alternatives
+
+            const request: NarrativeGenerationRequest = {
+
+              worldId: 'world-1',
+
+              characterIds: ['char-1'],
+
+              sessionId: 'session-1'
+
+            };
+
+      
+
+            await narrativeGenerator.generateSegment(request);
+
+      
+
+            const narrativePrompt = mockAiClient.getPrompts()[0];
+
+            
+
+            // Check that decision data is included (LLM will infer diplomatic consequences)
+
+            const hasDecisionData = narrativePrompt.includes('Negotiate instead of fighting') &&
+
+                                   narrativePrompt.includes('[diplomatic]');
+
+            expect(hasDecisionData).toBe(true);
+
+      
+
+            // Should have instruction to adapt narrative
+
+            const hasAdaptInstruction = narrativePrompt.toLowerCase().includes('adapt') ||
+
+                                       narrativePrompt.toLowerCase().includes('based on');
+
+            expect(hasAdaptInstruction).toBe(true);
+
+          });
+
+        });
+
+      
+
+        describe('Long-term Consequence Building', () => {
+
+          test('should create narrative threads that span multiple decisions', async () => {
+
+            // ACCEPTANCE CRITERIA: Multiple related decisions should build coherent consequences
+
+            const request: NarrativeGenerationRequest = {
+
+              worldId: 'world-1',
+
+              characterIds: ['char-1'],
+
+              sessionId: 'session-1'
+
+            };
+
+      
+
+            await narrativeGenerator.generateSegment(request);
+
+      
+
+            const narrativePrompt = mockAiClient.getPrompts()[0];
+
+            
+
+            // Check that multiple decisions are included (LLM will infer patterns)
+
+            const hasMultipleDecisions = narrativePrompt.includes('Help the injured merchant') &&
+
+                                        narrativePrompt.includes('Negotiate instead of fighting');
+
+            expect(hasMultipleDecisions).toBe(true);
+
+      
+
+            // Check that choice types are tagged for pattern recognition
+
+            const hasChoiceTypes = narrativePrompt.includes('[helpful]') &&
+
+                                  narrativePrompt.includes('[diplomatic]');
+
+            expect(hasChoiceTypes).toBe(true);
+
+          });
+
+      
+
+          test('should provide decision-informed story options', async () => {
+
+            // ACCEPTANCE CRITERIA: Narrative should suggest options that reflect past decision patterns
+
+            const request: NarrativeGenerationRequest = {
+
+              worldId: 'world-1',
+
+              characterIds: ['char-1'],
+
+              sessionId: 'session-1'
+
+            };
+
+      
+
+            await narrativeGenerator.generateSegment(request);
+
+      
+
+            const narrativePrompt = mockAiClient.getPrompts()[0];
+
+            
+
+            // Should include guidance about choice options that reflect past patterns
+
+            const hasChoiceGuidance = narrativePrompt.toLowerCase().includes('choice') ||
+
+                                     narrativePrompt.toLowerCase().includes('options') ||
+
+                                     narrativePrompt.toLowerCase().includes('decision') ||
+
+                                     narrativePrompt.toLowerCase().includes('consequences');
+
+            expect(hasChoiceGuidance).toBe(true);
+
+            
+
+            // Should reference past decision types that could inform future choices
+
+            const hasDecisionTypeReferences = narrativePrompt.toLowerCase().includes('compassionate') ||
+
+                                             narrativePrompt.toLowerCase().includes('diplomatic') ||
+
+                                             narrativePrompt.toLowerCase().includes('reputation') ||
+
+                                             narrativePrompt.toLowerCase().includes('trust');
+
+            expect(hasDecisionTypeReferences).toBe(true);
+
+          });
+
+        });
+
+      
+
+        describe('Error Handling and Edge Cases', () => {
+
+          test('should handle empty decision history gracefully', async () => {
+
+            // When no past decisions exist, should not break
+
+            mockPlayerDecisionTracker.getWorldDecisions.mockReturnValue([]);
+
+            
+
+            const request: NarrativeGenerationRequest = {
+
+              worldId: 'world-1',
+
+              characterIds: ['char-1'],
+
+              sessionId: 'session-1'
+
+            };
+
+      
+
+            await expect(narrativeGenerator.generateSegment(request)).resolves.toBeDefined();
+
+          });
+
+      
+
+          test('should limit decision history to prevent prompt overflow', async () => {
+
+            // Create many past decisions with deterministic timestamps
+
+            const manyDecisions = Array.from({ length: 20 }, (_, i) => {
+
+              // Set time to i seconds ago
+
+              const timeAgo = new Date('2025-01-15T12:00:00Z');
+
+              timeAgo.setSeconds(timeAgo.getSeconds() - i);
+
+              jest.setSystemTime(timeAgo);
+
+              const timestamp = getTimestamp();
+
+      
+
+              return {
+
+                id: `decision-${i}`,
+
+                prompt: `What will you do next? (Decision ${i})`,
+
+                sessionId: 'session-1',
+
+                worldId: 'world-1',
+
+                choiceText: `Choice ${i}`,
+
+                choiceType: 'neutral' as const,
+
+                timestamp,
+
+                context: { situation: 'generic' }
+
+              };
+
+            });
+
+      
+
+            // Reset to "now"
+
+            jest.setSystemTime(new Date('2025-01-15T12:00:00Z'));
+
+      
+
+            mockPlayerDecisionTracker.getWorldDecisions.mockReturnValue(manyDecisions);
+
+      
+
+            const request: NarrativeGenerationRequest = {
+
+              worldId: 'world-1',
+
+              characterIds: ['char-1'],
+
+              sessionId: 'session-1'
+
+            };
+
+      
+
+            await narrativeGenerator.generateSegment(request);
+
+      
+
+            const narrativePrompt = mockAiClient.getPrompts()[0];
+
+            
+
+            // Should include decisions but not overwhelm the prompt
+
+            const decisionMatches = narrativePrompt.match(/Choice \d+/g) || [];
+
+            expect(decisionMatches.length).toBeLessThanOrEqual(10); // Reasonable limit
+
+          });
+
+        });
+
       });
 
-      // Reset to "now"
-      jest.setSystemTime(new Date('2025-01-15T12:00:00Z'));
-
-      mockPlayerDecisionTracker.getWorldDecisions.mockReturnValue(manyDecisions);
-
-      const request: NarrativeGenerationRequest = {
-        worldId: 'world-1',
-        characterIds: ['char-1'],
-        sessionId: 'session-1'
-      };
-
-      await narrativeGenerator.generateSegment(request);
-
-      const lastPrompt = mockAiClient.getLastPrompt();
       
-      // Should include decisions but not overwhelm the prompt
-      const decisionMatches = lastPrompt.match(/Choice \d+/g) || [];
-      expect(decisionMatches.length).toBeLessThanOrEqual(10); // Reasonable limit
-    });
-  });
-});

--- a/src/lib/ai/__tests__/narrativeGenerator.toneSettings.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.toneSettings.test.ts
@@ -2,21 +2,17 @@ import { NarrativeGenerator } from '../narrativeGenerator';
 import { useWorldStore } from '@/state/worldStore';
 import { ToneSettings } from '@/types/tone-settings.types';
 import { EntityID } from '@/types/common.types';
-import { AIClient } from '../types';
-
-// Mock AI client
-const mockAIClient = {
-  generateContent: jest.fn()
-};
+import { MockAIClient } from '../../__mocks__/mockAiClient';
 
 describe('NarrativeGenerator Tone Settings Integration', () => {
   let generator: NarrativeGenerator;
+  let mockAiClient: MockAIClient;
   let worldId: EntityID;
 
   beforeEach(() => {
     useWorldStore.getState().reset();
-    mockAIClient.generateContent.mockClear();
-    generator = new NarrativeGenerator(mockAIClient as unknown as AIClient);
+    mockAiClient = new MockAIClient();
+    generator = new NarrativeGenerator(mockAiClient);
 
     // Create a world with tone settings
     const toneSettings: ToneSettings = {
@@ -43,9 +39,8 @@ describe('NarrativeGenerator Tone Settings Integration', () => {
   });
 
   test('should include tone settings in narrative generation prompt', async () => {
-    mockAIClient.generateContent.mockResolvedValue({
+    mockAiClient.setMockResponse({
       content: 'Generated narrative content',
-      tokenUsage: 100
     });
 
     await generator.generateSegment({
@@ -57,25 +52,18 @@ describe('NarrativeGenerator Tone Settings Integration', () => {
       }
     });
 
-    expect(mockAIClient.generateContent).toHaveBeenCalledWith(
-      expect.stringContaining('PG-13 CONTENT GUIDELINES')
-    );
-    expect(mockAIClient.generateContent).toHaveBeenCalledWith(
-      expect.stringContaining('DRAMATIC NARRATIVE STYLE')
-    );
-    expect(mockAIClient.generateContent).toHaveBeenCalledWith(
-      expect.stringContaining('ADVANCED LANGUAGE COMPLEXITY')
-    );
-    expect(mockAIClient.generateContent).toHaveBeenCalledWith(
-      expect.stringContaining('Focus on character development and emotional depth')
-    );
+    const narrativePrompt = mockAiClient.getPrompts()[0];
+
+    expect(narrativePrompt).toContain('PG-13 CONTENT GUIDELINES');
+    expect(narrativePrompt).toContain('DRAMATIC NARRATIVE STYLE');
+    expect(narrativePrompt).toContain('ADVANCED LANGUAGE COMPLEXITY');
+    expect(narrativePrompt).toContain('Focus on character development and emotional depth');
   });
 
   test('should respect content rating in generated content validation', async () => {
     const explicitContent = 'This contains explicit violence and mature themes...';
-    mockAIClient.generateContent.mockResolvedValue({
+    mockAiClient.setMockResponse({
       content: explicitContent,
-      tokenUsage: 100
     });
 
     const result = await generator.generateSegment({
@@ -90,9 +78,8 @@ describe('NarrativeGenerator Tone Settings Integration', () => {
   });
 
   test('should maintain consistent tone across multiple generations', async () => {
-    mockAIClient.generateContent.mockResolvedValue({
+    mockAiClient.setMockResponse({
       content: 'Consistent dramatic narrative',
-      tokenUsage: 100
     });
 
     // Generate multiple segments
@@ -108,12 +95,15 @@ describe('NarrativeGenerator Tone Settings Integration', () => {
       characterIds: ['test-character']
     });
 
-    // Both calls should include the same tone settings
-    expect(mockAIClient.generateContent).toHaveBeenCalledTimes(2);
-    mockAIClient.generateContent.mock.calls.forEach(call => {
-      expect(call[0]).toContain('dramatic');
-      expect(call[0]).toContain('PG-13');
-    });
+    const prompts = mockAiClient.getPrompts();
+    // 2 for narrative, 2 for item extraction
+    expect(prompts).toHaveLength(4);
+
+    // Check the narrative generation prompts (1st and 3rd calls)
+    expect(prompts[0]).toContain('dramatic');
+    expect(prompts[0]).toContain('PG-13');
+    expect(prompts[2]).toContain('dramatic');
+    expect(prompts[2]).toContain('PG-13');
   });
 
   test('should handle missing tone settings gracefully', async () => {
@@ -132,9 +122,8 @@ describe('NarrativeGenerator Tone Settings Integration', () => {
       }
     });
 
-    mockAIClient.generateContent.mockResolvedValue({
+    mockAiClient.setMockResponse({
       content: 'Default narrative content',
-      tokenUsage: 100
     });
 
     await generator.generateSegment({
@@ -143,28 +132,23 @@ describe('NarrativeGenerator Tone Settings Integration', () => {
       characterIds: ['test-character']
     });
 
+    const narrativePrompt = mockAiClient.getPrompts()[0];
+
     // Should use default tone settings with detailed guidance
-    expect(mockAIClient.generateContent).toHaveBeenCalledWith(
-      expect.stringContaining('PG-RATED CONTENT GUIDELINES')
-    );
-    expect(mockAIClient.generateContent).toHaveBeenCalledWith(
-      expect.stringContaining('BALANCED NARRATIVE STYLE')
-    );
+    expect(narrativePrompt).toContain('PG-RATED CONTENT GUIDELINES');
+    expect(narrativePrompt).toContain('BALANCED NARRATIVE STYLE');
   });
 
   test('should apply tone settings to initial scene generation', async () => {
-    mockAIClient.generateContent.mockResolvedValue({
+    mockAiClient.setMockResponse({
       content: 'Initial scene with dramatic tone',
-      tokenUsage: 100
     });
 
     await generator.generateInitialScene(worldId, ['test-character']);
 
-    expect(mockAIClient.generateContent).toHaveBeenCalledWith(
-      expect.stringContaining('DRAMATIC NARRATIVE STYLE')
-    );
-    expect(mockAIClient.generateContent).toHaveBeenCalledWith(
-      expect.stringContaining('PG-13 CONTENT GUIDELINES')
-    );
+    const narrativePrompt = mockAiClient.getPrompts()[0];
+
+    expect(narrativePrompt).toContain('DRAMATIC NARRATIVE STYLE');
+    expect(narrativePrompt).toContain('PG-13 CONTENT GUIDELINES');
   });
 });

--- a/src/lib/ai/narrativeGenerator.ts
+++ b/src/lib/ai/narrativeGenerator.ts
@@ -301,7 +301,7 @@ export class NarrativeGenerator {
     const acquisitionInstructions = `
 
 ITEM ACQUISITION INSTRUCTIONS:
-When your narrative describes the character finding, receiving, or acquiring items, include them in the metadata.itemsAcquired array in your JSON response.
+When your narrative describes the character finding, receiving, crafting, or otherwise newly obtaining an item, include it in the metadata.itemsAcquired array in your JSON response. Do not list objects the character already possessed earlier in the scene. If the text merely clarifies or renames an item the character already had in hand, update the description but do not add a duplicate entry.
 
 Each acquired item should include:
 - name: The item's name (required)
@@ -315,10 +315,11 @@ Examples:
 - Character receives a key as reward: Include {name: "Iron Key", description: "Opens the eastern gate", quantity: 1, acquisitionMethod: "reward"}
 
 Important:
-- Only include items the character ACTUALLY ACQUIRES (not items they see or consider)
+- Only include items the character ACTUALLY ACQUIRES during this segment (not items they merely see, remember, or were already carrying)
+- Avoid duplicate entries for the same object; use the description to capture clarifications or additional detail
 - Be specific with item names and descriptions
-- Use appropriate acquisitionMethod for the narrative context
-- If narrative mentions "some supplies" or is vague, still include with best guess at name/description
+- Use an appropriate acquisitionMethod for the narrative context
+- If the narrative mentions vague supplies, still include the best concrete description you can infer
 
 The items will be automatically added to the character's inventory with proper categorization and journal entries.`;
 
@@ -403,7 +404,7 @@ The items will be automatically added to the character's inventory with proper c
         }
       }
 
-      const result = this.formatResponse(
+      const result = await this.formatResponse(
         response,
         request.generationParameters?.segmentType || 'scene'
       );
@@ -505,7 +506,7 @@ The items will be automatically added to the character's inventory with proper c
         }
       }
 
-      const result = this.formatResponse(response, 'scene');
+      const result = await this.formatResponse(response, 'scene');
 
       // Process any acquired items from the initial scene
       if (result.metadata.itemsAcquired && result.metadata.itemsAcquired.length > 0) {
@@ -603,10 +604,10 @@ The items will be automatically added to the character's inventory with proper c
     };
   }
 
-  private formatResponse(
+  private async formatResponse(
     response: { content?: string; tokenUsage?: number },
     segmentType: string
-  ): NarrativeGenerationResult {
+  ): Promise<NarrativeGenerationResult> {
     let actualContent = response.content || '';
     let extractedMetadata: {
       location?: string;
@@ -754,6 +755,16 @@ The items will be automatically added to the character's inventory with proper c
     const fallbackMood = this.getMoodForGenre(this.getWorldGenre());
     const fallbackLocation = this.getLocationForGenre(this.getWorldGenre());
 
+    if (
+      !extractedMetadata.itemsAcquired ||
+      extractedMetadata.itemsAcquired.length === 0
+    ) {
+      const aiExtractedItems = await this.extractItemsFromNarrative(actualContent);
+      if (aiExtractedItems.length > 0) {
+        extractedMetadata.itemsAcquired = aiExtractedItems;
+      }
+    }
+
     // Normalize the content for consistent formatting
     const normalizedContent = normalizeText(actualContent, NORM_DESC);
 
@@ -785,6 +796,72 @@ The items will be automatically added to the character's inventory with proper c
               }
             : undefined,
     };
+  }
+
+  private async extractItemsFromNarrative(
+    content: string
+  ): Promise<AcquiredItemMetadata[]> {
+    const prompt = `
+You are a structured-data extraction assistant.
+
+Analyze the following narrative passage and list tangible objects the protagonist now possesses because of the events described. Only include items that the character physically acquires or adds to their inventory. Ignore objects that are merely observed, remembered, or immediately discarded.
+
+Return a strict JSON object with the following shape:
+{
+  "items": [
+    {
+      "name": string,                // Concise item name
+      "description": string,         // Optional 1–2 sentence description (omit if unnecessary)
+      "quantity": number,            // Default to 1 if not specified
+      "acquisitionMethod": "loot" | "quest" | "purchase" | "craft" | "reward" | "gift" | "manual" | "unknown"
+    }
+  ]
+}
+
+If the character does not acquire anything, return {"items": []}.
+
+Narrative:
+"""
+${content}
+"""
+`.trim();
+
+    try {
+      const response = await this.geminiClient.generateContent(prompt);
+      const raw = response.content ?? '';
+      const jsonMatch = raw.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        return [];
+      }
+
+      const parsed = JSON.parse(jsonMatch[0]) as {
+        items?: Array<{
+          name?: string;
+          description?: string;
+          quantity?: number;
+          acquisitionMethod?: InventoryAcquisitionMethod;
+        }>;
+      };
+
+      if (!Array.isArray(parsed.items) || parsed.items.length === 0) {
+        return [];
+      }
+
+      return parsed.items
+        .filter((item): item is Required<typeof item> => Boolean(item?.name))
+        .map((item) => ({
+          name: item.name!.trim(),
+          description: item.description ? safeTrim(item.description) : undefined,
+          quantity:
+            typeof item.quantity === 'number' && !Number.isNaN(item.quantity)
+              ? item.quantity
+              : 1,
+          acquisitionMethod: item.acquisitionMethod || 'unknown',
+        }))
+        .filter((item) => item.name.length > 0);
+    } catch {
+      return [];
+    }
   }
 
   // Helper methods for mock generation
@@ -936,7 +1013,7 @@ The items will be automatically added to the character's inventory with proper c
       const response =
         await this.geminiClient.generateContent(fullyEnhancedPrompt);
 
-      const result = this.formatResponse(response, 'scene');
+      const result = await this.formatResponse(response, 'scene');
 
       // Process any acquired items from skill acknowledgment
       if (result.metadata.itemsAcquired && result.metadata.itemsAcquired.length > 0) {

--- a/src/lib/ai/narrativeGenerator.ts
+++ b/src/lib/ai/narrativeGenerator.ts
@@ -604,6 +604,16 @@ The items will be automatically added to the character's inventory with proper c
     };
   }
 
+  /**
+   * Formats AI response into structured narrative result
+   *
+   * Changed to async to support AI-based item extraction fallback when the
+   * narrative generation doesn't include itemsAcquired metadata. This ensures
+   * inventory-gated decisions have reliable data by calling Gemini to extract
+   * structured item acquisitions from the narrative text.
+   *
+   * @see extractItemsFromNarrative for the fallback extraction logic
+   */
   private async formatResponse(
     response: { content?: string; tokenUsage?: number },
     segmentType: string

--- a/src/lib/narrative/__tests__/itemAcquisitionProcessor.test.ts
+++ b/src/lib/narrative/__tests__/itemAcquisitionProcessor.test.ts
@@ -20,6 +20,8 @@ describe('itemAcquisitionProcessor', () => {
     jest.clearAllMocks();
     mockGetState.mockReturnValue({
       addItem: mockAddItem,
+      getCharacterItems: jest.fn().mockReturnValue([]),
+      updateItemQuantity: jest.fn(),
     });
     (useInventoryStore as unknown as jest.Mock).mockReturnValue({});
     (useInventoryStore as unknown as { getState: jest.Mock }).getState = mockGetState;

--- a/src/lib/narrative/itemAcquisitionProcessor.ts
+++ b/src/lib/narrative/itemAcquisitionProcessor.ts
@@ -2,7 +2,7 @@
 
 import { useInventoryStore } from '@/state/inventoryStore';
 import { categorizeInventoryItemClient } from '@/lib/inventory/categorizeInventoryItemClient';
-import { getTimestamp } from '@/lib/utils';
+import { getTimestamp, titleCase } from '@/lib/utils';
 import type { AcquiredItemMetadata } from '@/types/narrative.types';
 import type { EntityID } from '@/types/common.types';
 import type { InventoryItemCategorization } from '@/types/inventory.types';
@@ -127,16 +127,15 @@ function isStackableCategory(categoryId: string): boolean {
   return categoryId !== 'equipment';
 }
 
+/**
+ * Normalizes item names to title case for consistency
+ * Uses the project's standard titleCase utility from @/lib/utils
+ */
 function normalizeItemName(rawName: string): string {
   const trimmed = (rawName || '').trim();
   if (!trimmed) {
     return 'Unnamed Item';
   }
 
-  return trimmed
-    .toLowerCase()
-    .split(' ')
-    .filter(Boolean)
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
+  return titleCase(trimmed);
 }

--- a/src/lib/narrative/itemAcquisitionProcessor.ts
+++ b/src/lib/narrative/itemAcquisitionProcessor.ts
@@ -34,6 +34,13 @@ export async function processAcquiredItems(
 
   for (const item of items) {
     try {
+      const normalizedName = normalizeItemName(item.name);
+      const existingItems = inventoryStore.getCharacterItems(characterId);
+      const existingMatch = existingItems.find(
+        (existing) =>
+          existing && normalizeItemName(existing.name).toLowerCase() === normalizedName.toLowerCase()
+      );
+
       // Use AI to categorize the item
       let categorization: InventoryItemCategorization;
 
@@ -68,7 +75,7 @@ export async function processAcquiredItems(
         // Add each equipment item separately
         for (let i = 0; i < quantity; i++) {
           inventoryStore.addItem(characterId, {
-            name: item.name,
+            name: normalizedName,
             description: item.description,
             quantity: 1,
             stackable: false,
@@ -82,9 +89,15 @@ export async function processAcquiredItems(
           });
         }
       } else {
+        if (stackable && existingMatch) {
+          const newQuantity = (existingMatch.quantity || 0) + quantity;
+          inventoryStore.updateItemQuantity(existingMatch.id, newQuantity);
+          continue;
+        }
+
         // Add item normally for stackable items or single equipment
         inventoryStore.addItem(characterId, {
-          name: item.name,
+          name: normalizedName,
           description: item.description,
           quantity,
           stackable,
@@ -112,4 +125,18 @@ function isStackableCategory(categoryId: string): boolean {
   // Equipment items are typically not stackable (each is unique)
   // All other categories typically allow stacking
   return categoryId !== 'equipment';
+}
+
+function normalizeItemName(rawName: string): string {
+  const trimmed = (rawName || '').trim();
+  if (!trimmed) {
+    return 'Unnamed Item';
+  }
+
+  return trimmed
+    .toLowerCase()
+    .split(' ')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
 }

--- a/src/lib/utils/__tests__/requirementEvaluator.item.test.ts
+++ b/src/lib/utils/__tests__/requirementEvaluator.item.test.ts
@@ -1,0 +1,270 @@
+import { evaluateRequirement } from '../requirementEvaluator';
+import { DecisionRequirement } from '@/types/narrative.types';
+import { InventoryItem } from '@/types/inventory.types';
+
+// Character interface with inventory support
+interface Character {
+  skills: Array<{
+    id: string;
+    characterId: string;
+    worldSkillId?: string;
+    name: string;
+    level: number;
+    category?: string;
+  }>;
+  inventory: {
+    items: InventoryItem[];
+  };
+}
+
+describe('requirementEvaluator - Item Requirements', () => {
+  const createMockItem = (
+    name: string,
+    quantity: number,
+    itemId?: string
+  ): InventoryItem => ({
+    id: itemId || `item-${name.toLowerCase()}`,
+    name,
+    description: '',
+    quantity,
+    stackable: true,
+    categoryId: 'equipment',
+    acquisitionHistory: [],
+    categorization: {
+      categoryId: 'equipment',
+      source: 'manual',
+      classifiedAt: new Date().toISOString(),
+    },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  });
+
+  const mockCharacter: Character = {
+    skills: [],
+    inventory: {
+      items: [
+        createMockItem('Lockpick', 1),
+        createMockItem('Healing Potion', 3),
+        createMockItem('Gold Coins', 50),
+        createMockItem('rope', 1), // lowercase for case-insensitive testing
+      ],
+    },
+  };
+
+  describe('item possession checks', () => {
+    it('should pass when character has the required item', () => {
+      const requirement: DecisionRequirement = {
+        type: 'item',
+        targetId: 'Lockpick',
+        operator: 'gte',
+        value: 1,
+      };
+
+      const result = evaluateRequirement(requirement, mockCharacter);
+
+      expect(result.success).toBe(true);
+      expect(result.current).toBe(1);
+      expect(result.required).toBe(1);
+    });
+
+    it('should fail when character does not have the required item', () => {
+      const requirement: DecisionRequirement = {
+        type: 'item',
+        targetId: 'Magic Key',
+        operator: 'gte',
+        value: 1,
+      };
+
+      const result = evaluateRequirement(requirement, mockCharacter);
+
+      expect(result.success).toBe(false);
+      expect(result.current).toBe(0);
+      expect(result.required).toBe(1);
+    });
+
+    it('should be case-insensitive for item name matching', () => {
+      const requirement: DecisionRequirement = {
+        type: 'item',
+        targetId: 'ROPE',
+        operator: 'gte',
+        value: 1,
+      };
+
+      const result = evaluateRequirement(requirement, mockCharacter);
+
+      expect(result.success).toBe(true);
+      expect(result.current).toBe(1);
+    });
+  });
+
+  describe('item quantity requirements', () => {
+    it('should pass when character has exact quantity required', () => {
+      const requirement: DecisionRequirement = {
+        type: 'item',
+        targetId: 'Healing Potion',
+        operator: 'gte',
+        value: 3,
+      };
+
+      const result = evaluateRequirement(requirement, mockCharacter);
+
+      expect(result.success).toBe(true);
+      expect(result.current).toBe(3);
+      expect(result.required).toBe(3);
+    });
+
+    it('should pass when character exceeds quantity required', () => {
+      const requirement: DecisionRequirement = {
+        type: 'item',
+        targetId: 'Gold Coins',
+        operator: 'gte',
+        value: 25,
+      };
+
+      const result = evaluateRequirement(requirement, mockCharacter);
+
+      expect(result.success).toBe(true);
+      expect(result.current).toBe(50);
+      expect(result.required).toBe(25);
+    });
+
+    it('should fail when character has insufficient quantity', () => {
+      const requirement: DecisionRequirement = {
+        type: 'item',
+        targetId: 'Healing Potion',
+        operator: 'gte',
+        value: 5,
+      };
+
+      const result = evaluateRequirement(requirement, mockCharacter);
+
+      expect(result.success).toBe(false);
+      expect(result.current).toBe(3);
+      expect(result.required).toBe(5);
+    });
+
+    it('should handle exact quantity match with eq operator', () => {
+      const requirement: DecisionRequirement = {
+        type: 'item',
+        targetId: 'Healing Potion',
+        operator: 'eq',
+        value: 3,
+      };
+
+      const result = evaluateRequirement(requirement, mockCharacter);
+
+      expect(result.success).toBe(true);
+      expect(result.current).toBe(3);
+      expect(result.required).toBe(3);
+    });
+  });
+
+  describe('operator support', () => {
+    it('should support gt (greater than) operator', () => {
+      const requirement: DecisionRequirement = {
+        type: 'item',
+        targetId: 'Gold Coins',
+        operator: 'gt',
+        value: 49,
+      };
+
+      const result = evaluateRequirement(requirement, mockCharacter);
+
+      expect(result.success).toBe(true);
+      expect(result.current).toBe(50);
+    });
+
+    it('should support lt (less than) operator', () => {
+      const requirement: DecisionRequirement = {
+        type: 'item',
+        targetId: 'Lockpick',
+        operator: 'lt',
+        value: 2,
+      };
+
+      const result = evaluateRequirement(requirement, mockCharacter);
+
+      expect(result.success).toBe(true);
+      expect(result.current).toBe(1);
+    });
+
+    it('should support lte (less than or equal) operator', () => {
+      const requirement: DecisionRequirement = {
+        type: 'item',
+        targetId: 'Healing Potion',
+        operator: 'lte',
+        value: 3,
+      };
+
+      const result = evaluateRequirement(requirement, mockCharacter);
+
+      expect(result.success).toBe(true);
+      expect(result.current).toBe(3);
+    });
+
+    it('should support neq (not equal) operator', () => {
+      const requirement: DecisionRequirement = {
+        type: 'item',
+        targetId: 'Lockpick',
+        operator: 'neq',
+        value: 5,
+      };
+
+      const result = evaluateRequirement(requirement, mockCharacter);
+
+      expect(result.success).toBe(true);
+      expect(result.current).toBe(1);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty inventory gracefully', () => {
+      const emptyCharacter: Character = {
+        skills: [],
+        inventory: {
+          items: [],
+        },
+      };
+
+      const requirement: DecisionRequirement = {
+        type: 'item',
+        targetId: 'Lockpick',
+        operator: 'gte',
+        value: 1,
+      };
+
+      const result = evaluateRequirement(requirement, emptyCharacter);
+
+      expect(result.success).toBe(false);
+      expect(result.current).toBe(0);
+      expect(result.required).toBe(1);
+    });
+
+    it('should handle matching by item ID when name is not found', () => {
+      const requirement: DecisionRequirement = {
+        type: 'item',
+        targetId: 'item-lockpick', // ID instead of name
+        operator: 'gte',
+        value: 1,
+      };
+
+      const result = evaluateRequirement(requirement, mockCharacter);
+
+      expect(result.success).toBe(true);
+      expect(result.current).toBe(1);
+    });
+
+    it('should return item name in metadata when available', () => {
+      const requirement: DecisionRequirement = {
+        type: 'item',
+        targetId: 'Lockpick',
+        operator: 'gte',
+        value: 1,
+      };
+
+      const result = evaluateRequirement(requirement, mockCharacter);
+
+      expect(result.itemName).toBe('Lockpick');
+    });
+  });
+});

--- a/src/lib/utils/requirementEvaluator.ts
+++ b/src/lib/utils/requirementEvaluator.ts
@@ -1,4 +1,5 @@
 import { DecisionRequirement } from '@/types/narrative.types';
+import { InventoryItem } from '@/types/inventory.types';
 
 // Local character interface matching the store structure
 interface Character {
@@ -10,6 +11,9 @@ interface Character {
     level: number;
     category?: string;
   }>;
+  inventory?: {
+    items: InventoryItem[];
+  };
 }
 
 export interface RequirementEvaluationResult {
@@ -17,6 +21,7 @@ export interface RequirementEvaluationResult {
   current: number;
   required: number | string;
   skillName?: string;
+  itemName?: string;
 }
 
 export const evaluateRequirement = (
@@ -25,13 +30,13 @@ export const evaluateRequirement = (
 ): RequirementEvaluationResult => {
   if (requirement.type === 'skill') {
     // Try to find skill by worldSkillId first, then by name (case-insensitive)
-    const skill = character.skills.find(s => 
-      s.worldSkillId === requirement.targetId || 
+    const skill = character.skills.find(s =>
+      s.worldSkillId === requirement.targetId ||
       s.name.toLowerCase() === requirement.targetId.toLowerCase()
     );
     const currentLevel = skill ? skill.level : 0;
     const requiredValue = typeof requirement.value === 'number' ? requirement.value : 0;
-    
+
     let success = false;
     switch (requirement.operator) {
       case 'gte':
@@ -53,14 +58,54 @@ export const evaluateRequirement = (
         success = currentLevel !== requiredValue;
         break;
     }
-    
+
     return {
       success,
       current: currentLevel,
       required: requiredValue
     };
   }
-  
+
+  if (requirement.type === 'item') {
+    // Try to find item by ID first, then by name (case-insensitive)
+    const inventoryItems = character.inventory?.items || [];
+    const item = inventoryItems.find(i =>
+      i.id === requirement.targetId ||
+      i.name.toLowerCase() === requirement.targetId.toLowerCase()
+    );
+    const currentQuantity = item ? item.quantity : 0;
+    const requiredValue = typeof requirement.value === 'number' ? requirement.value : 0;
+
+    let success = false;
+    switch (requirement.operator) {
+      case 'gte':
+        success = currentQuantity >= requiredValue;
+        break;
+      case 'gt':
+        success = currentQuantity > requiredValue;
+        break;
+      case 'lte':
+        success = currentQuantity <= requiredValue;
+        break;
+      case 'lt':
+        success = currentQuantity < requiredValue;
+        break;
+      case 'eq':
+        success = currentQuantity === requiredValue;
+        break;
+      case 'neq':
+        success = currentQuantity !== requiredValue;
+        break;
+    }
+
+    return {
+      success,
+      current: currentQuantity,
+      required: requiredValue,
+      itemName: item?.name
+    };
+  }
+
   return {
     success: false,
     current: 0,

--- a/src/lib/utils/requirementNormalizer.ts
+++ b/src/lib/utils/requirementNormalizer.ts
@@ -1,0 +1,87 @@
+import {
+  DecisionRequirement,
+  DecisionItemRequirementGroup,
+  DecisionItemRequirements,
+  RequirementLogic,
+} from '@/types/narrative.types';
+
+const DEFAULT_REQUIREMENT_LOGIC: RequirementLogic = 'all';
+
+/**
+ * Type guard to check if value is a DecisionItemRequirementGroup
+ */
+export const isDecisionItemRequirementGroup = (
+  value: unknown
+): value is DecisionItemRequirementGroup => {
+  return Boolean(
+    value &&
+      typeof value === 'object' &&
+      'requirements' in value &&
+      Array.isArray((value as DecisionItemRequirementGroup).requirements)
+  );
+};
+
+/**
+ * Converts a list of requirements to a normalized requirement group
+ * Filters only item-type requirements
+ */
+export const ensureItemRequirementGroup = (
+  requirements: DecisionRequirement[] | undefined,
+  logic?: RequirementLogic
+): DecisionItemRequirementGroup | null => {
+  const filtered = (requirements || []).filter((req) => req.type === 'item');
+  if (filtered.length === 0) {
+    return null;
+  }
+
+  return {
+    logic: logic ?? DEFAULT_REQUIREMENT_LOGIC,
+    requirements: filtered,
+  };
+};
+
+/**
+ * Normalizes various item requirement formats into a consistent array of requirement groups
+ * Handles:
+ * - undefined/null values
+ * - Flat arrays of requirements
+ * - Arrays of requirement groups
+ * - Single requirement groups
+ * - Fallback to legacy requirements array
+ */
+export const getNormalizedItemRequirementGroups = (
+  requiredItems: DecisionItemRequirements | undefined,
+  fallbackRequirements: DecisionRequirement[] | undefined
+): DecisionItemRequirementGroup[] => {
+  if (!requiredItems) {
+    const fallbackGroup = ensureItemRequirementGroup(fallbackRequirements);
+    return fallbackGroup ? [fallbackGroup] : [];
+  }
+
+  if (Array.isArray(requiredItems)) {
+    if (requiredItems.length === 0) {
+      return [];
+    }
+
+    const first = requiredItems[0] as DecisionRequirement | DecisionItemRequirementGroup;
+    if (isDecisionItemRequirementGroup(first)) {
+      return (requiredItems as DecisionItemRequirementGroup[])
+        .map((group) => ensureItemRequirementGroup(group.requirements, group.logic))
+        .filter((group): group is DecisionItemRequirementGroup => Boolean(group));
+    }
+
+    const fallbackGroup = ensureItemRequirementGroup(requiredItems as DecisionRequirement[]);
+    return fallbackGroup ? [fallbackGroup] : [];
+  }
+
+  if (isDecisionItemRequirementGroup(requiredItems)) {
+    const group = ensureItemRequirementGroup(
+      requiredItems.requirements,
+      requiredItems.logic
+    );
+    return group ? [group] : [];
+  }
+
+  const fallbackGroup = ensureItemRequirementGroup(fallbackRequirements);
+  return fallbackGroup ? [fallbackGroup] : [];
+};

--- a/src/state/inventoryStore.ts
+++ b/src/state/inventoryStore.ts
@@ -691,3 +691,9 @@ export const useInventoryStore = create<InventoryStore>()(
     }
   )
 );
+
+// Expose store globally in development for easier debugging & manual seeding
+if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).useInventoryStore = useInventoryStore;
+}

--- a/src/state/sessionStore.ts
+++ b/src/state/sessionStore.ts
@@ -18,6 +18,7 @@ let journalStoreModule: typeof import('./journalStore') | null = null;
 let worldStoreModule: typeof import('./worldStore') | null = null;
 let characterStoreModule: typeof import('./characterStore') | null = null;
 let narrativeStoreModule: typeof import('./narrativeStore') | null = null;
+let inventoryStoreModule: typeof import('./inventoryStore') | null = null;
 
 /**
  * Initial state for the session store
@@ -124,6 +125,39 @@ export const useSessionStore = create<SessionStore>()(
         logger.debug('🧹 Cleared global ending state for new session:', sessionId);
       } catch (error) {
         logger.warn('Failed to clear narrative data:', error);
+      }
+    }
+    if (force) {
+      try {
+        if (!inventoryStoreModule) {
+          inventoryStoreModule = await import('./inventoryStore');
+        }
+        const { useInventoryStore } = inventoryStoreModule;
+        const clearInventory = () => {
+          try {
+            useInventoryStore.getState().clearCharacterInventory(characterId);
+            logger.debug('🧹 Cleared inventory for character due to forced fresh session:', characterId);
+          } catch (clearError) {
+            logger.warn('Failed to clear inventory for fresh session (during hydration callback):', clearError);
+          }
+        };
+
+        const persistApi = (useInventoryStore as unknown as {
+          persist?: {
+            hasHydrated?: () => boolean;
+            onFinishHydration?: (callback: () => void) => () => void;
+          };
+        }).persist;
+
+        if (persistApi?.hasHydrated?.()) {
+          clearInventory();
+        } else if (persistApi?.onFinishHydration) {
+          persistApi.onFinishHydration(clearInventory);
+        } else {
+          clearInventory();
+        }
+      } catch (error) {
+        logger.warn('Failed to clear inventory for fresh session:', error);
       }
     }
     

--- a/src/stories/03-organisms/narrative/controls/ChoiceSelector.stories.tsx
+++ b/src/stories/03-organisms/narrative/controls/ChoiceSelector.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import ChoiceSelector from '@/components/shared/ChoiceSelector/ChoiceSelector';
 import { Decision } from '@/types/narrative.types';
+import type { InventoryItem } from '@/types/inventory.types';
 import { getTimestamp } from '@/lib/utils';
 
 const meta: Meta<typeof ChoiceSelector> = {
@@ -173,11 +174,99 @@ const createMockWorldSkills = () => [
   { id: 'magic', name: 'Magic', description: '', worldId: 'test-world', difficulty: 'hard', baseValue: 1, minValue: 1, maxValue: 10 }
 ];
 
+const createItemRequirementDecision = (): Decision => ({
+  id: 'item-requirement-decision',
+  prompt: 'The ancient vault resists entry unless you have the right tools. What will you do?',
+  options: [
+    {
+      id: 'option-pick',
+      text: 'Delicately pick the rune-etched lock',
+      hint: 'Requires fine tools',
+      requiredItems: [{ type: 'item', targetId: 'Lockpick', operator: 'gte', value: 1 }],
+    },
+    {
+      id: 'option-brew',
+      text: 'Brew a restorative salve for the wounded scout',
+      hint: 'Needs multiple potions',
+      requiredItems: [{ type: 'item', targetId: 'Healing Potion', operator: 'gte', value: 3 }],
+    },
+    {
+      id: 'option-ward',
+      text: 'Break the ward with a resonant talisman',
+      hint: 'Either an arcane focus or a gifted key works',
+      requiredItems: {
+        logic: 'any',
+        requirements: [
+          { type: 'item', targetId: 'Arcane Focus', operator: 'gte', value: 1 },
+          { type: 'item', targetId: 'Magic Key', operator: 'gte', value: 1 },
+        ],
+      },
+    },
+  ],
+  decisionWeight: 'major',
+  contextSummary: 'Foreign wards and injured allies make every choice matter.',
+});
+
+const createMockInventoryItems = (): InventoryItem[] => {
+  const now = new Date().toISOString();
+  return [
+    {
+      id: 'item-lockpick',
+      name: 'Lockpick',
+      description: 'Slim iron picks for delicate mechanisms.',
+      quantity: 1,
+      stackable: false,
+      categoryId: 'equipment',
+      acquisitionHistory: [],
+      categorization: {
+        categoryId: 'equipment',
+        source: 'manual',
+        classifiedAt: now,
+      },
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: 'item-potion',
+      name: 'Healing Potion',
+      description: 'Restores vitality when consumed.',
+      quantity: 3,
+      stackable: true,
+      categoryId: 'consumables',
+      acquisitionHistory: [],
+      categorization: {
+        categoryId: 'consumables',
+        source: 'manual',
+        classifiedAt: now,
+      },
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: 'item-fetish',
+      name: 'Arcane Focus',
+      description: 'Attuned crystal that channels ward-breaking resonance.',
+      quantity: 1,
+      stackable: false,
+      categoryId: 'quest-items',
+      acquisitionHistory: [],
+      categorization: {
+        categoryId: 'quest-items',
+        source: 'manual',
+        classifiedAt: now,
+      },
+      createdAt: now,
+      updatedAt: now,
+    },
+  ];
+};
+
 export const WithSkillRequirements: Story = {
   args: {
     decision: createSkillRequirementDecision(),
-    character: createMockCharacter(),
+    characterSkills: createMockCharacter().skills,
     worldSkills: createMockWorldSkills(),
+    inventoryItems: [],
     showHints: true,
   },
   parameters: {
@@ -189,3 +278,20 @@ export const WithSkillRequirements: Story = {
   },
 };
 
+export const WithItemRequirements: Story = {
+  args: {
+    decision: createItemRequirementDecision(),
+    characterSkills: createMockCharacter().skills,
+    worldSkills: createMockWorldSkills(),
+    inventoryItems: createMockInventoryItems(),
+    showHints: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates inventory-gated choices. The character carries lockpicks, potions, and an arcane focus, so two options unlock while the missing magic key keeps the ward option highlighted as unavailable.',
+      },
+    },
+  },
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,6 +28,9 @@ export type {
   Decision, 
   DecisionOption, 
   DecisionRequirement, 
+  DecisionItemRequirementGroup,
+  DecisionItemRequirements,
+  RequirementLogic,
   Consequence, 
   NarrativeMetadata 
 } from './narrative.types';

--- a/src/types/narrative.types.ts
+++ b/src/types/narrative.types.ts
@@ -52,10 +52,35 @@ export type ChoiceAlignment = 'lawful' | 'chaotic' | 'neutral';
 /**
  * Represents an option within a decision
  */
+export type RequirementLogic = 'all' | 'any';
+
+export interface DecisionItemRequirementGroup {
+  /**
+   * Logical evaluation for contained requirements.
+   * 'all' requires every item, 'any' requires at least one.
+   * Defaults to 'all' when omitted.
+   */
+  logic?: RequirementLogic;
+  /**
+   * Underlying DecisionRequirement entries with type 'item'.
+   */
+  requirements: DecisionRequirement[];
+}
+
+export type DecisionItemRequirements =
+  | DecisionRequirement[]
+  | DecisionItemRequirementGroup
+  | DecisionItemRequirementGroup[];
+
 export interface DecisionOption {
   id: EntityID;
   text: string;
   requirements?: DecisionRequirement[];
+  /**
+   * Inventory-based gating requirements.
+   * Supports simple arrays (defaults to 'all') or grouped logic blocks.
+   */
+  requiredItems?: DecisionItemRequirements;
   hint?: string;
   // Custom input support
   isCustomInput?: boolean;

--- a/src/types/narrative.types.ts
+++ b/src/types/narrative.types.ts
@@ -118,6 +118,11 @@ export interface AcquiredItemMetadata {
   description?: string;
   quantity?: number;
   acquisitionMethod?: InventoryAcquisitionMethod;
+  /**
+   * Indicates that this metadata refines the most recently acquired item
+   * rather than representing a completely new pickup.
+   */
+  refinesPrevious?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Description
  This branch extends the decision requirement system beyond skills so choices can be gated by inventory
  items, and tightens the supporting plumbing so the inventory state is trustworthy when those gates run. In
  addition to wiring up `requiredItems` in the UI and evaluator, we now:
  - clear a character's inventory when a "Start New" session is launched (even if the persisted store hydrates
  later)
  - normalize and merge stackable items coming from the narrative so duplicates don't pile up
  - rely on Gemini to populate `metadata.itemsAcquired`, with a fallback extractor that produces structured
  output instead of local keyword heuristics

  ## Related Issue
  Closes #756

  ## Type of Change
  - [x] New feature (non-breaking change which adds functionality)

  ## TDD Compliance
  - [x] Tests written before implementation
  - [x] All new code is tested
  - [x] All tests pass locally (`npm test -- ChoiceSelector`)
  - [x] Test coverage maintained or improved

  ## User Stories Addressed
  As a player, I want decision options to require specific inventory items so my choices reflect what I'm
  actually carrying and the game feels consistent.

  ## Implementation Notes
  - `DecisionOption.requiredItems` flows through `ChoiceSelector`, allowing AND logic across skills + items.
  Disabled options surface badge feedback with current vs required quantities.
  - `processAcquiredItems` title‑cases item names and merges stackable matches by quantity.
  - Session initialization honours `disableAutoResume`; when forced, it waits for the inventory store to
  hydrate and then clears items so fresh games start clean.
  - Narrative generator instructions are stricter, and the fallback calls Gemini to produce structured
  `itemsAcquired` metadata, returning whatever the model decides counts as a new acquisition.

  ## Flow Diagrams
  Decision option evaluates → reads skills/items → checks inventory (post-cleanup) → Gemini’s metadata updates
  inventory → gating reflects reality.

  ## Testing Instructions
  1. `npm run dev`
  2. Start a new session via “Start New” and verify the inventory is empty before narrative runs
  3. Play until the narrative grants an item (e.g., “you find a lockpick”) and confirm it appears once, with
  proper capitalization and badge feedback
  4. When a decision with `requiredItems` appears, confirm it enables/disables based on inventory
  5. Repeat “Start New” to confirm inventory clears again

  ## Quality Checks
  - [x] Linting passed
  - [x] Type checking passed
  - [x] No console.log statements in production code
  - [x] No unhandled promises

  ## Checklist
  - [x] Code follows project standards
  - [x] Self-review performed
  - [x] Comments added where logic isn’t obvious
  - [x] No new warnings generated
  - [x] Accessibility considerations addressed (disabled states mirror existing skill gating)