### PR TITLE
refactor: Extract duplicate genre prompt guidance into shared utility

### DIFF
--- a/src/app/api/generate-ending-image/route.ts
+++ b/src/app/api/generate-ending-image/route.ts
@@ -4,6 +4,7 @@ import type { StoryEnding } from '@/types/narrative.types';
 import type { World } from '@/types/world.types';
 import type { Character } from '@/types/character.types';
 import Logger from '@/lib/utils/logger';
+import { getGenreStyleGuidance, getGenreFallbackImage } from '@/lib/utils/genrePromptGuide';
 
 const logger = new Logger('EndingImageAPI');
 
@@ -51,34 +52,8 @@ function generateImagePrompt(ending: StoryEnding, world?: World, character?: Cha
       toneGuidance = 'Reflective ending atmosphere with dramatic lighting and emotional depth.';
   }
   
-  // Add genre-specific style guidance
-  let styleGuidance = '';
-  switch(genre) {
-    case 'fantasy':
-      styleGuidance = 'Epic fantasy setting with magical elements, ancient architecture, mystical lighting. Style: high fantasy art, detailed digital painting, cinematic composition.';
-      break;
-    case 'sci-fi':
-    case 'science fiction':
-      styleGuidance = 'Futuristic sci-fi setting with advanced technology, space stations, alien worlds. Style: concept art, sleek futuristic design, cinematic sci-fi aesthetic.';
-      break;
-    case 'horror':
-      styleGuidance = 'Gothic horror setting with dark atmosphere, but ending-appropriate mood. Style: atmospheric horror art, dramatic shadows, emotional depth.';
-      break;
-    case 'western':
-      styleGuidance = 'Wild west setting with desert landscapes, frontier towns, classic western imagery. Style: classic western film aesthetic, warm desert colors, cinematic composition.';
-      break;
-    case 'cyberpunk':
-      styleGuidance = 'Cyberpunk cityscape with neon lighting, urban environment, high-tech elements. Style: cyberpunk aesthetic, dramatic neon lighting, urban atmosphere.';
-      break;
-    case 'steampunk':
-      styleGuidance = 'Victorian steampunk setting with brass machinery, clockwork elements, industrial atmosphere. Style: steampunk aesthetic, warm brass tones, mechanical details.';
-      break;
-    case 'post-apocalyptic':
-      styleGuidance = 'Post-apocalyptic landscape with ruins and reclaimed nature, but showing the ending\'s emotional tone. Style: post-apocalyptic art, atmospheric depth.';
-      break;
-    default:
-      styleGuidance = 'Epic setting with dramatic lighting and detailed environment. Style: high-quality digital art, cinematic composition.';
-  }
+  // Get genre-specific style guidance from shared utility
+  const styleGuidance = getGenreStyleGuidance(genre, 'ending');
   
   // Include brief narrative context if available
   let narrativeContext = '';
