### PR TITLE
refactor: Consolidate direct jest timer calls to use centralized setupTestTimers utility

### DIFF
--- a/src/state/__tests__/characterStore.crud.test.ts
+++ b/src/state/__tests__/characterStore.crud.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { useCharacterStore } from '../characterStore';
-import { createTestCharacterData, setupTestTimers } from './characterStore.testHelpers';
+import { createTestCharacterData, setupTestTimers, cleanupTestTimers } from './characterStore.testHelpers';
 
 describe('useCharacterStore - CRUD Operations', () => {
   beforeEach(() => {
@@ -15,7 +15,7 @@ describe('useCharacterStore - CRUD Operations', () => {
 
   afterEach(() => {
     jest.clearAllTimers();
-    jest.useRealTimers();
+    cleanupTestTimers();
   });
 
   describe('createCharacter', () => {

--- a/src/state/__tests__/inventoryStore.test.ts
+++ b/src/state/__tests__/inventoryStore.test.ts
@@ -11,6 +11,7 @@ import type {
   InventoryAcquisitionRecord,
   StandardInventoryCategory,
 } from '@/types/inventory.types';
+import { setupTestTimers, cleanupTestTimers } from '@/lib/test-utils/testTimers';
 
 const buildCategorization = (
   categoryId: StandardInventoryCategory,
@@ -61,14 +62,13 @@ const buildAddPayload = (
 
 describe('useInventoryStore', () => {
   beforeEach(() => {
-    jest.useFakeTimers();
-    jest.setSystemTime(new Date('2025-01-15T12:00:00Z'));
+    setupTestTimers();
     useInventoryStore.getState().reset();
   });
 
   afterEach(() => {
     jest.clearAllTimers();
-    jest.useRealTimers();
+    cleanupTestTimers();
   });
 
   describe('createItem', () => {

--- a/src/state/__tests__/narrativeStore.decisionRecording.behavior.test.ts
+++ b/src/state/__tests__/narrativeStore.decisionRecording.behavior.test.ts
@@ -2,12 +2,12 @@
 
 import { useNarrativeStore } from '../narrativeStore';
 import { DecisionOption } from '../../types/narrative.types';
+import { setupTestTimers, cleanupTestTimers } from '@/lib/test-utils/testTimers';
 
 describe('narrativeStore - Decision Recording Behavior Tests (Issue #207)', () => {
   beforeEach(() => {
     // Use fake timers for deterministic timestamp generation
-    jest.useFakeTimers();
-    jest.setSystemTime(new Date('2025-01-15T12:00:00Z'));
+    setupTestTimers();
 
     // Reset store state before each test
     useNarrativeStore.setState({
@@ -25,7 +25,7 @@ describe('narrativeStore - Decision Recording Behavior Tests (Issue #207)', () =
   });
 
   afterEach(() => {
-    jest.useRealTimers();
+    cleanupTestTimers();
   });
 
   describe('Core Acceptance Criteria', () => {

--- a/src/state/__tests__/narrativeStore.decisionRecording.test.ts
+++ b/src/state/__tests__/narrativeStore.decisionRecording.test.ts
@@ -2,12 +2,12 @@
 
 import { useNarrativeStore } from '../narrativeStore';
 import { Decision, DecisionOption } from '../../types/narrative.types';
+import { setupTestTimers, cleanupTestTimers } from '@/lib/test-utils/testTimers';
 
 describe('narrativeStore - Decision Recording (Issue #207)', () => {
   beforeEach(() => {
     // Use fake timers for deterministic timestamp generation
-    jest.useFakeTimers();
-    jest.setSystemTime(new Date('2025-01-15T12:00:00Z'));
+    setupTestTimers();
 
     // Reset store state before each test
     useNarrativeStore.setState({
@@ -25,7 +25,7 @@ describe('narrativeStore - Decision Recording (Issue #207)', () => {
   });
 
   afterEach(() => {
-    jest.useRealTimers();
+    cleanupTestTimers();
   });
 
   describe('Decision Recording with Timestamps and Character Association', () => {

--- a/src/state/__tests__/narrativeStore.worldState.integration.test.ts
+++ b/src/state/__tests__/narrativeStore.worldState.integration.test.ts
@@ -1,6 +1,7 @@
 import { useNarrativeStore } from '../narrativeStore';
 import { useWorldStore } from '../worldStore';
 import { useSessionStore } from '../sessionStore';
+import { setupTestTimers, cleanupTestTimers } from '@/lib/test-utils/testTimers';
 
 const resetSessionStore = () => {
   useSessionStore.setState(() => ({
@@ -28,7 +29,7 @@ const resetSessionStore = () => {
 
 describe('Narrative store world state integration', () => {
   beforeEach(() => {
-    jest.useFakeTimers();
+    setupTestTimers();
     jest.setSystemTime(new Date('2025-02-01T12:00:00.000Z'));
     useWorldStore.getState().reset();
     useNarrativeStore.getState().reset();
@@ -36,7 +37,7 @@ describe('Narrative store world state integration', () => {
   });
 
   afterEach(() => {
-    jest.useRealTimers();
+    cleanupTestTimers();
     useNarrativeStore.getState().reset();
     useWorldStore.getState().reset();
     resetSessionStore();

--- a/src/state/__tests__/sessionStore.savedSessions.test.ts
+++ b/src/state/__tests__/sessionStore.savedSessions.test.ts
@@ -1,5 +1,6 @@
 import { getTimestamp } from '@/lib/utils/timestamp';
 import { useSessionStore } from '../sessionStore';
+import { setupTestTimers } from '@/lib/test-utils/testTimers';
 
 jest.mock('@/lib/utils/logger', () => ({
   __esModule: true,
@@ -128,7 +129,7 @@ describe('Session Persistence: savedSessions collection', () => {
       const worldId = 'test-world-id';
       const characterId = 'test-character-id';
 
-      jest.useFakeTimers();
+      setupTestTimers();
       const initialTime = new Date('2025-01-01T00:00:00.000Z');
       jest.setSystemTime(initialTime);
 


### PR DESCRIPTION
Replace inline jest.useFakeTimers() and jest.useRealTimers() calls across 6 test files with the centralized setupTestTimers() and cleanupTestTimers() utilities. This eliminates redundant timer setup code and ensures consistent test timer configuration across the codebase.

Files updated:
- src/state/__tests__/inventoryStore.test.ts
- src/state/__tests__/narrativeStore.decisionRecording.behavior.test.ts
- src/state/__tests__/narrativeStore.decisionRecording.test.ts
- src/state/__tests__/narrativeStore.worldState.integration.test.ts
- src/state/__tests__/sessionStore.savedSessions.test.ts
- src/state/__tests__/characterStore.crud.test.ts