### PR TITLE
feat(narrative): add marginalia term definition system (#1058)

### DIFF
--- a/src/components/Narrative/FormattedNarrativeContent.tsx
+++ b/src/components/Narrative/FormattedNarrativeContent.tsx
@@ -257,7 +257,7 @@ export const FormattedNarrativeContent: React.FC<
 
             // Fragment wrapping a plain text string: process it
             if (el.type === React.Fragment) {
-              const children = el.props.children;
+              const children = (el.props as { children?: React.ReactNode }).children;
               if (typeof children === 'string') {
                 const text = children;
                 const fragmentKey =

--- a/src/components/Narrative/FormattedNarrativeContent.tsx
+++ b/src/components/Narrative/FormattedNarrativeContent.tsx
@@ -6,6 +6,8 @@ interface FormattedNarrativeContentProps {
   className?: string;
   highlightTerms?: string[];
   highlightClassName?: string;
+  definitionTerms?: string[];
+  onTermClick?: (termText: string, anchorElement: HTMLElement) => void;
 }
 
 const escapeRegExp = (value: string) =>
@@ -13,7 +15,7 @@ const escapeRegExp = (value: string) =>
 
 export const FormattedNarrativeContent: React.FC<
   FormattedNarrativeContentProps
-> = ({ content, className, highlightTerms, highlightClassName }) => {
+> = ({ content, className, highlightTerms, highlightClassName, definitionTerms, onTermClick }) => {
   const normalizedContent = typeof content === 'string' ? content : '';
   const trimmedContent = safeTrim(normalizedContent);
 
@@ -60,6 +62,40 @@ export const FormattedNarrativeContent: React.FC<
       (a, b) => b.length - a.length
     );
   }, [highlightTerms]);
+
+  const normalizedDefinitionTerms = React.useMemo(() => {
+    if (!definitionTerms || definitionTerms.length === 0) {
+      return [];
+    }
+
+    const uniqueTerms = new Map<
+      string,
+      { pattern: RegExp; key: string; length: number }
+    >();
+
+    const addTerm = (term: string) => {
+      const cleaned = safeTrim(term).replace(/\s+/g, ' ');
+      if (!cleaned) {
+        return;
+      }
+      const key = cleaned.toLowerCase();
+      if (uniqueTerms.has(key)) {
+        return;
+      }
+      const pattern = new RegExp(escapeRegExp(cleaned), 'gi');
+      uniqueTerms.set(key, {
+        pattern,
+        key,
+        length: cleaned.length,
+      });
+    };
+
+    definitionTerms.forEach(addTerm);
+
+    return Array.from(uniqueTerms.values()).sort(
+      (a, b) => b.length - a.length
+    );
+  }, [definitionTerms]);
 
   const highlightClass =
     highlightClassName ||
@@ -198,6 +234,153 @@ export const FormattedNarrativeContent: React.FC<
     [highlightClass, normalizedHighlightTerms]
   );
 
+  const renderDefinitionNodes = React.useCallback(
+    (nodes: React.ReactNode[], keyBase: string): React.ReactNode[] => {
+      if (normalizedDefinitionTerms.length === 0) {
+        return nodes;
+      }
+
+      let current: React.ReactNode[] = nodes;
+
+      normalizedDefinitionTerms.forEach(({ pattern, key }) => {
+        const nextNodes: React.ReactNode[] = [];
+
+        current.forEach((node, nodeIndex) => {
+          if (React.isValidElement(node)) {
+            const el = node as React.ReactElement;
+
+            // Skip already-wrapped span highlights and button elements
+            if (el.type === 'span' || el.type === 'button') {
+              nextNodes.push(node);
+              return;
+            }
+
+            // Fragment wrapping a plain text string: process it
+            if (el.type === React.Fragment) {
+              const children = el.props.children;
+              if (typeof children === 'string') {
+                const text = children;
+                const fragmentKey =
+                  el.key ?? `${keyBase}-frag-${nodeIndex}`;
+                const innerNodes: React.ReactNode[] = [];
+                let lastIndex = 0;
+                let match: RegExpExecArray | null;
+
+                pattern.lastIndex = 0;
+                while ((match = pattern.exec(text)) !== null) {
+                  const start = match.index;
+                  const rawMatch = match[0];
+
+                  if (start > lastIndex) {
+                    const fragment = text.slice(lastIndex, start);
+                    if (fragment) {
+                      innerNodes.push(
+                        <React.Fragment
+                          key={`${fragmentKey}-pre-${start}-${key}`}
+                        >
+                          {fragment}
+                        </React.Fragment>
+                      );
+                    }
+                  }
+
+                  let end = start + rawMatch.length;
+
+                  const precedingChar =
+                    start > 0 ? text[start - 1] : '';
+                  if (
+                    precedingChar &&
+                    /[0-9A-Za-z]/.test(precedingChar)
+                  ) {
+                    const fragment = text.slice(start, end);
+                    if (fragment) {
+                      innerNodes.push(
+                        <React.Fragment
+                          key={`${fragmentKey}-partial-${start}-${key}`}
+                        >
+                          {fragment}
+                        </React.Fragment>
+                      );
+                    }
+                    lastIndex = end;
+                    continue;
+                  }
+
+                  const suffix = text.slice(end, end + 2);
+                  if (suffix === "'s" || suffix === '\u2019s') {
+                    end += 2;
+                  }
+
+                  const matchedText = text.slice(start, end);
+                  const trimmed = matchedText.trimEnd();
+                  const trailing = matchedText.slice(trimmed.length);
+
+                  innerNodes.push(
+                    <button
+                      type="button"
+                      className="manuscript-marginalia-term"
+                      aria-haspopup="dialog"
+                      onClick={(e) =>
+                        onTermClick?.(trimmed, e.currentTarget)
+                      }
+                      key={`${fragmentKey}-defterm-${key}-${start}`}
+                    >
+                      {trimmed}
+                    </button>
+                  );
+                  if (trailing) {
+                    innerNodes.push(
+                      <React.Fragment
+                        key={`${fragmentKey}-defterm-trailing-${key}-${start}`}
+                      >
+                        {trailing}
+                      </React.Fragment>
+                    );
+                  }
+                  lastIndex = end;
+                }
+
+                if (lastIndex === 0) {
+                  // No matches in this fragment; pass through unchanged
+                  nextNodes.push(node);
+                  return;
+                }
+
+                if (lastIndex < text.length) {
+                  const fragment = text.slice(lastIndex);
+                  if (fragment) {
+                    innerNodes.push(
+                      <React.Fragment
+                        key={`${fragmentKey}-post-${lastIndex}-${key}`}
+                      >
+                        {fragment}
+                      </React.Fragment>
+                    );
+                  }
+                }
+
+                nextNodes.push(...innerNodes);
+                return;
+              }
+            }
+
+            // Any other element type: pass through unchanged
+            nextNodes.push(node);
+            return;
+          }
+
+          // Raw string or other non-element: pass through
+          nextNodes.push(node);
+        });
+
+        current = nextNodes;
+      });
+
+      return current;
+    },
+    [normalizedDefinitionTerms, onTermClick]
+  );
+
   if (paragraphs.length === 0) {
     return null;
   }
@@ -218,8 +401,11 @@ export const FormattedNarrativeContent: React.FC<
                 key={`paragraph-${index}-strong-${partIndex}`}
                 
               >
-                {renderHighlightedNodes(
-                  part.slice(2, -2),
+                {renderDefinitionNodes(
+                  renderHighlightedNodes(
+                    part.slice(2, -2),
+                    `paragraph-${index}-strong-${partIndex}`
+                  ),
                   `paragraph-${index}-strong-${partIndex}`
                 )}
               </strong>
@@ -230,16 +416,22 @@ export const FormattedNarrativeContent: React.FC<
                 key={`paragraph-${index}-em-${partIndex}`}
                 
               >
-                {renderHighlightedNodes(
-                  part.slice(1, -1),
+                {renderDefinitionNodes(
+                  renderHighlightedNodes(
+                    part.slice(1, -1),
+                    `paragraph-${index}-em-${partIndex}`
+                  ),
                   `paragraph-${index}-em-${partIndex}`
                 )}
               </em>
             );
           } else {
             paragraphNodes.push(
-              ...renderHighlightedNodes(
-                part,
+              ...renderDefinitionNodes(
+                renderHighlightedNodes(
+                  part,
+                  `paragraph-${index}-text-${partIndex}`
+                ),
                 `paragraph-${index}-text-${partIndex}`
               )
             );

--- a/src/components/Narrative/NarrativeDisplay.tsx
+++ b/src/components/Narrative/NarrativeDisplay.tsx
@@ -7,6 +7,8 @@ import { cssClasses, parseNarrativeContent } from '@/lib/utils';
 import { FormattedNarrativeContent } from './FormattedNarrativeContent';
 import { PromptDebugSection } from './PromptDebugSection';
 import { ChoiceOutcomeCallout } from './ChoiceOutcomeCallout';
+import { TermDefinition } from './TermDefinition';
+import { useTermDefinitions, TermDefinitionData } from './useTermDefinitions';
 import { useNPCStore } from '@/state/npcStore';
 import { useDevTools } from '@/components/devtools/DevToolsContext';
 import {
@@ -73,6 +75,34 @@ export const NarrativeDisplay: React.FC<NarrativeDisplayProps> = ({
     getById,
   });
 
+  // Marginalia term definitions (Issue #1058)
+  const { termNames, getDefinition } = useTermDefinitions(
+    resolvedSegment?.worldId,
+    resolvedSegment?.sessionId
+  );
+
+  const [activeTerm, setActiveTerm] = React.useState<{
+    data: TermDefinitionData;
+    anchorRect: DOMRect;
+  } | null>(null);
+
+  const handleTermClick = React.useCallback(
+    (termText: string, anchorElement: HTMLElement) => {
+      const definition = getDefinition(termText);
+      if (definition) {
+        setActiveTerm({
+          data: definition,
+          anchorRect: anchorElement.getBoundingClientRect(),
+        });
+      }
+    },
+    [getDefinition]
+  );
+
+  const handleTermDismiss = React.useCallback(() => {
+    setActiveTerm(null);
+  }, []);
+
   if (isLoading) {
     return (
       <div>
@@ -121,7 +151,17 @@ export const NarrativeDisplay: React.FC<NarrativeDisplayProps> = ({
           resolvedSegment.type === 'transition' ? 'preserve-breaks' : ''
         )}
         highlightTerms={highlightTerms}
+        definitionTerms={termNames}
+        onTermClick={handleTermClick}
       />
+
+      {activeTerm && (
+        <TermDefinition
+          term={activeTerm.data}
+          anchorRect={activeTerm.anchorRect}
+          onDismiss={handleTermDismiss}
+        />
+      )}
 
       {/* Debug Information Section (dev mode only) */}
       {settings.showPromptDebugInfo && resolvedSegment.metadata?.debugInfo && (

--- a/src/components/Narrative/TermDefinition.tsx
+++ b/src/components/Narrative/TermDefinition.tsx
@@ -1,0 +1,62 @@
+import React, { useRef, useEffect } from 'react';
+import type { TermDefinitionData } from './useTermDefinitions';
+
+interface TermDefinitionProps {
+  term: TermDefinitionData;
+  anchorRect: DOMRect;
+  onDismiss: () => void;
+}
+
+/**
+ * Displays a lore term definition as an editorial margin note (desktop)
+ * or popover (mobile). Dismisses on Escape key or click outside.
+ */
+export const TermDefinition: React.FC<TermDefinitionProps> = ({
+  term,
+  anchorRect,
+  onDismiss,
+}) => {
+  const ref = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const handleMouseDown = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        onDismiss();
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onDismiss();
+      }
+    };
+
+    document.addEventListener('mousedown', handleMouseDown);
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [onDismiss]);
+
+  return (
+    <aside
+      ref={ref}
+      role="complementary"
+      className="manuscript-marginalia-definition"
+      aria-label={`Definition: ${term.name}`}
+      style={{
+        top: anchorRect.bottom + 8,
+        left: Math.max(8, Math.min(anchorRect.left, window.innerWidth - 288)),
+      }}
+    >
+      <span className="manuscript-marginalia-category">{term.category}</span>
+      <p className="manuscript-marginalia-name">{term.name}</p>
+      {term.type && (
+        <span className="manuscript-marginalia-type">{term.type}</span>
+      )}
+      <p className="manuscript-marginalia-description">{term.description}</p>
+    </aside>
+  );
+};

--- a/src/components/Narrative/__tests__/FormattedNarrativeContent.test.tsx
+++ b/src/components/Narrative/__tests__/FormattedNarrativeContent.test.tsx
@@ -89,4 +89,83 @@ Multiple newlines should create separate paragraphs.`;
       )
     ).toBe(true);
   });
+
+  describe('definition terms', () => {
+    it('renders definition term buttons when definitionTerms is provided', () => {
+      const { container } = render(
+        <FormattedNarrativeContent
+          content="The sword of power lies here."
+          definitionTerms={['sword of power']}
+        />
+      );
+
+      const buttons = container.querySelectorAll(
+        'button.manuscript-marginalia-term'
+      );
+      expect(buttons).toHaveLength(1);
+      expect(buttons[0]).toHaveTextContent('sword of power');
+    });
+
+    it('calls onTermClick with term text and anchor element when button clicked', () => {
+      const onTermClick = jest.fn();
+      const { container } = render(
+        <FormattedNarrativeContent
+          content="The sword of power lies here."
+          definitionTerms={['sword of power']}
+          onTermClick={onTermClick}
+        />
+      );
+
+      const button = container.querySelector(
+        'button.manuscript-marginalia-term'
+      ) as HTMLElement;
+      button.click();
+      expect(onTermClick).toHaveBeenCalledTimes(1);
+      expect(onTermClick).toHaveBeenCalledWith('sword of power', button);
+    });
+
+    it('renders both highlight spans and definition buttons when both props are provided', () => {
+      const { container } = render(
+        <FormattedNarrativeContent
+          content="Elara found the ancient relic in the vault."
+          highlightTerms={['Elara']}
+          definitionTerms={['ancient relic']}
+        />
+      );
+
+      const highlights = container.querySelectorAll(
+        'span.narrative-highlight'
+      );
+      const buttons = container.querySelectorAll(
+        'button.manuscript-marginalia-term'
+      );
+      expect(highlights).toHaveLength(1);
+      expect(highlights[0]).toHaveTextContent('Elara');
+      expect(buttons).toHaveLength(1);
+      expect(buttons[0]).toHaveTextContent('ancient relic');
+    });
+
+    it('renders definition term buttons with correct ARIA attribute', () => {
+      const { container } = render(
+        <FormattedNarrativeContent
+          content="The dragon scale armor is legendary."
+          definitionTerms={['dragon scale armor']}
+        />
+      );
+
+      const button = container.querySelector(
+        'button.manuscript-marginalia-term'
+      );
+      expect(button).toHaveAttribute('aria-haspopup', 'dialog');
+    });
+
+    it('renders no buttons when definitionTerms is not provided', () => {
+      const { container } = render(
+        <FormattedNarrativeContent content="Normal content with no definition terms." />
+      );
+
+      const buttons = container.querySelectorAll('button');
+      expect(buttons).toHaveLength(0);
+    });
+  });
 });

--- a/src/components/Narrative/__tests__/NarrativeDisplay.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeDisplay.test.tsx
@@ -1,16 +1,25 @@
 import React from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { NarrativeDisplay } from '../NarrativeDisplay';
 import { getTimestamp } from '@/lib/utils/timestamp';
 import { useNPCStore } from '@/state/npcStore';
+import { useLoreStore } from '@/state/loreStore';
 import { NPC } from '@/types/npc.types';
 import { mockZustandStore, createMockNPCStore, createMockNarrativeSegment } from '@/lib/test-utils';
 
 jest.mock('@/state/npcStore');
+jest.mock('@/state/loreStore');
+
+const mockGetFacts = jest.fn().mockReturnValue([]);
+(useLoreStore as unknown as jest.Mock).mockImplementation(
+  (selector: (state: { getFacts: typeof mockGetFacts }) => unknown) =>
+    selector({ getFacts: mockGetFacts })
+);
 
 describe('NarrativeDisplay', () => {
   beforeEach(() => {
+    mockGetFacts.mockReturnValue([]);
     mockZustandStore(useNPCStore as jest.MockedFunction<typeof useNPCStore>, createMockNPCStore({
       npcs: {},
     }));
@@ -148,5 +157,73 @@ describe('NarrativeDisplay', () => {
 
     await user.click(screen.getByText('Try Again'));
     expect(mockRetry).toHaveBeenCalledTimes(1);
+  });
+
+  describe('marginalia term definitions', () => {
+    const loreFacts = [
+      {
+        id: 'fact-1',
+        key: 'world-test-1:character_aria',
+        value: 'Aria',
+        category: 'characters' as const,
+        source: 'narrative' as const,
+        worldId: 'world-test-1',
+        aliases: [],
+        visibility: 'world-shared' as const,
+        metadata: {
+          description: 'A powerful mage from the Northern Tower.',
+          type: 'protagonist',
+          importance: 'high' as const,
+        },
+        createdAt: '2025-01-01T00:00:00Z',
+        updatedAt: '2025-01-01T00:00:00Z',
+      },
+    ];
+
+    it('renders term definition buttons when lore facts exist', () => {
+      mockGetFacts.mockReturnValue(loreFacts);
+
+      const segment = createMockNarrativeSegment({
+        id: 'seg-marginalia',
+        content: 'Aria stepped into the moonlit glade.',
+        type: 'scene',
+        worldId: 'world-test-1',
+        sessionId: 'session-test-1',
+        metadata: { characterIds: [], mood: 'neutral', tags: [] },
+      });
+
+      render(<NarrativeDisplay segment={segment} />);
+
+      const buttons = screen.getAllByRole('button', { name: /Aria/i });
+      expect(buttons.length).toBeGreaterThan(0);
+      expect(buttons[0]).toHaveAttribute('aria-haspopup', 'dialog');
+    });
+
+    it('shows term definition on click and dismisses on Escape', () => {
+      mockGetFacts.mockReturnValue(loreFacts);
+
+      const segment = createMockNarrativeSegment({
+        id: 'seg-marginalia-2',
+        content: 'Aria raised her staff.',
+        type: 'scene',
+        worldId: 'world-test-1',
+        sessionId: 'session-test-1',
+        metadata: { characterIds: [], mood: 'neutral', tags: [] },
+      });
+
+      render(<NarrativeDisplay segment={segment} />);
+
+      const termButton = screen.getAllByRole('button', { name: /Aria/i })[0];
+      fireEvent.click(termButton);
+
+      // Definition panel should appear
+      const definition = screen.getByRole('complementary');
+      expect(definition).toHaveAttribute('aria-label', 'Definition: Aria');
+      expect(screen.getByText('A powerful mage from the Northern Tower.')).toBeInTheDocument();
+
+      // Escape should dismiss
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/Narrative/__tests__/TermDefinition.test.tsx
+++ b/src/components/Narrative/__tests__/TermDefinition.test.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TermDefinition } from '../TermDefinition';
+import type { TermDefinitionData } from '../useTermDefinitions';
+
+const mockAnchorRect = {
+  top: 100,
+  right: 200,
+  bottom: 120,
+  left: 50,
+  width: 150,
+  height: 20,
+  x: 50,
+  y: 100,
+  toJSON: () => ({}),
+} as DOMRect;
+
+const baseTerm: TermDefinitionData = {
+  name: 'Aria',
+  category: 'characters',
+  type: 'protagonist',
+  description: 'A powerful mage from the Northern Tower.',
+  importance: 'high',
+};
+
+describe('TermDefinition', () => {
+  it('renders term name and description', () => {
+    render(
+      <TermDefinition
+        term={baseTerm}
+        anchorRect={mockAnchorRect}
+        onDismiss={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Aria')).toBeInTheDocument();
+    expect(
+      screen.getByText('A powerful mage from the Northern Tower.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders category badge', () => {
+    render(
+      <TermDefinition
+        term={baseTerm}
+        anchorRect={mockAnchorRect}
+        onDismiss={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('characters')).toBeInTheDocument();
+  });
+
+  it('renders type when provided', () => {
+    render(
+      <TermDefinition
+        term={baseTerm}
+        anchorRect={mockAnchorRect}
+        onDismiss={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('protagonist')).toBeInTheDocument();
+  });
+
+  it('does not render type when not provided', () => {
+    const termWithoutType: TermDefinitionData = {
+      name: 'Northern Tower',
+      category: 'locations',
+      description: 'A tall tower in the north.',
+    };
+
+    render(
+      <TermDefinition
+        term={termWithoutType}
+        anchorRect={mockAnchorRect}
+        onDismiss={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByText('protagonist')).not.toBeInTheDocument();
+  });
+
+  it('calls onDismiss on Escape key press', () => {
+    const onDismiss = jest.fn();
+
+    render(
+      <TermDefinition
+        term={baseTerm}
+        anchorRect={mockAnchorRect}
+        onDismiss={onDismiss}
+      />
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onDismiss on click outside', () => {
+    const onDismiss = jest.fn();
+
+    render(
+      <TermDefinition
+        term={baseTerm}
+        anchorRect={mockAnchorRect}
+        onDismiss={onDismiss}
+      />
+    );
+
+    fireEvent.mouseDown(document.body);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT dismiss on click inside', () => {
+    const onDismiss = jest.fn();
+
+    render(
+      <TermDefinition
+        term={baseTerm}
+        anchorRect={mockAnchorRect}
+        onDismiss={onDismiss}
+      />
+    );
+
+    const aside = screen.getByRole('complementary');
+    fireEvent.mouseDown(aside);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('has correct ARIA attributes', () => {
+    render(
+      <TermDefinition
+        term={baseTerm}
+        anchorRect={mockAnchorRect}
+        onDismiss={jest.fn()}
+      />
+    );
+
+    const aside = screen.getByRole('complementary');
+    expect(aside).toHaveAttribute('aria-label', 'Definition: Aria');
+  });
+
+  it('cleans up event listeners on unmount', () => {
+    const onDismiss = jest.fn();
+
+    const { unmount } = render(
+      <TermDefinition
+        term={baseTerm}
+        anchorRect={mockAnchorRect}
+        onDismiss={onDismiss}
+      />
+    );
+
+    unmount();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    fireEvent.mouseDown(document.body);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Narrative/__tests__/useTermDefinitions.test.ts
+++ b/src/components/Narrative/__tests__/useTermDefinitions.test.ts
@@ -1,0 +1,147 @@
+import { renderHook } from '@testing-library/react';
+import { useTermDefinitions } from '../useTermDefinitions';
+import { useLoreStore } from '@/state/loreStore';
+import type { LoreFact } from '@/types/lore.types';
+
+// Mock the lore store
+jest.mock('@/state/loreStore');
+
+const mockGetFacts = jest.fn();
+(useLoreStore as unknown as jest.Mock).mockImplementation((selector: (state: { getFacts: typeof mockGetFacts }) => unknown) =>
+  selector({ getFacts: mockGetFacts })
+);
+
+const baseFact: LoreFact = {
+  id: 'fact-1',
+  key: 'world-1:character_aria',
+  value: 'Aria',
+  category: 'characters',
+  source: 'narrative',
+  worldId: 'world-1',
+  aliases: ['The Silver Mage'],
+  visibility: 'world-shared',
+  metadata: {
+    description: 'A powerful mage from the Northern Tower.',
+    type: 'protagonist',
+    importance: 'high',
+  },
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+};
+
+beforeEach(() => {
+  mockGetFacts.mockReset();
+});
+
+describe('useTermDefinitions', () => {
+  it('returns empty when no worldId provided', () => {
+    const { result } = renderHook(() => useTermDefinitions(undefined));
+    expect(result.current.termNames).toEqual([]);
+    expect(result.current.getDefinition('Aria')).toBeNull();
+  });
+
+  it('extracts term names from facts with descriptions', () => {
+    mockGetFacts.mockReturnValue([baseFact]);
+    const { result } = renderHook(() => useTermDefinitions('world-1'));
+
+    expect(result.current.termNames).toContain('Aria');
+    expect(result.current.termNames).toContain('The Silver Mage');
+  });
+
+  it('excludes facts without metadata.description', () => {
+    const noDescFact: LoreFact = {
+      ...baseFact,
+      id: 'fact-2',
+      value: 'Bob',
+      metadata: { type: 'npc' },
+    };
+    mockGetFacts.mockReturnValue([noDescFact]);
+    const { result } = renderHook(() => useTermDefinitions('world-1'));
+
+    expect(result.current.termNames).toEqual([]);
+  });
+
+  it('excludes non-definable categories (rules)', () => {
+    const rulesFact: LoreFact = {
+      ...baseFact,
+      id: 'fact-3',
+      category: 'rules',
+      value: 'Magic costs stamina',
+      metadata: { description: 'A world rule' },
+    };
+    mockGetFacts.mockReturnValue([rulesFact]);
+    const { result } = renderHook(() => useTermDefinitions('world-1'));
+
+    expect(result.current.termNames).toEqual([]);
+  });
+
+  it('looks up definition by canonical name (case-insensitive)', () => {
+    mockGetFacts.mockReturnValue([baseFact]);
+    const { result } = renderHook(() => useTermDefinitions('world-1'));
+
+    const def = result.current.getDefinition('aria');
+    expect(def).not.toBeNull();
+    expect(def?.name).toBe('Aria');
+    expect(def?.description).toBe('A powerful mage from the Northern Tower.');
+  });
+
+  it('looks up definition by alias (case-insensitive)', () => {
+    mockGetFacts.mockReturnValue([baseFact]);
+    const { result } = renderHook(() => useTermDefinitions('world-1'));
+
+    const def = result.current.getDefinition('the silver mage');
+    expect(def).not.toBeNull();
+    expect(def?.name).toBe('Aria');
+  });
+
+  it('returns null for unknown terms', () => {
+    mockGetFacts.mockReturnValue([baseFact]);
+    const { result } = renderHook(() => useTermDefinitions('world-1'));
+
+    expect(result.current.getDefinition('Unknown Character')).toBeNull();
+  });
+
+  it('respects session-private visibility scoping', () => {
+    const privateFact: LoreFact = {
+      ...baseFact,
+      id: 'fact-4',
+      value: 'Secret NPC',
+      visibility: 'session-private',
+      sessionId: 'session-A',
+      metadata: { description: 'A secret character' },
+    };
+    mockGetFacts.mockReturnValue([privateFact]);
+
+    // Different session — should not see it
+    const { result: r1 } = renderHook(() => useTermDefinitions('world-1', 'session-B'));
+    expect(r1.current.termNames).toEqual([]);
+
+    // Same session — should see it
+    const { result: r2 } = renderHook(() => useTermDefinitions('world-1', 'session-A'));
+    expect(r2.current.termNames).toContain('Secret NPC');
+  });
+
+  it('includes location and event categories', () => {
+    const locationFact: LoreFact = {
+      ...baseFact,
+      id: 'fact-5',
+      category: 'locations',
+      value: 'Northern Tower',
+      aliases: [],
+      metadata: { description: 'A tall tower in the north.' },
+    };
+    const eventFact: LoreFact = {
+      ...baseFact,
+      id: 'fact-6',
+      category: 'events',
+      value: 'The Great Siege',
+      aliases: [],
+      metadata: { description: 'A historic battle.' },
+    };
+    mockGetFacts.mockReturnValue([locationFact, eventFact]);
+    const { result } = renderHook(() => useTermDefinitions('world-1'));
+
+    expect(result.current.termNames).toContain('Northern Tower');
+    expect(result.current.termNames).toContain('The Great Siege');
+  });
+});

--- a/src/components/Narrative/useTermDefinitions.ts
+++ b/src/components/Narrative/useTermDefinitions.ts
@@ -1,0 +1,77 @@
+import { useMemo } from 'react';
+import { useLoreStore } from '@/state/loreStore';
+import type { EntityID } from '@/types/common.types';
+import type { LoreCategory } from '@/types/lore.types';
+
+export interface TermDefinitionData {
+  name: string;
+  category: LoreCategory;
+  type?: string;
+  description: string;
+  importance?: 'low' | 'medium' | 'high';
+}
+
+const DEFINABLE_CATEGORIES: LoreCategory[] = ['characters', 'locations', 'events'];
+
+/**
+ * Builds a term lookup map from lore facts for the current world/session.
+ * Returns term names (for highlighting) and a lookup function (for definitions).
+ */
+export function useTermDefinitions(
+  worldId?: EntityID,
+  sessionId?: EntityID
+) {
+  const getFacts = useLoreStore((state) => state.getFacts);
+
+  const { termNames, lookupMap } = useMemo(() => {
+    if (!worldId) {
+      return { termNames: [] as string[], lookupMap: new Map<string, TermDefinitionData>() };
+    }
+
+    const facts = getFacts({ worldId });
+    const map = new Map<string, TermDefinitionData>();
+    const names: string[] = [];
+
+    for (const fact of facts) {
+      if (!DEFINABLE_CATEGORIES.includes(fact.category)) continue;
+      if (!fact.metadata?.description) continue;
+
+      // Scope: session-private facts only show for their session
+      if (fact.visibility === 'session-private' && fact.sessionId !== sessionId) continue;
+
+      const data: TermDefinitionData = {
+        name: fact.value,
+        category: fact.category,
+        type: fact.metadata.type,
+        description: fact.metadata.description,
+        importance: fact.metadata.importance,
+      };
+
+      // Register canonical name
+      const canonKey = fact.value.toLowerCase();
+      if (!map.has(canonKey)) {
+        map.set(canonKey, data);
+        names.push(fact.value);
+      }
+
+      // Register aliases
+      for (const alias of fact.aliases || []) {
+        const aliasKey = alias.toLowerCase();
+        if (!map.has(aliasKey)) {
+          map.set(aliasKey, data);
+          names.push(alias);
+        }
+      }
+    }
+
+    return { termNames: names, lookupMap: map };
+  }, [worldId, sessionId, getFacts]);
+
+  const getDefinition = useMemo(() => {
+    return (matchedText: string): TermDefinitionData | null => {
+      return lookupMap.get(matchedText.toLowerCase()) ?? null;
+    };
+  }, [lookupMap]);
+
+  return { termNames, getDefinition };
+}

--- a/src/stories/02-molecules/narrative/FormattedNarrativeContent.stories.tsx
+++ b/src/stories/02-molecules/narrative/FormattedNarrativeContent.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
 import { FormattedNarrativeContent } from '../../../components/Narrative/FormattedNarrativeContent';
 
 const meta: Meta<typeof FormattedNarrativeContent> = {
@@ -57,5 +58,22 @@ export const WithHighlights: Story = {
   args: {
     content: `Marge, the Waitress slides a chipped mug across the counter. Moments later, Marge's voice drops to a hush, warning you about Old Man Rivers. Old Man Rivers chuckles from the corner booth, his weathered hands wrapped around a steaming bowl of chowder. You can't tell if the glint in Old Man Rivers' eye is mischief or menace.`,
     highlightTerms: ['Marge, the Waitress', 'Old Man Rivers'],
+  },
+};
+
+export const WithDefinitionTerms: Story = {
+  args: {
+    content: `Lady Seraphina raised her silver staff as the gates of the Northern Tower swung open. The cold wind from the Frozen Wastes carried whispers of the Great Siege, a conflict that had shaped the realm for generations. She paused, recalling her years studying within those ancient walls.`,
+    definitionTerms: ['Lady Seraphina', 'Northern Tower', 'Great Siege', 'Frozen Wastes'],
+    onTermClick: fn(),
+  },
+};
+
+export const HighlightsAndDefinitions: Story = {
+  args: {
+    content: `Marge, the Waitress whispered about the Northern Tower as she refilled your mug. Old Man Rivers overheard and mentioned Lady Seraphina by name, his voice carrying the weight of someone who had survived the Great Siege firsthand.`,
+    highlightTerms: ['Marge, the Waitress', 'Old Man Rivers'],
+    definitionTerms: ['Northern Tower', 'Lady Seraphina', 'Great Siege'],
+    onTermClick: fn(),
   },
 };

--- a/src/stories/02-molecules/narrative/TermDefinition.stories.tsx
+++ b/src/stories/02-molecules/narrative/TermDefinition.stories.tsx
@@ -1,0 +1,120 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { TermDefinition } from '@/components/Narrative/TermDefinition';
+import type { TermDefinitionData } from '@/components/Narrative/useTermDefinitions';
+
+const mockAnchorRect = {
+  top: 200,
+  right: 300,
+  bottom: 220,
+  left: 100,
+  width: 200,
+  height: 20,
+  x: 100,
+  y: 200,
+  toJSON: () => ({}),
+} as DOMRect;
+
+const meta: Meta<typeof TermDefinition> = {
+  title: '02-Molecules/narrative/TermDefinition',
+  component: TermDefinition,
+  parameters: {
+    layout: 'padded',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ position: 'relative', minHeight: 400, padding: '2rem' }}>
+        <p style={{ fontFamily: 'var(--font-narrative)', marginBottom: '1rem' }}>
+          The narrative text flows here. Below is the term definition panel,
+          positioned as it would appear when a player clicks a highlighted term.
+        </p>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const characterTerm: TermDefinitionData = {
+  name: 'Lady Seraphina',
+  category: 'characters',
+  type: 'protagonist',
+  description:
+    'A former court mage who turned rogue after discovering the king\'s dark pact with the shadow realm. Known for her silver staff and dry wit.',
+  importance: 'high',
+};
+
+const locationTerm: TermDefinitionData = {
+  name: 'The Northern Tower',
+  category: 'locations',
+  type: 'fortress',
+  description:
+    'An ancient watchtower perched on the edge of the Frozen Wastes. Once a beacon of civilization, now home to a reclusive order of scholars.',
+};
+
+const eventTerm: TermDefinitionData = {
+  name: 'The Great Siege',
+  category: 'events',
+  description:
+    'A month-long assault on the capital city by the combined forces of the northern clans. Ended with the Treaty of Ash.',
+  importance: 'medium',
+};
+
+export const Character: Story = {
+  args: {
+    term: characterTerm,
+    anchorRect: mockAnchorRect,
+    onDismiss: () => {},
+  },
+};
+
+export const Location: Story = {
+  args: {
+    term: locationTerm,
+    anchorRect: mockAnchorRect,
+    onDismiss: () => {},
+  },
+};
+
+export const Event: Story = {
+  args: {
+    term: eventTerm,
+    anchorRect: mockAnchorRect,
+    onDismiss: () => {},
+  },
+};
+
+export const WithoutType: Story = {
+  args: {
+    term: {
+      name: 'The Shadow Pact',
+      category: 'events',
+      description: 'A secret agreement between the king and forces from the shadow realm.',
+    },
+    anchorRect: mockAnchorRect,
+    onDismiss: () => {},
+  },
+};
+
+export const AllCategories: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      <TermDefinition
+        term={characterTerm}
+        anchorRect={mockAnchorRect}
+        onDismiss={() => {}}
+      />
+      <TermDefinition
+        term={locationTerm}
+        anchorRect={{ ...mockAnchorRect, bottom: 280 } as DOMRect}
+        onDismiss={() => {}}
+      />
+      <TermDefinition
+        term={eventTerm}
+        anchorRect={{ ...mockAnchorRect, bottom: 340 } as DOMRect}
+        onDismiss={() => {}}
+      />
+    </div>
+  ),
+};

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -4435,3 +4435,136 @@ body.manuscript-overlay-open {
   display: none;
 }
 
+/* ═══════════════════════════════════════════════════════════════════════
+   MARGINALIA TERM DEFINITIONS (Issue #1058)
+   Editorial annotations — key terms in narrative text link to lore definitions.
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* Term link in narrative text — dotted underline like a proofreader's mark */
+.manuscript-marginalia-term {
+  appearance: none;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  padding: 0;
+  text-decoration: underline dotted var(--color-text-muted);
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+  transition: text-decoration-color 120ms ease;
+}
+
+.manuscript-marginalia-term:hover {
+  text-decoration-color: var(--color-accent);
+}
+
+.manuscript-marginalia-term:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* Definition panel — mobile-first (fixed popover) */
+.manuscript-marginalia-definition {
+  position: fixed;
+  z-index: 200;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  box-shadow: var(--shadow-overlay);
+  max-width: 280px;
+  animation: manuscript-marginalia-appear 150ms ease;
+}
+
+@keyframes manuscript-marginalia-appear {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Category badge — small-caps editorial label */
+.manuscript-marginalia-category {
+  display: inline-block;
+  font-family: var(--font-system);
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  background: rgb(from var(--color-text-muted) r g b / 10%);
+  padding: 1px var(--space-1);
+  border-radius: 2px;
+  line-height: 1.4;
+  margin-bottom: var(--space-1);
+}
+
+/* Term name — narrative font, slightly prominent */
+.manuscript-marginalia-name {
+  font-family: var(--font-narrative);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--color-text-primary);
+  margin: 0 0 var(--space-1) 0;
+}
+
+/* Optional type sub-label */
+.manuscript-marginalia-type {
+  display: inline-block;
+  font-family: var(--font-system);
+  font-size: 0.6875rem;
+  font-style: italic;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-1);
+}
+
+/* Description body */
+.manuscript-marginalia-description {
+  font-family: var(--font-narrative);
+  font-size: 0.8125rem;
+  line-height: 1.55;
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+/* Desktop: float-right margin note (matches DS3 choice-outcome-callout pattern) */
+@media (width >= 1024px) {
+  .manuscript-marginalia-definition {
+    position: relative;
+    float: right;
+    clear: right;
+    width: 200px;
+    margin: 0 0 var(--space-3) var(--space-3);
+    z-index: auto;
+    box-shadow: none;
+    top: auto;
+    left: auto;
+  }
+}
+
+/* DS1 theme: dashed-border note card */
+[data-theme="ds1"] .manuscript-marginalia-definition {
+  border-style: dashed;
+  background: var(--color-surface-hover);
+}
+
+[data-theme="ds1"] .manuscript-marginalia-category {
+  font-family: var(--font-system);
+  letter-spacing: 0.12em;
+}
+
+/* DS3 theme: subtle shadow on desktop float */
+@media (width >= 1024px) {
+  [data-theme="ds3"] .manuscript-marginalia-definition {
+    box-shadow: 0 2px 8px rgb(0 0 0 / 6%);
+  }
+}
+


### PR DESCRIPTION
## Description

The narrative text in game sessions has always rendered as plain prose — when the AI mentions characters, locations, or events from the world, players had no way to see what those terms meant without breaking out of the narrative flow. This ports the marginalia concept from the DS3 design prototype into production: key terms in the narrative get a subtle dotted underline, and clicking one shows its lore definition in the margin (desktop) or as a popover (mobile).

The approach builds on the existing `FormattedNarrativeContent` highlight system, which already splits narrative text and wraps matched terms. A second highlight pass runs after the participant-name highlights, wrapping lore terms in `<button>` elements with `aria-haspopup="dialog"`. The `TermDefinition` panel uses the same float-right marginalia pattern that the DS3 `ChoiceOutcomeCallout` already proved out, so the layout is consistent with what's already in production.

Term definitions pull from the existing lore store — the `useTermDefinitions` hook builds a pre-computed lookup map from `LoreFact` objects that have descriptions, filtered by category (characters, locations, events) and session visibility scoping. This avoids re-iterating all facts on every paragraph render.

## Related Issue

Closes #1058

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed

- As a player, clicking a highlighted term in the narrative shows its definition without leaving the story
- As a player, the definition dismisses when pressing Escape or clicking elsewhere
- As a player on mobile, the definition appears as a popover below the term
- As a player on desktop, the definition floats in the right margin like an editorial note

## Component Development

- [x] Storybook stories created/updated
- [x] Components developed in isolation first
- [x] Visual consistency verified

## Implementation Notes

The feature introduces three new pieces and modifies two existing components:

**New files:**
- `useTermDefinitions.ts` — hook that reads lore facts from the store, builds a normalized Map keyed by lowercase term name (canonical value + aliases) for O(1) lookup, and returns `termNames` for highlighting plus a `getDefinition()` function
- `TermDefinition.tsx` — the definition panel component with dismiss-on-Escape, dismiss-on-click-outside, and proper ARIA attributes (`role="complementary"`, `aria-label`)
- `TermDefinition.stories.tsx` — Storybook stories for character, location, and event category variants

**Modified files:**
- `FormattedNarrativeContent.tsx` — added `definitionTerms` and `onTermClick` props with a second highlight pass that wraps matches in `<button>` elements. The two highlight systems coexist: participant highlights are bold `<span>` elements, definition terms are dotted-underline `<button>` elements. When a term matches both, participant highlighting wins since it runs first.
- `NarrativeDisplay.tsx` — wires up the hook, manages `activeTerm` state, renders `TermDefinition` when a term is clicked

**CSS (`manuscript-session.css`):**
- All new classes use the `manuscript-marginalia-` prefix
- Term buttons use dotted underline styling (like a proofreader's annotation mark)
- Definition panel uses semantic design tokens for all colors/spacing, with theme-specific overrides — DS1 gets a dashed-border note card, DS3 gets the subtle shadow on desktop float
- Mobile-first: fixed popover on mobile, float-right margin note on desktop (>=1024px)

One trade-off worth noting: the definition panel positioning on mobile uses `position: fixed` with coordinates computed from `getBoundingClientRect()`. This works well for static content but may need adjustment if the narrative container scrolls independently. For the current manuscript layout where the overlay handles scrolling, this approach is solid.

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

1. Run the test suite: `npx jest --testPathPattern="useTermDefinitions|TermDefinition|FormattedNarrativeContent|NarrativeDisplay" --no-coverage` — all 60 tests should pass
2. Start Storybook: `npx storybook dev -p 6006` — navigate to "02-Molecules/narrative/TermDefinition" and "02-Molecules/narrative/FormattedNarrativeContent" stories
3. In the "WithDefinitionTerms" story, verify that term buttons render with dotted underlines and the Actions panel logs click events
4. In the "HighlightsAndDefinitions" story, verify that participant highlight spans and definition term buttons coexist in the same text

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] No new warnings generated
- [x] Accessibility considerations addressed