### PR TITLE
fix: form DS wrappers inject default semantic CSS classes (#1114)

### DIFF
--- a/src/components/forms/ToneSettingsForm.tsx
+++ b/src/components/forms/ToneSettingsForm.tsx
@@ -69,7 +69,6 @@ export const ToneSettingsForm: React.FC<ToneSettingsFormProps> = ({
             <p id="content-rating-description" >Set the age-appropriate content level for generated narratives</p>
             <Select
               id="content-rating"
-              className="form-select"
               value={toneSettings.contentRating}
               onChange={(e) => formUpdater.updateField('contentRating', e.target.value as ContentRating)}
               aria-describedby="content-rating-description"
@@ -89,7 +88,6 @@ export const ToneSettingsForm: React.FC<ToneSettingsFormProps> = ({
             <p id="narrative-style-description" >Choose how the story will be told and presented</p>
             <Select
               id="narrative-style"
-              className="form-select"
               value={toneSettings.narrativeStyle}
               onChange={(e) => formUpdater.updateField('narrativeStyle', e.target.value as NarrativeStyle)}
               aria-describedby="narrative-style-description"
@@ -109,7 +107,6 @@ export const ToneSettingsForm: React.FC<ToneSettingsFormProps> = ({
             <p id="language-complexity-description" >Set the vocabulary and sentence complexity level</p>
             <Select
               id="language-complexity"
-              className="form-select"
               value={toneSettings.languageComplexity}
               onChange={(e) => formUpdater.updateField('languageComplexity', e.target.value as LanguageComplexity)}
               aria-describedby="language-complexity-description"

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cssClasses(
-          "file:border-0 file:bg-transparent file:text-sm file:font-medium",
+          "form-input",
           className
         )}
         ref={ref}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -9,6 +9,7 @@ const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
       <label
         ref={ref}
         className={cssClasses(
+          "form-label",
           className
         )}
         {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { cssClasses } from '@/lib/utils/classNames'
 
 export type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement>
 
@@ -6,7 +7,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
   ({ className, children, ...props }, ref) => {
     return (
       <select
-        className={className}
+        className={cssClasses("form-select", className)}
         ref={ref}
         {...props}
       >

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -8,6 +8,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cssClasses(
+          "form-textarea",
           className
         )}
         ref={ref}


### PR DESCRIPTION
## Summary

- `Input`, `Select`, `Textarea`, and `Label` now apply their `form-*` classes by default — matching the pattern `Button` already uses
- Consumers no longer need to pass `className="form-input"` etc. manually; correct DS styling is automatic
- Removed redundant `className="form-select"` from `ToneSettingsForm` (3 occurrences, now handled by the component default)

No CSS changes needed — `form-input`, `form-select`, `form-textarea`, `form-label` already existed in `wizard.css` and were already globally loaded via `layout.tsx`.

Closes #1114

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 2140 tests pass (`npm test`)
- [x] Visual check: form elements on `/worlds/create` render with IBM Plex Sans, token-backed borders, padding, border-radius, and accent focus ring — no browser defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)