### PR TITLE
feat(storybook): expand game session story coverage (#1102)

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -123,8 +123,6 @@ const preview: Preview = {
       default: 'theme',
       values: [
         { name: 'theme', value: 'transparent' },
-        { name: 'light', value: '#ffffff' },
-        { name: 'dark', value: '#1a1a1a' },
       ],
     },
     nextjs: {

--- a/src/stories/03-organisms/game-session/ActiveGameSessionChoicesColumn.stories.tsx
+++ b/src/stories/03-organisms/game-session/ActiveGameSessionChoicesColumn.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import ActiveGameSessionChoicesColumn from '@/components/GameSession/ActiveGameSessionChoicesColumn';
+import { mockDecision } from './gameSessionStoryData';
+
+const meta = {
+  title: '03-Organisms/Game Session/ActiveGameSessionChoicesColumn',
+  component: ActiveGameSessionChoicesColumn,
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    onChoiceSelected: fn(),
+    onCustomSubmit: fn(),
+  },
+} satisfies Meta<typeof ActiveGameSessionChoicesColumn>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithChoices: Story = {
+  args: {
+    currentDecision: mockDecision,
+    segmentCount: 5,
+    status: 'active',
+    isGenerating: false,
+    isGeneratingChoices: false,
+    isSessionEnded: false,
+    worldSkills: [],
+    characterSkills: [],
+    inventoryItems: [],
+  },
+};
+
+export const GeneratingChoices: Story = {
+  args: {
+    currentDecision: null,
+    isGenerating: true,
+    isGeneratingChoices: true,
+    segmentCount: 5,
+    status: 'active',
+    isSessionEnded: false,
+    worldSkills: [],
+    characterSkills: [],
+    inventoryItems: [],
+  },
+};
+
+export const Skeleton: Story = {
+  args: {
+    currentDecision: null,
+    segmentCount: 0,
+    status: 'active',
+    isGenerating: false,
+    isGeneratingChoices: false,
+    isSessionEnded: false,
+    worldSkills: [],
+    characterSkills: [],
+    inventoryItems: [],
+  },
+};
+
+export const WithEndingSuggestion: Story = {
+  args: {
+    currentDecision: mockDecision,
+    segmentCount: 5,
+    status: 'active',
+    isGenerating: false,
+    isGeneratingChoices: false,
+    isSessionEnded: false,
+    worldSkills: [],
+    characterSkills: [],
+    inventoryItems: [],
+    endingSuggestion: {
+      reason: 'Your story has reached a natural conclusion point.',
+      onAccept: fn(),
+      onDismiss: fn(),
+    },
+  },
+};

--- a/src/stories/03-organisms/game-session/ActiveGameSessionControls.stories.tsx
+++ b/src/stories/03-organisms/game-session/ActiveGameSessionControls.stories.tsx
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    character: mockCharacter as any,
+    character: mockCharacter,
     characterId: STORY_CHARACTER_ID,
     worldId: STORY_WORLD_ID,
     sessionId: STORY_SESSION_ID,
@@ -36,7 +36,7 @@ export const Default: Story = {
 
 export const WithEndConfirmation: Story = {
   args: {
-    character: mockCharacter as any,
+    character: mockCharacter,
     characterId: STORY_CHARACTER_ID,
     worldId: STORY_WORLD_ID,
     sessionId: STORY_SESSION_ID,
@@ -46,7 +46,7 @@ export const WithEndConfirmation: Story = {
 
 export const ProgressiveDisclosureHidden: Story = {
   args: {
-    character: mockCharacter as any,
+    character: mockCharacter,
     characterId: STORY_CHARACTER_ID,
     worldId: STORY_WORLD_ID,
     sessionId: STORY_SESSION_ID,

--- a/src/stories/03-organisms/game-session/ActiveGameSessionControls.stories.tsx
+++ b/src/stories/03-organisms/game-session/ActiveGameSessionControls.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import ActiveGameSessionControls from '@/components/GameSession/ActiveGameSessionControls';
+import {
+  mockCharacter,
+  STORY_WORLD_ID,
+  STORY_SESSION_ID,
+  STORY_CHARACTER_ID,
+} from './gameSessionStoryData';
+
+const meta = {
+  title: '03-Organisms/Game Session/ActiveGameSessionControls',
+  component: ActiveGameSessionControls,
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    onConfirmEndStory: fn(),
+    onCloseEndStory: fn(),
+    onOpenJournal: fn(),
+  },
+} satisfies Meta<typeof ActiveGameSessionControls>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    character: mockCharacter as any,
+    characterId: STORY_CHARACTER_ID,
+    worldId: STORY_WORLD_ID,
+    sessionId: STORY_SESSION_ID,
+    showEndConfirmation: false,
+  },
+};
+
+export const WithEndConfirmation: Story = {
+  args: {
+    character: mockCharacter as any,
+    characterId: STORY_CHARACTER_ID,
+    worldId: STORY_WORLD_ID,
+    sessionId: STORY_SESSION_ID,
+    showEndConfirmation: true,
+  },
+};
+
+export const ProgressiveDisclosureHidden: Story = {
+  args: {
+    character: mockCharacter as any,
+    characterId: STORY_CHARACTER_ID,
+    worldId: STORY_WORLD_ID,
+    sessionId: STORY_SESSION_ID,
+    showEndConfirmation: false,
+    isProgressiveDisclosureEnabled: true,
+  },
+};

--- a/src/stories/03-organisms/game-session/CharacterSnapshot.stories.tsx
+++ b/src/stories/03-organisms/game-session/CharacterSnapshot.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { CharacterSnapshot } from '@/components/GameSession/CharacterSnapshot';
+import { mockCharacter, WithMockWorldStore } from './gameSessionStoryData';
+
+const meta = {
+  title: '03-Organisms/Game Session/CharacterSnapshot',
+  component: CharacterSnapshot,
+  parameters: {
+    layout: 'padded',
+  },
+  decorators: [WithMockWorldStore],
+} satisfies Meta<typeof CharacterSnapshot>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    character: mockCharacter as never,
+  },
+};
+
+export const NoSkills: Story = {
+  args: {
+    character: {
+      ...mockCharacter,
+      skills: [],
+    } as never,
+  },
+};

--- a/src/stories/03-organisms/game-session/CharacterSummary.stories.tsx
+++ b/src/stories/03-organisms/game-session/CharacterSummary.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import CharacterSummary from '@/components/GameSession/CharacterSummary';
+import { mockCharacter, WithMockWorldStore } from './gameSessionStoryData';
+
+const meta = {
+  title: '03-Organisms/Game Session/CharacterSummary',
+  component: CharacterSummary,
+  parameters: {
+    layout: 'padded',
+  },
+  decorators: [WithMockWorldStore],
+} satisfies Meta<typeof CharacterSummary>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    character: mockCharacter as never,
+  },
+};
+
+export const Expanded: Story = {
+  args: {
+    character: mockCharacter as never,
+    initialExpanded: true,
+  },
+};
+
+export const DrawerVariant: Story = {
+  args: {
+    character: mockCharacter as never,
+    variant: 'drawer',
+  },
+};
+
+export const WithAllDetails: Story = {
+  args: {
+    character: {
+      ...mockCharacter,
+      derivedStats: [
+        { id: 'ds-hp', name: 'Hit Points', currentValue: 38, maxValue: 45 },
+        { id: 'ds-mp', name: 'Mana', currentValue: 22, maxValue: 30 },
+      ],
+      status: {
+        health: 38,
+        maxHealth: 45,
+        conditions: ['Arcane Focus', 'Fatigued'],
+        location: 'Thornhaven Docks',
+      },
+    } as never,
+    variant: 'drawer',
+  },
+};

