### PR TITLE
docs: define Storybook migration contract for prep issue #1045

### DIFF
--- a/public_docs/design-system/redesign-planning/issue-1037-legacy-styling-audit.md
+++ b/public_docs/design-system/redesign-planning/issue-1037-legacy-styling-audit.md
@@ -3,6 +3,7 @@
 - Part of #1020
 - Implements #1037
 - Feeds #1038
+- Storybook contract: [issue-1045 storybook migration contract](./issue-1045-storybook-migration-contract.md)
 - Companion: [issue-1046 non-game-session audit](./issue-1046-non-game-session-legacy-styling-audit.md)
 - Last updated: 2026-02-08
 
@@ -252,6 +253,8 @@ Component source-to-table coverage check:
 | Virtualization and deferred optimization | No (deferred) | #1036 | #1036 |
 
 ## Storybook mapping table (surface -> story -> keep/update/deprecate)
+
+Mapping and gap statuses follow the canonical contract in [`issue-1045-storybook-migration-contract.md`](./issue-1045-storybook-migration-contract.md).
 
 | Surface | Story file(s) | Story action | Story gap handling |
 | --- | --- | --- | --- |

--- a/public_docs/design-system/redesign-planning/issue-1045-storybook-migration-contract.md
+++ b/public_docs/design-system/redesign-planning/issue-1045-storybook-migration-contract.md
@@ -1,0 +1,105 @@
+# Issue #1045 Storybook Migration Contract
+
+- Part of #1020
+- Implements #1045
+- Applies to #1037, #1038, #1032, #1033, #1034, #1035
+- Extended in #1046 and #1047 for non-game-session rollout
+- Last updated: 2026-02-08
+
+## Purpose
+
+This contract prevents Storybook drift during design-system migration.
+
+Migration changes are not complete unless Storybook coverage changes in the same PR and `npm run build-storybook` passes. This keeps implementation, documentation, and visual regression surfaces aligned.
+
+## Required contract for migration PRs
+
+1. Maintain a mapping table for touched surfaces using the canonical format (`surface -> story file -> keep/update/deprecate`).
+2. Update or deprecate stories in the same PR as implementation changes for those surfaces.
+3. Record story gaps explicitly using the story-gap policy below; no silent gaps.
+4. Run `npm run build-storybook` for migration PRs that touch mapped surfaces, stories, or shared styling layers (`src/app/globals.css`, tokens, shared UI wrappers).
+5. Treat Storybook build failures as blocking.
+
+## Canonical mapping table format
+
+Use this table format in migration artifacts:
+
+| Surface | Story file | Action (`keep`/`update`/`deprecate`) | Gap status | Owner issue | Notes |
+| --- | --- | --- | --- | --- | --- |
+
+- `Surface`: production file or styling surface being migrated.
+- `Story file`: direct story path. If no direct story exists, point to the current parent/indirect coverage.
+- `Action`: required action now.
+- `Gap status`: one of `none`, `temporary-parent-coverage`, `missing-direct-story`.
+- `Owner issue`: issue responsible for closing the mapping action and gap.
+
+## Story-gap policy
+
+### Allowed gap statuses
+
+- `none`: direct story exists and is current for the surface.
+- `temporary-parent-coverage`: no direct story yet, but behavior is currently validated through a parent integration story.
+- `missing-direct-story`: no direct or parent coverage that meaningfully validates the surface.
+
+### Required handling
+
+- Every `temporary-parent-coverage` or `missing-direct-story` row must include:
+  - owner issue,
+  - closure path (`add direct story` or `add explicit state variant to parent story`),
+  - migration phase where closure happens.
+- Migration issues must not close with unresolved `missing-direct-story` rows for touched surfaces.
+
+## Foundation vs feature story update rules
+
+| Change type | Story scope | Owner issue |
+| --- | --- | --- |
+| Token and neutral-palette changes | `src/stories/00-foundation/*` first, then affected component/page stories | #1032 |
+| Streaming behavior and narrative stability changes | Narrative and streaming stories under `03-organisms/narrative` and game-session pages | #1033 |
+| Game-session composition/layout changes | Game-session pages and related organism stories | #1034 |
+| Progressive disclosure interaction changes | Drawer, marginalia, and progressive disclosure stories | #1035 |
+
+## Required actions by issue
+
+| Issue | Contract action | Expected story scope |
+| --- | --- | --- |
+| #1037 | Produce initial game-session mapping and gaps | `05-pages/game-session`, `03-organisms/narrative`, `03-organisms/character/display`, `00-foundation` |
+| #1038 | Apply removals and update/deprecate mapped stories in same PR | Game-session pages + any story impacted by removed global classes |
+| #1032 | Update foundation/token stories before or with token migration | `00-foundation/*` + any surface relying on neutral/token changes |
+| #1033 | Update streaming/narrative stories with anchoring behavior changes | Narrative streaming stories + game-session narrative page coverage |
+| #1034 | Update game-session composition stories and resolve layout-linked temporary gaps | Game-session page stories, choices/narrative integration coverage |
+| #1035 | Update progressive disclosure story coverage behind flag-safe behavior | Drawer/marginalia/progressive disclosure stories |
+
+## Applied mapping snapshot for current game-session audit surfaces
+
+This applies the policy to known game-session surfaces from #1037.
+
+| Surface | Story file | Action (`keep`/`update`/`deprecate`) | Gap status | Owner issue | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `src/components/GameSession/ActiveGameSession.tsx` | `src/stories/05-pages/game-session/ActiveGameSession.stories.tsx` | `update` | `none` | #1034 | Page-level integration surface for layout migration. |
+| `src/components/GameSession/ActiveGameSessionNarrativeColumn.tsx` | `src/stories/05-pages/game-session/ActiveGameSession.stories.tsx` | `update` | `temporary-parent-coverage` | #1034 | Direct story absent; parent coverage accepted until composition migration lands. |
+| `src/components/GameSession/ActiveGameSessionChoicesColumn.tsx` | `src/stories/05-pages/game-session/ActiveGameSession.stories.tsx` | `update` | `temporary-parent-coverage` | #1034 | Direct story absent; parent coverage accepted until composition migration lands. |
+| `src/components/GameSession/CharacterSummary.tsx` | `src/stories/03-organisms/character/display/CharacterSummary.stories.tsx` | `update` | `none` | #1032/#1034 | Existing organism story should track token and layout changes. |
+| `src/components/GameSession/GameSessionSkeleton.tsx` | No dedicated story | `update` | `missing-direct-story` | #1038/#1034 | Close by adding dedicated skeleton story or explicit loading-state variant in page stories. |
+| `src/app/globals.css` (`.narrative-content*`, `.card`, `.btn`, `.btn-primary`) | Impacted game-session stories | `update` | `none` | #1038 | Story updates required in same PR as removals. |
+| Foundation token surfaces | `src/stories/00-foundation/DesignTokens.stories.tsx`, `src/stories/00-foundation/DesignSystemShowcase.stories.tsx` | `update` | `none` | #1032 | Required when gray->zinc token migration lands. |
+
+## Verification gate
+
+Run for migration PRs touching mapped surfaces:
+
+```bash
+npm run build-storybook
+```
+
+Expected:
+- Build succeeds.
+- No unresolved Storybook drift for touched surfaces.
+- Mapping table rows are updated in the same PR when story state changes.
+
+## References
+
+- [Epic #1020](https://github.com/jerseycheese/Narraitor/issues/1020)
+- [Issue #1045](https://github.com/jerseycheese/Narraitor/issues/1045)
+- [`migration-plan.md`](./migration-plan.md)
+- [`issue-1037-legacy-styling-audit.md`](./issue-1037-legacy-styling-audit.md)
+- [`issue-1046-non-game-session-legacy-styling-audit.md`](./issue-1046-non-game-session-legacy-styling-audit.md)

--- a/public_docs/design-system/redesign-planning/issue-1046-non-game-session-legacy-styling-audit.md
+++ b/public_docs/design-system/redesign-planning/issue-1046-non-game-session-legacy-styling-audit.md
@@ -3,6 +3,7 @@
 - Part of #1020
 - Implements #1046
 - Feeds #1047
+- Storybook contract: [issue-1045 storybook migration contract](./issue-1045-storybook-migration-contract.md)
 - Companion: [issue-1037 game-session audit](./issue-1037-legacy-styling-audit.md)
 - Last updated: 2026-02-08
 
@@ -311,6 +312,8 @@ Required one-off pattern classifications:
 | Non-game-session pages that link into play flow | No new flag | Existing feature flag infra from #1039 remains unchanged for game-session flags. | #1047/#1039 |
 
 ## Storybook mapping table (surface -> story -> keep/update/deprecate)
+
+Mapping and gap statuses follow the canonical contract in [`issue-1045-storybook-migration-contract.md`](./issue-1045-storybook-migration-contract.md).
 
 | Surface | Story file(s) | Story action | Story gap handling |
 | --- | --- | --- | --- |

--- a/public_docs/design-system/redesign-planning/migration-plan.md
+++ b/public_docs/design-system/redesign-planning/migration-plan.md
@@ -116,32 +116,7 @@ Storybook is part of the migration safety net, not optional documentation.
 - Storybook loads app globals via `.storybook/preview.js` importing `src/app/globals.css`, so token/global CSS changes are visible there immediately.
 - Storybook build is already a CI gate (`npm run build-storybook`), so migration PRs should treat story breakage as a blocking regression.
 - For each migrated surface, update or add corresponding stories in the same PR. This keeps design intent, implementation, and regression checks aligned.
-
-**Storybook contract per migration issue:**
-- #1037 / #1038: add a mapping of audited surfaces to story files (keep/update/deprecate)
-- #1046: add non-game-session mapping and route-shell gap callouts
-- #1032: update token/foundation stories first (`00-foundation`)
-- #1033: update narrative/streaming stories
-- #1034: update game-session page and organism stories
-- #1035: update progressive disclosure and drawer interaction stories
-- #1047: update non-game-session stories (navigation, wizards, journal, shared wrappers) in the same PRs as implementation changes
-
----
-
-## Storybook Role in Migration
-
-Storybook is part of the migration safety net, not optional documentation.
-
-- Storybook loads app globals via `.storybook/preview.js` importing `src/app/globals.css`, so token/global CSS changes are visible there immediately.
-- Storybook build is already a CI gate (`npm run build-storybook`), so migration PRs should treat story breakage as a blocking regression.
-- For each migrated surface, update or add corresponding stories in the same PR. This keeps design intent, implementation, and regression checks aligned.
-
-**Storybook contract per migration issue:**
-- #1037 / #1038: add a mapping of audited surfaces to story files (keep/update/deprecate)
-- #1032: update token/foundation stories first (`00-foundation`)
-- #1033: update narrative/streaming stories
-- #1034: update game-session page and organism stories
-- #1035: update progressive disclosure and drawer interaction stories
+- Use [`issue-1045-storybook-migration-contract.md`](./issue-1045-storybook-migration-contract.md) as the canonical migration contract for mapping format, gap policy, and per-issue Storybook obligations.
 
 ---
 
@@ -271,7 +246,7 @@ The current design-system.html has generic components (buttons, inputs, cards) a
 - Use [`issue-1037-legacy-styling-audit.md`](./issue-1037-legacy-styling-audit.md) as the source-of-truth for #1038 removal scope and Storybook follow-up actions
 - Track non-game-session audit coverage in [#1046](https://github.com/jerseycheese/Narraitor/issues/1046)
 - Use [`issue-1046-non-game-session-legacy-styling-audit.md`](./issue-1046-non-game-session-legacy-styling-audit.md) as the source-of-truth for #1047 migration scope and #1038 shared-global removal readiness
-- Include a Storybook mapping table (`surface -> story file -> keep/update/deprecate`) so #1038 removals do not leave stale stories behind
+- Use [`issue-1045-storybook-migration-contract.md`](./issue-1045-storybook-migration-contract.md) as the source-of-truth for Storybook mapping format, gap policy, and `npm run build-storybook` migration gating
 
 **Clean-Slate Cutover**
 - Remove or neutralize legacy game-session styling based on the audit


### PR DESCRIPTION
## Description
This addresses #1045 by turning the Storybook expectations into one explicit migration contract instead of leaving them spread across audit notes and duplicated plan sections. The main issue was process drift risk: migration work could look complete in code while Storybook coverage and gap handling stayed inconsistent.

The approach here is documentation-first and intentionally narrow. A canonical contract document now defines the required mapping format, the story-gap policy, issue-by-issue Storybook obligations for #1037/#1038/#1032/#1033/#1034/#1035, and the `npm run build-storybook` verification gate. Existing planning artifacts now reference that single contract so downstream migration issues have one source of truth.

## Related Issue
Relates to #1045  
Part of #1020

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [ ] Test coverage maintained or improved

Notes: Documentation-only change; no production logic added.

## User Stories Addressed
- Define a reusable Storybook migration contract used by migration issues.
- Define canonical mapping format: `surface -> story file -> keep/update/deprecate`.
- Define explicit story-gap handling and apply it to known game-session gaps.
- Require `npm run build-storybook` as a migration verification gate.
- Clarify foundation-vs-feature story update expectations by issue.

## Flow Diagrams
Not applicable for this documentation-only prep issue.

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

Notes: No component code changed. Storybook planning/coverage contract was updated and validated via build.

## Implementation Notes
- Added canonical contract doc: `public_docs/design-system/redesign-planning/issue-1045-storybook-migration-contract.md`.
- Updated `migration-plan.md` to reference that contract as the single Storybook source of truth and removed duplicate Storybook sections.
- Added explicit contract references to both audit artifacts:
  - `public_docs/design-system/redesign-planning/issue-1037-legacy-styling-audit.md`
  - `public_docs/design-system/redesign-planning/issue-1046-non-game-session-legacy-styling-audit.md`

## Screenshots
Not applicable (documentation-only changes).

## Code Review Summary (if applicable)
Not applicable.

## Chrome DevTools MCP Verification Summary (if applicable)
Not applicable.

## Quality Checks (if applicable)
- [x] Linting passed
- [ ] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
Stage 1: Review docs and verify there is now one canonical Storybook contract document.
- Open `public_docs/design-system/redesign-planning/issue-1045-storybook-migration-contract.md`
- Confirm it includes mapping format, gap policy, per-issue obligations, and build gate.

Stage 2: Verify plan and audit docs point to the canonical contract.
- Check `public_docs/design-system/redesign-planning/migration-plan.md`
- Check `public_docs/design-system/redesign-planning/issue-1037-legacy-styling-audit.md`
- Check `public_docs/design-system/redesign-planning/issue-1046-non-game-session-legacy-styling-audit.md`

Stage 3: Run verification commands.
- `npm run lint`
- `npm run build-storybook`

Observed locally:
- Both commands pass.
- Existing repository warnings remain (pre-existing lint warnings and Storybook bundle-size warnings).

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed
