### PR TITLE
a11y: keyboard focus management and WCAG AA contrast audit (#1068)

### DIFF
--- a/src/components/GameSession/ActiveGameSession.tsx
+++ b/src/components/GameSession/ActiveGameSession.tsx
@@ -87,6 +87,9 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
   const [activeDrawer, setActiveDrawer] = React.useState<DrawerType | null>(null);
   const [lastOpenedDrawer, setLastOpenedDrawer] = React.useState<DrawerType | null>(null);
   const [isToolsMenuOpen, setIsToolsMenuOpen] = React.useState(false);
+
+  const characterButtonRef = React.useRef<HTMLButtonElement>(null);
+  const toolsButtonRef = React.useRef<HTMLButtonElement>(null);
   const [isStreamingPreview, setIsStreamingPreview] = React.useState(false);
   const [isEndingSuggestionPreview, setIsEndingSuggestionPreview] = React.useState(false);
 
@@ -170,10 +173,19 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
       if (event.key === 'Escape') {
         if (activeDrawer !== null) {
           setActiveDrawer(null);
+          toolsButtonRef.current?.focus();
           return;
         }
-        setIsCharacterSummaryExpanded(false);
-        setIsToolsMenuOpen(false);
+        if (isToolsMenuOpen) {
+          setIsToolsMenuOpen(false);
+          toolsButtonRef.current?.focus();
+          return;
+        }
+        if (isCharacterSummaryExpanded) {
+          setIsCharacterSummaryExpanded(false);
+          characterButtonRef.current?.focus();
+          return;
+        }
       }
     };
 