--- a/src/stories/03-organisms/game-session/EndingScreen.stories.tsx
+++ b/src/stories/03-organisms/game-session/EndingScreen.stories.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { EndingScreen } from '@/components/GameSession/EndingScreen';
+import { useNarrativeStore } from '@/state/narrativeStore';
+import {
+  withEndingScreenStores,
+  mockStoryEndingTriumphant,
+  mockStoryEndingTragic,
+} from './gameSessionStoryData';
+
+const meta = {
+  title: '03-Organisms/Game Session/EndingScreen',
+  component: EndingScreen,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof EndingScreen>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Triumphant: Story = {
+  decorators: [withEndingScreenStores(mockStoryEndingTriumphant)],
+};
+
+export const Tragic: Story = {
+  decorators: [withEndingScreenStores(mockStoryEndingTragic)],
+};
+
+export const Bittersweet: Story = {
+  decorators: [
+    withEndingScreenStores({
+      ...mockStoryEndingTriumphant,
+      id: 'ending-bittersweet',
+      tone: 'mysterious',
+      epilogue:
+        'The truth, when it finally came, was smaller than expected. Not a revelation but a quiet acknowledgement that some questions were never meant to be answered.',
+      achievements: [],
+    }),
+  ],
+};
+
+export const Loading: Story = {
+  decorators: [
+    (Story: React.FC) => {
+      React.useEffect(() => {
+        useNarrativeStore.setState({ isGeneratingEnding: true, currentEnding: null });
+        return () => {
+          useNarrativeStore.setState({ isGeneratingEnding: false });
+        };
+      }, []);
+      return React.createElement(Story);
+    },
+  ],
+};

--- a/src/stories/03-organisms/game-session/EndingSuggestionBanner.stories.tsx
+++ b/src/stories/03-organisms/game-session/EndingSuggestionBanner.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { EndingSuggestionBanner } from './EndingSuggestionBanner';
+import { EndingSuggestionBanner } from '@/components/GameSession/EndingSuggestionBanner';
 import { fn } from '@storybook/test';
 
 const meta = {
-  title: 'GameSession/EndingSuggestionBanner',
+  title: '03-Organisms/Game Session/EndingSuggestionBanner',
   component: EndingSuggestionBanner,
   parameters: {
     layout: 'padded',

--- a/src/stories/03-organisms/game-session/GameSessionConfirmationDialog.stories.tsx
+++ b/src/stories/03-organisms/game-session/GameSessionConfirmationDialog.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { GameSessionConfirmationDialog } from '@/components/GameSession/GameSessionConfirmationDialog';
+
+const meta = {
+  title: '03-Organisms/Game Session/GameSessionConfirmationDialog',
+  component: GameSessionConfirmationDialog,
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    onClose: fn(),
+    onConfirm: fn(),
+  },
+} satisfies Meta<typeof GameSessionConfirmationDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const StartNew: Story = {
+  args: {
+    isOpen: true,
+    type: 'start-new',
+    currentProgress: 15,
+  },
+};
+
+export const CharacterSwitch: Story = {
+  args: {
+    isOpen: true,
+    type: 'character-switch',
+    characterName: 'Elena the Brave',
+    currentProgress: 8,
+  },
+};
+
+export const WithProgress: Story = {
+  args: {
+    isOpen: true,
+    type: 'start-new',
+    currentProgress: 42,
+  },
+};

--- a/src/stories/03-organisms/game-session/GameSessionError.stories.tsx
+++ b/src/stories/03-organisms/game-session/GameSessionError.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import GameSessionError from '@/components/GameSession/GameSessionError';
+
+const meta = {
+  title: '03-Organisms/Game Session/GameSessionError',
+  component: GameSessionError,
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    onRetry: fn(),
+  },
+} satisfies Meta<typeof GameSessionError>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    error: 'Failed to load game session data. Please try again.',
+  },
+};
+
+export const WithDismiss: Story = {
+  args: {
+    error: 'Failed to load game session data. Please try again.',
+    onDismiss: fn(),
+  },
+};
+
+export const LongError: Story = {
+  args: {
+    error: 'An unexpected error occurred while attempting to load the game session. The server returned a 503 Service Unavailable response. This may be due to a temporary outage or high server load. Please wait a moment and try again. If the problem persists, check your connection or contact support.',
+  },
+};

