### PR TITLE
fix: replace dead Tailwind classes and fix stylelint errors (#1126)

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -76,6 +76,19 @@
         }
       },
       {
+        "files": ["src/app/workshop.css"],
+        "rules": {
+          "function-allowed-list": ["hsl", "hsla", "var", "calc", "theme", "translateY", "translateX", "translate", "scale", "rotate", "linear-gradient", "radial-gradient", "color-mix", "clamp", "cubic-bezier", "brightness"],
+          "function-disallowed-list": [],
+          "declaration-property-value-disallowed-list": {
+            "/^(background|border|color|fill|stroke|outline|text-decoration|box-shadow).*$/": [
+              "/^#[0-9a-fA-F]+$/",
+              "/^(red|blue|green|yellow|orange|purple|pink|brown|indigo|violet|cyan|teal|lime|emerald|sky|rose|slate|stone|neutral|zinc|fuchsia|magenta)$/i"
+            ]
+          }
+        }
+      },
+      {
         "files": ["src/styles/manuscript-session.css"],
         "rules": {
           "function-allowed-list": ["hsl", "hsla", "var", "calc", "theme", "translateY", "translateX", "translate", "scale", "rotate", "linear-gradient", "radial-gradient", "repeating-linear-gradient", "rgb", "rgba", "blur", "cubic-bezier", "minmax", "min", "clamp"],

--- a/src/app/workshop.css
+++ b/src/app/workshop.css
@@ -50,7 +50,7 @@
   );
   background-size: 24px 24px;
   pointer-events: none;
-  mask-image: radial-gradient(ellipse 100% 100% at 50% 0%, black 20%, transparent 80%);
+  mask-image: radial-gradient(ellipse 100% 100% at 50% 0%, hsl(0deg 0% 0%) 20%, transparent 80%);
 }
 
 /* Accent glow rising from below */
@@ -976,7 +976,7 @@
   display: none;
 }
 
-@media (min-width: 768px) {
+@media (width >= 768px) {
   .journal-content {
     flex-direction: row;
   }
@@ -1130,4 +1130,44 @@
 .journal-empty-state {
   padding: var(--space-8) var(--space-4);
   text-align: center;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   Form Controls
+   ═══════════════════════════════════════════════════════════════ */
+
+.range-slider {
+  appearance: none;
+  width: 100%;
+  accent-color: var(--color-accent);
+}
+
+.range-slider-constrained {
+  accent-color: var(--color-warning, hsl(45deg 93% 47%));
+}
+
+/* ─── Logo ─── */
+
+.logo-icon-inverted {
+  filter: brightness(0);
+}
+
+/* ─── Toast ─── */
+
+.toast-dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-1);
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  border-radius: var(--radius-sm, 0.25rem);
+  transition: color 120ms ease, background-color 120ms ease;
+}
+
+.toast-dismiss:hover {
+  color: var(--color-text-primary);
+  background: var(--color-surface-hover);
 }

--- a/src/components/Navigation/HeaderNavigation.tsx
+++ b/src/components/Navigation/HeaderNavigation.tsx
@@ -129,7 +129,7 @@ export function HeaderNavigation() {
                 )}
 
                 <Link href="/">
-                  <LogoIcon size="small" className="brightness-0" />
+                  <LogoIcon size="small" className="logo-icon-inverted" />
                   <LogoText size="sm" />
                 </Link>
 

