### PR TITLE
docs: document theme switcher and design token system

### DIFF
--- a/public_docs/design-system/design-tokens.md
+++ b/public_docs/design-system/design-tokens.md
@@ -2,104 +2,171 @@
 title: "Design Token System"
 type: design-system
 category: tokens
-tags: [design-tokens, colors, architecture, theming]
+tags: [design-tokens, colors, architecture, theming, dark-mode]
 created: 2025-01-09
-updated: 2025-01-09
+updated: 2025-06-15
 ---
 
 # Design Token System
 
-Design tokens manage colors, spacing, and other properties across the app. When you need a color or spacing value, grab it from here instead of hardcoding.
+Design tokens manage colors, spacing, typography, and elevation across the app via CSS custom properties. Every visual value consumed by components comes from token variables scoped to the active design system and color scheme.
 
 ## Architecture Overview
 
-The token system uses a three-tier approach that keeps things organized and maintainable:
+The token system uses a three-tier hierarchy of CSS custom properties, defined per-theme in dedicated CSS files:
 
-**Primitive Tokens** → **Semantic Tokens** → **Component/Contextual Tokens**
+**Global Tokens** → **Semantic Tokens** → **Component Tokens**
 
-This hierarchy means you can change the entire visual feel of the app by adjusting primitive values, and everything else updates automatically.
+Each design system (DS1, DS2, DS3) defines all three tiers under a `[data-theme]` attribute selector, with separate blocks for light and dark mode. Changing the active theme swaps the entire token set at the root level — every component that consumes `var(--token-name)` updates automatically.
 
-### Primitive Tokens
+### Tier 1: Global Tokens
 
-These are the raw color values - the actual hex codes that define our palette. They live in `src/lib/design-tokens/tokens/primitives.ts` and represent the foundational colors we use throughout the app.
+These establish the design system's identity — fonts, surface colors, spacing, and border radii. They live in `src/lib/theme/themes/ds1.css`, `ds2.css`, and `ds3.css`.
 
