### PR TITLE
Fix character level and notoriety generation defaults

### DIFF
--- a/src/app/characters/page.tsx
+++ b/src/app/characters/page.tsx
@@ -334,7 +334,7 @@ export default function CharactersPage() {
       // Reset dialog state
       setShowGenerateDialog(false);
       setCharacterName('');
-      setGenerationType('known');
+      setGenerationType('original');
       setGenerateError(null);
       
       // Navigate to view the character

--- a/src/app/characters/page.tsx
+++ b/src/app/characters/page.tsx
@@ -130,7 +130,7 @@ export default function CharactersPage() {
   const [generateError, setGenerateError] = useState<string | null>(null);
   const [showGenerateDialog, setShowGenerateDialog] = useState(false);
   const [characterName, setCharacterName] = useState('');
-  const [generationType, setGenerationType] = useState<'known' | 'original' | 'specific'>('known');
+  const [generationType, setGenerationType] = useState<'known' | 'original' | 'specific'>('original');
   const [deleteDialog, setDeleteDialog] = useState({
     isOpen: false,
     characterId: null as string | null,

--- a/src/lib/ai/characterGenerator.ts
+++ b/src/lib/ai/characterGenerator.ts
@@ -20,7 +20,7 @@ export async function generateCharacter(
   world: World,
   existingCharacterNames: string[],
   suggestedName?: string,
-  generationType: 'known' | 'original' | 'specific' = 'known'
+  generationType: 'known' | 'original' | 'specific' = 'original'
 ): Promise<GeneratedCharacterData> {
   return generateAICharacter(world, existingCharacterNames, suggestedName, generationType);
 }

--- a/src/lib/generators/characterGenerator.ts
+++ b/src/lib/generators/characterGenerator.ts
@@ -5,6 +5,9 @@ import { validateWorld } from '@/types/type-guards';
 
 const logger = new Logger('CharacterGenerator');
 
+// Character level range for generated characters
+const CHARACTER_LEVEL_RANGE = { min: 1, max: 5 };
+
 export interface GeneratedCharacterData {
   name: string;
   background: {
@@ -108,7 +111,7 @@ export function generateFromTemplate(options: CharacterGenerationOptions): Gener
   
   return {
     name: finalName,
-    level: Math.floor(Math.random() * 3) + 1, // Level 1-3
+    level: Math.floor(Math.random() * (CHARACTER_LEVEL_RANGE.max - CHARACTER_LEVEL_RANGE.min + 1)) + CHARACTER_LEVEL_RANGE.min,
     background: {
       description: `A mysterious figure with an interesting past${world.reference ? ` from the ${world.reference} universe` : ''}.`,
       personality: personalities[Math.floor(Math.random() * personalities.length)],
@@ -197,10 +200,9 @@ Generate a character and return ONLY a valid JSON object:
 
 {
   "name": "Character Name",
-  "level": 3,
   "background": {
     "description": "Their complete history and background story",
-    "personality": "Their personality traits and behavioral patterns", 
+    "personality": "Their personality traits and behavioral patterns",
     "motivation": "What drives them and their goals",
     "fears": ["List 2-3 specific fears or anxieties this character has"],
     "physicalDescription": "Their appearance including age, race/ethnicity, height, build, hair, eyes, and typical clothing"
@@ -464,7 +466,10 @@ CRITICAL INSTRUCTIONS:
       characterData.isKnownFigure = false;
       characterData.characterType = 'original';
     }
-    
+
+    // Calculate character level (1-5 range) - not from AI
+    characterData.level = Math.floor(Math.random() * (CHARACTER_LEVEL_RANGE.max - CHARACTER_LEVEL_RANGE.min + 1)) + CHARACTER_LEVEL_RANGE.min;
+
     return characterData;
   } catch (error) {
     // Don't fall back for certain types of validation errors


### PR DESCRIPTION
## Summary

Fixes #912

Characters were always generating as "level 3" with "Known Figure" labels regardless of user intent. This PR fixes the root causes and implements proper defaults.

## Changes Made

### Character Level Generation
- Added `CHARACTER_LEVEL_RANGE` constant (1-5) for consistent level generation across all methods
- Removed hardcoded `"level": 3` from AI prompt template
- Updated template generation to use the constant level range
- Added level calculation after AI response parsing (removes dependency on AI for level values)

### Character Type Defaults
- Changed default generation type from `'known'` to `'original'`
- Users must now explicitly select 'known' to generate canon characters
- 'Known Figure' label reserved for actual canon characters from established universes

## Testing

### Automated Tests
- ✅ All 214 test suites pass (1,479 tests)
- ✅ No regressions detected

### Manual Testing
- ✅ DevTools character generation: Level 5, Original character (Lysandra Shadowmoon)
- ✅ Main UI character generation: Level 1, Original character (Angelo "The Angel" Pacelli)
- ✅ Default generation type is 'original' in dialog
- ✅ Character cards display "Original" label correctly
- ✅ Levels vary within 1-5 range

## Before vs After

### Before
- Characters always level 3
- Default type: 'known' → all characters labeled "Known Figure"
- Level hardcoded in AI prompt

### After
- Characters generate with random levels 1-5
- Default type: 'original' → characters labeled "Original"
- 'Known Figure' only appears when explicitly selected
- Level calculated in code for consistency

## Files Modified

- `src/lib/generators/characterGenerator.ts` - Level constant, prompt update, calculation logic
- `src/app/characters/page.tsx` - Default generation type change

## Acceptance Criteria

- [x] Characters generate with random levels in 1-5 range
- [x] Default generation type is 'original' (creates custom characters)
- [x] 'Known' type must be explicitly selected for canon characters
- [x] Level not included in AI prompt template
- [x] Character cards show "Original" label by default
- [x] "Known Figure" only when 'known' type explicitly used
- [x] All tests pass