### PR TITLE
feat: Add Unicode/international character support for lore keys (#447)

### DIFF
--- a/src/lib/utils/__tests__/unicodeNormalization.test.ts
+++ b/src/lib/utils/__tests__/unicodeNormalization.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for Unicode normalization utilities
+ * Focus: Acceptance criteria and edge cases, NOT implementation details
+ */
+
+import { removeAccents, hasNonLatinCharacters, generateSafeKey } from '../unicodeNormalization';
+
+describe('Unicode Normalization', () => {
+  describe('removeAccents', () => {
+    it('handles Western European accents', () => {
+      expect(removeAccents('François')).toBe('Francois');
+      expect(removeAccents('Zürich')).toBe('Zurich');
+      expect(removeAccents('naïve')).toBe('naive');
+      expect(removeAccents('Café')).toBe('Cafe');
+      expect(removeAccents('Øresund')).toBe('Øresund'); // Ø is not decomposable
+    });
+
+    it('handles multiple accents in single word', () => {
+      expect(removeAccents('Größe')).toBe('Große'); // ö decomposes, ß doesn't
+      expect(removeAccents('Naïveté')).toBe('Naivete');
+    });
+
+    it('handles empty and whitespace', () => {
+      expect(removeAccents('')).toBe('');
+      expect(removeAccents('   ')).toBe('   ');
+    });
+
+    it('preserves non-accented text', () => {
+      expect(removeAccents('Hello World')).toBe('Hello World');
+      expect(removeAccents('123abc')).toBe('123abc');
+    });
+  });
+
+  describe('hasNonLatinCharacters', () => {
+    it('detects non-Latin scripts', () => {
+      // CJK (Chinese, Japanese, Korean)
+      expect(hasNonLatinCharacters('村田さん')).toBe(true);
+      expect(hasNonLatinCharacters('李明')).toBe(true);
+      expect(hasNonLatinCharacters('김철수')).toBe(true);
+
+      // Cyrillic
+      expect(hasNonLatinCharacters('Владимир')).toBe(true);
+      expect(hasNonLatinCharacters('Москва')).toBe(true);
+
+      // Arabic
+      expect(hasNonLatinCharacters('محمد')).toBe(true);
+
+      // Mixed scripts
+      expect(hasNonLatinCharacters('Jean-李')).toBe(true);
+      expect(hasNonLatinCharacters('Café 村田')).toBe(true);
+
+      // Emoji
+      expect(hasNonLatinCharacters('Player💀')).toBe(true);
+      expect(hasNonLatinCharacters('🎮Game')).toBe(true);
+    });
+
+    it('accepts Latin scripts with accents', () => {
+      expect(hasNonLatinCharacters('François')).toBe(false);
+      expect(hasNonLatinCharacters('Zürich')).toBe(false);
+      expect(hasNonLatinCharacters('naïve')).toBe(false);
+      expect(hasNonLatinCharacters('Größe')).toBe(false);
+    });
+
+    it('accepts basic ASCII', () => {
+      expect(hasNonLatinCharacters('John Smith')).toBe(false);
+      expect(hasNonLatinCharacters('Hello-World')).toBe(false);
+      expect(hasNonLatinCharacters("O'Brien")).toBe(false);
+      expect(hasNonLatinCharacters('Dr. Watson')).toBe(false);
+    });
+
+    it('accepts Latin Extended characters', () => {
+      expect(hasNonLatinCharacters('Ĉapelo')).toBe(false); // Esperanto
+      expect(hasNonLatinCharacters('Đorđe')).toBe(false); // Serbian Latin
+    });
+
+    it('handles empty and whitespace', () => {
+      expect(hasNonLatinCharacters('')).toBe(false); // Empty matches Latin range
+      expect(hasNonLatinCharacters('   ')).toBe(false);
+    });
+  });
+
+  describe('generateSafeKey', () => {
+    describe('Western European normalization', () => {
+      it('normalizes accented characters to lowercase ASCII', () => {
+        expect(generateSafeKey('François')).toBe('francois');
+        expect(generateSafeKey('Zürich')).toBe('zurich');
+        expect(generateSafeKey('Café')).toBe('cafe');
+        expect(generateSafeKey('naïve')).toBe('naive');
+      });
+
+      it('replaces special characters with underscores', () => {
+        expect(generateSafeKey('Jean-Pierre')).toBe('jean_pierre');
+        expect(generateSafeKey("O'Brien")).toBe('o_brien');
+        expect(generateSafeKey('Dr. Watson')).toBe('dr_watson');
+      });
+
+      it('collapses multiple underscores', () => {
+        expect(generateSafeKey('Name   With    Spaces')).toBe('name_with_spaces');
+        expect(generateSafeKey('Multiple---Dashes')).toBe('multiple_dashes');
+      });
+
+      it('trims leading and trailing underscores', () => {
+        expect(generateSafeKey('  Leading')).toBe('leading');
+        expect(generateSafeKey('Trailing  ')).toBe('trailing');
+        expect(generateSafeKey('  Both  ')).toBe('both');
+      });
+
+      it('handles mixed case input', () => {
+        expect(generateSafeKey('UPPERCASE')).toBe('uppercase');
+        expect(generateSafeKey('MixedCase')).toBe('mixedcase');
+        expect(generateSafeKey('camelCase')).toBe('camelcase');
+      });
+    });
+
+    describe('Non-Latin UUID fallback', () => {
+      it('generates UUID for CJK characters', () => {
+        const key1 = generateSafeKey('村田さん');
+        const key2 = generateSafeKey('李明');
+        const key3 = generateSafeKey('김철수');
+
+        // UUID format: 8-4-4-4-12 hex digits
+        const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+        expect(key1).toMatch(uuidPattern);
+        expect(key2).toMatch(uuidPattern);
+        expect(key3).toMatch(uuidPattern);
+      });
+
+      it('generates UUID for Cyrillic characters', () => {
+        const key = generateSafeKey('Владимир');
+        const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+        expect(key).toMatch(uuidPattern);
+      });
+
+      it('generates UUID for Arabic characters', () => {
+        const key = generateSafeKey('محمد');
+        const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+        expect(key).toMatch(uuidPattern);
+      });
+
+      it('generates UUID for emoji', () => {
+        const key = generateSafeKey('Player💀');
+        const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+        expect(key).toMatch(uuidPattern);
+      });
+
+      it('generates UUID for mixed scripts', () => {
+        const key = generateSafeKey('Jean-李');
+        const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+        expect(key).toMatch(uuidPattern);
+      });
+
+      it('generates random UUIDs for same input', () => {
+        const key1 = generateSafeKey('村田さん');
+        const key2 = generateSafeKey('村田さん');
+
+        // UUIDs should be different (random, not deterministic)
+        expect(key1).not.toBe(key2);
+      });
+
+      it('uses prefix for UUID fallback when provided', () => {
+        const key = generateSafeKey('村田さん', 'character');
+        expect(key).toMatch(/^character_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+      });
+    });
+
+    describe('Edge cases with UUID fallback', () => {
+      it('handles empty string', () => {
+        const key = generateSafeKey('');
+        const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+        expect(key).toMatch(uuidPattern);
+      });
+
+      it('handles whitespace-only string', () => {
+        const key = generateSafeKey('   ');
+        const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+        expect(key).toMatch(uuidPattern);
+      });
+
+      it('handles symbols-only string', () => {
+        const key = generateSafeKey('!!!');
+        const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+        expect(key).toMatch(uuidPattern);
+      });
+
+      it('handles single character (below minimum)', () => {
+        const key = generateSafeKey('a');
+        const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+        expect(key).toMatch(uuidPattern);
+      });
+
+      it('handles single character with prefix', () => {
+        const key = generateSafeKey('a', 'character');
+        expect(key).toMatch(/^character_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+      });
+    });
+
+    describe('Consistency and determinism', () => {
+      it('generates consistent keys for same Latin input', () => {
+        const key1 = generateSafeKey('François');
+        const key2 = generateSafeKey('François');
+        const key3 = generateSafeKey('François');
+
+        expect(key1).toBe('francois');
+        expect(key2).toBe('francois');
+        expect(key3).toBe('francois');
+      });
+
+      it('generates consistent keys for same ASCII input', () => {
+        const key1 = generateSafeKey('John Smith');
+        const key2 = generateSafeKey('John Smith');
+
+        expect(key1).toBe('john_smith');
+        expect(key2).toBe('john_smith');
+      });
+    });
+
+    describe('Length limits', () => {
+      it('truncates very long names to 100 characters', () => {
+        const longName = 'A'.repeat(150);
+        const key = generateSafeKey(longName);
+
+        expect(key).toBe('a'.repeat(100));
+        expect(key.length).toBe(100);
+      });
+
+      it('handles exactly 100 character input', () => {
+        const name = 'A'.repeat(100);
+        const key = generateSafeKey(name);
+
+        expect(key).toBe('a'.repeat(100));
+        expect(key.length).toBe(100);
+      });
+
+      it('does not truncate short names', () => {
+        const key = generateSafeKey('François');
+        expect(key).toBe('francois');
+        expect(key.length).toBeLessThan(100);
+      });
+    });
+  });
+});

--- a/src/lib/utils/__tests__/unicodeNormalization.test.ts
+++ b/src/lib/utils/__tests__/unicodeNormalization.test.ts
@@ -77,6 +77,24 @@ describe('Unicode Normalization', () => {
       expect(hasNonLatinCharacters('')).toBe(false); // Empty matches Latin range
       expect(hasNonLatinCharacters('   ')).toBe(false);
     });
+
+    it('handles NFD pre-decomposed Latin input consistently', () => {
+      // NFD (pre-decomposed) form: e + combining acute accent (U+0301)
+      const francoisNFD = 'Franc\u0327ois'; // ç in NFD form (c + combining cedilla)
+      const francoisNFC = 'François'; // Normal NFC form
+
+      // Both forms should be treated as Latin
+      expect(hasNonLatinCharacters(francoisNFD)).toBe(false);
+      expect(hasNonLatinCharacters(francoisNFC)).toBe(false);
+
+      // Multiple combining diacritics
+      const accentedNFD = 'e\u0301'; // é in NFD form (e + combining acute)
+      expect(hasNonLatinCharacters(accentedNFD)).toBe(false);
+
+      // Complex case: café with all diacritics in NFD
+      const cafeNFD = 'cafe\u0301'; // café in NFD
+      expect(hasNonLatinCharacters(cafeNFD)).toBe(false);
+    });
   });
 
   describe('generateSafeKey', () => {
@@ -211,6 +229,19 @@ describe('Unicode Normalization', () => {
 
         expect(key1).toBe('john_smith');
         expect(key2).toBe('john_smith');
+      });
+
+      it('generates consistent keys for NFD vs NFC input', () => {
+        // NFD (pre-decomposed) vs NFC (composed) should produce same key
+        const francoisNFD = 'Franc\u0327ois'; // ç in NFD form (c + combining cedilla)
+        const francoisNFC = 'François'; // Normal NFC form
+
+        const keyNFD = generateSafeKey(francoisNFD);
+        const keyNFC = generateSafeKey(francoisNFC);
+
+        // Both should normalize to the same key
+        expect(keyNFD).toBe(keyNFC);
+        expect(keyNFD).toBe('francois');
       });
     });
 

--- a/src/lib/utils/unicodeNormalization.ts
+++ b/src/lib/utils/unicodeNormalization.ts
@@ -36,18 +36,26 @@ export function removeAccents(text: string): string {
  * Returns false for:
  * - Latin with accents (François, Zürich)
  * - Basic ASCII (John, Smith)
+ * - NFD decomposed Latin (e\u0301 → é in NFC)
+ *
+ * Normalizes to NFC first to handle pre-decomposed (NFD) input consistently.
+ * This ensures "François" in both NFC and NFD forms are treated identically.
  *
  * @param text - Text to check
  * @returns true if text contains non-Latin characters
  */
 export function hasNonLatinCharacters(text: string): boolean {
+  // Normalize to NFC first to handle pre-decomposed input (NFD)
+  // This ensures combining diacritics (U+0300-U+036F) are composed with base chars
+  const normalized = text.normalize('NFC');
+
   // Latin-1 Supplement (includes accented chars): U+0000-U+00FF
   // Latin Extended-A: U+0100-U+017F
   // Latin Extended-B: U+0180-U+024F
   // Allow spaces, hyphens, apostrophes, periods, underscores
   // Use * instead of + to match empty string as Latin
   const latinRange = /^[\u0000-\u024F\s\-'._]*$/;
-  return !latinRange.test(text);
+  return !latinRange.test(normalized);
 }
 
 /**

--- a/src/lib/utils/unicodeNormalization.ts
+++ b/src/lib/utils/unicodeNormalization.ts
@@ -1,0 +1,94 @@
+/**
+ * Unicode normalization utilities for lore key generation
+ * Handles international characters with NFD decomposition and diacritic removal
+ */
+
+import { generateUniqueId } from './generateId';
+
+/**
+ * Remove accents and diacritics from text using Unicode NFD decomposition
+ *
+ * Examples:
+ * - François → Francois
+ * - Zürich → Zurich
+ * - naïve → naive
+ *
+ * @param text - Text to normalize
+ * @returns Text with diacritics removed
+ */
+export function removeAccents(text: string): string {
+  return text
+    .normalize('NFD')                    // Decompose: é → e + ´ (combining accent)
+    .replace(/[\u0300-\u036f]/g, '')     // Remove combining diacritical marks
+    .normalize('NFC');                   // Recompose for consistency
+}
+
+/**
+ * Detect if text contains non-Latin characters
+ *
+ * Returns true for:
+ * - Cyrillic (Владимир)
+ * - CJK (村田さん, 李明)
+ * - Arabic (محمد)
+ * - Emoji (💀, 🎮)
+ * - Other non-Latin scripts
+ *
+ * Returns false for:
+ * - Latin with accents (François, Zürich)
+ * - Basic ASCII (John, Smith)
+ *
+ * @param text - Text to check
+ * @returns true if text contains non-Latin characters
+ */
+export function hasNonLatinCharacters(text: string): boolean {
+  // Latin-1 Supplement (includes accented chars): U+0000-U+00FF
+  // Latin Extended-A: U+0100-U+017F
+  // Latin Extended-B: U+0180-U+024F
+  // Allow spaces, hyphens, apostrophes, periods, underscores
+  // Use * instead of + to match empty string as Latin
+  const latinRange = /^[\u0000-\u024F\s\-'._]*$/;
+  return !latinRange.test(text);
+}
+
+/**
+ * Generate safe ASCII key with UUID fallback
+ *
+ * Strategy:
+ * 1. Western European (Latin + accents): Normalize accents, lowercase, replace special chars
+ * 2. Non-Latin scripts (Cyrillic, CJK, Arabic): UUID fallback
+ * 3. Empty/invalid after normalization: UUID fallback
+ *
+ * Examples:
+ * - François → francois
+ * - Zürich → zurich
+ * - 村田さん → character_uuid-abc123 (with fallbackPrefix='character')
+ * - Владимир → uuid-def456 (no prefix)
+ * - "!!!" → uuid-ghi789 (symbols only)
+ *
+ * @param name - Original name to normalize
+ * @param fallbackPrefix - Optional prefix for UUID fallback (e.g., 'character', 'location')
+ * @returns Normalized key (lowercase alphanumeric + underscores) or UUID
+ */
+export function generateSafeKey(name: string, fallbackPrefix?: string): string {
+  // Early detection: non-Latin scripts → UUID fallback
+  if (hasNonLatinCharacters(name)) {
+    const uuid = generateUniqueId();
+    return fallbackPrefix ? `${fallbackPrefix}_${uuid}` : uuid;
+  }
+
+  // Normal flow for Latin-based scripts
+  const normalized = removeAccents(name)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')         // Replace non-alphanumeric with underscores
+    .replace(/^_+|_+$/g, '')             // Trim leading/trailing underscores
+    .substring(0, 100);                  // Reasonable length limit
+
+  // Validation: require minimum 2 characters
+  // If normalization produces empty or too-short result, fall back to UUID
+  if (!normalized || normalized.length < 2) {
+    const uuid = generateUniqueId();
+    return fallbackPrefix ? `${fallbackPrefix}_${uuid}` : uuid;
+  }
+
+  return normalized;
+}

--- a/src/state/__tests__/loreStore.advanced.test.ts
+++ b/src/state/__tests__/loreStore.advanced.test.ts
@@ -176,17 +176,15 @@ describe('LoreStore - Advanced Features', () => {
     test('should validate key format', () => {
       const { result } = renderHook(() => useLoreStore());
 
-      // Valid keys (new format: lowercase only)
+      // Valid keys
       expect(result.current.validateKey('valid_key')).toBe(true);
       expect(result.current.validateKey('key123')).toBe(true);
-      expect(result.current.validateKey('key_name')).toBe(true); // lowercase variant
+      expect(result.current.validateKey('key_name')).toBe(true);
 
       // Invalid keys
       expect(result.current.validateKey('key with spaces')).toBe(false);
       expect(result.current.validateKey('key-with-dashes')).toBe(false);
       expect(result.current.validateKey('123startswithnumber')).toBe(false);
-
-      // BREAKING CHANGE: Old uppercase format now invalid
       expect(result.current.validateKey('KEY_NAME')).toBe(false);
       expect(result.current.validateKey('KeyWithCaps')).toBe(false);
     });
@@ -514,7 +512,7 @@ describe('LoreStore - Advanced Features', () => {
       expect(andreFact?.key).toBe('world-1:character_andre_duval');
       expect(francoiseFact?.key).toBe('world-1:character_francoise_laurent');
 
-      // Validation should accept new format
+      // Keys should pass validation
       expect(result.current.validateKey(andreFact!.key)).toBe(true);
       expect(result.current.validateKey(francoiseFact!.key)).toBe(true);
     });
@@ -576,19 +574,19 @@ describe('LoreStore - Advanced Features', () => {
       expect(locationFact?.value).toBe('François Plaza');
     });
 
-    test('BREAKING CHANGE: rejects old uppercase key format', () => {
+    test('rejects uppercase keys, accepts lowercase and UUID keys', () => {
       const { result } = renderHook(() => useLoreStore());
 
-      // Old format validation explicitly rejected
+      // Uppercase keys rejected
       expect(result.current.validateKey('OLD_KEY_FORMAT')).toBe(false);
       expect(result.current.validateKey('KeyWithCaps')).toBe(false);
       expect(result.current.validateKey('world-1:OLD_FORMAT')).toBe(false);
 
-      // New format validation accepted
+      // Lowercase keys accepted
       expect(result.current.validateKey('new_lowercase_format')).toBe(true);
       expect(result.current.validateKey('world-1:character_francois')).toBe(true);
 
-      // UUID format accepted
+      // UUID keys accepted
       const uuidKey = 'world-1:character_character_abc12345-def6-7890-abcd-ef1234567890';
       expect(result.current.validateKey(uuidKey)).toBe(true);
     });

--- a/src/state/__tests__/loreStore.advanced.test.ts
+++ b/src/state/__tests__/loreStore.advanced.test.ts
@@ -640,5 +640,41 @@ describe('LoreStore - Advanced Features', () => {
       expect(fact?.key).toMatch(/^world-1:character_character_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
       expect(fact?.value).toBe('Player💀'); // Original preserved
     });
+
+    test('does not truncate UUID keys for non-Latin event/rule descriptions', () => {
+      const { result } = renderHook(() => useLoreStore());
+
+      const extraction = {
+        characters: [],
+        locations: [],
+        events: [
+          { description: '大きな戦いが始まる', importance: 'high' as const } // Japanese: "A great battle begins"
+        ],
+        rules: [
+          { rule: '魔法には集中が必要', importance: 'medium' as const } // Japanese: "Magic requires focus"
+        ]
+      };
+
+      act(() => {
+        result.current.addStructuredLore(extraction, 'world-1', 'session-1');
+      });
+
+      const facts = result.current.getFacts({ worldId: 'world-1' });
+      const eventFact = facts.find(f => f.category === 'events');
+      const ruleFact = facts.find(f => f.category === 'rules');
+
+      // UUID keys should remain valid (not truncated by maxLength)
+      // Events/rules use maxLength=30, but UUIDs are ~47 chars with prefix
+      expect(eventFact?.key).toMatch(/^world-1:event_event_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+      expect(ruleFact?.key).toMatch(/^world-1:rule_rule_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+
+      // Keys should pass validation (not truncated to invalid partial UUID)
+      expect(result.current.validateKey(eventFact!.key)).toBe(true);
+      expect(result.current.validateKey(ruleFact!.key)).toBe(true);
+
+      // Original descriptions preserved
+      expect(eventFact?.value).toBe('大きな戦いが始まる');
+      expect(ruleFact?.value).toBe('魔法には集中が必要');
+    });
   });
 });

--- a/src/state/__tests__/loreStore.advanced.test.ts
+++ b/src/state/__tests__/loreStore.advanced.test.ts
@@ -176,15 +176,19 @@ describe('LoreStore - Advanced Features', () => {
     test('should validate key format', () => {
       const { result } = renderHook(() => useLoreStore());
 
-      // Valid keys
+      // Valid keys (new format: lowercase only)
       expect(result.current.validateKey('valid_key')).toBe(true);
       expect(result.current.validateKey('key123')).toBe(true);
-      expect(result.current.validateKey('KEY_NAME')).toBe(true);
+      expect(result.current.validateKey('key_name')).toBe(true); // lowercase variant
 
       // Invalid keys
       expect(result.current.validateKey('key with spaces')).toBe(false);
       expect(result.current.validateKey('key-with-dashes')).toBe(false);
       expect(result.current.validateKey('123startswithnumber')).toBe(false);
+
+      // BREAKING CHANGE: Old uppercase format now invalid
+      expect(result.current.validateKey('KEY_NAME')).toBe(false);
+      expect(result.current.validateKey('KeyWithCaps')).toBe(false);
     });
   });
 
@@ -480,6 +484,161 @@ describe('LoreStore - Advanced Features', () => {
       const characterFacts = facts.filter(f => f.category === 'characters' && f.value === 'Duplicate Character');
 
       expect(characterFacts.length).toBe(1);
+    });
+  });
+
+  describe('International Character Handling', () => {
+    test('handles Western European character names', () => {
+      const { result } = renderHook(() => useLoreStore());
+
+      const extraction = {
+        characters: [
+          { name: 'André Duval', importance: 'medium' as const }, // No 's' endings to avoid plural detection
+          { name: 'Françoise Laurent', importance: 'medium' as const }
+        ],
+        locations: [],
+        events: [],
+        rules: []
+      };
+
+      act(() => {
+        result.current.addStructuredLore(extraction, 'world-1', 'session-1');
+      });
+
+      const facts = result.current.getFacts({ worldId: 'world-1' });
+
+      const andreFact = facts.find(f => f.value === 'André Duval');
+      const francoiseFact = facts.find(f => f.value === 'Françoise Laurent');
+
+      // Keys should be normalized (lowercase, no accents)
+      expect(andreFact?.key).toBe('world-1:character_andre_duval');
+      expect(francoiseFact?.key).toBe('world-1:character_francoise_laurent');
+
+      // Validation should accept new format
+      expect(result.current.validateKey(andreFact!.key)).toBe(true);
+      expect(result.current.validateKey(francoiseFact!.key)).toBe(true);
+    });
+
+    test('handles non-Latin character names with UUID fallback', () => {
+      const { result } = renderHook(() => useLoreStore());
+
+      const extraction = {
+        characters: [
+          { name: '村田さん', importance: 'medium' as const },
+          { name: 'Владимир', importance: 'medium' as const }
+        ],
+        locations: [],
+        events: [],
+        rules: []
+      };
+
+      act(() => {
+        result.current.addStructuredLore(extraction, 'world-1', 'session-1');
+      });
+
+      const facts = result.current.getFacts({ worldId: 'world-1' });
+      const japaneseFact = facts.find(f => f.value === '村田さん');
+      const cyrillicFact = facts.find(f => f.value === 'Владимир');
+
+      // Keys should have UUID fallback for non-Latin scripts
+      expect(japaneseFact?.key).toMatch(/^world-1:character_character_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+      expect(cyrillicFact?.key).toMatch(/^world-1:character_character_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+
+      // Validation should accept UUID format
+      expect(result.current.validateKey(japaneseFact!.key)).toBe(true);
+      expect(result.current.validateKey(cyrillicFact!.key)).toBe(true);
+    });
+
+    test('preserves original names in fact values', () => {
+      const { result } = renderHook(() => useLoreStore());
+
+      const extraction = {
+        characters: [
+          { name: '村田さん', importance: 'medium' as const }
+        ],
+        locations: [
+          { name: 'François Plaza', importance: 'medium' as const }
+        ],
+        events: [],
+        rules: []
+      };
+
+      act(() => {
+        result.current.addStructuredLore(extraction, 'world-1', 'session-1');
+      });
+
+      const facts = result.current.getFacts({ worldId: 'world-1' });
+      const characterFact = facts.find(f => f.category === 'characters');
+      const locationFact = facts.find(f => f.category === 'locations');
+
+      // Original Unicode names preserved in values
+      expect(characterFact?.value).toBe('村田さん');
+      expect(locationFact?.value).toBe('François Plaza');
+    });
+
+    test('BREAKING CHANGE: rejects old uppercase key format', () => {
+      const { result } = renderHook(() => useLoreStore());
+
+      // Old format validation explicitly rejected
+      expect(result.current.validateKey('OLD_KEY_FORMAT')).toBe(false);
+      expect(result.current.validateKey('KeyWithCaps')).toBe(false);
+      expect(result.current.validateKey('world-1:OLD_FORMAT')).toBe(false);
+
+      // New format validation accepted
+      expect(result.current.validateKey('new_lowercase_format')).toBe(true);
+      expect(result.current.validateKey('world-1:character_francois')).toBe(true);
+
+      // UUID format accepted
+      const uuidKey = 'world-1:character_character_abc12345-def6-7890-abcd-ef1234567890';
+      expect(result.current.validateKey(uuidKey)).toBe(true);
+    });
+
+    test('handles mixed Latin and special characters', () => {
+      const { result } = renderHook(() => useLoreStore());
+
+      const extraction = {
+        characters: [
+          { name: "Jean-Pierre O'Neill", importance: 'medium' as const }
+        ],
+        locations: [],
+        events: [],
+        rules: []
+      };
+
+      act(() => {
+        result.current.addStructuredLore(extraction, 'world-1', 'session-1');
+      });
+
+      const facts = result.current.getFacts({ worldId: 'world-1' });
+      const fact = facts.find(f => f.category === 'characters');
+
+      // Special characters replaced with underscores
+      expect(fact?.key).toBe('world-1:character_jean_pierre_o_neill');
+      expect(fact?.value).toBe("Jean-Pierre O'Neill"); // Original preserved
+    });
+
+    test('handles emoji in names with UUID fallback', () => {
+      const { result } = renderHook(() => useLoreStore());
+
+      const extraction = {
+        characters: [
+          { name: 'Player💀', importance: 'medium' as const }
+        ],
+        locations: [],
+        events: [],
+        rules: []
+      };
+
+      act(() => {
+        result.current.addStructuredLore(extraction, 'world-1', 'session-1');
+      });
+
+      const facts = result.current.getFacts({ worldId: 'world-1' });
+      const fact = facts.find(f => f.category === 'characters');
+
+      // Emoji triggers UUID fallback
+      expect(fact?.key).toMatch(/^world-1:character_character_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+      expect(fact?.value).toBe('Player💀'); // Original preserved
     });
   });
 });

--- a/src/state/__tests__/loreStore.aliases.test.ts
+++ b/src/state/__tests__/loreStore.aliases.test.ts
@@ -14,7 +14,7 @@ describe('LoreStore - Alias Management', () => {
       let factId!: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -36,7 +36,7 @@ describe('LoreStore - Alias Management', () => {
       let factId!: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -60,7 +60,7 @@ describe('LoreStore - Alias Management', () => {
       let factId!: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -83,7 +83,7 @@ describe('LoreStore - Alias Management', () => {
       let factId!: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -106,7 +106,7 @@ describe('LoreStore - Alias Management', () => {
       let factId!: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -140,7 +140,7 @@ describe('LoreStore - Alias Management', () => {
       let factId!: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -163,7 +163,7 @@ describe('LoreStore - Alias Management', () => {
       let factId!: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -198,7 +198,7 @@ describe('LoreStore - Alias Management', () => {
       let factId!: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -220,7 +220,7 @@ describe('LoreStore - Alias Management', () => {
       let factId!: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -243,7 +243,7 @@ describe('LoreStore - Alias Management', () => {
       let factId!: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -265,7 +265,7 @@ describe('LoreStore - Alias Management', () => {
       let factId!: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -287,7 +287,7 @@ describe('LoreStore - Alias Management', () => {
       let factId!: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -309,7 +309,7 @@ describe('LoreStore - Alias Management', () => {
       let factId!: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -344,7 +344,7 @@ describe('LoreStore - Alias Management', () => {
       let factId!: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -365,7 +365,7 @@ describe('LoreStore - Alias Management', () => {
       let factId!: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -389,7 +389,7 @@ describe('LoreStore - Alias Management', () => {
       let factId!: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -421,7 +421,7 @@ describe('LoreStore - Alias Management', () => {
       let factId1!: string, factId2!: string;
       act(() => {
         factId1 = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -430,7 +430,7 @@ describe('LoreStore - Alias Management', () => {
         result.current.setAliases(factId1, ['Seraphina']);
 
         factId2 = result.current.addFact(
-          'character:lady-victoria',
+          'world-2:character_lady_victoria',
           'Lady Victoria',
           'characters',
           'manual',
@@ -456,7 +456,7 @@ describe('LoreStore - Alias Management', () => {
       let specialFactId!: string;
       act(() => {
         specialFactId = result.current.addFact(
-          'character:dr-oconnor',
+          'world-1:character_dr_oconnor',
           "Dr. O'Connor",
           'characters',
           'manual',

--- a/src/state/__tests__/loreStore.search.test.ts
+++ b/src/state/__tests__/loreStore.search.test.ts
@@ -134,7 +134,7 @@ describe('LoreStore - Duplicate Detection and Search', () => {
       let factId: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -157,7 +157,7 @@ describe('LoreStore - Duplicate Detection and Search', () => {
       let factId: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -189,7 +189,7 @@ describe('LoreStore - Duplicate Detection and Search', () => {
       let factId: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -212,7 +212,7 @@ describe('LoreStore - Duplicate Detection and Search', () => {
       let factId1: string, factId2: string;
       act(() => {
         factId1 = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Seraphina',
           'characters',
           'manual',
@@ -221,7 +221,7 @@ describe('LoreStore - Duplicate Detection and Search', () => {
         result.current.setAliases(factId1, ['Lady Seraphina', 'Lady Sera']);
 
         factId2 = result.current.addFact(
-          'character:lady-victoria',
+          'world-1:character_lady_victoria',
           'Victoria',
           'characters',
           'manual',
@@ -245,7 +245,7 @@ describe('LoreStore - Duplicate Detection and Search', () => {
       let charFactId: string, locFactId: string;
       act(() => {
         charFactId = result.current.addFact(
-          'character:starweaver',
+          'world-1:character_starweaver',
           'Lyra Starweaver',
           'characters',
           'manual',
@@ -254,7 +254,7 @@ describe('LoreStore - Duplicate Detection and Search', () => {
         result.current.setAliases(charFactId, ['Star Mage', 'The Starweaver']);
 
         locFactId = result.current.addFact(
-          'location:star-tower',
+          'world-1:location_star_tower',
           'The Star Tower',
           'locations',
           'manual',
@@ -283,7 +283,7 @@ describe('LoreStore - Duplicate Detection and Search', () => {
       let factId: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -306,7 +306,7 @@ describe('LoreStore - Duplicate Detection and Search', () => {
       let factId: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',
@@ -332,7 +332,7 @@ describe('LoreStore - Duplicate Detection and Search', () => {
       let factId: string;
       act(() => {
         factId = result.current.addFact(
-          'character:lady-seraphina',
+          'world-1:character_lady_seraphina',
           'Lady Seraphina',
           'characters',
           'manual',

--- a/src/state/loreStore.helpers.ts
+++ b/src/state/loreStore.helpers.ts
@@ -1,5 +1,6 @@
 import { normalizeText, NORM_NAME } from '../lib/utils/textNormalization';
 import { safeTrim } from '@/lib/utils';
+import { generateSafeKey } from '@/lib/utils/unicodeNormalization';
 
 /**
  * Maximum number of events to extract per narrative segment
@@ -8,12 +9,22 @@ import { safeTrim } from '@/lib/utils';
 export const MAX_EVENTS_PER_EXTRACTION = 3;
 
 /**
- * Helper function to generate normalized lore keys
+ * Helper function to generate normalized lore keys with Unicode support
+ *
+ * Handles international characters via NFD decomposition and diacritic removal:
+ * - Western European: François → world-123:character_francois
+ * - Non-Latin scripts: 村田さん → world-123:character_character_uuid-abc123
+ *
+ * @param worldId - World identifier
+ * @param category - Lore category (character, location, event, rule)
+ * @param name - Original name (preserves Unicode in fact.value)
+ * @param maxLength - Optional maximum length for truncation
+ * @returns Normalized lore key in format: {worldId}:{category}_{normalizedName}
  */
 export function generateLoreKey(worldId: string, category: string, name: string, maxLength?: number): string {
-  const normalizedName = normalizeText(name, NORM_NAME).toLowerCase().replace(/[^a-z0-9]+/g, '_');
-  const truncatedName = maxLength ? normalizedName.substring(0, maxLength) : normalizedName;
-  return `${worldId}:${category}_${truncatedName}`;
+  const safeKey = generateSafeKey(name, category);
+  const truncatedKey = maxLength ? safeKey.substring(0, maxLength) : safeKey;
+  return `${worldId}:${category}_${truncatedKey}`;
 }
 
 /**

--- a/src/state/loreStore.helpers.ts
+++ b/src/state/loreStore.helpers.ts
@@ -23,7 +23,11 @@ export const MAX_EVENTS_PER_EXTRACTION = 3;
  */
 export function generateLoreKey(worldId: string, category: string, name: string, maxLength?: number): string {
   const safeKey = generateSafeKey(name, category);
-  const truncatedKey = maxLength ? safeKey.substring(0, maxLength) : safeKey;
+
+  // Don't truncate UUID keys - they need to remain valid
+  const hasUUID = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(safeKey);
+  const truncatedKey = (maxLength && !hasUUID) ? safeKey.substring(0, maxLength) : safeKey;
+
   return `${worldId}:${category}_${truncatedKey}`;
 }
 

--- a/src/state/loreStore.utils.ts
+++ b/src/state/loreStore.utils.ts
@@ -149,7 +149,7 @@ export function validateFactUniquenessImpl(
 }
 
 /**
- * Validates a lore key format (NEW FORMAT ONLY - no backwards compatibility)
+ * Validates a lore key format
  *
  * Accepts:
  * - Structured keys: worldId:category_name (lowercase + underscores)
@@ -157,20 +157,19 @@ export function validateFactUniquenessImpl(
  * - Simple lowercase keys: my_key_name
  * - UUIDs: abc123-def456-...
  *
- * Rejects (BREAKING CHANGE):
- * - Old uppercase keys: KEY_NAME, MyKey
- * - Keys starting with uppercase: KeyName
+ * Rejects:
+ * - Uppercase keys: KEY_NAME, MyKey, KeyName
+ * - Keys with special characters: key-name, key.name
  */
 export function validateKeyImpl(key: string): boolean {
   if (key.includes(':')) {
-    // Structured keys: worldId:category_name or worldId:category_uuid-abc123
-    // Format: lowercase + underscores OR UUID after last underscore
+    // Structured keys: worldId:category_name or worldId:category_uuid
     const structuredPattern = /^[a-zA-Z0-9_-]+:[a-z0-9_]+(?:_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})?$/;
     return structuredPattern.test(key);
   }
 
-  // Simple keys: lowercase alphanumeric + underscore OR valid UUID only
-  const normalizedPattern = /^[a-z][a-z0-9_]*$/;  // lowercase only (new format)
+  // Simple keys: lowercase alphanumeric + underscore OR valid UUID
+  const normalizedPattern = /^[a-z][a-z0-9_]*$/;
   const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
   return normalizedPattern.test(key) || uuidPattern.test(key);

--- a/src/state/loreStore.utils.ts
+++ b/src/state/loreStore.utils.ts
@@ -149,15 +149,31 @@ export function validateFactUniquenessImpl(
 }
 
 /**
- * Validates a lore key format
+ * Validates a lore key format (NEW FORMAT ONLY - no backwards compatibility)
+ *
+ * Accepts:
+ * - Structured keys: worldId:category_name (lowercase + underscores)
+ * - Structured keys with UUID: worldId:category_uuid-abc123
+ * - Simple lowercase keys: my_key_name
+ * - UUIDs: abc123-def456-...
+ *
+ * Rejects (BREAKING CHANGE):
+ * - Old uppercase keys: KEY_NAME, MyKey
+ * - Keys starting with uppercase: KeyName
  */
 export function validateKeyImpl(key: string): boolean {
   if (key.includes(':')) {
-    const structuredPattern = /^[a-zA-Z0-9_-]+:[a-zA-Z0-9:_-]+$/;
+    // Structured keys: worldId:category_name or worldId:category_uuid-abc123
+    // Format: lowercase + underscores OR UUID after last underscore
+    const structuredPattern = /^[a-zA-Z0-9_-]+:[a-z0-9_]+(?:_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})?$/;
     return structuredPattern.test(key);
   }
-  const keyPattern = /^[a-zA-Z][a-zA-Z0-9_]*$/;
-  return keyPattern.test(key);
+
+  // Simple keys: lowercase alphanumeric + underscore OR valid UUID only
+  const normalizedPattern = /^[a-z][a-z0-9_]*$/;  // lowercase only (new format)
+  const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+  return normalizedPattern.test(key) || uuidPattern.test(key);
 }
 
 /**


### PR DESCRIPTION
## Description

The lore key generation system wasn't handling international characters properly - names like "François" and "村田さん" were either getting mangled or rejected entirely. This adds proper Unicode normalization using NFD decomposition, which strips accents from Western European characters and falls back to UUIDs for non-Latin scripts.

The approach keeps it simple - no external transliteration libraries, just native JavaScript Unicode normalization. Keys stay clean and searchable while the original Unicode names get preserved in the fact values where they belong.

## Related Issue

Closes #447

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Built the Unicode normalization utilities first, added comprehensive unit tests (31 tests covering Western European, CJK, Cyrillic, Arabic, emoji, and edge cases), then integrated into the lore system with 6 additional integration tests. Full loreStore suite passes (94/94 tests).

## User Stories Addressed

From #447:
- Handle accented characters (François → francois)
- Support non-Latin scripts with fallback (村田さん → UUID)
- Maintain backwards compatibility ~~(Updated: clean break approach chosen)~~
- Generate consistent keys for same names
- Performance remains acceptable

## Implementation Notes

### Core Changes

Created `unicodeNormalization.ts` with three main functions:
- `removeAccents()` - NFD decomposition + diacritic stripping
- `hasNonLatinCharacters()` - Detects non-Latin scripts (Cyrillic, CJK, Arabic, emoji)
- `generateSafeKey()` - Orchestrates normalization with UUID fallback

Updated `generateLoreKey()` to use the new Unicode-aware normalization instead of the basic text normalization. This handles the actual conversion:
- Western European: François → francois, Zürich → zurich  
- Non-Latin: 村田さん → character_uuid-abc123
- Edge cases (empty, symbols, single chars) → UUID fallback

### Breaking Change: Key Validation

Updated `validateKeyImpl()` to only accept the new lowercase format. This was a deliberate choice - the old uppercase keys (like "KEY_NAME") were inconsistent with the new normalized approach, and supporting both would have added complexity without much benefit since keys are descriptive identifiers, not functional IDs (EntityID handles lookups).

**Old format (now rejected)**:
- `KEY_NAME`
- `character:lady-seraphina` (hyphens)

**New format (required)**:
- `key_name` (lowercase + underscores)
- `world-123:character_francois`
- `world-123:character_character_uuid-abc123` (UUID fallback)

### Test Updates

Had to update existing test keys from the old hyphenated format to the new underscore format. This touched `loreStore.aliases.test.ts` and `loreStore.search.test.ts` - just replaced hyphens with underscores to match the new validation pattern.

### Design Decisions

**Why UUID fallback instead of transliteration?**
Adding a transliteration library would have been ~14KB+ with maintenance overhead and varying quality across languages. Since keys are descriptive identifiers (not used for lookups), UUIDs work fine and the original names stay intact in `fact.value`.

**Why no backwards compatibility?**
Keys aren't used for database lookups (EntityID handles that), so this breaking change only affects new key generation. Cleaner to make a clean break than maintain dual validation paths.

**Why NFD normalization?**
NFD (Canonical Decomposition) separates base characters from combining diacritics, which makes it straightforward to strip accents. More reliable than trying to map individual accented characters.

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

### Unit Tests
```bash
npm test -- unicodeNormalization.test.ts
```
Should see 31 tests pass covering:
- Western European accents (François, Zürich, naïve)
- Non-Latin scripts (CJK, Cyrillic, Arabic)
- Edge cases (empty, whitespace, symbols, emoji, very long names)
- Consistency (same input → same output for Latin, random for non-Latin)

### Integration Tests  
```bash
npm test -- loreStore.advanced.test.ts -t "International Character"
```
Should see 6 tests pass covering:
- End-to-end lore extraction with international names
- Original name preservation in fact values
- Breaking change validation (old uppercase format rejected)
- Mixed Latin and special characters

### Full Suite
```bash
npm test -- loreStore
```
Should see 94/94 tests pass.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required) - Added lore key format section to CLAUDE.md
- [x] No new warnings generated
- [x] Accessibility considerations addressed