### PR TITLE
Fix nav bleed-through in manuscript mode + game session token migration

### DIFF
--- a/docs/plans/2026-03-06-issue-1083-game-session-token-migration-design.md
+++ b/docs/plans/2026-03-06-issue-1083-game-session-token-migration-design.md
@@ -1,0 +1,67 @@
+# Issue 1083: Game Session Legacy Style Migration Design
+
+## Context
+
+The `globals.css` manuscript class system uses design tokens (`var(--color-*)`, `var(--space-*)`, `var(--radius-*)`, `var(--font-*)`, `var(--shadow-*)`) consistently. But 11 game session TSX components still use Tailwind utilities, creating two competing styling approaches in the same surface. This makes theme switching inconsistent and future layout work harder.
+
+This design covers eliminating Tailwind utility classes from all game session components and aligning them to the existing manuscript CSS class system. No visual changes -- styling consolidation only.
+
+## Scope
+
+11 production component files, plus `globals.css`. Story files are out of scope.
+
+### Files with Tailwind to migrate
+
+| File | Severity | Instance count |
+|---|---|---|
+| GameSessionSkeleton.tsx | Heavy | ~15 (entire component is Tailwind) |
+| ActiveGameSessionChoicesColumn.tsx | Mixed | ~10 (skeleton state + stray utilities) |
+| ChoiceHistorySection.tsx | Mixed | ~3 clusters |
+| EndingScreen.tsx | Moderate | 4 (prose plugin classes) |
+| ManuscriptCharactersRail.tsx | Minor | ~5 (avatar wrapper) |
+| EndingSuggestionBanner.tsx | Minor | 3 (button row) |
+| ManuscriptSessionShell.tsx | Minor | 3 (spacing + max-width) |
+| CharacterSnapshot.tsx | Trivial | 1 (single mb-2) |
+| ActiveGameSessionNarrativeColumn.tsx | Trivial | 1 (w-full) |
+| play/page.tsx | Minor | 2 (page wrapper) |
+| ActiveGameSession.tsx | Exception | 1 (sr-only -- kept as-is) |
+
+### Also in scope
+
+- New `--color-text-inverse` token replacing 10 hardcoded `rgb(255 255 255)` instances in globals.css
+- Documenting magic numbers in ManuscriptSessionShell.tsx syncPosition logic
+
+## Design Decisions
+
+**Slicing strategy:** Component-by-component, heaviest first. Each component gets its own commit for easy review.
+
+**GameSessionSkeleton:** Dedicated `manuscript-skeleton-*` CSS classes. The skeleton is a simplified approximation of the real UI, not a mirror of it. Coupling skeleton classes to active-state classes would mean changes to one could break the other.
+
+**EndingSuggestionBanner:** Keep the shadcn Alert component for its accessible semantics (role, structure). Add manuscript CSS on top via newly defined class rules.
+
+**ManuscriptSessionShell inline styles:** Document the magic numbers (`8px` gap, `3px` multiplier) with inline comments rather than tokenize them. These are geometric constants tied to ResizeObserver math, not themeable design decisions.
+
+**Hardcoded whites:** New `--color-text-inverse: rgb(255 255 255)` token. Alpha variants derived using relative color syntax: `rgb(from var(--color-text-inverse) r g b / 20%)`.
+
+**`sr-only` utility:** Intentional exception. This is a functional accessibility utility, not a themeable design decision.
+
+## Implementation Order
+
+1. GameSessionSkeleton.tsx -- new `manuscript-skeleton-*` classes in globals.css
+2. ActiveGameSessionChoicesColumn.tsx -- skeleton state classes + absorb stray utilities
+3. ChoiceHistorySection.tsx -- new empty state class + absorb button utilities
+4. EndingScreen.tsx -- `manuscript-ending-prose` class replacing Tailwind Typography plugin
+5. ManuscriptCharactersRail.tsx -- absorb avatar utilities into existing CSS
+6. EndingSuggestionBanner.tsx -- define CSS for dangling class + button row
+7. CharacterSnapshot.tsx -- absorb single `mb-2`
+8. ManuscriptSessionShell.tsx -- absorb spacing/width + document magic numbers
+9. Remaining small files (ActiveGameSessionNarrativeColumn, play/page.tsx)
+10. `--color-text-inverse` token + 10 replacements
+
+## Verification
+
+- Per-component visual check after each step (active play, loading, ending, mobile)
+- Theme switching consistency across all game session states
+- Full test suite pass (behavior unchanged)
+- Clean `npm run build` and `npm run lint`
+- Edge cases: rail positioning, skeleton-to-active transition, EndingSuggestionBanner rendering

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "lucide-react": "^0.548.0",
         "next": "^15.5.7",
         "react": "^19.2.3",