--- a/src/components/Navigation/MobileNavigationMenu.tsx
+++ b/src/components/Navigation/MobileNavigationMenu.tsx
@@ -119,7 +119,7 @@ export const MobileNavigationMenu = React.memo(function MobileNavigationMenu({
       {/* Header with close button */}
       <div className="mobile-nav-header">
         <div className="mobile-nav-brand">
-          <LogoIcon size="small" className="brightness-0" />
+          <LogoIcon size="small" className="logo-icon-inverted" />
           <LogoText size="sm" />
         </div>
         <div className="mobile-nav-header-actions">

--- a/src/components/Navigation/SidebarNavigation.tsx
+++ b/src/components/Navigation/SidebarNavigation.tsx
@@ -62,7 +62,7 @@ export function SidebarNavigation({ onNavigate }: SidebarNavigationProps) {
     <nav aria-label="Workshop navigation" className="workshop-sidebar-nav">
       <div className="workshop-sidebar-header">
         <Link href="/" onClick={() => onNavigate?.()} className="workshop-sidebar-brand">
-          <LogoIcon size="small" className="brightness-0" />
+          <LogoIcon size="small" className="logo-icon-inverted" />
           <LogoText size="sm" />
         </Link>
         <TutorialMenu />

--- a/src/components/ui/RangeSlider/RangeSlider.tsx
+++ b/src/components/ui/RangeSlider/RangeSlider.tsx
@@ -232,12 +232,11 @@ const RangeSlider: React.FC<RangeSliderProps> = ({
               onChange={handleChange}
               disabled={disabled}
               className={[
-                'appearance-none',
-                'accent-primary',
+                'range-slider',
                 isConstrained &&
                 effectiveMax !== undefined &&
                 value === effectiveMax
-                  ? 'accent-amber-500'
+                  ? 'range-slider-constrained'
                   : '',
               ]
                 .filter(Boolean)

--- a/src/components/ui/toast/toast.tsx
+++ b/src/components/ui/toast/toast.tsx
@@ -105,7 +105,7 @@ const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
             <div>{title}</div>
             {description && <div>{description}</div>}
           </div>
-          <button onClick={handleDismiss} aria-label="Dismiss notification">
+          <button className="toast-dismiss" onClick={handleDismiss} aria-label="Dismiss notification">
             <X aria-hidden="true" />
           </button>
         </div>


### PR DESCRIPTION
## Description

The Tailwind removal in PR #1097 left a few utility classes behind in production components. They don't throw errors or fail tests — they just silently fall back to browser defaults, which means the RangeSlider lost its custom appearance, the logo icons stopped being darkened, and the toast dismiss button had no styling at all. This PR replaces all of them with proper CSS classes backed by design tokens, and cleans up the stylelint violations that were flagged in `workshop.css`.

## Related Issue

Closes #1126

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## What changed

**RangeSlider** (`src/components/ui/RangeSlider/RangeSlider.tsx`): The dead `appearance-none`, `accent-primary`, and `accent-amber-500` Tailwind classes are replaced with `.range-slider` and `.range-slider-constrained`. The new CSS classes apply `appearance: none` and `accent-color: var(--color-accent)` / `var(--color-warning)` through design tokens.

**Logo icons** (3 navigation components): `brightness-0` was a Tailwind utility that applied `filter: brightness(0)` to make the logo a black silhouette. Replaced with `.logo-icon-inverted` which does the same thing via a proper CSS class.

**Toast dismiss button** (`src/components/ui/toast/toast.tsx`): The dismiss button had no className at all — just a raw `<button>` with an aria-label. Added `className="toast-dismiss"` with styling for alignment, hover states, and proper cursor behavior.

**workshop.css**: Added the CSS for all three fixes above, plus fixed a named color `black` (now `hsl(0deg 0% 0%)`), and converted the journal media query from `min-width` to range notation (`width >= 768px`).

**stylelintrc.json**: Added a `workshop.css` override section to allow `radial-gradient`, `color-mix`, `clamp`, and `brightness` — all legitimate CSS functions used for atmospheric effects on the home page hero.

## Quality Checks

- [x] Linting passed (`npx next lint` — only pre-existing warnings)
- [x] CSS linting passed (`npm run lint:css` — 0 errors, down from 8)
- [x] All 297 test suites pass (2143 tests)
- [x] No console errors

## Verification

- Logo: `preview_inspect` confirms `filter: brightness(0)` applied on `.logo-icon-inverted`
- Range slider: bdg confirms `appearance: none` and `accentColor: rgb(156, 170, 138)` (the DS accent color)
- Toast dismiss: className applied, styled via `.toast-dismiss` CSS class
- No console errors on any route

## Testing Instructions

1. Run `npm run lint:css` — should pass with 0 errors
2. Run `npx jest` — all tests pass
3. Navigate to a world edit page — range sliders should show the accent color, not browser default blue
4. Check the sidebar/header logo — should be a black silhouette (filter brightness 0)
5. Trigger a toast notification — dismiss X button should have hover styling, not browser default