-```typescript
-export const primitiveColors = {
-  white: '#ffffff',
-  black: '#000000',
-  zinc: {
-    50: '#fafafa',
-    100: '#f4f4f5',
-    200: '#e4e4e7',
-    300: '#d4d4d8',
-    400: '#a1a1aa',
-    500: '#71717a',
-    600: '#52525b',
-    700: '#3f3f46',
-    800: '#27272a',
-    900: '#18181b',
-    950: '#09090b',
-  },
-  blue: {
-    100: '#dbeafe',
-    300: '#93c5fd',
-    500: '#3b82f6',
-    700: '#1d4ed8',
-    900: '#1e3a8a',
-  },
-  // green, red, amber follow the same pattern
+```css
+/* From ds1.css — "The Drafting Table" */
+[data-theme="ds1"] {
+  /* Typography: semantic names map to specific font families */
+  --font-narrative: var(--font-lora);
+  --font-system: var(--font-ibm-plex-mono);
+  --font-interface: var(--font-ibm-plex-sans);
+
+  /* Surface colors */
+  --color-canvas: rgb(253 251 247);        /* Page background */
+  --color-surface: rgb(255 255 255);       /* Component backgrounds */
+  --color-surface-hover: rgb(244 244 245); /* Interactive hover state */
+
+  /* Border colors */
+  --color-border: rgb(228 228 231);        /* Default borders */
+  --color-border-strong: rgb(212 212 216); /* Emphasized borders */
+
+  /* Text colors */
+  --color-text-primary: rgb(17 17 17);     /* Main body text */
+  --color-text-secondary: rgb(63 63 70);   /* Secondary text */
+  --color-text-muted: rgb(113 113 122);    /* Disabled/hint text */
+  --color-text-inverse: rgb(255 255 255);  /* Text on dark surfaces */
+
+  /* Accent */
+  --color-accent: rgb(49 46 129);          /* Primary accent */
+  --color-accent-hover: rgb(30 27 75);     /* Accent hover state */
+  --color-accent-soft: rgb(49 46 129 / 8%);
+
+  /* Spacing scale (Tailwind-aligned) */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-4: 1rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+
+  /* Radius */
+  --radius: 0.5rem;
+  --radius-sm: 2px;
+  --radius-md: 4px;
+  --radius-full: 9999px;
 }
 ```
 
-The palette uses the full Zinc scale for neutrals to support subtle UI nuances, while other colors use a simplified scale (100, 300, 500, 700, 900) to keep decisions manageable.
+Each design system provides these same tokens with different values — DS2 uses warmer tones and softer radii, DS3 uses cooler tones and tighter radii.
 
-### Semantic Tokens
+### Tier 2: Semantic Tokens
 
-These map primitive colors to their intended purpose in the interface. Instead of using `blue-500` directly, you'd use `primary` which happens to be `blue-500`. This layer lets you change what "primary" means without touching every component.
+These map intent and context onto the global foundation. Status feedback, storytelling contexts, and elevation are all semantic tokens.
 
-```typescript
-export const semanticColors = {
-  primary: primitiveColors.blue[700],      // Main action color
-  secondary: primitiveColors.zinc[700],    // Secondary actions
-  success: primitiveColors.green[700],     // Positive feedback
-  warning: primitiveColors.amber[700],     // Caution states
-  danger: primitiveColors.red[700],        // Error states
-  info: primitiveColors.blue[500],         // Informational content
-  muted: primitiveColors.zinc[500],        // Subtle text
-  accent: primitiveColors.blue[300],       // Highlights
+```css
+[data-theme="ds1"] {
+  /* Status colors */
+  --color-warning: rgb(146 64 14);
+  --color-success: hsl(var(--success));
+  --color-info: hsl(var(--info));
+  --color-danger: rgb(185 28 28);
+
+  /* Story ending tones (HSL values) */
+  --ending-triumphant: 43 96% 56%;
+  --ending-bittersweet: 221.2 83.2% 53.1%;
+  --ending-mysterious: 240 5.9% 10%;
+  --ending-tragic: 0 84% 60%;
+  --ending-hopeful: 142.1 76.2% 45.3%;
+
+  /* Lore category tags (background / border / text triplets) */
+  --lore-characters-bg: 214 92% 91%;
+  --lore-characters-border: 213 84% 73%;
+  --lore-characters-text: 224 76% 25%;
+  --lore-locations-bg: 142 69% 83%;
+  --lore-locations-border: 34 84% 44%;
+  --lore-locations-text: 154 86% 27%;
+
+  /* Choice alignment colors */
+  --alignment-lawful-bg: 213 100% 96%;
+  --alignment-lawful-border: 221 91% 91%;
+  --alignment-lawful-text: 224 76% 48%;
+  --alignment-chaotic-bg: 33 100% 96%;
+  --alignment-chaotic-border: 32 98% 83%;
+  --alignment-chaotic-text: 20 91% 48%;
+
+  /* Elevation (shadows) */
+  --shadow-overlay: 0 6px 18px rgb(0 0 0 / 8%);
+  --shadow-drawer: -12px 0 18px rgb(0 0 0 / 8%);
 }
 ```
 
-### Component & Contextual Tokens
+### Tier 3: Component Tokens (shadcn/ui)
 
-The third layer handles specific use cases - like colors for different types of story endings or lore categories. These tokens understand the context they'll be used in.
+HSL-based tokens that integrate with the shadcn/ui component library. These are consumed by component classes like `bg-primary`, `text-muted-foreground`, etc.
 
-```typescript
-export const contextualColors = {
-  endings: {
-    triumphant: primitiveColors.green[700],
-    bittersweet: primitiveColors.amber[700],
-    mysterious: primitiveColors.blue[700],
-    tragic: primitiveColors.red[700],
-    hopeful: primitiveColors.blue[500],
-  },
-  lore: {
-    characters: primitiveColors.blue[700],
-    locations: primitiveColors.green[700], 
-    events: primitiveColors.amber[700],
-    rules: primitiveColors.red[700],
-  }
+```css
+[data-theme="ds1"] {
+  --background: 0 0% 100%;
+  --foreground: 240 5.9% 10%;
+  --primary: 221.2 83.2% 44.3%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 240 3.8% 26.1%;
+  --secondary-foreground: 0 0% 100%;
+  --muted: 240 4.8% 95.9%;
+  --muted-foreground: 240 3.8% 46.1%;
+  --accent: 240 4.8% 95.9%;
+  --accent-foreground: 240 5.9% 10%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 240 5.2% 90%;
+  --input: 240 5.2% 90%;
+  --ring: 221.2 83.2% 53.3%;
+  --radius: 0.5rem;
+
+  /* Extended status tokens with background/border/muted variants */
+  --success: 142 71% 45%;
+  --success-background: 142 69% 83%;
+  --success-border: 142 69% 83%;
+  --warning: 32 95% 44%;
+  --warning-background: 43 76% 83%;
+  --warning-border: 43 76% 83%;
+  --info: 217 91% 60%;
+  --info-background: 214 92% 91%;
+  --info-border: 214 92% 91%;
 }
 ```
 
 ## Using Design Tokens
 
+### In CSS (Preferred)
+
+Use `var()` to consume tokens. This is the primary pattern:
+
+```css
+.custom-card {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-primary);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-overlay);
+}
+```
+
 ### In Tailwind Classes
 
-The most common way you'll use tokens is through semantic Tailwind classes. Use design token classes instead of primitive colors:
+Semantic Tailwind classes consume the component-tier tokens automatically:
 
 ```tsx
