### PR TITLE
refactor: Consolidate duplicate image type definitions into shared GeneratedImage type

### DIFF
--- a/src/app/characters/page.tsx
+++ b/src/app/characters/page.tsx
@@ -26,15 +26,11 @@ import { getGenreLabel } from '@/lib/constants/genres';
 import { GameSessionConfirmationDialog } from '@/components/GameSession/GameSessionConfirmationDialog';
 import type { PlayerCharacterThread } from '@/types/world-state.types';
 import { summarizeThreadHighlight } from '@/lib/utils/worldStateFormatters';
+import type { GeneratedImage } from '@/types/common.types';
 
 // Type for character portrait update
 type CharacterPortraitUpdate = {
-  portrait: {
-    type: 'ai-generated' | 'placeholder';
-    url: string | null;
-    generatedAt?: string;
-    prompt?: string;
-  };
+  portrait: GeneratedImage;
 };
 
 // Helper function to transform generated data to character attributes

--- a/src/components/CharacterCreationWizard/steps/PortraitStep.tsx
+++ b/src/components/CharacterCreationWizard/steps/PortraitStep.tsx
@@ -32,21 +32,21 @@ interface PortraitStepProps {
     characterData: CharacterFormData;
     worldId: string;
   };
-  onUpdate: (updates: { portrait: CharacterPortraitType }) => void;
+  onUpdate: (updates: { portrait: GeneratedImage }) => void;
   worldConfig: Partial<World>;
 }
 
 export function PortraitStep({ data, onUpdate, worldConfig }: PortraitStepProps) {
   const [isGenerating, setIsGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  
+
   // Local state for prompt-affecting fields
   const [localPhysicalDescription, setLocalPhysicalDescription] = useState(
     data.characterData.background?.physicalDescription || ''
   );
   const [environmentHint, setEnvironmentHint] = useState('');
 
-  const portrait: CharacterPortraitType = data.characterData.portrait || {
+  const portrait: GeneratedImage = data.characterData.portrait || {
     type: 'placeholder',
     url: null
   };

--- a/src/components/CharacterCreationWizard/steps/PortraitStep.tsx
+++ b/src/components/CharacterCreationWizard/steps/PortraitStep.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from 'react';
 import { CheckCircle } from 'lucide-react';
 import { CharacterPortrait } from '@/components/CharacterPortrait';
-import { CharacterPortrait as CharacterPortraitType } from '@/types/character.types';
+import { GeneratedImage } from '@/types/common.types';
 // Removed direct AI client imports - using API routes instead
 import { Character } from '@/types/character.types';
 import { World } from '@/types/world.types';
@@ -14,7 +14,7 @@ import { getTimestamp } from '@/lib/utils';
 interface CharacterFormData {
   name: string;
   description?: string;
-  portrait?: CharacterPortraitType;
+  portrait?: GeneratedImage;
   attributes: Array<{ attributeId: string; value: number }>;
   skills: Array<{ skillId: string; level: number; isSelected: boolean }>;
   background: {

--- a/src/components/CharacterPortrait/CharacterPortrait.tsx
+++ b/src/components/CharacterPortrait/CharacterPortrait.tsx
@@ -2,11 +2,11 @@
 
 import React from 'react';
 import Image from 'next/image';
-import { CharacterPortrait as CharacterPortraitType } from '@/types/character.types';
+import { GeneratedImage } from '@/types/common.types';
 import { cn } from '@/lib/utils/classNames';
 
 interface CharacterPortraitProps {
-  portrait: CharacterPortraitType;
+  portrait: GeneratedImage;
   characterName: string;
   size?: 'small' | 'medium' | 'large' | 'xlarge';
   isGenerating?: boolean;

--- a/src/components/CharacterPortrait/__tests__/CharacterPortrait.test.tsx
+++ b/src/components/CharacterPortrait/__tests__/CharacterPortrait.test.tsx
@@ -3,13 +3,13 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { CharacterPortrait } from '../CharacterPortrait';
-import { CharacterPortrait as CharacterPortraitType } from '../../../types/character.types';
+import { GeneratedImage } from '../../../types/common.types';
 import { getTimestamp } from '@/lib/utils/timestamp';
 
 describe('CharacterPortrait', () => {
   describe('rendering states', () => {
     it('should render AI-generated portrait', () => {
-      const portrait: CharacterPortraitType = {
+      const portrait: GeneratedImage = {
         type: 'ai-generated',
         url: 'data:image/png;base64,abc123',
         generatedAt: getTimestamp(),

--- a/src/components/CharacterPortrait/__tests__/CharacterPortrait.test.tsx
+++ b/src/components/CharacterPortrait/__tests__/CharacterPortrait.test.tsx
@@ -28,7 +28,7 @@ describe('CharacterPortrait', () => {
     });
 
     it('should render placeholder when no portrait', () => {
-      const portrait: CharacterPortraitType = {
+      const portrait: GeneratedImage = {
         type: 'placeholder',
         url: null
       };

--- a/src/components/WorldCreationWizard/steps/FinalizeStep.tsx
+++ b/src/components/WorldCreationWizard/steps/FinalizeStep.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { World, WorldImage } from '@/types/world.types';
+import { World } from '@/types/world.types';
+import { GeneratedImage } from '@/types/common.types';
 import { wizardStyles, WizardFormSection } from '@/components/shared/wizard';
 import { DataField } from '@/components/shared/DataField';
 import { ImageGenerationSection } from '@/components/shared';
@@ -83,13 +84,13 @@ export default function FinalizeStep({
 
   const handleRemoveImage = () => {
     if (!onUpdateWorldData) return;
-    
-    const placeholderImage: WorldImage = {
+
+    const placeholderImage: GeneratedImage = {
       type: 'placeholder',
       url: null,
       generatedAt: getTimestamp()
     };
-    
+
     onUpdateWorldData({ image: placeholderImage });
   };
 

--- a/src/components/WorldCreationWizard/steps/ImageGenerationStep.tsx
+++ b/src/components/WorldCreationWizard/steps/ImageGenerationStep.tsx
@@ -2,7 +2,8 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import Image from 'next/image';
-import { World, WorldImage } from '@/types/world.types';
+import { World } from '@/types/world.types';
+import { GeneratedImage } from '@/types/common.types';
 import { WizardFormSection } from '@/components/shared/wizard';
 import { createAIClient } from '@/lib/ai';
 import { WorldImageGenerator } from '@/lib/ai/worldImageGenerator';
@@ -31,7 +32,7 @@ export default function ImageGenerationStep({
 }: ImageGenerationStepProps) {
   const [isGenerating, setIsGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [generatedImage, setGeneratedImage] = useState<WorldImage | null>(worldData.image || null);
+  const [generatedImage, setGeneratedImage] = useState<GeneratedImage | null>(worldData.image || null);
 
   const generateImage = useCallback(async () => {
     setIsGenerating(true);
@@ -62,12 +63,12 @@ export default function ImageGenerationStep({
 
   const handleSkip = () => {
     // Set a placeholder image
-    const placeholderImage: WorldImage = {
+    const placeholderImage: GeneratedImage = {
       type: 'placeholder',
       url: null,
       generatedAt: getTimestamp()
     };
-    
+
     onUpdate({ image: placeholderImage });
     onComplete();
   };

--- a/src/components/WorldImage/WorldImage.tsx
+++ b/src/components/WorldImage/WorldImage.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import Image from 'next/image';
-import { WorldImage as WorldImageType } from '@/types/world.types';
+import { GeneratedImage } from '@/types/common.types';
 import { ImageOff, AlertCircle } from 'lucide-react';
 
 interface WorldImageProps {
-  image?: WorldImageType;
+  image?: GeneratedImage;
   worldName: string;
   size?: 'small' | 'medium' | 'large' | 'xlarge';
   className?: string;

--- a/src/components/devtools/TestDataGeneratorSection/TestDataGeneratorSection.tsx
+++ b/src/components/devtools/TestDataGeneratorSection/TestDataGeneratorSection.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 // Using API routes for secure AI operations - combines both approaches
 import { generateTestCharacter } from '@/lib/generators/characterGenerator';
 import { generateUniqueId } from '@/lib/utils/generateId';
-import type { WorldImage } from '@/types/world.types';
+import type { GeneratedImage } from '@/types/common.types';
 import { getTimestamp } from '@/lib/utils';
 import { ensureWorldNpcRoster } from '@/lib/services/worldCreationService';
 
@@ -118,8 +118,8 @@ export const TestDataGeneratorSection: React.FC = () => {
           
           if (response.ok) {
             const { imageUrl, aiGenerated, service } = await response.json();
-            // Update the world with the generated image in WorldImage format (my enhancement)
-            const image: WorldImage = {
+            // Update the world with the generated image in GeneratedImage format (my enhancement)
+            const image: GeneratedImage = {
               type: aiGenerated ? 'ai-generated' as const : 'placeholder' as const,
               url: imageUrl,
               generatedAt: getTimestamp()
@@ -252,8 +252,8 @@ export const TestDataGeneratorSection: React.FC = () => {
             
             if (response.ok) {
               const { imageUrl, aiGenerated, service } = await response.json();
-              // Update the world with the generated image in WorldImage format (my enhancement)
-              const image: WorldImage = {
+              // Update the world with the generated image in GeneratedImage format (my enhancement)
+              const image: GeneratedImage = {
                 type: aiGenerated ? 'ai-generated' as const : 'placeholder' as const,
                 url: imageUrl,
                 generatedAt: getTimestamp()

--- a/src/components/forms/WorldImageForm.tsx
+++ b/src/components/forms/WorldImageForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { World, WorldImage } from '@/types/world.types';
+import { World } from '@/types/world.types';
+import { GeneratedImage } from '@/types/common.types';
 import { createAIClient } from '@/lib/ai';
 import { WorldImageGenerator } from '@/lib/ai/worldImageGenerator';
 import { ImageGenerationSection } from '@/components/shared';
@@ -32,12 +33,12 @@ const WorldImageForm: React.FC<WorldImageFormProps> = ({ world, onChange }) => {
   };
 
   const handleRemoveImage = () => {
-    const placeholderImage: WorldImage = {
+    const placeholderImage: GeneratedImage = {
       type: 'placeholder',
       url: null,
       generatedAt: getTimestamp()
     };
-    
+
     onChange({ image: placeholderImage });
   };
 

--- a/src/components/world/WorldImageDisplay.tsx
+++ b/src/components/world/WorldImageDisplay.tsx
@@ -2,11 +2,11 @@
 
 import React from 'react';
 import { DataField } from '@/components/shared/DataField';
-import { WorldImage } from '@/types/world.types';
+import { GeneratedImage } from '@/types/common.types';
 import { formatDate } from '@/lib/utils';
 
 interface WorldImageDisplayProps {
-  image?: WorldImage;
+  image?: GeneratedImage;
 }
 
 export function WorldImageDisplay({ image }: WorldImageDisplayProps) {

--- a/src/lib/ai/__mocks__/worldImageGenerator.ts
+++ b/src/lib/ai/__mocks__/worldImageGenerator.ts
@@ -1,6 +1,7 @@
 // src/lib/ai/__mocks__/worldImageGenerator.ts
 
-import { World, WorldImage } from '../../../types/world.types';
+import { World } from '../../../types/world.types';
+import { GeneratedImage } from '../../../types/common.types';
 import { AIClient } from '../types';
 import { getTimestamp } from '@/lib/utils';
 
@@ -110,7 +111,7 @@ export class WorldImageGenerator {
   /**
    * Generate an image for a world (mocked version)
    */
-  async generateWorldImage(world: World): Promise<WorldImage> {
+  async generateWorldImage(world: World): Promise<GeneratedImage> {
     // Simulate async delay
     await new Promise(resolve => setTimeout(resolve, 1500));
     

--- a/src/lib/ai/portraitGenerator.ts
+++ b/src/lib/ai/portraitGenerator.ts
@@ -1,6 +1,7 @@
 // src/lib/ai/portraitGenerator.ts
 
-import { Character, CharacterPortrait } from '../../types/character.types';
+import { Character } from '../../types/character.types';
+import { GeneratedImage } from '../../types/common.types';
 import { AIClient } from './types';
 import { capitalize, truncate, safeTrim, getTimestamp } from '@/lib/utils';
 import { normalizeText, NORM_NAME, NORM_DESC } from '@/lib/utils/textNormalization';
@@ -94,7 +95,7 @@ Answer with JSON only: {"actorName": "actor's full name" or null, "figureName": 
   async generatePortrait(
     character: Character,
     options: PortraitGenerationOptions = {}
-  ): Promise<CharacterPortrait> {
+  ): Promise<GeneratedImage> {
     if (!this.aiClient.generateImage) {
       throw new Error('AI client does not support image generation');
     }

--- a/src/lib/ai/worldImageGenerator.ts
+++ b/src/lib/ai/worldImageGenerator.ts
@@ -1,6 +1,7 @@
 // src/lib/ai/worldImageGenerator.ts
 
-import { World, WorldImage } from '../../types/world.types';
+import { World } from '../../types/world.types';
+import { GeneratedImage } from '../../types/common.types';
 import { AIClient } from './types';
 import { getTimestamp } from '@/lib/utils';
 
@@ -64,7 +65,7 @@ export class WorldImageGenerator {
    * @param world - The world to generate an image for
    * @param customPrompt - Optional custom prompt to override the auto-generated one
    */
-  async generateWorldImage(world: World, customPrompt?: string): Promise<WorldImage> {
+  async generateWorldImage(world: World, customPrompt?: string): Promise<GeneratedImage> {
     try {
       const prompt = customPrompt || this.buildPrompt(world);
       

--- a/src/types/character.types.ts
+++ b/src/types/character.types.ts
@@ -1,17 +1,7 @@
 // src/types/character.types.ts
 
-import { EntityID, NamedEntity, TimestampedEntity } from './common.types';
+import { EntityID, GeneratedImage, NamedEntity, TimestampedEntity } from './common.types';
 import { Inventory } from './inventory.types';
-
-/**
- * Character portrait data
- */
-export interface CharacterPortrait {
-  type: 'ai-generated' | 'placeholder';
-  url: string | null;
-  generatedAt?: string;
-  prompt?: string;
-}
 
 /**
  * Represents a character in the game
@@ -23,7 +13,7 @@ export interface Character extends NamedEntity, TimestampedEntity {
   background: CharacterBackground;
   inventory: Inventory;
   status: CharacterStatus;
-  portrait?: CharacterPortrait;
+  portrait?: GeneratedImage;
 }
 
 /**

--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -29,3 +29,14 @@ export interface TimestampedEntity {
   updatedAt: ISODateString;
 }
 
+/**
+ * Generated image data
+ * Used for AI-generated images attached to entities (characters, worlds, etc.)
+ */
+export interface GeneratedImage {
+  type: 'ai-generated' | 'placeholder';
+  url: string | null;
+  generatedAt?: string;
+  prompt?: string;
+}
+

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Re-export all types from their respective files
-export type { EntityID, ISODateString, TimestampedEntity, NamedEntity } from './common.types';
+export type { EntityID, ISODateString, TimestampedEntity, NamedEntity, GeneratedImage } from './common.types';
 export type { World, WorldAttribute, WorldSkill, WorldSettings } from './world.types';
 export type {
   Character,

--- a/src/types/type-guards.ts
+++ b/src/types/type-guards.ts
@@ -119,9 +119,9 @@ export function validateWorld(obj: unknown, partial: boolean = false): Validatio
 
   // Optional property validation
   if (world.image !== undefined && world.image !== null) {
-    const imageValidation = validateWorldImage(world.image);
+    const imageValidation = validateGeneratedImage(world.image);
     if (!imageValidation.valid) {
-      errors.push(...imageValidation.errors.map(e => `WorldImage: ${e}`));
+      errors.push(...imageValidation.errors.map(e => `GeneratedImage: ${e}`));
     }
   }
 
@@ -299,12 +299,12 @@ export function validateWorldSettings(obj: unknown, partial: boolean = false): V
   return { valid: errors.length === 0, errors };
 }
 
-export function validateWorldImage(obj: unknown): ValidationResult {
+export function validateGeneratedImage(obj: unknown): ValidationResult {
   const errors: string[] = [];
   const validTypes = ['ai-generated', 'placeholder'];
 
   if (obj === null || obj === undefined) {
-    errors.push('WorldImage cannot be null or undefined');
+    errors.push('GeneratedImage cannot be null or undefined');
     return { valid: false, errors };
   }
 

--- a/src/types/world.types.ts
+++ b/src/types/world.types.ts
@@ -1,19 +1,9 @@
 // src/types/world.types.ts
 
-import { EntityID, NamedEntity, TimestampedEntity } from './common.types';
+import { EntityID, GeneratedImage, NamedEntity, TimestampedEntity } from './common.types';
 import { SkillDifficulty } from '@/lib/constants/skillDifficultyLevels';
 import { ToneSettings } from './tone-settings.types';
 import { GenreValue } from '@/lib/constants/genres';
-
-/**
- * World image data
- */
-export interface WorldImage {
-  type: 'ai-generated' | 'placeholder';
-  url: string | null;
-  generatedAt?: string;
-  prompt?: string;
-}
 
 /**
  * Represents a game world configuration
@@ -24,7 +14,7 @@ export interface World extends NamedEntity, TimestampedEntity {
   attributes: WorldAttribute[];
   skills: WorldSkill[];
   settings: WorldSettings;
-  image?: WorldImage;
+  image?: GeneratedImage;
   reference?: string;
   relationship?: 'set_within' | 'inspired_by';
   toneSettings?: ToneSettings;


### PR DESCRIPTION
Remove redundant CharacterPortrait and WorldImage types by introducing a shared
GeneratedImage type in common.types.ts. Both types had identical structure:
- type: 'ai-generated' | 'placeholder'
- url: string | null
- generatedAt?: string
- prompt?: string

This consolidation improves type consistency across the codebase and reduces
duplication, making it easier to maintain and extend image-related functionality.

Changes:
- Added GeneratedImage type to src/types/common.types.ts
- Updated Character interface to use GeneratedImage for portrait property
- Updated World interface to use GeneratedImage for image property
- Updated all components and services to import and use GeneratedImage
- Updated test files to use the new shared type

Files affected: 15 files across type definitions, AI generators, components,
and tests.