### PR TITLE
Refine visual tests to use shared collapsible helper

### DIFF
--- a/tests/visual/game-session.spec.ts
+++ b/tests/visual/game-session.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { hideDynamicContent } from './utils/wait-helpers';
+import { hideDynamicContent, expandAllCollapsibleSections } from './utils/wait-helpers';
 import { seedTestData } from './utils/seedTestData';
 import { mockApiEndpoints } from './utils/mockApi';
 import {
@@ -10,8 +10,6 @@ import {
   removeDuplicateSuggestedActionsTextarea,
   relaxStoryColumnHeight,
   seedStorySummaryForVisual,
-  expandStorySummarySection,
-  expandInventorySection,
 } from './utils/game-session-page-seeder';
 
 /**
@@ -368,7 +366,8 @@ test.describe('Game Session Visual Tests', () => {
     await ensureSuggestedActionsExpanded(page);
     await renderSeededSuggestedActions(page);
     await seedInventoryItemsForVisual(page);
-    await expandInventorySection(page);
+    await seedStorySummaryForVisual(page);
+    await expandAllCollapsibleSections(page);
 
     await page.waitForSelector('[data-testid^="choice-option-"]', {
       state: 'visible',
@@ -383,8 +382,6 @@ test.describe('Game Session Visual Tests', () => {
     await ensureSuggestedActionsContentVisible(page);
     await removeDuplicateSuggestedActionsTextarea(page);
     await relaxStoryColumnHeight(page);
-    await seedStorySummaryForVisual(page);
-    await expandStorySummarySection(page);
 
     await page.waitForTimeout(200); // Wait for layout to adjust
 

--- a/tests/visual/utils/game-session-page-seeder.ts
+++ b/tests/visual/utils/game-session-page-seeder.ts
@@ -3,9 +3,6 @@ import type { Page } from '@playwright/test';
 const SUGGESTED_ACTIONS_TITLE_LOCATOR = '[data-testid="collapsible-section-title"]';
 const SUGGESTED_ACTIONS_CONTENT_LOCATOR = '[data-testid="collapsible-section-content"]';
 const SUGGESTED_ACTIONS_TOGGLE_LOCATOR = '[data-testid="collapsible-section-toggle"]';
-const STORY_SUMMARY_SECTION_LOCATOR = '[data-testid="story-summary-section"]';
-const STORY_SUMMARY_TOGGLE_LOCATOR = '[data-testid="collapsible-section-toggle"]';
-const INVENTORY_SECTION_LOCATOR = '[data-testid="inventory-collapsible"]';
 
 /**
  * Ensure the Suggested Actions collapsible section is expanded so the visual baseline
@@ -441,87 +438,6 @@ export async function seedStorySummaryForVisual(page: Page): Promise<void> {
       sessionId,
     );
   });
-}
-
-/**
- * Ensure the Story Summary collapsible is expanded so the snapshot includes the checkpoint content.
- */
-export async function expandStorySummarySection(page: Page): Promise<void> {
-  const section = page.locator(STORY_SUMMARY_SECTION_LOCATOR);
-
-  if (!(await section.count())) {
-    return;
-  }
-
-  const toggle = section.locator(STORY_SUMMARY_TOGGLE_LOCATOR).first();
-  const expanded = await toggle.getAttribute('aria-expanded');
-
-  if (expanded !== 'true') {
-    await toggle.click();
-    await page.waitForTimeout(200);
-  }
-
-  await page.evaluate(
-    ({ sectionSelector }) => {
-      const sectionEl = document.querySelector(sectionSelector);
-      const content = sectionEl?.querySelector('[data-testid="collapsible-section-content"]') as HTMLElement | null;
-      const toggleButton = sectionEl?.querySelector('[data-testid="collapsible-section-toggle"]') as HTMLElement | null;
-
-      if (content) {
-        content.classList.add('block');
-        content.classList.remove('hidden');
-        content.setAttribute('aria-hidden', 'false');
-        content.style.display = 'block';
-      }
-
-      if (toggleButton) {
-        toggleButton.setAttribute('aria-expanded', 'true');
-        toggleButton.textContent = '−';
-      }
-    },
-    { sectionSelector: STORY_SUMMARY_SECTION_LOCATOR },
-  );
-}
-
-/**
- * Ensure the Inventory collapsible renders its contents for visual baselines.
- */
-export async function expandInventorySection(page: Page): Promise<void> {
-  const section = page.locator(INVENTORY_SECTION_LOCATOR);
-
-  if (!(await section.count())) {
-    return;
-  }
-
-  const toggle = section.locator('[data-testid="collapsible-section-toggle"]').first();
-  const expanded = await toggle.getAttribute('aria-expanded');
-
-  if (expanded !== 'true') {
-    await toggle.click();
-    await page.waitForTimeout(200);
-  }
-
-  await page.evaluate(({ selector }) => {
-    const sectionEl = document.querySelector(selector);
-    if (!sectionEl) {
-      return;
-    }
-
-    const content = sectionEl.querySelector('[data-testid="collapsible-section-content"]') as HTMLElement | null;
-    const toggleButton = sectionEl.querySelector('[data-testid="collapsible-section-toggle"]') as HTMLElement | null;
-
-    if (content) {
-      content.classList.add('block');
-      content.classList.remove('hidden');
-      content.setAttribute('aria-hidden', 'false');
-      content.style.display = 'block';
-    }
-
-    if (toggleButton) {
-      toggleButton.setAttribute('aria-expanded', 'true');
-      toggleButton.textContent = '−';
-    }
-  }, { selector: INVENTORY_SECTION_LOCATOR });
 }
 
 /**


### PR DESCRIPTION
Summary

  - Replace bespoke story summary and inventory expand helpers with shared expandAllCollapsibleSections for visual tests.
  - Simplify game session visual spec by seeding story summary before expansion and relying on shared helper.
  - Trim unused constants/helpers from the seeder utility.

  Testing

  - Not run (visual tests not requested).