-// ✅ Good - Uses semantic design tokens
+// Good — uses semantic design tokens
 const Button = ({ variant = 'primary' }) => {
   return (
     <button className="bg-primary text-primary-foreground px-4 py-2 rounded-md hover:bg-primary/90">
@@ -108,7 +175,7 @@ const Button = ({ variant = 'primary' }) => {
   )
 }
 
-// ❌ Avoid - Uses primitive colors directly  
+// Bad — hardcodes specific color values
 const BadButton = () => {
   return (
     <button className="bg-blue-700 text-white px-4 py-2 rounded-md hover:bg-blue-900">
@@ -117,7 +184,7 @@ const BadButton = () => {
   )
 }
 
-// ✅ Good - Uses semantic warning tokens
+// Good — uses semantic warning tokens
 const WarningAlert = () => {
   return (
     <div className="bg-warning-background border border-warning-border text-warning-foreground p-3 rounded-md">
@@ -127,125 +194,85 @@ const WarningAlert = () => {
 }
 ```
 
-### With CSS theme() Functions
+### Font Utility Classes
 
-For more complex styling or when you need to reference tokens in CSS, use the `theme()` function:
+Three semantic font slots are available as utility classes that resolve per-theme:
 
-```css
-.custom-component {
-  background-color: theme('colors.blue.500');
-  border: 1px solid theme('colors.zinc.300');
-  color: theme('colors.zinc.900');
-}
+```tsx
+// Narrative text (Lora in DS1, Crimson Pro in DS2, Newsreader in DS3)
+<p className="font-narrative">Story content goes here...</p>
+
+// System/code text (IBM Plex Mono in DS1, JetBrains Mono in DS2, Fira Code in DS3)
+<code className="font-system">const x = 42;</code>
+
+// Interface text (IBM Plex Sans in DS1, Manrope in DS2, DM Sans in DS3)
+<span className="font-interface">Button Label</span>
 ```
 
 ### Direct Import (Rare)
 
-Sometimes you need the actual color values in JavaScript - like for chart libraries or dynamic styling:
+For JavaScript contexts like chart libraries that need actual values, the legacy TypeScript tokens at `src/lib/design-tokens/` still exist. However, CSS custom properties are the canonical system — prefer reading computed styles when JS values are needed.
 
-```typescript
-import { primitiveColors, semanticColors } from '@/lib/design-tokens'
+## Theme-Specific Differences
 
-// For a chart library that needs hex values
-const chartColors = [
-  primitiveColors.blue[500],
-  primitiveColors.green[500], 
-  primitiveColors.amber[500],
-]
+Each design system has a distinct visual personality:
 
-// For dynamic theme switching
-const buttonColor = isActive ? semanticColors.primary : semanticColors.muted
+| Property | DS1 "Drafting Table" | DS2 "Warm Earth" | DS3 "Mechanical Manuscript" |
+|----------|---------------------|-------------------|---------------------------|
+| **Narrative Font** | Lora | Crimson Pro | Newsreader |
+| **System Font** | IBM Plex Mono | JetBrains Mono | Fira Code |
+| **Interface Font** | IBM Plex Sans | Manrope | DM Sans |
+| **Canvas** | `rgb(253 251 247)` | `rgb(250 248 243)` | `rgb(247 243 237)` |
+| **Accent** | Archival Ink Blue `rgb(49 46 129)` | Sage Green `rgb(124 139 111)` | Steel Blue `rgb(91 122 140)` |
+| **Radius** | `0.5rem` (square) | `0.75rem` (soft) | `0.375rem` (tight) |
+| **Background** | Mechanical grid (72x72px) | Clean solid | Dot grid (24x24px) |
+
+## Shadow Tokens
+
+Two shadow tokens handle different elevation contexts:
+
+**`--shadow-overlay`** — Centered shadow for modals, popovers, and floating elements:
+```css
+/* DS1 light */ --shadow-overlay: 0 6px 18px rgb(0 0 0 / 8%);
+/* DS1 dark  */ --shadow-overlay: 0 8px 24px rgb(0 0 0 / 40%);
 ```
 
-## Color Palette Breakdown
-
-### Core UI Colors (Genre-Neutral)
-
-**Blue Family**: Primary actions, informational content, and trustworthy interactions
-- `blue-100`: Light backgrounds and subtle highlights  
-- `blue-300`: Soft accents and secondary information
-- `blue-500`: Standard informational blue
-- `blue-700`: Primary action color (buttons, links)
-- `blue-900`: Deep blue for emphasis
-
-**Zinc Family**: Neutral elements, text, and subtle UI components
-- `zinc-100`: Light backgrounds, subtle sections
-- `zinc-300`: Borders, dividers, inactive states
-- `zinc-500`: Muted text, secondary information  
-- `zinc-700`: Primary text, active states
-- `zinc-900`: High contrast text, headings
-
-**Green Family**: Success states and positive feedback
-- `green-500`: Standard success messaging
-- `green-700`: Success actions and confirmation
-
-**Amber Family**: Warning states and caution indicators  
-- `amber-500`: Standard warning messaging
-- `amber-700`: Warning actions
-
-**Red Family**: Error states and destructive actions
-- `red-500`: Standard error messaging  
-- `red-700`: Destructive actions (delete, remove)
-
-### Contextual Colors
-
-**Story Endings**: Colors that match the emotional tone of different story conclusions
-- Triumphant endings use green (positive, victorious)
-- Bittersweet endings use amber (mixed emotions)
-- Mysterious endings use blue (unknown, intriguing)
-- Tragic endings use red (loss, sadness)
-- Hopeful endings use lighter blue (optimism, possibility)
-
-**Lore Categories**: Visual organization for different types of world-building content
-- Characters use blue (trustworthy, personal)
-- Locations use green (natural, grounding)
-- Events use amber (important, noteworthy)
-- Rules use red (important, systematic)
-
-## Integration with Tailwind
-
-The design tokens are enforced through the Tailwind configuration, which restricts the available colors to only our design token palette. This prevents accidentally using colors outside the system.
-
-```typescript
-// tailwind.config.ts
-colors: {
-  white: primitiveColors.white,
-  black: primitiveColors.black,  
-  zinc: primitiveColors.zinc,
-  blue: primitiveColors.blue,
-  green: primitiveColors.green,
-  red: primitiveColors.red,
-  amber: primitiveColors.amber,
-}
+**`--shadow-drawer`** — Directional shadow with negative x-offset for side panels and drawers:
+```css
+/* DS1 light */ --shadow-drawer: -12px 0 18px rgb(0 0 0 / 8%);
+/* DS1 dark  */ --shadow-drawer: -12px 0 24px rgb(0 0 0 / 40%);
 ```
 
-If you try to use a color like `purple-400` or `indigo-600`, Tailwind will ignore it since those colors aren't in our token system.
+The pattern: dark mode increases shadow opacity (8% → 40%) because shadows need more contrast against dark backgrounds to remain visible. The `-12px` x-offset on drawer shadows keeps the shadow on the leading edge of a left-anchored panel.
+
+## What Stays Hardcoded
+
+Some values are intentionally constant across all themes:
+
+- **Font sizes** — Typography scale doesn't change per theme; readability consistency matters more than thematic variation
+- **Blur values** — Backdrop blur amounts are perceptual constants
+- **Transforms** — Animation translations and scales are functional, not decorative
+- **Component heights** — Input heights, header heights, etc. maintain layout consistency across theme switches
+
+These values live in `globals.css` or component-level CSS, not in theme files.
 
 ## Storybook Documentation
 
-All design tokens are documented in Storybook with interactive color swatches. You can see the full palette, copy hex values, and understand the relationships between different token levels.
-
-Navigate to the "Foundation → Design Tokens" story to explore the complete system visually.
+All design tokens are documented in Storybook with interactive swatches. Navigate to "Foundation → Design Tokens" to explore the complete system visually.
 
 ## Accessibility & Contrast
 
-All color combinations in the token system meet WCAG accessibility standards:
+All color combinations meet WCAG accessibility standards:
 - Normal text: 4.5:1 contrast ratio minimum
-- Large text: 3:1 contrast ratio minimum  
-- Interactive elements maintain proper contrast in all states
-- Warning/alert colors provide sufficient contrast for accessibility compliance
-
-The zinc scale particularly ensures readable text across all backgrounds, while the color families provide sufficient contrast for their intended uses.
-
-### Accessibility Implementation Requirements
-
-When using design tokens for UI components, follow these accessibility patterns:
+- Large text: 3:1 contrast ratio minimum
+- Interactive elements maintain proper contrast in all states and themes
+- Dark mode tokens are specifically tuned for sufficient contrast on dark backgrounds
 
 ```tsx
-// ✅ Proper alert implementation with accessibility
+// Proper alert with accessibility attributes
 const AccessibleWarning = () => {
   return (
-    <div 
+    <div
       className="bg-warning-background border border-warning-border text-warning-foreground p-3 rounded-md"
       role="alert"
       aria-live="polite"
@@ -255,33 +282,40 @@ const AccessibleWarning = () => {
     </div>
   )
 }
-
-// ✅ Proper interactive element with ARIA
-const AccessibleButton = ({ isExpanded, onToggle, children }) => {
-  return (
-    <button
-      className="bg-primary text-primary-foreground px-3 py-1 rounded-md hover:bg-primary/90 focus:ring-2 focus:ring-ring"
-      aria-expanded={isExpanded}
-      onClick={onToggle}
-    >
-      {children}
-    </button>
-  )
-}
 ```
 
 Always pair design tokens with proper semantic markup and ARIA attributes for full accessibility compliance.
 
-## Dark Mode Ready
+## Dark Mode
 
-The token architecture supports theme switching - though dark mode isn't implemented yet, the foundation is there. When we add dark mode, we'll create alternate token values that map to the same semantic meanings.
+Dark mode is fully implemented. Each design system defines a complete set of dark-mode token overrides using the `.dark` class on `<html>`:
+
+```css
+/* Light mode tokens */
+[data-theme="ds1"] {
+  --color-canvas: rgb(253 251 247);
+  --color-text-primary: rgb(17 17 17);
+}
+
+/* Dark mode overrides */
+[data-theme="ds1"].dark {
+  --color-canvas: rgb(9 9 11);
+  --color-text-primary: rgb(250 250 250);
+}
+```
+
+Color scheme selection supports three modes:
+- **Light** — forces light tokens
+- **Dark** — forces dark tokens
+- **System** — follows `prefers-color-scheme` media query, updates in real time
+
+See [global-styles.md](./global-styles.md) for the `ThemeProvider` API and resolution chain.
 
 ## Future Considerations
 
 The three-tier system makes it straightforward to:
-- Add new color families (like purple for premium features)
-- Create seasonal or themed color variations
-- Implement user-customizable themes
-- Support brand-specific color schemes for different story worlds
+- Add new design systems (DS4+) by creating a new theme CSS file with the same token interface
+- Add new contextual token families for future game features
+- Support per-world theme overrides where story worlds customize token subsets
 
-The key principle is that components reference semantic or contextual tokens, never primitive values directly. This keeps the system flexible as visual requirements evolve.
+The key principle: components reference semantic or contextual tokens via `var()`, never raw color values. This keeps the system flexible as visual requirements evolve.

--- a/public_docs/design-system/global-styles.md
+++ b/public_docs/design-system/global-styles.md
@@ -2,44 +2,70 @@
 title: "Narraitor Global Styles"
 type: design-system
 category: styling
-tags: [global-styles, css, design-system, theming]
+tags: [global-styles, css, design-system, theming, dark-mode]
 created: 2025-05-17
-updated: 2025-06-08
+updated: 2025-06-15
 ---
 
 # Narraitor Global Styles
 
-The global styling system is designed to get us to MVP fast while laying groundwork for a proper design system later. Think of it as wireframes that actually work - clean, functional, and ready to be styled properly when we have more time.
+The global styling system provides a theme-aware foundation built on CSS custom properties and Tailwind CSS v4. Three design systems (DS1, DS2, DS3) with light and dark modes are fully supported — components consume tokens through `var()` and adapt automatically when the user switches themes.
 
 ## CSS Architecture
 
-Built on Tailwind CSS v4, the styles are organized to stay maintainable:
+The styling stack loads in this order:
 
-1. **CSS Variables**: The foundation colors, fonts, and spacing that everything builds on
-2. **Base Styles**: Sensible defaults for HTML elements so things look decent out of the box
-3. **Component Classes**: A few reusable classes for common patterns
-4. **Utility Classes**: Custom utilities that Tailwind doesn't provide
+1. **Theme CSS files** (`src/lib/theme/themes/ds1.css`, `ds2.css`, `ds3.css`) — define all CSS custom properties under `[data-theme]` selectors
+2. **Global styles** (`src/app/globals.css`) — base element resets and defaults that consume `var(--token)` values
+3. **Component CSS** — co-located styles for specific components
+4. **Tailwind utilities** — atomic utility classes for layout, spacing, and responsive design
 
 ## Design Token Integration
 
-This file works with the [design token system](./design-tokens.md) to provide consistent styling. Colors, spacing, and other design properties should use design tokens through Tailwind's theme() function or utility classes rather than hardcoded values.
+This file works with the [design token system](./design-tokens.md) to provide consistent styling. Colors, spacing, typography, and elevation values should always reference CSS custom properties rather than hardcoded values.
 
 ### Style Guidelines
 
 **The Golden Rule: No Inline Styles**
 
-We stick to Tailwind classes because inline styles are the enemy of maintainable code:
+We stick to Tailwind classes and CSS custom properties because inline styles bypass the theme system:
 
-- Always use Tailwind CSS utility classes for styling
-- Never use inline styles (style prop) in components
-- If Tailwind doesn't provide what you need, create a custom CSS class
-- This keeps everything consistent and easy to refactor later
+- Always use Tailwind utility classes or `var(--token)` references
+- Never use inline styles (`style` prop) in components
+- If Tailwind doesn't provide what you need, create a custom CSS class that consumes tokens
+
+### In Component CSS
+
+```css
+/* Good — consumes theme tokens */
+.custom-card {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-primary);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-overlay);
+}
+
+.custom-card:hover {
+  background-color: var(--color-surface-hover);
+  border-color: var(--color-border-strong);
+}
+```
 
 ### In Tailwind Classes
 
 ```tsx
-// Example of using Tailwind classes - PREFERRED approach
+// Good — uses semantic design tokens via Tailwind
 const CustomButton = ({ children }) => {
+  return (
+    <button className="bg-primary text-primary-foreground px-4 py-2 rounded-md hover:bg-primary/90">
+      {children}
+    </button>
+  );
+};
+
+// Bad — bypasses theme system with hardcoded colors
+const BadButton = ({ children }) => {
   return (
     <button className="bg-blue-600 px-4 py-2 rounded-md text-white hover:bg-blue-700">
       {children}
@@ -48,40 +74,132 @@ const CustomButton = ({ children }) => {
 };
 ```
 
-### In CSS/SCSS Files
+## Theme Resolution Chain
+
+The theme system resolves through four stages from CSS definition to rendered output:
+
+### 1. CSS Files Define Tokens
+
+Three theme CSS files (`ds1.css`, `ds2.css`, `ds3.css`) define the complete token set under attribute selectors. Each file has two blocks:
 
 ```css
-/* Example of using design tokens through theme() function */
-.customCard {
-  background-color: theme('colors.white');
-  border: 1px solid theme('colors.gray.200');
-  padding: theme('spacing.4');
-  border-radius: theme('borderRadius.lg');
-  box-shadow: theme('boxShadow.md');
-}
-
-.customCard:hover {
-  box-shadow: theme('boxShadow.lg');
-}
+[data-theme="ds1"]      { /* light mode tokens */ }
+[data-theme="ds1"].dark { /* dark mode overrides */ }
 ```
 
-### With Tailwind CSS
+These files are imported in `src/app/layout.tsx` so all tokens are available globally.
 
-Always use Tailwind classes for styling: no inline styles:
+### 2. FOUC Prevention Script
+
+An inline `<script>` in `layout.tsx` runs before React hydrates, reading stored preferences from `localStorage` and applying them immediately to avoid a flash of unstyled content:
+
+```javascript
+// Reads narraitor-theme → sets data-theme attribute
+// Reads narraitor-color-scheme → adds .dark class if needed
+// Runs synchronously before first paint
+```
+
+This script matches what `ThemeProvider` will set after hydration, preventing a visible theme flash.
+
+### 3. ThemeProvider Manages State
+
+After React hydrates, `ThemeProvider` takes over. It syncs React state from `localStorage`, applies DOM attributes, and listens for system preference changes.
+
+### 4. CSS Selectors Resolve
+
+The browser resolves `var(--token-name)` references based on the active selectors:
+- `[data-theme="ds2"]` → DS2 light tokens win
+- `[data-theme="ds2"].dark` → DS2 dark tokens override
+
+Components never need to know which theme is active — they just reference `var(--color-surface)` and the cascade handles the rest.
+
+## ThemeProvider and useTheme() API
+
+### ThemeProvider
+
+Wrap your app tree with `ThemeProvider` (already done in `layout.tsx`):
 
 ```tsx
-// Example using only Tailwind classes
-const InfoPanel = ({ title, children }) => {
+import { ThemeProvider } from '@/lib/theme';
+
+export default function RootLayout({ children }) {
   return (
-    <div className="p-4 mb-4 rounded-md bg-purple-600 text-white">
-      <h3 className="text-lg font-bold mb-2">{title}</h3>
-      <div>{children}</div>
-    </div>
+    <html lang="en" data-theme="ds1">
+      <body>
+        <ThemeProvider>{children}</ThemeProvider>
+      </body>
+    </html>
   );
-};
+}
 ```
 
-If you need to use CSS variables, create a custom CSS class instead of using inline styles.
+### useTheme() Hook
+
+Access theme state from any component:
+
+```tsx
+import { useTheme } from '@/lib/theme';
+
+function MyComponent() {
+  const { theme, colorScheme, resolvedColorScheme, setTheme, setColorScheme } = useTheme();
+
+  // theme: 'ds1' | 'ds2' | 'ds3'
+  // colorScheme: 'light' | 'dark' | 'system'
+  // resolvedColorScheme: 'light' | 'dark' (computed — resolves 'system' to actual)
+  // setTheme: (theme) => void
+  // setColorScheme: (scheme) => void
+}
+```
+
+Throws `Error('useTheme must be used within a ThemeProvider')` if called outside the provider.
+
+### Storage & Defaults
+
+| Key | localStorage Key | Default | Purpose |
+|-----|-----------------|---------|---------|
+| Theme | `narraitor-theme` | `'ds1'` | Which design system is active |
+| Color scheme | `narraitor-color-scheme` | `'light'` | Light, dark, or system preference |
+
+Server-side renders default to DS1 + light. The FOUC script and ThemeProvider sync the actual preference after the page loads, preventing hydration mismatches.
+
+### System Preference Detection
+
+When `colorScheme` is `'system'`, ThemeProvider listens to `window.matchMedia('(prefers-color-scheme: dark)')` and updates `resolvedColorScheme` in real time when the OS setting changes.
+
+## Adding Theme-Aware Styles to New Components
+
+When building a new component, follow these patterns:
+
+```css
+/* Good — uses token variables, works across all themes and modes */
+.my-component {
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  font-family: var(--font-interface);
+}
+
+/* Bad — hardcoded values that ignore the theme system */
+.my-component {
+  background: #ffffff;
+  color: #111111;
+  border: 1px solid #e4e4e7;
+  padding: 1rem;
+  border-radius: 4px;
+  font-family: 'Inter', sans-serif;
+}
+```
+
+For elevation, use the shadow tokens rather than custom shadow values:
+```css
+/* Modals, popovers, floating elements */
+.modal { box-shadow: var(--shadow-overlay); }
+
+/* Side panels, drawers */
+.drawer { box-shadow: var(--shadow-drawer); }
+```
 
 ## Semantic HTML
 
@@ -126,10 +244,7 @@ Essential utility classes for common needs:
 - `.visually-hidden`: Hide content visually but keep it accessible to screen readers
 - `.focus-visible`: Enhanced focus styling for accessibility
 
-Example usage:
-
 ```tsx
-// Example of using utility classes
 const AccessibleComponent = () => {
   return (
     <div>
@@ -141,16 +256,6 @@ const AccessibleComponent = () => {
 };
 ```
 
-## Future Theming
-
-The CSS variables are set up so we can add proper theming later without rewriting everything:
-
-1. Create theme CSS files with custom variable values
-2. Apply theme classes to the root element
-3. Define theme variable values within the appropriate selectors
-
-When we're ready for dark mode or custom themes, the foundation is already there.
-
 ## Testing and Development
 
-The global styles can be viewed and tested through the `GlobalStylesDemo` component in Storybook, which demonstrates all styled elements.
+The global styles can be viewed and tested through the `GlobalStylesDemo` component in Storybook, which demonstrates all styled elements across all theme and color scheme combinations.

--- a/public_docs/development/ui-ux-guidelines.md
+++ b/public_docs/development/ui-ux-guidelines.md
@@ -3,7 +3,7 @@ title: UI/UX Guidelines
 aliases: [User Interface Guidelines, Design Guidelines]
 tags: [narraitor, design, ui, ux, guidelines]
 created: 2025-04-29
-updated: 2025-04-29
+updated: 2025-06-15
 ---
 
 # UI/UX Guidelines
@@ -20,27 +20,40 @@ UI approach: create immersive experiences that adapt to different fictional worl
 
 **Intuitive Flow** - Users should understand what to do next without reading documentation. Good design guides behavior through visual hierarchy and familiar patterns.
 
-## World Theming
+## Design Systems
 
-### Theme Components
-Each world theme includes:
-- Primary and secondary colors
-- Typography settings (font family, sizes, weights)
-- Background textures or colors
-- UI element styling (buttons, cards, inputs)
-- Specialized iconography
+Three design systems ship with the app, each providing a complete set of CSS custom properties for light and dark mode. Users switch between them via the theme picker in the navigation bar.
+
+### DS1 — "The Drafting Table"
+Sharp lines, archival ink, graph paper grid. Technical and precise.
+- **Fonts**: Lora (narrative), IBM Plex Mono (system), IBM Plex Sans (interface)
+- **Accent**: Archival Ink Blue `rgb(49 46 129)`
+- **Radius**: `0.5rem` — square and deliberate
+- **Background**: Mechanical drafting grid (72x72px)
+
+### DS2 — "Warm Earth"
+Organic earth tones, soft forms, breathing space. Welcoming and grounded.
+- **Fonts**: Crimson Pro (narrative), JetBrains Mono (system), Manrope (interface)
+- **Accent**: Sage Green `rgb(124 139 111)`
+- **Radius**: `0.75rem` — soft and rounded
+- **Background**: Clean solid (no pattern)
+
+### DS3 — "Mechanical Manuscript"
+Aged paper, drafting ink, dot grid aesthetic. Textured and literary.
+- **Fonts**: Newsreader (narrative), Fira Code (system), DM Sans (interface)
+- **Accent**: Steel Blue `rgb(91 122 140)`
+- **Radius**: `0.375rem` — tight and compact
+- **Background**: Dot grid (24x24px)
 
 ### Theme Implementation
-- Theme context provides current theme settings
-- Theme-aware components adapt styling based on context
-- Tailwind CSS classes dynamically applied
-- CSS variables for theme-specific values
+- `ThemeProvider` React context manages the active design system and color scheme
+- `data-theme` attribute on `<html>` selects which CSS token set is active
+- `.dark` class on `<html>` toggles dark mode overrides
+- Components consume tokens via `var(--token-name)` — no theme-specific logic in components
+- FOUC prevention script applies stored preferences before React hydrates
+- Preferences persist in `localStorage` (`narraitor-theme`, `narraitor-color-scheme`)
 
-### Default Themes
-The application includes these template themes:
-1. **Western**: Rustic with serif fonts, earthy colors, and aged paper textures
-2. **Sitcom**: Modern with clean sans-serif, bright colors, and minimal styling
-3. **Adventure**: Fantasy with decorative fonts, rich colors, and ornate styling
+See [design-tokens.md](../design-system/design-tokens.md) for the full token reference and [global-styles.md](../design-system/global-styles.md) for the `useTheme()` API.
 
 ## Component Design
 
@@ -148,12 +161,12 @@ Use React DevTools Profiler to catch re-render issues.
 4. Verify responsive behavior
 5. Integrate into application
 
-### Theme System
-1. Define theme interface and default themes
-2. Create theme context provider
-3. Implement theme-aware component styling
-4. Add theme switching capability
-5. Persist theme preferences
+### Theme-Aware Development
+1. Add new tokens to all 3 theme CSS files (`ds1.css`, `ds2.css`, `ds3.css`) — both light and dark blocks
+2. Consume tokens in component CSS via `var(--token-name)`
+3. Use semantic Tailwind classes (`bg-primary`, `text-muted-foreground`) for shadcn/ui-integrated components
+4. Test across all 6 combinations (3 design systems x 2 color schemes)
+5. Verify WCAG contrast in both light and dark mode
 
 ## Consistent Design Patterns
 


### PR DESCRIPTION
## Summary

- Updates `design-tokens.md` to document the CSS custom property architecture replacing old TS-based token references, adds shadow token docs, theme-specific differences table, what-stays-hardcoded section, and dark mode
- Updates `global-styles.md` to document the theme resolution chain (CSS files → FOUC script → ThemeProvider → CSS selectors), full `ThemeProvider`/`useTheme()` API reference, and practical theme-aware component guide
- Updates `ui-ux-guidelines.md` to replace Western/Sitcom/Adventure placeholder themes with real DS1/DS2/DS3 details and reflect actual implementation steps

## What changed and why

Three developer-facing docs were left behind when the theme switcher shipped in #1078–#1080. They still said "dark mode isn't implemented yet" and referenced old TypeScript token files (`src/lib/design-tokens/tokens/primitives.ts`) as the canonical system.

All three docs now reflect what's actually in the codebase: CSS custom properties scoped to `[data-theme]` + `.dark` selectors, the `ThemeProvider` context, `useTheme()` hook API, FOUC prevention pattern, and the DS1/DS2/DS3 design system specifics.

## Test plan

- [x] Grepped all three updated files — zero "isn't implemented", "not implemented yet", "when we add dark mode", or "future theming" language remains
- [x] All 49 CSS token names referenced in docs verified to exist in `ds1.css`
- [x] bdg screenshot verification across all 6 theme/mode combinations (DS1/DS2/DS3 × light/dark) — tokens render correctly
- [x] Verified `data-theme` attribute, `.dark` class, and computed `--shadow-overlay`/`--shadow-drawer` values via DOM inspection
- [x] Next.js production build passes clean

Closes #1082

🤖 Generated with [Claude Code](https://claude.com/claude-code)