@@ -115,22 +90,12 @@ Requirements:
 
 // Generate fallback placeholder if AI generation fails
 function generateFallbackImage(ending: StoryEnding, world?: World): string {
+  const genre = world?.genre || 'fantasy';
   const tone = ending.tone;
   const seed = `${world?.name || 'ending'}-${ending.id}`;
-  
-  // Use tone-themed placeholder as fallback
-  switch(tone) {
-    case 'triumphant':
-      return `https://picsum.photos/seed/${seed}/800/600?sepia`;
-    case 'mysterious':
-      return `https://picsum.photos/seed/${seed}/800/600?grayscale&blur=2`;
-    case 'tragic':
-      return `https://picsum.photos/seed/${seed}/800/600?grayscale`;
-    case 'hopeful':
-      return `https://picsum.photos/seed/${seed}/800/600`;
-    default:
-      return `https://picsum.photos/seed/${seed}/800/600`;
-  }
+
+  // Use tone-themed placeholder with genre fallback
+  return getGenreFallbackImage(genre, seed, tone);
 }
 
 export async function POST(request: NextRequest) {

--- a/src/app/api/generate-world-image/route.ts
+++ b/src/app/api/generate-world-image/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
 import type { World } from '@/types/world.types';
 import Logger from '@/lib/utils/logger';
+import { getGenreStyleGuidance, getGenreFallbackImage } from '@/lib/utils/genrePromptGuide';
 
 const logger = new Logger('WorldImageAPI');
 
@@ -12,47 +13,16 @@ interface GenerateWorldImageRequest {
 
 // Generate a detailed image prompt based on world characteristics
 function generateImagePrompt(world: World): string {
-  const genre = world.genre?.toLowerCase() || 'fantasy';
+  const genre = world.genre || 'fantasy';
   const name = world.name;
   const description = world.description;
-  
+
   // Create a detailed prompt for image generation
   const basePrompt = `Create a highly detailed, cinematic landscape image representing the world "${name}". Genre: ${genre}. Description: ${description}`;
-  
-  // Add theme-specific style guidance
-  let styleGuidance = '';
-  switch(genre) {
-    case 'fantasy':
-      styleGuidance = 'Epic fantasy landscape with magical elements, mystical lighting, ancient architecture, floating islands or magical forests. Style: high fantasy art, detailed digital painting, dramatic lighting.';
-      break;
-    case 'sci-fi':
-    case 'science fiction':
-      styleGuidance = 'Futuristic sci-fi landscape with advanced technology, space stations, alien worlds, or cybernetic cities. Style: concept art, sleek futuristic design, neon lighting, technological elements.';
-      break;
-    case 'horror':
-      styleGuidance = 'Dark, ominous landscape with gothic architecture, twisted trees, fog, abandoned buildings, eerie atmosphere. Style: dark gothic art, horror atmosphere, dim lighting, unsettling mood.';
-      break;
-    case 'western':
-      styleGuidance = 'Wild west landscape with desert mesas, old towns, saloons, dusty trails, canyon landscapes. Style: classic western film aesthetic, warm desert colors, vintage atmosphere.';
-      break;
-    case 'cyberpunk':
-      styleGuidance = 'Neon-lit cyberpunk cityscape with towering skyscrapers, flying vehicles, holographic advertisements, rain-soaked streets. Style: cyberpunk aesthetic, neon colors, urban decay, high-tech low-life.';
-      break;
-    case 'steampunk':
-      styleGuidance = 'Victorian-era landscape with steam-powered machinery, brass and copper elements, airships, clockwork mechanisms. Style: steampunk aesthetic, brass and bronze tones, mechanical details.';
-      break;
-    case 'post-apocalyptic':
-      styleGuidance = 'Desolate post-apocalyptic landscape with ruined cities, overgrown vegetation, abandoned vehicles, wasteland atmosphere. Style: post-apocalyptic art, muted colors, decay and reclamation by nature.';
-      break;
-    case 'biopunk':
-    case 'gothic horror':
-    case 'biopunk/gothic horror':
-      styleGuidance = 'Bio-organic gothic landscape with mutated flora, twisted architecture, bio-mechanical elements, perpetual twilight atmosphere. Style: bio-horror aesthetic, organic and mechanical fusion, dark atmospheric lighting.';
-      break;
-    default:
-      styleGuidance = 'Epic landscape with dramatic lighting and detailed environment. Style: high-quality digital art, cinematic composition, professional concept art.';
-  }
-  
+
+  // Get genre-specific style guidance from shared utility
+  const styleGuidance = getGenreStyleGuidance(genre, 'landscape');
+
   return `${basePrompt}
 
 ${styleGuidance}
@@ -69,29 +39,8 @@ Requirements:
 
 // Generate fallback placeholder if AI generation fails
 function generateFallbackImage(world: World): string {
-  const genre = world.genre?.toLowerCase() || 'fantasy';
-  
-  // Use themed placeholder as fallback
-  switch(genre) {
-    case 'fantasy':
-      return `https://picsum.photos/seed/${world.name}/800/600?blur=1`;
-    case 'sci-fi':
-    case 'science fiction':
-      return `https://picsum.photos/seed/${world.name}/800/600?grayscale`;
-    case 'horror':
-    case 'biopunk':
-    case 'gothic horror':
-    case 'biopunk/gothic horror':
-      return `https://picsum.photos/seed/${world.name}/800/600?blur=2`;
-    case 'western':
-      return `https://picsum.photos/seed/${world.name}/800/600?sepia`;
-    case 'cyberpunk':
-      return `https://picsum.photos/seed/${world.name}/800/600`;
-    case 'post-apocalyptic':
-      return `https://picsum.photos/seed/${world.name}/800/600?grayscale&blur=1`;
-    default:
-      return `https://picsum.photos/seed/${world.name}/800/600`;
-  }
+  const genre = world.genre || 'fantasy';
+  return getGenreFallbackImage(genre, world.name);
 }
 
 export async function POST(request: NextRequest) {

--- a/src/lib/utils/genrePromptGuide.ts
+++ b/src/lib/utils/genrePromptGuide.ts
@@ -1,0 +1,142 @@
+/**
+ * Genre-based style guidance for AI image generation
+ *
+ * Provides consistent style guidance across different image generation contexts
+ * (world images, ending images, portraits, etc.)
+ */
+
+export type ImageContext = 'landscape' | 'ending' | 'portrait';
+
+/**
+ * Get style guidance based on genre and image context
+ *
+ * @param genre - The world genre (e.g., 'fantasy', 'sci-fi', 'horror')
+ * @param context - The type of image being generated
+ * @returns Style guidance string for AI image generation
+ */
+export function getGenreStyleGuidance(
+  genre: string,
+  context: ImageContext = 'landscape'
+): string {
+  const normalizedGenre = genre?.toLowerCase() || 'fantasy';
+
+  switch(normalizedGenre) {
+    case 'fantasy':
+      return context === 'landscape'
+        ? 'Epic fantasy landscape with magical elements, mystical lighting, ancient architecture, floating islands or magical forests. Style: high fantasy art, detailed digital painting, dramatic lighting.'
+        : context === 'ending'
+        ? 'Epic fantasy setting with magical elements, ancient architecture, mystical lighting. Style: high fantasy art, detailed digital painting, cinematic composition.'
+        : 'Epic fantasy setting with magical elements. Style: high fantasy art, detailed digital painting.';
+
+    case 'sci-fi':
+    case 'science fiction':
+      return context === 'landscape'
+        ? 'Futuristic sci-fi landscape with advanced technology, space stations, alien worlds, or cybernetic cities. Style: concept art, sleek futuristic design, neon lighting, technological elements.'
+        : context === 'ending'
+        ? 'Futuristic sci-fi setting with advanced technology, space stations, alien worlds. Style: concept art, sleek futuristic design, cinematic sci-fi aesthetic.'
+        : 'Futuristic sci-fi setting with advanced technology. Style: concept art, sleek futuristic design.';
+
+    case 'horror':
+      return context === 'landscape'
+        ? 'Dark, ominous landscape with gothic architecture, twisted trees, fog, abandoned buildings, eerie atmosphere. Style: dark gothic art, horror atmosphere, dim lighting, unsettling mood.'
+        : context === 'ending'
+        ? 'Gothic horror setting with dark atmosphere, but ending-appropriate mood. Style: atmospheric horror art, dramatic shadows, emotional depth.'
+        : 'Gothic horror setting with dark atmosphere. Style: atmospheric horror art, dramatic shadows.';
+
+    case 'western':
+      return context === 'landscape'
+        ? 'Wild west landscape with desert mesas, old towns, saloons, dusty trails, canyon landscapes. Style: classic western film aesthetic, warm desert colors, vintage atmosphere.'
+        : context === 'ending'
+        ? 'Wild west setting with desert landscapes, frontier towns, classic western imagery. Style: classic western film aesthetic, warm desert colors, cinematic composition.'
+        : 'Wild west setting with classic western imagery. Style: classic western film aesthetic, warm desert colors.';
+
+    case 'cyberpunk':
+      return context === 'landscape'
+        ? 'Neon-lit cyberpunk cityscape with towering skyscrapers, flying vehicles, holographic advertisements, rain-soaked streets. Style: cyberpunk aesthetic, neon colors, urban decay, high-tech low-life.'
+        : context === 'ending'
+        ? 'Cyberpunk cityscape with neon lighting, urban environment, high-tech elements. Style: cyberpunk aesthetic, dramatic neon lighting, urban atmosphere.'
+        : 'Cyberpunk cityscape with neon lighting. Style: cyberpunk aesthetic, dramatic neon lighting.';
+
+    case 'steampunk':
+      return context === 'landscape'
+        ? 'Victorian-era landscape with steam-powered machinery, brass and copper elements, airships, clockwork mechanisms. Style: steampunk aesthetic, brass and bronze tones, mechanical details.'
+        : context === 'ending'
+        ? 'Victorian steampunk setting with brass machinery, clockwork elements, industrial atmosphere. Style: steampunk aesthetic, warm brass tones, mechanical details.'
+        : 'Victorian steampunk setting with brass machinery. Style: steampunk aesthetic, warm brass tones.';
+
+    case 'post-apocalyptic':
+      return context === 'landscape'
+        ? 'Desolate post-apocalyptic landscape with ruined cities, overgrown vegetation, abandoned vehicles, wasteland atmosphere. Style: post-apocalyptic art, muted colors, decay and reclamation by nature.'
+        : context === 'ending'
+        ? 'Post-apocalyptic landscape with ruins and reclaimed nature, but showing the ending\'s emotional tone. Style: post-apocalyptic art, atmospheric depth.'
+        : 'Post-apocalyptic setting with ruins and reclaimed nature. Style: post-apocalyptic art, atmospheric depth.';
+
+    case 'biopunk':
+    case 'gothic horror':
+    case 'biopunk/gothic horror':
+      return context === 'landscape'
+        ? 'Bio-organic gothic landscape with mutated flora, twisted architecture, bio-mechanical elements, perpetual twilight atmosphere. Style: bio-horror aesthetic, organic and mechanical fusion, dark atmospheric lighting.'
+        : 'Bio-organic gothic setting with mutated elements, twisted architecture, bio-mechanical fusion. Style: bio-horror aesthetic, dark atmospheric lighting.';
+
+    default:
+      return context === 'landscape'
+        ? 'Epic landscape with dramatic lighting and detailed environment. Style: high-quality digital art, cinematic composition, professional concept art.'
+        : context === 'ending'
+        ? 'Epic setting with dramatic lighting and detailed environment. Style: high-quality digital art, cinematic composition.'
+        : 'Epic setting with dramatic lighting. Style: high-quality digital art.';
+  }
+}
+
+/**
+ * Get fallback placeholder image based on genre and tone
+ *
+ * @param genre - The world genre
+ * @param seed - Unique seed for consistent placeholder generation
+ * @param tone - Optional tone for ending-specific placeholders
+ * @returns URL for placeholder image
+ */
+export function getGenreFallbackImage(
+  genre: string,
+  seed: string,
+  tone?: string
+): string {
+  const normalizedGenre = genre?.toLowerCase() || 'fantasy';
+
+  // If tone is provided, use tone-based fallback
+  if (tone) {
+    switch(tone) {
+      case 'triumphant':
+        return `https://picsum.photos/seed/${seed}/800/600?sepia`;
+      case 'mysterious':
+        return `https://picsum.photos/seed/${seed}/800/600?grayscale&blur=2`;
+      case 'tragic':
+        return `https://picsum.photos/seed/${seed}/800/600?grayscale`;
+      case 'hopeful':
+        return `https://picsum.photos/seed/${seed}/800/600`;
+      default:
+        return `https://picsum.photos/seed/${seed}/800/600`;
+    }
+  }
+
+  // Otherwise use genre-based fallback
+  switch(normalizedGenre) {
+    case 'fantasy':
+      return `https://picsum.photos/seed/${seed}/800/600?blur=1`;
+    case 'sci-fi':
+    case 'science fiction':
+      return `https://picsum.photos/seed/${seed}/800/600?grayscale`;
+    case 'horror':
+    case 'biopunk':
+    case 'gothic horror':
+    case 'biopunk/gothic horror':
+      return `https://picsum.photos/seed/${seed}/800/600?blur=2`;
+    case 'western':
+      return `https://picsum.photos/seed/${seed}/800/600?sepia`;
+    case 'cyberpunk':
+      return `https://picsum.photos/seed/${seed}/800/600`;
+    case 'post-apocalyptic':
+      return `https://picsum.photos/seed/${seed}/800/600?grayscale&blur=1`;
+    default:
+      return `https://picsum.photos/seed/${seed}/800/600`;
+  }
+}


### PR DESCRIPTION
Consolidated duplicate genre-based style guidance logic from two image generation API routes into a new shared utility module.

Changes:
- Created src/lib/utils/genrePromptGuide.ts with two reusable functions:
  - getGenreStyleGuidance(): Returns genre-specific style guidance for image prompts
  - getGenreFallbackImage(): Returns genre-appropriate fallback placeholder images
- Updated generate-world-image route to use shared utility (reduced from ~95 to ~44 lines)
- Updated generate-ending-image route to use shared utility (reduced from ~134 to ~99 lines)
- Eliminated ~60 lines of duplicated switch statement logic

This improves maintainability by ensuring genre style guidance is consistent across all image generation endpoints and only needs to be updated in one place.