### PR TITLE
fix: show save indicator on mobile viewports

### DIFF
--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -1981,11 +1981,33 @@ body.manuscript-overlay-open {
   }
 
   .manuscript-save-indicator .save-indicator-copy {
-    display: none;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .manuscript-save-indicator .save-indicator-button {
     display: none;
+  }
+
+  /* Override DS1 theme rule that sets display: block on .save-indicator-copy */
+  [data-theme="ds1"] .manuscript-save-indicator .save-indicator-copy {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+    display: block;
   }
 
   .manuscript-save-indicator .save-indicator-status::after {

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -1973,8 +1973,28 @@ body.manuscript-overlay-open {
 }
 
 @media (width < 640px) {
+  /* Mobile: show save indicator as a compact status dot across all themes */
   .manuscript-save-indicator {
+    border: none;
+    background: transparent;
+    padding: var(--space-1);
+  }
+
+  .manuscript-save-indicator .save-indicator-copy {
     display: none;
+  }
+
+  .manuscript-save-indicator .save-indicator-button {
+    display: none;
+  }
+
+  .manuscript-save-indicator .save-indicator-status::after {
+    content: '';
+    display: block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--color-success);
   }
 
   .manuscript-hud-reset-button {


### PR DESCRIPTION
## Summary

- Replace `display: none` on `.manuscript-save-indicator` at mobile breakpoints with a compact status-dot treatment
- All themes now show a 6px success-colored dot on mobile (`<640px`) instead of hiding the indicator entirely
- DS2/DS3 already use this dot pattern on desktop; this extends it uniformly to all themes on small screens
- Text, metadata, and manual-save button are hidden via CSS on mobile — the dot conveys status visually

## Test plan

- [x] SaveIndicator unit tests pass (7/7)
- [x] Next.js production build succeeds
- [ ] Verify at 375px viewport: dot is visible in the HUD area
- [ ] Verify desktop layout unchanged across DS1/DS2/DS3

Fixes #1067