-        "react-dom": "^19.2.0",
+        "react-dom": "^19.2.3",
         "react-joyride": "^3.0.0-7",
         "tailwind-merge": "^3.4.1",
         "zustand": "^5.0.8"
@@ -17003,15 +17003,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
-      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.0"
+        "react": "^19.2.4"
       }
     },
     "node_modules/react-floater": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "lucide-react": "^0.548.0",
     "next": "^15.5.7",
     "react": "^19.2.3",
-    "react-dom": "^19.2.0",
+    "react-dom": "^19.2.3",
     "react-joyride": "^3.0.0-7",
     "tailwind-merge": "^3.4.1",
     "zustand": "^5.0.8"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2652,7 +2652,7 @@ body.manuscript-overlay-open {
   left: 0;
   right: 0;
   z-index: 40;
-  background: color-mix(in srgb, var(--color-surface) 95%, transparent);
+  background: rgb(from var(--color-surface) r g b / 95%);
   backdrop-filter: blur(12px);
   border-top: 1px solid var(--color-border);
   padding: var(--space-4);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -356,6 +356,31 @@ body.manuscript-overlay-open {
   z-index: 1;
   overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
+  padding-bottom: var(--space-4);
+}
+
+.manuscript-main-content-inner {
+  max-width: 48rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.manuscript-narrative-container {
+  width: 100%;
+}
+
+/* ─── Play Page ─── */
+
+.manuscript-play-page {
+  min-height: 100vh;
+  background: var(--color-surface);
+}
+
+.manuscript-play-page-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
 }
 
 .manuscript-main-stage {
@@ -476,6 +501,59 @@ body.manuscript-overlay-open {
   }
 }
 
+/* End story action responsive visibility */
+.manuscript-end-story-desktop {
+  display: none;
+}
+
+.manuscript-end-story-mobile {
+  display: inline-flex;
+}
+
+@media (width >= 1024px) {
+  .manuscript-end-story-desktop {
+    display: inline-flex;
+  }
+
+  .manuscript-end-story-mobile {
+    display: none;
+  }
+}
+
+/* Choices column skeleton state */
+.manuscript-choices-skeleton {
+  min-width: 0;
+}
+
+.manuscript-choices-skeleton-prompt {
+  height: 1.5rem;
+  width: 75%;
+  border-radius: var(--radius-sm);
+  margin-bottom: var(--space-4);
+}
+
+.manuscript-choices-skeleton-action {
+  height: 4.125rem;
+  border-radius: var(--radius-sm);
+}
+
+.manuscript-choices-skeleton-input-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+}
+
+.manuscript-choices-skeleton-input {
+  flex: 1;
+  border-radius: var(--radius-sm);
+}
+
+.manuscript-choices-skeleton-send {
+  width: 4rem;
+  border-radius: var(--radius-sm);
+}
+
 .manuscript-characters-rail {
   display: none;
   background: var(--color-overlay-surface);
@@ -542,14 +620,14 @@ body.manuscript-overlay-open {
 .manuscript-suggested-action[aria-pressed="true"] {
   background: var(--color-accent);
   border-color: var(--color-accent);
-  color: rgb(255 255 255);
+  color: var(--color-text-inverse);
 }
 
 .manuscript-suggested-action.is-selected:hover,
 .manuscript-suggested-action[aria-pressed="true"]:hover {
   background: var(--color-accent-hover);
   border-color: var(--color-accent-hover);
-  color: rgb(255 255 255);
+  color: var(--color-text-inverse);
 }
 
 .manuscript-suggested-action:active {
@@ -722,7 +800,7 @@ body.manuscript-overlay-open {
 .manuscript-tools-menu-item-active {
   background: var(--color-accent);
   border: none;
-  color: rgb(255 255 255);
+  color: var(--color-text-inverse);
 }
 
 .manuscript-tools-menu-item-active:hover {
@@ -782,7 +860,16 @@ body.manuscript-overlay-open {
 }
 
 .manuscript-character-avatar {
+  position: relative;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 9999px;
+  overflow: hidden;
   border: 1px solid var(--color-border);
+}
+
+.manuscript-character-avatar img {
+  object-fit: cover;
 }
 
 .manuscript-character-name {
@@ -900,6 +987,9 @@ body.manuscript-overlay-open {
   font-size: 0.875rem;
   line-height: 1.4;
   font-weight: 500;
+  margin-bottom: var(--space-1_5);
+  padding-left: var(--space-1);
+  padding-right: var(--space-1);
 }
 
 .manuscript-choice-prompt {
@@ -959,7 +1049,7 @@ body.manuscript-overlay-open {
   border-radius: var(--radius-sm);
   padding: var(--space-2) var(--space-4);
   background: var(--color-accent);
-  color: rgb(255 255 255);
+  color: var(--color-text-inverse);
   font-family: var(--font-interface), system-ui, sans-serif;
   font-size: 0.875rem;
   font-weight: 500;
@@ -1086,7 +1176,7 @@ body.manuscript-overlay-open {
 
 .manuscript-journal-snapshot-badge-new {
   background: var(--color-accent);
-  color: rgb(255 255 255);
+  color: var(--color-text-inverse);
   border-color: var(--color-accent);
 }
 
@@ -1245,7 +1335,7 @@ body.manuscript-overlay-open {
   padding: var(--space-2) var(--space-4);
   border: 1px solid transparent;
   background: var(--color-danger);
-  color: rgb(255 255 255);
+  color: var(--color-text-inverse);
   font-family: var(--font-system);
   font-size: 0.75rem;
   font-weight: 600;
@@ -1505,7 +1595,7 @@ body.manuscript-overlay-open {
 
 
 
-  background: rgb(255 255 255 / 20%);
+  background: rgb(from var(--color-text-inverse) r g b / 20%);
 
 
 
@@ -1513,7 +1603,7 @@ body.manuscript-overlay-open {
 
 
 
-  color: rgb(255 255 255);
+  color: var(--color-text-inverse);
 
 
 
@@ -1521,7 +1611,7 @@ body.manuscript-overlay-open {
 
 
 
-  border-color: rgb(255 255 255 / 30%);
+  border-color: rgb(from var(--color-text-inverse) r g b / 30%);
 
 
 
@@ -1546,7 +1636,7 @@ body.manuscript-overlay-open {
 
 
 .manuscript-suggested-action-selected {
-  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 20%);
+  box-shadow: inset 0 0 0 1px rgb(from var(--color-text-inverse) r g b / 20%);
 }
 
 .manuscript-secondary-controls {
@@ -2048,7 +2138,86 @@ body.manuscript-overlay-open {
   border: 1px dashed var(--color-border);
 }
 
+.manuscript-choice-history-empty {
+  font-family: var(--font-system);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+}
 
+.manuscript-choice-history-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.manuscript-choice-history-details-button {
+  font-family: var(--font-system);
+  font-size: 0.625rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  height: 1.25rem;
+  padding-left: var(--space-2);
+  padding-right: var(--space-2);
+  margin-left: auto;
+}
+
+/* ─── Ending Screen Prose ─── */
+
+.manuscript-ending-prose {
+  font-family: var(--font-narrative);
+  font-size: 1rem;
+  line-height: 1.75;
+  color: var(--color-text-primary);
+}
+
+.manuscript-ending-prose p {
+  margin-bottom: var(--space-4);
+}
+
+.manuscript-ending-prose p:last-child {
+  margin-bottom: 0;
+}
+
+.manuscript-ending-prose h1,
+.manuscript-ending-prose h2,
+.manuscript-ending-prose h3 {
+  font-family: var(--font-interface);
+  color: var(--color-text-primary);
+  margin-top: var(--space-6);
+  margin-bottom: var(--space-3);
+}
+
+.manuscript-ending-prose ul,
+.manuscript-ending-prose ol {
+  padding-left: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.manuscript-ending-prose li {
+  margin-bottom: var(--space-1);
+}
+
+.manuscript-ending-prose strong {
+  font-weight: 600;
+}
+
+.manuscript-ending-prose em {
+  font-style: italic;
+}
+
+/* ─── Ending Suggestion Banner ─── */
+
+.ending-suggestion-banner {
+  border-radius: var(--radius-sm);
+}
+
+.ending-suggestion-banner-actions {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
 
 .save-indicator {
   display: inline-flex;
@@ -2299,6 +2468,7 @@ body.manuscript-overlay-open {
   border-radius: var(--radius-sm);
   overflow: hidden;
   background: var(--color-surface-hover);
+  margin-bottom: var(--space-2);
 }
 
 .manuscript-character-snapshot-portrait .component-character-portrait {
@@ -2413,4 +2583,126 @@ body.manuscript-overlay-open {
   line-height: 1.5;
   color: var(--color-text-secondary);
   margin: 0;
+}
+
+/* ─── Game Session Skeleton ─── */
+
+@keyframes manuscript-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.manuscript-skeleton-pulse {
+  background: var(--color-surface-muted);
+  animation: manuscript-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+.manuscript-skeleton-viewport {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-surface);
+}
+
+.manuscript-skeleton-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  padding: var(--space-4);
+  display: flex;
+  justify-content: space-between;
+}
+
+.manuscript-skeleton-avatar {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+}
+
+.manuscript-skeleton-body {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: var(--space-4);
+  padding-top: 5rem;
+  padding-bottom: 10rem;
+}
+
+.manuscript-skeleton-content {
+  width: 100%;
+  max-width: 48rem;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+}
+
+.manuscript-skeleton-paragraph {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.manuscript-skeleton-footer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 40;
+  background: color-mix(in srgb, var(--color-surface) 95%, transparent);
+  backdrop-filter: blur(12px);
+  border-top: 1px solid var(--color-border);
+  padding: var(--space-4);
+}
+
+@media (width >= 768px) {
+  .manuscript-skeleton-body {
+    padding-left: var(--space-6);
+    padding-right: var(--space-6);
+  }
+
+  .manuscript-skeleton-footer {
+    padding: var(--space-6);
+  }
+}
+
+.manuscript-skeleton-footer-content {
+  max-width: 48rem;
+  margin-left: auto;
+  margin-right: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.manuscript-skeleton-prompt {
+  height: 1.5rem;
+  width: 33%;
+  border-radius: var(--radius-sm);
+}
+
+.manuscript-skeleton-choice-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-3);
+}
+
+@media (width >= 768px) {
+  .manuscript-skeleton-choice-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.manuscript-skeleton-choice {
+  height: 3rem;
+  border-radius: var(--radius-md);
+}
+
+.manuscript-skeleton-input {
+  height: 3.5rem;
+  width: 100%;
+  border-radius: var(--radius-sm);
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -546,11 +546,13 @@ body.manuscript-overlay-open {
 
 .manuscript-choices-skeleton-input {
   flex: 1;
+  height: 2.375rem;
   border-radius: var(--radius-sm);
 }
 
 .manuscript-choices-skeleton-send {
   width: 4rem;
+  height: 2.375rem;
   border-radius: var(--radius-sm);
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2593,7 +2593,7 @@ body.manuscript-overlay-open {
 }
 
 .manuscript-skeleton-pulse {
-  background: var(--color-surface-muted);
+  background: var(--color-surface-hover);
   animation: manuscript-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 

--- a/src/app/workshop.css
+++ b/src/app/workshop.css
@@ -5,6 +5,13 @@
   background: var(--color-canvas);
 }
 
+.app-surface-manuscript {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: var(--color-canvas);
+}
+
 .default-surface-main {
   flex: 1;
   min-height: 0;

--- a/src/app/worlds/[id]/play/page.tsx
+++ b/src/app/worlds/[id]/play/page.tsx
@@ -53,7 +53,7 @@ export default function PlayPage() {
   // For server rendering, show a simple placeholder
   if (!isClient) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
+      <div className="manuscript-play-page-loading">
         <p>Creating your game...</p>
       </div>
     );
@@ -65,7 +65,7 @@ export default function PlayPage() {
   }
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="manuscript-play-page">
       <GameSession 
         worldId={worldId} 
         disableAutoResume={disableAutoResume}

--- a/src/components/GameSession/ActiveGameSessionChoicesColumn.tsx
+++ b/src/components/GameSession/ActiveGameSessionChoicesColumn.tsx
@@ -72,7 +72,7 @@ const ActiveGameSessionChoicesColumn: React.FC<
   const resolvedInputActions = isProgressiveDisclosureEnabled ? (
     <>
       {inputActions}
-      <span className="hidden lg:inline-flex">{renderEndStoryAction()}</span>
+      <span className="manuscript-end-story-desktop">{renderEndStoryAction()}</span>
     </>
   ) : (
     inputActions
@@ -83,7 +83,7 @@ const ActiveGameSessionChoicesColumn: React.FC<
       <div className="player-choices-container" data-tutorial={dataTutorial}>
         {/* Context summary shown above suggested actions toggle on mobile, and above selector on desktop */}
         {isProgressiveDisclosureEnabled && currentDecision?.contextSummary && !hidePrompt && (
-          <p className="manuscript-context-summary mb-1.5 px-1">
+          <p className="manuscript-context-summary">
             {currentDecision.contextSummary}
           </p>
         )}
@@ -101,7 +101,7 @@ const ActiveGameSessionChoicesColumn: React.FC<
                 ? 'Hide Suggested Actions'
                 : 'Suggested Actions'}
             </button>
-            <span className="lg:hidden">{renderEndStoryAction()}</span>
+            <span className="manuscript-end-story-mobile">{renderEndStoryAction()}</span>
           </div>
         )}
 
@@ -128,23 +128,23 @@ const ActiveGameSessionChoicesColumn: React.FC<
           )
         ) : (
           !hideChoices && (
-            <div className="choice-selector manuscript-choice-selector animate-pulse">
+            <div className="choice-selector manuscript-choice-selector manuscript-choices-skeleton">
               <div className="manuscript-choice-selector-body">
                 {/* Choice prompt skeleton */}
-                {!hidePrompt && <div className="manuscript-choice-prompt bg-muted rounded h-6 w-3/4 mb-4" />}
+                {!hidePrompt && <div className="manuscript-choices-skeleton-prompt manuscript-skeleton-pulse" />}
 
                 {/* Choice buttons skeleton */}
                 <div className="manuscript-suggested-actions-grid">
                   {[1, 2, 3].map((i) => (
-                    <div key={i} className="manuscript-suggested-action bg-muted rounded h-[4.125rem]" />
+                    <div key={i} className="manuscript-choices-skeleton-action manuscript-skeleton-pulse" />
                   ))}
                 </div>
 
                 {/* Custom input skeleton */}
                 {!hideCustomInput && (
-                  <div className="manuscript-input-row mt-4">
-                    <div className="manuscript-custom-input bg-muted rounded flex-1" />
-                    <div className="manuscript-send-button bg-muted rounded w-16" />
+                  <div className="manuscript-choices-skeleton-input-row">
+                    <div className="manuscript-choices-skeleton-input manuscript-skeleton-pulse" />
+                    <div className="manuscript-choices-skeleton-send manuscript-skeleton-pulse" />
                   </div>
                 )}
               </div>

--- a/src/components/GameSession/ActiveGameSessionNarrativeColumn.tsx
+++ b/src/components/GameSession/ActiveGameSessionNarrativeColumn.tsx
@@ -45,7 +45,7 @@ const ActiveGameSessionNarrativeColumn: React.FC<
     <div
       id="narrative-container"
       data-tutorial="narrative-display"
-      className="w-full"
+      className="manuscript-narrative-container"
     >
       {/* Fade-out overlay at top when multiple segments */}
       {segmentCount > 1 && <div />}

--- a/src/components/GameSession/CharacterSnapshot.tsx
+++ b/src/components/GameSession/CharacterSnapshot.tsx
@@ -34,7 +34,7 @@ export const CharacterSnapshot: React.FC<CharacterSnapshotProps> = ({ character 
 
       <div className="manuscript-character-snapshot-identity">
         {character.portrait && (
-          <div className="manuscript-character-snapshot-portrait mb-2">
+          <div className="manuscript-character-snapshot-portrait">
             <CharacterPortrait
               portrait={character.portrait}
               characterName={character.name}

--- a/src/components/GameSession/ChoiceHistorySection.tsx
+++ b/src/components/GameSession/ChoiceHistorySection.tsx
@@ -73,12 +73,12 @@ const ChoiceHistoryContent: React.FC<ChoiceHistoryContentProps> = ({
       data-tutorial="choice-history-section"
     >
       {resolvedEntries.length === 0 ? (
-        <p className="font-system text-xs text-muted-foreground uppercase tracking-wider">
+        <p className="manuscript-choice-history-empty">
           No recorded choices yet. Your decisions will appear here once you
           start choosing.
         </p>
       ) : (
-        <div className="space-y-4">
+        <div className="manuscript-choice-history-list">
           {resolvedEntries.map((entry) => {
             const choiceText = getChoiceText(entry);
             const decisionPrompt = entry.decision.prompt.trim();
@@ -135,7 +135,7 @@ const ChoiceHistoryContent: React.FC<ChoiceHistoryContentProps> = ({
                     <Button
                       type="button"
                       variant="ghost"
-                      className="font-system text-[10px] uppercase tracking-wider h-5 px-2 ml-auto"
+                      className="manuscript-choice-history-details-button"
                       aria-expanded={isExpanded}
                       aria-controls={detailsId}
                       onClick={() => {

--- a/src/components/GameSession/EndingScreen.tsx
+++ b/src/components/GameSession/EndingScreen.tsx
@@ -378,7 +378,7 @@ export function EndingScreen() {
           {/* Epilogue */}
           <section>
             <SectionWrapper title="Epilogue">
-              <div className="prose prose-gray dark:prose-invert">
+              <div className="manuscript-ending-prose">
                 {currentEnding.epilogue}
               </div>
             </SectionWrapper>
@@ -388,7 +388,7 @@ export function EndingScreen() {
             {/* Character Legacy */}
             <section>
               <SectionWrapper title="Character Legacy">
-                <div className="prose prose-gray dark:prose-invert">
+                <div className="manuscript-ending-prose">
                   {currentEnding.characterLegacy}
                 </div>
               </SectionWrapper>
@@ -430,7 +430,7 @@ export function EndingScreen() {
           {/* World Impact */}
           <section>
             <SectionWrapper title="Impact on the World">
-              <div className="prose prose-gray dark:prose-invert">
+              <div className="manuscript-ending-prose">
                 {currentEnding.worldImpact}
               </div>
             </SectionWrapper>
@@ -441,7 +441,7 @@ export function EndingScreen() {
             <CollapsibleSection title="Your Story" initialCollapsed={true}>
               <div>
                 {fullStory ? (
-                  <div className="prose prose-gray dark:prose-invert">
+                  <div className="manuscript-ending-prose">
                     {fullStory.split(/\n{2,}/).map((paragraph, index) => (
                       <p key={`story-paragraph-${index}`}>{paragraph.trim()}</p>
                     ))}

--- a/src/components/GameSession/EndingSuggestionBanner.tsx
+++ b/src/components/GameSession/EndingSuggestionBanner.tsx
@@ -19,7 +19,7 @@ export function EndingSuggestionBanner({
         Your story could end here
       </AlertTitle>
       <AlertDescription>{reason}</AlertDescription>
-      <div className="flex gap-2 mt-2">
+      <div className="ending-suggestion-banner-actions">
         <Button size="sm" onClick={onAccept}>
           View Ending
         </Button>

--- a/src/components/GameSession/GameSessionSkeleton.tsx
+++ b/src/components/GameSession/GameSessionSkeleton.tsx
@@ -12,20 +12,20 @@ export const GameSessionSkeleton: React.FC<GameSessionSkeletonProps> = ({
   className = '',
 }) => {
   return (
-    <div 
-      data-testid="game-session-skeleton" 
-      className={cssClasses("relative min-h-screen flex flex-col bg-background", className)}
+    <div
+      data-testid="game-session-skeleton"
+      className={cssClasses("manuscript-skeleton-viewport", className)}
     >
       {/* Floating HUD Skeleton */}
-      <div className="fixed top-0 left-0 right-0 z-50 p-4 flex justify-between">
-        <div className="h-10 w-10 rounded-full bg-muted animate-pulse" />
-        <div className="h-10 w-10 rounded-full bg-muted animate-pulse" />
+      <div className="manuscript-skeleton-header">
+        <div className="manuscript-skeleton-avatar manuscript-skeleton-pulse" />
+        <div className="manuscript-skeleton-avatar manuscript-skeleton-pulse" />
       </div>
 
       {/* Main Narrative Stage Skeleton */}
-      <main className="flex-grow flex flex-col items-center px-4 pt-20 pb-40">
-        <div className="w-full max-w-3xl space-y-8">
-          <div className="space-y-4">
+      <main className="manuscript-skeleton-body">
+        <div className="manuscript-skeleton-content">
+          <div className="manuscript-skeleton-paragraph">
             <LoadingSkeleton
               skeletonLines={6}
               size="md"
@@ -33,7 +33,7 @@ export const GameSessionSkeleton: React.FC<GameSessionSkeletonProps> = ({
               centered={false}
             />
           </div>
-          <div className="space-y-4">
+          <div className="manuscript-skeleton-paragraph">
             <LoadingSkeleton
               skeletonLines={4}
               size="md"
@@ -45,15 +45,15 @@ export const GameSessionSkeleton: React.FC<GameSessionSkeletonProps> = ({
       </main>
 
       {/* Docked Action Rail Skeleton */}
-      <div className="fixed bottom-0 left-0 right-0 z-40 bg-background/95 backdrop-blur-md border-t border-border p-4 md:p-6">
-        <div className="max-w-3xl mx-auto space-y-4">
-          <div className="h-6 w-1/3 bg-muted animate-pulse rounded" />
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+      <div className="manuscript-skeleton-footer">
+        <div className="manuscript-skeleton-footer-content">
+          <div className="manuscript-skeleton-prompt manuscript-skeleton-pulse" />
+          <div className="manuscript-skeleton-choice-grid">
             {[1, 2].map((i) => (
-              <div key={i} className="h-12 bg-muted animate-pulse rounded-lg" />
+              <div key={i} className="manuscript-skeleton-choice manuscript-skeleton-pulse" />
             ))}
           </div>
-          <div className="h-14 w-full bg-muted animate-pulse rounded-md" />
+          <div className="manuscript-skeleton-input manuscript-skeleton-pulse" />
         </div>
       </div>
     </div>

--- a/src/components/GameSession/ManuscriptCharactersRail.tsx
+++ b/src/components/GameSession/ManuscriptCharactersRail.tsx
@@ -34,13 +34,12 @@ export const ManuscriptCharactersRail: React.FC<ManuscriptCharactersRailProps> =
       className="manuscript-character-badge"
     >
       {participant.avatarUrl && (
-        <div className="relative w-5 h-5 rounded-full overflow-hidden manuscript-character-avatar">
+        <div className="manuscript-character-avatar">
           <Image
             src={participant.avatarUrl}
             alt={`${participant.name}'s avatar`}
             fill
             sizes="20px"
-            className="object-cover"
           />
         </div>
       )}

--- a/src/components/GameSession/ManuscriptSessionShell.tsx
+++ b/src/components/GameSession/ManuscriptSessionShell.tsx
@@ -104,8 +104,14 @@ export const ManuscriptSessionShell: React.FC<ManuscriptSessionShellProps> = ({
         const headerRect = header.getBoundingClientRect();
         const actionRailRect = actionRailElement.getBoundingClientRect();
         const mainStageRect = mainStage.getBoundingClientRect();
+
+        // Visual breathing room between fixed-position panels.
+        // This is a layout geometry constant (not a design token) because it
+        // governs runtime overlap prevention, not themeable appearance.
         const gapPx = 8;
 
+        // Subtract 3x the gap to account for spacing above the character panel,
+        // between the character and tools panels, and below the tools panel.
         const availableSpace = actionRailRect.top - headerRect.bottom - (gapPx * 3);
         const halfSpace = Math.floor(availableSpace / 2);
         const panelTop = headerRect.bottom + gapPx;
@@ -198,7 +204,7 @@ export const ManuscriptSessionShell: React.FC<ManuscriptSessionShellProps> = ({
           </header>
 
           {/* Main Narrative Stage */}
-          <main className="manuscript-overlay-main pb-4">
+          <main className="manuscript-overlay-main">
             {mobileTopContent}
 
             <div className={cssClasses("manuscript-main-stage manuscript-main-stage-mobile-stack", !marginContent && "manuscript-no-rail")}>
@@ -213,7 +219,7 @@ export const ManuscriptSessionShell: React.FC<ManuscriptSessionShellProps> = ({
                 )}
 
                 <div className="manuscript-main-content">
-                  <div className="max-w-3xl mx-auto">
+                  <div className="manuscript-main-content-inner">
                     {children}
                   </div>
                 </div>

--- a/src/components/layout/AppSurfaceShell.tsx
+++ b/src/components/layout/AppSurfaceShell.tsx
@@ -37,7 +37,6 @@ export function AppSurfaceShell({ children }: AppSurfaceShellProps) {
   if (surfaceMode === 'manuscript') {
     return (
       <div className="app-surface app-surface-manuscript" data-surface-mode="manuscript">
-        <HeaderNavigation />
         <main id="main-content" tabIndex={-1}>
           {children}
         </main>

--- a/src/lib/theme/themes/ds1.css
+++ b/src/lib/theme/themes/ds1.css
@@ -19,6 +19,7 @@
   --color-text-primary: rgb(17 17 17);
   --color-text-secondary: rgb(63 63 70);
   --color-text-muted: rgb(113 113 122);
+  --color-text-inverse: rgb(255 255 255);
 
   /* Mechanical Accent - Archival Ink Blue */
   --color-accent: rgb(49 46 129);
@@ -146,6 +147,7 @@
   --color-text-primary: rgb(250 250 250);
   --color-text-secondary: rgb(212 212 216);
   --color-text-muted: rgb(113 113 122);
+  --color-text-inverse: rgb(255 255 255);
 
   --color-accent: rgb(129 140 248);
   --color-accent-hover: rgb(165 180 252);

--- a/src/lib/theme/themes/ds2.css
+++ b/src/lib/theme/themes/ds2.css
@@ -19,6 +19,7 @@
   --color-text-primary: rgb(45 37 32);
   --color-text-secondary: rgb(107 93 82);
   --color-text-muted: rgb(156 141 126);
+  --color-text-inverse: rgb(255 255 255);
 
   /* Sage Green accent */
   --color-accent: rgb(124 139 111);
@@ -145,6 +146,7 @@
   --color-text-primary: rgb(245 241 232);
   --color-text-secondary: rgb(212 201 186);
   --color-text-muted: rgb(156 141 126);
+  --color-text-inverse: rgb(255 255 255);
 
   --color-accent: rgb(156 170 138);
   --color-accent-hover: rgb(176 190 160);

--- a/src/lib/theme/themes/ds3.css
+++ b/src/lib/theme/themes/ds3.css
@@ -19,6 +19,7 @@
   --color-text-primary: rgb(42 35 28);
   --color-text-secondary: rgb(115 102 88);
   --color-text-muted: rgb(169 157 143);
+  --color-text-inverse: rgb(255 255 255);
 
   /* Steel Blue accent */
   --color-accent: rgb(91 122 140);
@@ -145,6 +146,7 @@
   --color-text-primary: rgb(237 232 224);
   --color-text-secondary: rgb(168 156 142);
   --color-text-muted: rgb(107 96 87);
+  --color-text-inverse: rgb(255 255 255);
 
   --color-accent: rgb(123 160 180);
   --color-accent-hover: rgb(141 177 195);


### PR DESCRIPTION
## Summary

- **Game session token migration**: Migrated all game session components to design token system, replacing hardcoded colors with `var(--token)` references, normalizing px to rem, and aligning to the 23-color design token palette
- **Nav bleed-through fix**: Removed `HeaderNavigation` from manuscript surface mode -- the workshop-style nav was rendering behind the manuscript overlay, causing unstyled links to bleed through during gameplay
- **Build fixes**: Aligned react-dom version with react, replaced `color-mix()` with relative color syntax for browser compatibility, added height to choices skeleton, used existing token for skeleton pulse background

Also opened #1089 for adapting game session layout per design system theme (structural adaptation beyond token swapping) and linked it in epic #1020.

## Test plan
- [ ] Navigate to a play route -- confirm no nav links bleeding through behind manuscript overlay
- [ ] Confirm manuscript HUD (Character, Tools, Saved, Reset, Close) still works
- [ ] Confirm non-manuscript routes (`/worlds`, `/characters`) still show HeaderNavigation
- [ ] `npx jest --testPathPattern="ManuscriptSession"` passes (6/6)
- [ ] `npx jest --testPathPattern="Navigation"` passes (3 suites, all green)