--- a/src/stories/03-organisms/game-session/GameSessionLoading.stories.tsx
+++ b/src/stories/03-organisms/game-session/GameSessionLoading.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import GameSessionLoading from '@/components/GameSession/GameSessionLoading';
+
+const meta = {
+  title: '03-Organisms/Game Session/GameSessionLoading',
+  component: GameSessionLoading,
+  parameters: {
+    layout: 'padded',
+  },
+} satisfies Meta<typeof GameSessionLoading>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const CustomMessage: Story = {
+  args: {
+    loadingMessage: 'Preparing your adventure...',
+  },
+};

--- a/src/stories/03-organisms/game-session/GameSessionResume.stories.tsx
+++ b/src/stories/03-organisms/game-session/GameSessionResume.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import GameSessionResume from '@/components/GameSession/GameSessionResume';
+import type { SavedSessionInfo } from '@/types/game.types';
+import { mockSavedSession } from './gameSessionStoryData';
+
+const meta = {
+  title: '03-Organisms/Game Session/GameSessionResume',
+  component: GameSessionResume,
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    onResume: fn(),
+    onNewGame: fn(),
+  },
+} satisfies Meta<typeof GameSessionResume>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    savedSession: { ...mockSavedSession, narrativeCount: 12 },
+  },
+};
+
+export const RecentSession: Story = {
+  args: {
+    savedSession: {
+      ...mockSavedSession,
+      lastPlayed: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      narrativeCount: 3,
+    } satisfies SavedSessionInfo,
+  },
+};
+
+export const LongProgress: Story = {
+  args: {
+    savedSession: { ...mockSavedSession, narrativeCount: 87 },
+  },
+};

--- a/src/stories/03-organisms/game-session/GameSessionSkeleton.stories.tsx
+++ b/src/stories/03-organisms/game-session/GameSessionSkeleton.stories.tsx
@@ -1,13 +1,20 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { GameSessionSkeleton } from '@/components/GameSession/GameSessionSkeleton';
 
-const meta: Meta<typeof GameSessionSkeleton> = {
-  title: '03-Organisms/GameSession/GameSessionSkeleton',
+const meta = {
+  title: '03-Organisms/Game Session/GameSessionSkeleton',
   component: GameSessionSkeleton,
   parameters: {
     layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Loading skeleton shown while the first narrative segment generates. ' +
+          'Use the theme toolbar to verify skeleton appearance across DS1, DS2, and DS3.',
+      },
+    },
   },
-};
+} satisfies Meta<typeof GameSessionSkeleton>;
 
 export default meta;
 type Story = StoryObj<typeof GameSessionSkeleton>;