@@ -335,6 +347,8 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
     <ManuscriptSessionShell
       hud={
         <ManuscriptFloatingHud
+          characterButtonRef={characterButtonRef}
+          toolsButtonRef={toolsButtonRef}
           onToggleCharacterSummary={() => {
             setIsCharacterSummaryExpanded((prev) => {
               const next = !prev;
@@ -508,7 +522,12 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
       {isProgressiveDisclosureEnabled && (
         <ManuscriptDrawer
           open={activeDrawer !== null}
-          onOpenChange={(open) => !open && setActiveDrawer(null)}
+          onOpenChange={(open) => {
+            if (!open) {
+              setActiveDrawer(null);
+              toolsButtonRef.current?.focus();
+            }
+          }}
           title={
             activeDrawer === 'character'
               ? 'Character Sheet'

--- a/src/components/GameSession/ActiveGameSession.tsx
+++ b/src/components/GameSession/ActiveGameSession.tsx
@@ -90,6 +90,7 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
 
   const characterButtonRef = React.useRef<HTMLButtonElement>(null);
   const toolsButtonRef = React.useRef<HTMLButtonElement>(null);
+  const drawerTriggerRef = React.useRef<HTMLElement | null>(null);
   const [isStreamingPreview, setIsStreamingPreview] = React.useState(false);
   const [isEndingSuggestionPreview, setIsEndingSuggestionPreview] = React.useState(false);
 
@@ -173,7 +174,8 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
       if (event.key === 'Escape') {
         if (activeDrawer !== null) {
           setActiveDrawer(null);
-          toolsButtonRef.current?.focus();
+          drawerTriggerRef.current?.focus();
+          drawerTriggerRef.current = null;
           return;
         }
         if (isToolsMenuOpen) {
@@ -369,6 +371,7 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
             <ToolsMenuPanelContent
               activeDrawer={activeDrawer ?? lastOpenedDrawer}
               onOpenDrawer={(drawerType) => {
+                drawerTriggerRef.current = document.activeElement as HTMLElement;
                 setActiveDrawer(drawerType);
                 setLastOpenedDrawer(drawerType);
                 setIsCharacterSummaryExpanded(false);
@@ -401,6 +404,7 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
           drawerTriggers={isProgressiveDisclosureEnabled}
           characterName={character?.name}
           onOpenDrawer={(drawerType) => {
+            drawerTriggerRef.current = document.activeElement as HTMLElement;
             setActiveDrawer(drawerType as DrawerType);
             setLastOpenedDrawer(drawerType as DrawerType);
             setIsCharacterSummaryExpanded(false);
@@ -525,7 +529,8 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
           onOpenChange={(open) => {
             if (!open) {
               setActiveDrawer(null);
-              toolsButtonRef.current?.focus();
+              drawerTriggerRef.current?.focus();
+              drawerTriggerRef.current = null;
             }
           }}
           title={

--- a/src/components/GameSession/ManuscriptFloatingHud.tsx
+++ b/src/components/GameSession/ManuscriptFloatingHud.tsx
@@ -20,6 +20,8 @@ interface ManuscriptFloatingHudProps {
   onBack?: () => void;
   onEndStory?: () => void;
   saveIndicator?: React.ReactNode;
+  characterButtonRef?: React.RefObject<HTMLButtonElement | null>;
+  toolsButtonRef?: React.RefObject<HTMLButtonElement | null>;
 }
 
 export const ManuscriptFloatingHud: React.FC<ManuscriptFloatingHudProps> = (props) => {
@@ -40,12 +42,19 @@ function DS1ChromeBar({
   toolsMenuPanel,
   rightContent,
   drawerTriggers,
+  characterButtonRef,
+  toolsButtonRef,
 }: ManuscriptFloatingHudProps) {
+  const focusPanel = React.useCallback((node: HTMLDivElement | null) => {
+    node?.focus();
+  }, []);
+
   return (
     <>
       <div className="manuscript-overlay-header-left">
         <div className="manuscript-header-controls">
           <button
+            ref={characterButtonRef}
             type="button"
             onClick={onToggleCharacterSummary}
             aria-expanded={isCharacterSummaryExpanded}
@@ -56,6 +65,7 @@ function DS1ChromeBar({
 
           {drawerTriggers && (
             <button
+              ref={toolsButtonRef}
               type="button"
               onClick={onToggleToolsMenu}
               aria-label="Toggle Tools menu"
@@ -68,13 +78,13 @@ function DS1ChromeBar({
         </div>
 
         {isCharacterSummaryExpanded && characterSummaryPanel && (
-          <div className="manuscript-hud-panel manuscript-hud-panel-left manuscript-hud-character-panel">
+          <div ref={focusPanel} tabIndex={-1} className="manuscript-hud-panel manuscript-hud-panel-left manuscript-hud-character-panel">
             {characterSummaryPanel}
           </div>
         )}
 
         {isToolsMenuOpen && toolsMenuPanel && (
-          <div className="manuscript-hud-panel manuscript-hud-panel-left">
+          <div ref={focusPanel} tabIndex={-1} className="manuscript-hud-panel manuscript-hud-panel-left">
             {toolsMenuPanel}
           </div>
         )}
@@ -98,12 +108,19 @@ function DS2RunningHead({
   rightContent,
   drawerTriggers,
   characterName,
+  characterButtonRef,
+  toolsButtonRef,
 }: ManuscriptFloatingHudProps) {
+  const focusPanel = React.useCallback((node: HTMLDivElement | null) => {
+    node?.focus();
+  }, []);
+
   return (
     <>
       <div className="manuscript-overlay-header-left">
         <div className="manuscript-header-controls">
           <button
+            ref={characterButtonRef}
             type="button"
             onClick={onToggleCharacterSummary}
             aria-expanded={isCharacterSummaryExpanded}
@@ -114,6 +131,7 @@ function DS2RunningHead({
 
           {drawerTriggers && (
             <button
+              ref={toolsButtonRef}
               type="button"
               onClick={onToggleToolsMenu}
               aria-label="Toggle Tools menu"
@@ -126,13 +144,13 @@ function DS2RunningHead({
         </div>
 
         {isCharacterSummaryExpanded && characterSummaryPanel && (
-          <div className="manuscript-hud-panel manuscript-hud-panel-left manuscript-hud-character-panel">
+          <div ref={focusPanel} tabIndex={-1} className="manuscript-hud-panel manuscript-hud-panel-left manuscript-hud-character-panel">
             {characterSummaryPanel}
           </div>
         )}
 
         {isToolsMenuOpen && toolsMenuPanel && (
-          <div className="manuscript-hud-panel manuscript-hud-panel-left">
+          <div ref={focusPanel} tabIndex={-1} className="manuscript-hud-panel manuscript-hud-panel-left">
             {toolsMenuPanel}
           </div>
         )}
@@ -157,12 +175,18 @@ function DS3FloatingPill({
   onStartNew,
   onEndStory,
   saveIndicator,
+  characterButtonRef,
 }: ManuscriptFloatingHudProps) {
+  const focusPanel = React.useCallback((node: HTMLDivElement | null) => {
+    node?.focus();
+  }, []);
+
   return (
     <>
       <div className="manuscript-overlay-header-left">
         <div className="manuscript-header-controls">
           <button
+            ref={characterButtonRef}
             type="button"
             onClick={onToggleCharacterSummary}
             aria-expanded={isCharacterSummaryExpanded}
@@ -176,7 +200,7 @@ function DS3FloatingPill({
         </div>
 
         {isCharacterSummaryExpanded && characterSummaryPanel && (
-          <div className="manuscript-hud-panel manuscript-hud-panel-left manuscript-hud-character-panel">
+          <div ref={focusPanel} tabIndex={-1} className="manuscript-hud-panel manuscript-hud-panel-left manuscript-hud-character-panel">
             {characterSummaryPanel}
           </div>
         )}

--- a/src/components/GameSession/__tests__/ManuscriptFloatingHud.a11y.test.tsx
+++ b/src/components/GameSession/__tests__/ManuscriptFloatingHud.a11y.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ManuscriptFloatingHud } from '../ManuscriptFloatingHud';
+
+// Mock useTheme to control which DS variant renders
+const mockTheme = { theme: 'ds1', colorScheme: 'light', setTheme: jest.fn(), setColorScheme: jest.fn() };
+jest.mock('@/lib/theme/ThemeProvider', () => ({
+  useTheme: () => mockTheme,
+}));
+
+describe('ManuscriptFloatingHud accessibility', () => {
+  const baseProps = {
+    onToggleCharacterSummary: jest.fn(),
+    isCharacterSummaryExpanded: false,
+    onToggleToolsMenu: jest.fn(),
+    isToolsMenuOpen: false,
+    drawerTriggers: true,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTheme.theme = 'ds1';
+  });
+
+  it('attaches characterButtonRef to the character button', () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    render(
+      <ManuscriptFloatingHud {...baseProps} characterButtonRef={ref} />
+    );
+
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    expect(ref.current?.textContent).toContain('Character');
+  });
+
+  it('attaches toolsButtonRef to the tools button', () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    render(
+      <ManuscriptFloatingHud {...baseProps} toolsButtonRef={ref} />
+    );
+
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    expect(ref.current).toHaveAttribute('aria-label', 'Toggle Tools menu');
+  });
+
+  it('moves focus into character panel when it opens', () => {
+    const panelContent = <div>Character info</div>;
+    render(
+      <ManuscriptFloatingHud
+        {...baseProps}
+        isCharacterSummaryExpanded={true}
+        characterSummaryPanel={panelContent}
+      />
+    );
+
+    const panel = document.querySelector('.manuscript-hud-character-panel');
+    expect(panel).toHaveFocus();
+  });
+
+  it('moves focus into tools panel when it opens', () => {
+    const panelContent = <div>Tools menu</div>;
+    render(
+      <ManuscriptFloatingHud
+        {...baseProps}
+        isToolsMenuOpen={true}
+        toolsMenuPanel={panelContent}
+      />
+    );
+
+    const panel = document.querySelector('.manuscript-hud-panel:not(.manuscript-hud-character-panel)');
+    expect(panel).toHaveFocus();
+  });
+
+  it('character button has aria-expanded reflecting panel state', () => {
+    const { rerender } = render(
+      <ManuscriptFloatingHud {...baseProps} isCharacterSummaryExpanded={false} />
+    );
+
+    const button = screen.getByText('Character');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+
+    rerender(
+      <ManuscriptFloatingHud {...baseProps} isCharacterSummaryExpanded={true} />
+    );
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('tools button has aria-expanded reflecting menu state', () => {
+    const { rerender } = render(
+      <ManuscriptFloatingHud {...baseProps} isToolsMenuOpen={false} />
+    );
+
+    const button = screen.getByLabelText('Toggle Tools menu');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+
+    rerender(
+      <ManuscriptFloatingHud {...baseProps} isToolsMenuOpen={true} />
+    );
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  describe('DS2 variant', () => {
+    beforeEach(() => {
+      mockTheme.theme = 'ds2';
+    });
+
+    it('attaches characterButtonRef to the character link button', () => {
+      const ref = React.createRef<HTMLButtonElement>();
+      render(
+        <ManuscriptFloatingHud {...baseProps} characterButtonRef={ref} characterName="Elara" />
+      );
+
+      expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+      expect(ref.current?.textContent).toContain('Elara');
+    });
+  });
+
+  describe('DS3 variant', () => {
+    beforeEach(() => {
+      mockTheme.theme = 'ds3';
+    });
+
+    it('attaches characterButtonRef to the character pill button', () => {
+      const ref = React.createRef<HTMLButtonElement>();
+      render(
+        <ManuscriptFloatingHud {...baseProps} characterButtonRef={ref} characterName="Finn" />
+      );
+
+      expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+      expect(ref.current?.textContent).toContain('Finn');
+    });
+  });
+});

--- a/src/lib/theme/themes/ds1.css
+++ b/src/lib/theme/themes/ds1.css
@@ -158,7 +158,7 @@
   --color-border-strong: rgb(82 82 91);
   --color-text-primary: rgb(250 250 250);
   --color-text-secondary: rgb(212 212 216);
-  --color-text-muted: rgb(113 113 122);
+  --color-text-muted: rgb(129 129 138);
   --color-text-inverse: rgb(255 255 255);
 
   --color-accent: rgb(129 140 248);

--- a/src/lib/theme/themes/ds2.css
+++ b/src/lib/theme/themes/ds2.css
@@ -18,7 +18,7 @@
   --color-border-strong: rgb(212 201 186);
   --color-text-primary: rgb(45 37 32);
   --color-text-secondary: rgb(107 93 82);
-  --color-text-muted: rgb(156 141 126);
+  --color-text-muted: rgb(128 113 98);
   --color-text-inverse: rgb(255 255 255);
 
   /* Sage Green accent */

--- a/src/lib/theme/themes/ds3.css
+++ b/src/lib/theme/themes/ds3.css
@@ -18,7 +18,7 @@
   --color-border-strong: rgb(212 201 186);
   --color-text-primary: rgb(42 35 28);
   --color-text-secondary: rgb(115 102 88);
-  --color-text-muted: rgb(169 157 143);
+  --color-text-muted: rgb(125 113 99);
   --color-text-inverse: rgb(255 255 255);
 
   /* Steel Blue accent */
@@ -158,7 +158,7 @@
   --color-border-strong: rgb(61 53 45);
   --color-text-primary: rgb(237 232 224);
   --color-text-secondary: rgb(168 156 142);
-  --color-text-muted: rgb(107 96 87);
+  --color-text-muted: rgb(141 130 121);
   --color-text-inverse: rgb(255 255 255);
 
   --color-accent: rgb(123 160 180);

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -418,6 +418,9 @@ body.manuscript-overlay-open {
   top: 100%;
   margin-top: var(--space-2);
   left: 0;
+}
+
+.manuscript-hud-panel:focus:not(:focus-visible) {
   outline: none;
 }
 

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -233,6 +233,11 @@ body.manuscript-overlay-open {
   background: var(--color-surface-hover);
 }
 
+.manuscript-mobile-suggested-actions-toggle:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .hide-mobile-actions .manuscript-suggested-actions-section,
 .hide-mobile-actions .manuscript-choice-prompt,
 .hide-mobile-actions .manuscript-choice-selector-body > .manuscript-choice-prompt {
@@ -374,6 +379,11 @@ body.manuscript-overlay-open {
   color: var(--color-text-primary);
 }
 
+.manuscript-suggested-action:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .manuscript-suggested-action.is-selected,
 .manuscript-suggested-action[aria-pressed="true"] {
   background: var(--color-accent);
@@ -408,6 +418,7 @@ body.manuscript-overlay-open {
   top: 100%;
   margin-top: var(--space-2);
   left: 0;
+  outline: none;
 }
 
 /* Streaming lock styles */
@@ -693,6 +704,11 @@ body.manuscript-overlay-open {
   transform: scale(0.98);
 }
 
+.manuscript-warning-action-button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .manuscript-session-action-button {
   display: inline-flex;
   align-items: center;
@@ -764,7 +780,7 @@ body.manuscript-overlay-open {
   height: 2.375rem;
   padding: 0 var(--space-2);
   border-radius: var(--radius-sm);
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--color-text-muted);
   background: var(--color-surface);
   color: var(--color-text-primary);
   font-family: var(--font-interface), system-ui, sans-serif;
@@ -3146,6 +3162,11 @@ body.manuscript-overlay-open {
   color: var(--color-accent);
 }
 
+[data-theme="ds2"] .manuscript-hud-character-link:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 /* Action rail: dashed top border, transparent bg */
 [data-theme="ds2"] #manuscript-action-rail {
   background: transparent;
@@ -3244,7 +3265,7 @@ body.manuscript-overlay-open {
 /* Input: solid underline style, transparent bg */
 [data-theme="ds2"] .manuscript-custom-input {
   border: none;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-text-muted);
   border-radius: 0;
   background: transparent;
   font-family: var(--font-narrative);
@@ -3256,6 +3277,7 @@ body.manuscript-overlay-open {
 [data-theme="ds2"] .manuscript-custom-input:focus-visible {
   outline: none;
   border-bottom-color: var(--color-accent);
+  box-shadow: 0 2px 0 0 var(--color-accent);
 }
 
 [data-theme="ds2"] .manuscript-custom-input::placeholder {
@@ -3778,6 +3800,11 @@ body.manuscript-overlay-open {
   transition: all 120ms ease;
 }
 
+[data-theme="ds3"] .manuscript-hud-character-pill:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 [data-theme="ds3"] .manuscript-hud-character-pill:hover {
   background: var(--color-overlay-surface-strong);
   border-color: var(--color-accent);
@@ -3922,7 +3949,7 @@ body.manuscript-overlay-open {
 /* Input: transparent with warm border */
 [data-theme="ds3"] .manuscript-custom-input {
   background: transparent;
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--color-text-muted);
   border-radius: var(--radius-md);
   padding: var(--space-2_5) 0.875rem;
   height: auto;


### PR DESCRIPTION
## Summary

Addresses the accessibility non-negotiables from the design system epic (#1020): keyboard navigation and WCAG AA contrast across all three design systems in both light and dark modes.

- Fixed `--color-text-muted` contrast ratios in four theme/mode combos that failed 4.5:1 (DS1 dark 3.67:1, DS2 light 3.16:1, DS3 light 2.59:1, DS3 dark 2.83:1 -- all now 4.5+:1)
- Added `:focus-visible` outlines on choice buttons, End Story button, mobile toggle, DS2 character link, and DS3 character pill
- Wired up focus-return-on-Escape for character panel, tools menu, and drawers so keyboard users aren't stranded
- Panels auto-focus on open via callback ref with `tabIndex={-1}`
- Strengthened input field borders from `--color-border` to `--color-text-muted` for WCAG 1.4.11 non-text contrast (3:1)
- Fixed DS2 input focus indicator by adding `box-shadow` to make the underline change visible

## Closes

Closes #1068

## Test plan

- [x] 8 unit tests covering ref attachment, focus-on-open, and aria-expanded across DS1/DS2/DS3
- [x] All 87 GameSession tests pass
- [x] Build passes (Next.js + Storybook)
- [x] Browser-verified: focus ring on choice buttons via keyboard Tab
- [x] Browser-verified: focus moves into character panel on open, returns to trigger on Escape
- [x] Browser-verified: design tokens applied correctly in DS1/DS2/DS3 light and dark modes