--- a/src/stories/03-organisms/game-session/ManuscriptDrawerPanels.stories.tsx
+++ b/src/stories/03-organisms/game-session/ManuscriptDrawerPanels.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { ToolsMenuPanelContent } from '@/components/GameSession/ManuscriptDrawerPanels';
+
+const meta = {
+  title: '03-Organisms/Game Session/ToolsMenuPanelContent',
+  component: ToolsMenuPanelContent,
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    activeDrawer: null,
+    onOpenDrawer: fn(),
+    onClosePanel: fn(),
+    onOpenJournalRoute: fn(),
+  },
+} satisfies Meta<typeof ToolsMenuPanelContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithActiveDrawer: Story = {
+  args: {
+    activeDrawer: 'character',
+  },
+};
+
+export const WithDevActions: Story = {
+  args: {
+    onSimulateTurn: fn(),
+    onToggleStreamingPreview: fn(),
+    onToggleEndingSuggestionPreview: fn(),
+  },
+};

--- a/src/stories/03-organisms/game-session/StorySummarySection.stories.tsx
+++ b/src/stories/03-organisms/game-session/StorySummarySection.stories.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { StorySummarySection } from '@/components/GameSession/StorySummarySection';
+import { useWorldStore } from '@/state/worldStore';
+import { createEmptyWorldState } from '@/types/world-state.types';
+import {
+  WithMockWorldStore,
+  STORY_WORLD_ID,
+  STORY_SESSION_ID,
+  STORY_CHARACTER_ID,
+} from './gameSessionStoryData';
+
+const meta = {
+  title: '03-Organisms/Game Session/StorySummarySection',
+  component: StorySummarySection,
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    worldId: STORY_WORLD_ID,
+    sessionId: STORY_SESSION_ID,
+    characterId: STORY_CHARACTER_ID,
+  },
+  decorators: [WithMockWorldStore],
+} satisfies Meta<typeof StorySummarySection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {};
+
+const WithCheckpoints = (Story: React.FC) => {
+  useEffect(() => {
+    useWorldStore.setState({
+      worldStates: {
+        [STORY_WORLD_ID]: {
+          ...createEmptyWorldState(STORY_WORLD_ID),
+          storyCheckpoints: [
+            {
+              id: 'cp-1',
+              sessionId: STORY_SESSION_ID,
+              segment:
+                'Kael arrived at the storm-battered docks of Thornhaven as the last light faded over the archipelago.',
+              createdAt: '2025-06-14T17:00:00Z',
+              highlights: [],
+              eventIds: [],
+            },
+            {
+              id: 'cp-2',
+              sessionId: STORY_SESSION_ID,
+              segment:
+                'The harbour-master grudgingly allowed passage after Kael mentioned the Old Archive. Inside the inner docks, a weathered ship awaited.',
+              createdAt: '2025-06-14T17:05:00Z',
+              highlights: [],
+              eventIds: [],
+            },
+          ],
+        },
+      },
+    });
+    return () => {
+      useWorldStore.setState({ worldStates: {} });
+    };
+  }, []);
+  return React.createElement(Story);
+};
+
+export const WithContent: Story = {
+  decorators: [WithCheckpoints],
+};

--- a/src/stories/03-organisms/game-session/gameSessionStoryData.ts
+++ b/src/stories/03-organisms/game-session/gameSessionStoryData.ts
@@ -1,0 +1,264 @@
+/**
+ * Shared mock data for game session Storybook stories.
+ * Provides reusable objects and store-mocking decorators.
+ */
+import React, { useEffect } from 'react';
+import type { SavedSessionInfo } from '@/types/game.types';
+import type {
+  StoryEnding,
+  Decision,
+  NarrativeSegment,
+} from '@/types/narrative.types';
+import type { World } from '@/types/world.types';
+import { useWorldStore } from '@/state/worldStore';
+import { useCharacterStore } from '@/state/characterStore';
+import { useNarrativeStore } from '@/state/narrativeStore';
+
+// ── Constants ────────────────────────────────────────────────────────
+
+export const STORY_WORLD_ID = 'world-storybook';
+export const STORY_SESSION_ID = 'session-storybook';
+export const STORY_CHARACTER_ID = 'char-storybook';
+
+// ── Mock World ───────────────────────────────────────────────────────
+
+export const mockWorld: World = {
+  id: STORY_WORLD_ID,
+  name: 'The Shattered Isles',
+  description: 'A storm-ravaged archipelago where ancient magic stirs beneath volcanic rock.',
+  theme: 'dark fantasy',
+  attributes: [
+    { id: 'attr-str', name: 'Strength', description: 'Physical power', minValue: 1, maxValue: 20, defaultValue: 10 },
+    { id: 'attr-int', name: 'Intelligence', description: 'Mental acuity', minValue: 1, maxValue: 20, defaultValue: 10 },
+    { id: 'attr-cha', name: 'Charisma', description: 'Force of personality', minValue: 1, maxValue: 20, defaultValue: 10 },
+  ],
+  skills: [
+    { id: 'skill-sword', name: 'Swordsmanship', description: 'Blade combat', attributeIds: ['attr-str'], difficulty: 'medium' },
+    { id: 'skill-lore', name: 'Arcane Lore', description: 'Knowledge of magic', attributeIds: ['attr-int'], difficulty: 'hard' },
+    { id: 'skill-persuade', name: 'Persuasion', description: 'Convincing others', attributeIds: ['attr-cha'], difficulty: 'easy' },
+  ],
+  settings: {
+    maxAttributes: 6,
+    maxSkills: 8,
+    startingAttributePoints: 30,
+    startingSkillPoints: 10,
+    allowCustomSkills: false,
+    allowCustomAttributes: false,
+    attributePointPool: 30,
+    skillPointPool: 10,
+  },
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+};
+
+// ── Mock Character ───────────────────────────────────────────────────
+
+export const mockCharacter = {
+  id: STORY_CHARACTER_ID,
+  name: 'Kael Stormwright',
+  description: 'A wandering swordmage seeking the truth behind the Shattering.',
+  worldId: STORY_WORLD_ID,
+  level: 5,
+  isPlayer: true,
+  attributes: [
+    { id: 'cattr-1', name: 'Strength', modifiedValue: 14, worldAttributeId: 'attr-str' },
+    { id: 'cattr-2', name: 'Intelligence', modifiedValue: 16, worldAttributeId: 'attr-int' },
+    { id: 'cattr-3', name: 'Charisma', modifiedValue: 12, worldAttributeId: 'attr-cha' },
+  ],
+  skills: [
+    { id: 'cskill-1', name: 'Swordsmanship', level: 4, worldSkillId: 'skill-sword' },
+    { id: 'cskill-2', name: 'Arcane Lore', level: 3, worldSkillId: 'skill-lore' },
+    { id: 'cskill-3', name: 'Persuasion', level: 2, worldSkillId: 'skill-persuade' },
+  ],
+  background: {
+    history: 'Born on the outermost isle during a lightning storm, Kael was raised by the keepers of the Old Archive.',
+    personality: 'Curious and determined, with a dry sense of humour that surfaces at the worst times.',
+    physicalDescription: 'Tall and lean with storm-grey eyes and a scar across the left temple.',
+    goals: ['Uncover the cause of the Shattering', 'Master the lost storm magic'],
+    fears: ['Losing control of arcane power', 'The sea'],
+  },
+  derivedStats: [
+    { id: 'ds-hp', name: 'Hit Points', currentValue: 38, maxValue: 45 },
+    { id: 'ds-mp', name: 'Mana', currentValue: 22, maxValue: 30 },
+  ],
+  status: {
+    health: 38,
+    maxHealth: 45,
+    conditions: ['Arcane Focus'],
+    location: 'Thornhaven Docks',
+  },
+  portrait: {
+    type: 'placeholder' as const,
+    url: null,
+  },
+  inventory: [],
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-15T00:00:00Z',
+};
+
+// ── Mock Saved Session ───────────────────────────────────────────────
+
+export const mockSavedSession: SavedSessionInfo = {
+  id: STORY_SESSION_ID,
+  worldId: STORY_WORLD_ID,
+  characterId: STORY_CHARACTER_ID,
+  lastPlayed: '2025-06-14T18:30:00Z',
+  narrativeCount: 12,
+};
+
+// ── Mock Decision ────────────────────────────────────────────────────
+
+export const mockDecision: Decision = {
+  id: 'decision-1',
+  prompt: 'The harbour-master blocks your path, arms folded. How do you proceed?',
+  contextSummary: 'You need to reach the inner docks before the tide turns.',
+  decisionWeight: 'major',
+  options: [
+    { id: 'opt-1', text: 'Draw your blade and demand passage' },
+    { id: 'opt-2', text: 'Offer a bribe of 50 silver marks' },
+    { id: 'opt-3', text: 'Attempt to talk your way through' },
+  ],
+};
+
+// ── Mock Story Ending ────────────────────────────────────────────────
+
+export const mockStoryEndingTriumphant: StoryEnding = {
+  id: 'ending-1',
+  sessionId: STORY_SESSION_ID,
+  characterId: STORY_CHARACTER_ID,
+  worldId: STORY_WORLD_ID,
+  type: 'story-complete',
+  tone: 'triumphant',
+  epilogue:
+    'The storm broke at last. Standing atop the Spire of Winds, Kael raised the restored shard skyward and felt the archipelago shudder as the ancient wards knit themselves whole. The Shattering was undone.',
+  characterLegacy:
+    'Kael Stormwright became known as the Mender of Isles. Scholars still debate whether it was skill or stubbornness that carried the day, but the keepers of the Old Archive simply say it was both.',
+  worldImpact:
+    'Trade routes reopened within a season. The outer isles, long cut off by magical storms, sent delegations to Thornhaven for the first time in a generation. The sea was calm again.',
+  achievements: [
+    'Storm Breaker: Restored the ancient wards',
+    'Silver Tongue: Convinced the harbour-master without violence',
+    'Lore Keeper: Decoded every archive fragment',
+  ],
+  playTime: 5400,
+  timestamp: new Date('2025-06-14T19:00:00Z'),
+  createdAt: '2025-06-14T19:00:00Z',
+  updatedAt: '2025-06-14T19:00:00Z',
+};
+
+export const mockStoryEndingTragic: StoryEnding = {
+  ...mockStoryEndingTriumphant,
+  id: 'ending-tragic',
+  tone: 'tragic',
+  epilogue:
+    'The shard cracked in Kael\'s hands. Storm magic poured through the fracture lines, and the Spire groaned as centuries of pressure found their release. The Isles held, but at a cost no-one had foreseen.',
+  characterLegacy:
+    'They found Kael\'s journal washed ashore three days later. The last entry simply read: "The storm remembers what we forget." The Archive keeps it under glass now.',
+  worldImpact:
+    'The outer isles were saved, but Thornhaven itself sank beneath the waves. A new capital rose on higher ground, and every year on the anniversary the citizens light lanterns and set them adrift.',
+};
+
+// ── Mock Narrative Segments ──────────────────────────────────────────
+
+export const mockNarrativeSegments: NarrativeSegment[] = [
+  {
+    id: 'seg-1',
+    sessionId: STORY_SESSION_ID,
+    worldId: STORY_WORLD_ID,
+    content: 'You arrive at the storm-battered docks of Thornhaven as the last light fades. The harbour-master eyes you with suspicion.',
+    type: 'scene',
+    characterIds: [STORY_CHARACTER_ID],
+    metadata: { tags: ['arrival', 'thornhaven'] },
+    timestamp: new Date('2025-06-14T17:00:00Z'),
+    createdAt: '2025-06-14T17:00:00Z',
+    updatedAt: '2025-06-14T17:00:00Z',
+  },
+  {
+    id: 'seg-2',
+    sessionId: STORY_SESSION_ID,
+    worldId: STORY_WORLD_ID,
+    content: 'You talk your way past the harbour-master with a mention of the Old Archive. His expression shifts from suspicion to grudging respect.',
+    type: 'dialogue',
+    characterIds: [STORY_CHARACTER_ID],
+    metadata: { tags: ['dialogue', 'persuasion'] },
+    timestamp: new Date('2025-06-14T17:05:00Z'),
+    createdAt: '2025-06-14T17:05:00Z',
+    updatedAt: '2025-06-14T17:05:00Z',
+  },
+];
+
+// ── Store-mocking Decorators ─────────────────────────────────────────
+
+/**
+ * Populates the world store with mockWorld for stories that need
+ * world attribute/skill lookups (e.g. CharacterSnapshot, CharacterSummary).
+ */
+export const WithMockWorldStore = (Story: React.FC) => {
+  useEffect(() => {
+    useWorldStore.setState({
+      worlds: { [STORY_WORLD_ID]: mockWorld },
+      entities: { [STORY_WORLD_ID]: mockWorld },
+    });
+    return () => {
+      useWorldStore.setState({ worlds: {}, entities: {} });
+    };
+  }, []);
+  return React.createElement(Story);
+};
+
+/**
+ * Populates character store for stories that need character data.
+ */
+export const WithMockCharacterStore = (Story: React.FC) => {
+  useEffect(() => {
+    useCharacterStore.setState({
+      characters: { [STORY_CHARACTER_ID]: mockCharacter as never },
+      entities: { [STORY_CHARACTER_ID]: mockCharacter as never },
+    });
+    return () => {
+      useCharacterStore.setState({ characters: {}, entities: {} });
+    };
+  }, []);
+  return React.createElement(Story);
+};
+
+/**
+ * Sets up all stores needed by EndingScreen.
+ * Accepts a StoryEnding to control the tone variant.
+ */
+export const withEndingScreenStores = (ending: StoryEnding) => {
+  const Decorator = (Story: React.FC) => {
+    useEffect(() => {
+      useNarrativeStore.setState({
+        currentEnding: ending,
+        isGeneratingEnding: false,
+        endingError: null,
+        segments: Object.fromEntries(mockNarrativeSegments.map((s) => [s.id, s])),
+        sessionSegments: {
+          [STORY_SESSION_ID]: mockNarrativeSegments.map((s) => s.id),
+        },
+      });
+      useCharacterStore.setState({
+        characters: { [STORY_CHARACTER_ID]: mockCharacter as never },
+        entities: { [STORY_CHARACTER_ID]: mockCharacter as never },
+      });
+      useWorldStore.setState({
+        worlds: { [STORY_WORLD_ID]: mockWorld },
+        entities: { [STORY_WORLD_ID]: mockWorld },
+      });
+      return () => {
+        useNarrativeStore.setState({
+          currentEnding: null,
+          isGeneratingEnding: false,
+          endingError: null,
+          segments: {},
+          sessionSegments: {},
+        });
+        useCharacterStore.setState({ characters: {}, entities: {} });
+        useWorldStore.setState({ worlds: {}, entities: {} });
+      };
+    }, []);
+    return React.createElement(Story);
+  };
+  return Decorator;
+};

--- a/src/stories/03-organisms/game-session/gameSessionStoryData.ts
+++ b/src/stories/03-organisms/game-session/gameSessionStoryData.ts
@@ -12,6 +12,7 @@ import type {
 import type { World } from '@/types/world.types';
 import { useWorldStore } from '@/state/worldStore';
 import { useCharacterStore } from '@/state/characterStore';
+import type { Character } from '@/state/characterStore';
 import { useNarrativeStore } from '@/state/narrativeStore';
 
 // ── Constants ────────────────────────────────────────────────────────
@@ -26,24 +27,20 @@ export const mockWorld: World = {
   id: STORY_WORLD_ID,
   name: 'The Shattered Isles',
   description: 'A storm-ravaged archipelago where ancient magic stirs beneath volcanic rock.',
-  theme: 'dark fantasy',
+  genre: 'fantasy',
   attributes: [
-    { id: 'attr-str', name: 'Strength', description: 'Physical power', minValue: 1, maxValue: 20, defaultValue: 10 },
-    { id: 'attr-int', name: 'Intelligence', description: 'Mental acuity', minValue: 1, maxValue: 20, defaultValue: 10 },
-    { id: 'attr-cha', name: 'Charisma', description: 'Force of personality', minValue: 1, maxValue: 20, defaultValue: 10 },
+    { id: 'attr-str', worldId: STORY_WORLD_ID, name: 'Strength', description: 'Physical power', baseValue: 10, minValue: 1, maxValue: 20 },
+    { id: 'attr-int', worldId: STORY_WORLD_ID, name: 'Intelligence', description: 'Mental acuity', baseValue: 10, minValue: 1, maxValue: 20 },
+    { id: 'attr-cha', worldId: STORY_WORLD_ID, name: 'Charisma', description: 'Force of personality', baseValue: 10, minValue: 1, maxValue: 20 },
   ],
   skills: [
-    { id: 'skill-sword', name: 'Swordsmanship', description: 'Blade combat', attributeIds: ['attr-str'], difficulty: 'medium' },
-    { id: 'skill-lore', name: 'Arcane Lore', description: 'Knowledge of magic', attributeIds: ['attr-int'], difficulty: 'hard' },
-    { id: 'skill-persuade', name: 'Persuasion', description: 'Convincing others', attributeIds: ['attr-cha'], difficulty: 'easy' },
+    { id: 'skill-sword', worldId: STORY_WORLD_ID, name: 'Swordsmanship', description: 'Blade combat', attributeIds: ['attr-str'], difficulty: 'medium', baseValue: 0, minValue: 0, maxValue: 10 },
+    { id: 'skill-lore', worldId: STORY_WORLD_ID, name: 'Arcane Lore', description: 'Knowledge of magic', attributeIds: ['attr-int'], difficulty: 'hard', baseValue: 0, minValue: 0, maxValue: 10 },
+    { id: 'skill-persuade', worldId: STORY_WORLD_ID, name: 'Persuasion', description: 'Convincing others', attributeIds: ['attr-cha'], difficulty: 'easy', baseValue: 0, minValue: 0, maxValue: 10 },
   ],
   settings: {
     maxAttributes: 6,
     maxSkills: 8,
-    startingAttributePoints: 30,
-    startingSkillPoints: 10,
-    allowCustomSkills: false,
-    allowCustomAttributes: false,
     attributePointPool: 30,
     skillPointPool: 10,
   },
@@ -53,7 +50,7 @@ export const mockWorld: World = {
 
 // ── Mock Character ───────────────────────────────────────────────────
 
-export const mockCharacter = {
+export const mockCharacter: Character = {
   id: STORY_CHARACTER_ID,
   name: 'Kael Stormwright',
   description: 'A wandering swordmage seeking the truth behind the Shattering.',
@@ -61,14 +58,14 @@ export const mockCharacter = {
   level: 5,
   isPlayer: true,
   attributes: [
-    { id: 'cattr-1', name: 'Strength', modifiedValue: 14, worldAttributeId: 'attr-str' },
-    { id: 'cattr-2', name: 'Intelligence', modifiedValue: 16, worldAttributeId: 'attr-int' },
-    { id: 'cattr-3', name: 'Charisma', modifiedValue: 12, worldAttributeId: 'attr-cha' },
+    { id: 'cattr-1', characterId: STORY_CHARACTER_ID, worldAttributeId: 'attr-str', name: 'Strength', baseValue: 10, modifiedValue: 14 },
+    { id: 'cattr-2', characterId: STORY_CHARACTER_ID, worldAttributeId: 'attr-int', name: 'Intelligence', baseValue: 10, modifiedValue: 16 },
+    { id: 'cattr-3', characterId: STORY_CHARACTER_ID, worldAttributeId: 'attr-cha', name: 'Charisma', baseValue: 10, modifiedValue: 12 },
   ],
   skills: [
-    { id: 'cskill-1', name: 'Swordsmanship', level: 4, worldSkillId: 'skill-sword' },
-    { id: 'cskill-2', name: 'Arcane Lore', level: 3, worldSkillId: 'skill-lore' },
-    { id: 'cskill-3', name: 'Persuasion', level: 2, worldSkillId: 'skill-persuade' },
+    { id: 'cskill-1', characterId: STORY_CHARACTER_ID, worldSkillId: 'skill-sword', name: 'Swordsmanship', level: 4 },
+    { id: 'cskill-2', characterId: STORY_CHARACTER_ID, worldSkillId: 'skill-lore', name: 'Arcane Lore', level: 3 },
+    { id: 'cskill-3', characterId: STORY_CHARACTER_ID, worldSkillId: 'skill-persuade', name: 'Persuasion', level: 2 },
   ],
   background: {
     history: 'Born on the outermost isle during a lightning storm, Kael was raised by the keepers of the Old Archive.',
@@ -76,10 +73,11 @@ export const mockCharacter = {
     physicalDescription: 'Tall and lean with storm-grey eyes and a scar across the left temple.',
     goals: ['Uncover the cause of the Shattering', 'Master the lost storm magic'],
     fears: ['Losing control of arcane power', 'The sea'],
+    relationships: [],
   },
   derivedStats: [
-    { id: 'ds-hp', name: 'Hit Points', currentValue: 38, maxValue: 45 },
-    { id: 'ds-mp', name: 'Mana', currentValue: 22, maxValue: 30 },
+    { id: 'ds-hp', characterId: STORY_CHARACTER_ID, derivedStatId: 'ds-hp', name: 'Hit Points', currentValue: 38, maxValue: 45, lastCalculated: '2025-01-15T00:00:00Z' },
+    { id: 'ds-mp', characterId: STORY_CHARACTER_ID, derivedStatId: 'ds-mp', name: 'Mana', currentValue: 22, maxValue: 30, lastCalculated: '2025-01-15T00:00:00Z' },
   ],
   status: {
     health: 38,
@@ -88,10 +86,16 @@ export const mockCharacter = {
     location: 'Thornhaven Docks',
   },
   portrait: {
-    type: 'placeholder' as const,
+    type: 'placeholder',
     url: null,
   },
-  inventory: [],
+  inventory: {
+    characterId: STORY_CHARACTER_ID,
+    items: [],
+    capacity: 20,
+    categories: [],
+    itemOrder: [],
+  },
   createdAt: '2025-01-01T00:00:00Z',
   updatedAt: '2025-01-15T00:00:00Z',
 };


### PR DESCRIPTION
## Description

Game session components were missing Storybook coverage, which meant verifying their appearance across DS1/DS2/DS3 themes required spinning up the full app. This adds 11 new story files, a shared mock data module, and a few housekeeping fixes — so all the meaningful game session UI can now be visually checked in isolation.

## Related Issue

Closes #1102

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [ ] Test coverage maintained or improved

N/A — this is Storybook coverage, not unit tests. Stories are the "tests" here.

## User Stories Addressed

As a developer, I want to preview game session UI components across all three design systems without running the full app, so I can catch visual regressions early.

## Component Development

- [x] Storybook stories created/updated
- [x] Components developed in isolation first
- [x] Visual consistency verified

Stories verified visually via bdg across DS1/DS2/DS3 and light/dark before committing.

## Implementation Notes

**New story files** — all under `src/stories/03-organisms/game-session/`:

- `GameSessionLoading` — Default, CustomMessage
- `GameSessionError` — Default, WithDismiss, LongError
- `GameSessionResume` — Default, RecentSession, LongProgress
- `GameSessionConfirmationDialog` — StartNew, CharacterSwitch, WithProgress
- `CharacterSnapshot` — Default, NoSkills
- `CharacterSummary` — Default, Expanded, DrawerVariant, WithAllDetails
- `ActiveGameSessionChoicesColumn` — WithChoices, GeneratingChoices, Skeleton, WithEndingSuggestion
- `ActiveGameSessionControls` — Default, WithEndConfirmation, ProgressiveDisclosureHidden
- `EndingScreen` — Triumphant, Tragic, Bittersweet, Loading
- `ManuscriptDrawerPanels` — Default, WithActiveDrawer, WithDevActions
- `StorySummarySection` — Empty, WithContent

**Shared mock data** — `gameSessionStoryData.ts` centralises mock world/character/session/ending objects and store decorator factories (`WithMockWorldStore`, `WithMockCharacterStore`, `withEndingScreenStores`). The decorator pattern matches the existing `ManuscriptCharactersRail` approach: `useStore.setState()` inside `useEffect` with cleanup.

**EndingSuggestionBanner moved** — was co-located at `src/components/GameSession/EndingSuggestionBanner.stories.tsx`, now lives with the rest of the game session stories. Git tracked it as a rename.

**preview.tsx backgrounds fix** — removed the hardcoded `#ffffff`/`#1a1a1a` background entries. The design system CSS sets the canvas color via `--color-canvas`, so these overrides were fighting the theme switcher rather than helping it.

**Skipped (intentionally)** — `GameSession`, `ActiveGameSession`, and `ActiveGameSessionNarrativeColumn` are too coupled to async hooks, routing, and live API calls to produce useful static stories.

## Testing Instructions

1. Check out the branch and run `npx storybook dev -p 6006`
2. Verify all new stories appear under `03-Organisms/Game Session/` in the sidebar
3. Switch through DS1/DS2/DS3 and light/dark using the toolbar — all stories should update
4. Confirm `EndingSuggestionBanner` no longer appears under the old co-located path
5. `npx storybook build` should complete with zero errors

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed