### PR TITLE
fix(nav): drafting rail + contextual header for workshop routes (#1140)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,10 @@ project-config.json
 docs/
 docs/plans/
 
+# Cross-theme audit captures (#1129) — large PNG output, regenerable
+scripts/audit/captures/
+scripts/audit/seeds/*.json
+
 # Generated dependency diagrams (regenerate with npm run deps:diagram:all)
 public_docs/architecture/*.mmd
 public_docs/architecture/*.svg

--- a/scripts/audit/README.md
+++ b/scripts/audit/README.md
@@ -1,0 +1,181 @@
+# Cross-theme audit (#1129)
+
+Tooling for the design-system migration audit on `1020-design-system-integration`.
+Captures component-level screenshots across `develop` + `DS1`/`DS2`/`DS3` integration
+themes and produces a per-route review UI for side-by-side comparison and triage.
+
+## Layout
+
+```
+scripts/audit/
+  build-seed.ts             # Emits per-state IDB+localStorage seed JSON
+  playwright-crawl.ts       # Primary crawler (replaces bdg-based bash scripts)
+  build-review-html.py      # Generates review/ from captures/
+  run-parallel.sh           # 3-worker parallel runner (one worker per state)
+  component-crawl.sh        # Desktop bdg crawl (deprecated; kept as fallback)
+  component-crawl-mobile.sh # Mobile bdg crawl (deprecated; kept as fallback)
+  review/
+    index.html              # Route index with live mark counts
+    <route>.html            # Per-route review page (x14)
+  review.html               # Legacy redirect stub -> review/index.html
+  seeds/                    # Generated seed JSON (gitignored)
+  captures/                 # PNG output (gitignored)
+    comp-<branch>/
+      <viewport>/           # desktop | mobile
+        <state>/            # empty | seeded | mid-session
+          <route>__<component>.png
+```
+
+## Running a capture pass
+
+### Serial (single state)
+
+Runs all 14 routes for one branch × viewport × state sequentially:
+
+```sh
+npx tsx scripts/audit/playwright-crawl.ts \
+  --theme ds3 --mode light --state seeded \
+  --branch integration-ds3-light --viewport desktop
+```
+
+Key flags:
+- `--branch <label>` — used as the capture subdir suffix (`comp-<label>`). Required.
+- `--theme <ds1|ds2|ds3|default>` — sets `narraitor-theme` in localStorage.
+- `--mode <light|dark>` — sets `narraitor-color-scheme` in localStorage.
+- `--state <empty|seeded|mid-session>` — which fixture seed to inject.
+- `--viewport <desktop|mobile>` — desktop=1320×900, mobile=390×844.
+- `--base-url <url>` — defaults to `http://localhost:3000`.
+- `--route <slug>` — capture a single route only (e.g. `--route worlds-create`).
+  Only that route's PNGs are written; other captures in the dir are untouched.
+
+For `develop` (no theme switch), use `--theme default --branch develop-default`.
+Run develop from its worktree on a different port so it doesn't kill the integration server:
+
+```sh
+# From /tmp/narraitor-develop-1129 (the develop worktree)
+npx next dev -p 3001
+
+# In another terminal:
+npx tsx scripts/audit/playwright-crawl.ts \
+  --theme default --mode light --state seeded \
+  --branch develop-default --viewport desktop \
+  --base-url http://localhost:3001
+```
+
+### Parallel (3 states concurrently against one server)
+
+`run-parallel.sh` spawns one worker per state (empty / seeded / mid-session) sharing
+a single dev server. This cuts wall time to ~1/3 of a serial 3-state pass.
+
+```sh
+# Integration branch (server already on :3000):
+bash scripts/audit/run-parallel.sh \
+  --branch integration-ds3-light \
+  --viewport desktop \
+  --theme ds3 \
+  --mode light \
+  --skip-server
+
+# Develop branch (spawns its own server on :3001):
+bash scripts/audit/run-parallel.sh \
+  --branch develop-default \
+  --viewport desktop \
+  --theme default \
+  --mode light \
+  --worktree /tmp/narraitor-develop-1129
+```
+
+Key flags:
+- `--worktree <path>` — directory to `cd` into when starting the dev server.
+  Defaults to the repo root.
+- `--base-url <url>` — skip port selection; use this URL directly.
+- `--skip-server` — don't start/stop a dev server (use when one is already running).
+
+**Collision safety:** each worker writes to `captures/comp-<branch>/<viewport>/<state>/`
+— state segments are disjoint, so no file conflicts. Seeds are regenerated once
+before workers start and are read-only during the crawl.
+
+**Why not cross-branch parallel?** Running 4 dev servers simultaneously multiplies
+cold-compile cost (each server JIT-compiles all 14 routes on first nav). Cross-state
+parallelism amortizes the compile cost because all 3 workers hit the same warm server.
+Run this script once per branch to parallelize; loop over branches yourself.
+
+## Generating / refreshing the review pages
+
+```sh
+python3 scripts/audit/build-review-html.py
+# writes scripts/audit/review/index.html + one page per route
+```
+
+Serve with any static HTTP server so relative paths resolve:
+
+```sh
+python3 -m http.server 8765 --directory scripts/audit
+# open http://localhost:8765/review/index.html
+```
+
+## Review UI
+
+The review lives in `scripts/audit/review/`:
+- **`index.html`** — route list table with live mark counts, total/unresolved per
+  route, and category breakdowns. Refreshes counts on window focus (when another
+  tab sets marks) and on the `storage` event.
+- **`<route>.html`** — per-route grid (all branches × states × viewports). Includes
+  prev/next route navigation and a Back to Index link.
+
+### Marks and triage
+
+Cells have a **Mark** button. When marked, a toolbar expands with:
+- **Category** chips: `bug` / `tooling` / `intentional` / `unclear`
+- **Why** — one-line summary used for issue grouping / markdown export
+- **Note** — freeform scratchpad
+- **Copy re-capture command** — copies a single-route playwright-crawl.ts invocation
+  to the clipboard. Run it in your terminal, then reload the page to see the fresh
+  capture.
+
+Mark state persists in localStorage (`narraitor-audit-marks-v3`). The key shape is
+`route__component__viewport__state__theme` and the value shape is:
+
+```json
+{
+  "marked": true,
+  "note": "freeform scratchpad",
+  "category": "bug",
+  "why": "header overflows mobile viewport",
+  "updatedAt": "2026-04-30T18:22:00.000Z"
+}
+```
+
+Use **Export markdown** to produce a triage punch list grouped by route (includes
+category tags and why). Use **Export JSON** / **Import JSON** to migrate marks across
+browsers or machines.
+
+### Mark schema migrations
+
+| Source  | Destination | What happens                                                   |
+|---------|-------------|----------------------------------------------------------------|
+| v1 (4 segments, no state in key) | v3 | State segment `__seeded` inserted; value upgraded to v3 shape |
+| v2 (5-segment key, old value)    | v3 | Key copied as-is; `category=null`, `why=""`, `updatedAt=now` added |
+
+Migrations are lazy (on first load or import). v1 and v2 namespaces are left untouched
+for rollback.
+
+## States captured
+
+| State         | Worlds        | Characters        | Active session | Segments / Decisions / Journal |
+|---            |---            |---                |---             |---                             |
+| `empty`       | none          | none              | none           | none                           |
+| `seeded`      | SAMPLE_WORLDS | SAMPLE_CHARACTERS | none           | none                           |
+| `mid-session` | SAMPLE_WORLDS | SAMPLE_CHARACTERS | first session  | full set                       |
+
+`tutorialProgress` is fully completed for `seeded` / `mid-session`, and fully
+incomplete for `empty`.
+
+## Known issues (from Phase 1 captures)
+
+- **`worlds-play-journal`**: `net::ERR_ABORTED` on both DS3 and develop — heavy lazy-load
+  or redirect loop. Investigate independently of the audit.
+- **`worlds-create` empty state**: world-creation tour popup fires for first-time users.
+  This is real first-time UX, not a tooling artifact.
+- **Mobile empty state (home, about)**: HeaderNavigation overflows 390px viewport.
+  This is a real bug (see GitHub issue tracker).

--- a/scripts/audit/build-review-html.py
+++ b/scripts/audit/build-review-html.py
@@ -1,0 +1,1323 @@
+#!/usr/bin/env python3
+"""Build the cross-theme audit review HTML (#1129).
+
+Discovers captures under:
+  scripts/audit/captures/comp-<branch>/<viewport>/<state>/<route>__<component>.png
+
+Emits:
+  scripts/audit/review/index.html  -- route list w/ live mark counts
+  scripts/audit/review/<route>.html (x14)  -- one page per route
+  scripts/audit/review.html  -- legacy redirect stub
+
+Mark schema (v3):
+  Storage key: narraitor-audit-marks-v3
+  Value:       { marked, note, category, why, updatedAt }
+  Migration: lazy v2 -> v3 on first load (v2 left untouched for rollback);
+             v2 migration also chains to v1 if v3 + v2 are both absent.
+
+Per-cell toolbar:
+  - Category radios (bug | tooling | intentional | unclear)
+  - Why one-line summary
+  - Note (freeform scratchpad)
+  - Copy re-capture command (single-route playwright-crawl invocation)
+"""
+import os
+import json
+from collections import defaultdict
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+CAPTURES_ROOT = REPO_ROOT / "scripts" / "audit" / "captures"
+REVIEW_DIR = REPO_ROOT / "scripts" / "audit" / "review"
+LEGACY_OUTPUT_PATH = REPO_ROOT / "scripts" / "audit" / "review.html"
+
+# branch label -> capture subdir name under captures/
+DIRS = {
+    "develop": "comp-develop-default",
+    "DS3": "comp-integration-ds3-light",
+    "DS1": "comp-integration-ds1-light",
+    "DS2": "comp-integration-ds2-light",
+}
+
+# Meta used to assemble the per-cell re-capture command. Keys mirror DIRS.
+BRANCH_META = {
+    "develop": {"theme": "default", "mode": "light", "branchArg": "develop-default"},
+    "DS3":     {"theme": "ds3",     "mode": "light", "branchArg": "integration-ds3-light"},
+    "DS1":     {"theme": "ds1",     "mode": "light", "branchArg": "integration-ds1-light"},
+    "DS2":     {"theme": "ds2",     "mode": "light", "branchArg": "integration-ds2-light"},
+}
+
+VIEWPORTS = ["desktop", "mobile"]
+# `mid-session` was dropped from the default pipeline — visually redundant
+# with `seeded` for triage. Old marks/captures with the segment still parse.
+STATES = ["empty", "seeded"]
+
+MAPPED_COMPONENTS = {
+    "global-nav": {"develop": "nav", "DS3": "nav", "DS1": "nav", "DS2": "nav"},
+}
+SUPPRESSED_COMPONENTS = {"nav", "header"}
+
+ROUTE_ORDER = [
+    "home", "about",
+    "worlds", "worlds-detail", "worlds-edit", "worlds-create",
+    "worlds-play", "worlds-play-journal",
+    "characters", "characters-detail", "characters-edit", "characters-create",
+    "play", "settings",
+]
+
+
+def route_sort_key(r):
+    try:
+        return (0, ROUTE_ORDER.index(r))
+    except ValueError:
+        return (1, r)
+
+
+def component_sort_key(c):
+    order = {"page": 0, "header": 1, "nav": 2, "form": 3, "main": 4}
+    if c in order:
+        return (order[c], 0)
+    if c.startswith("main-section-"):
+        try:
+            return (5, int(c.replace("main-section-", "")))
+        except ValueError:
+            return (5, 0)
+    return (9, c)
+
+
+def discover():
+    """Walk captures dir; return { (route, component): set(states) } and discovered branches."""
+    pairs = defaultdict(set)
+    branches_seen = set()
+    for branch_label, subdir in DIRS.items():
+        base = CAPTURES_ROOT / subdir
+        if not base.is_dir():
+            continue
+        branches_seen.add(branch_label)
+        for vp in VIEWPORTS:
+            for state in STATES:
+                state_dir = base / vp / state
+                if not state_dir.is_dir():
+                    continue
+                for png in state_dir.glob("*.png"):
+                    stem = png.stem
+                    if "__" not in stem:
+                        continue
+                    route, component = stem.split("__", 1)
+                    pairs[(route, component)].add(state)
+    return pairs, branches_seen
+
+
+def cell_id(route, component_label, viewport, state, theme):
+    return f"{route}__{component_label}__{viewport}__{state}__{theme}"
+
+
+def rel_capture_path(branch_subdir, viewport, state, route, component):
+    """Path relative to a per-route page in review/."""
+    return f"../captures/{branch_subdir}/{viewport}/{state}/{route}__{component}.png"
+
+
+def absolute_capture_path(branch_subdir, viewport, state, route, component):
+    return CAPTURES_ROOT / branch_subdir / viewport / state / f"{route}__{component}.png"
+
+
+SHARED_CSS = """
+  :root { --col-gap: 8px; --row-gap: 16px; }
+  html, body { margin: 0; padding: 0; font-family: -apple-system, system-ui, sans-serif; background: #fafafa; color: #222; }
+  .sticky-shell { position: sticky; top: 0; z-index: 100; border-bottom: 1px solid #444; }
+  header.top {
+    background: #1a1a1a; color: #fff; padding: 12px 16px;
+    display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+  }
+  header.top h1 { font-size: 14px; margin: 0; font-weight: 600; }
+  header.top .legend { display: flex; gap: 12px; font-size: 12px; }
+  header.top .legend .col { padding: 2px 8px; border-radius: 3px; }
+  header.top .legend .develop { background: #6b7280; }
+  header.top .legend .ds3 { background: #4338ca; }
+  header.top .legend .ds1 { background: #92400e; }
+  header.top .legend .ds2 { background: #166534; }
+  header.top a.back { color: #9cf; font-size: 12px; text-decoration: none; padding: 2px 6px; border-radius: 2px; }
+  header.top a.back:hover { background: #444; color: #fff; }
+  header.top .nav-routes { display: flex; gap: 4px; align-items: center; font-size: 12px; }
+  header.top .nav-routes a { color: #9cf; text-decoration: none; padding: 2px 8px; border-radius: 2px; background: #2a2a2a; }
+  header.top .nav-routes a:hover { background: #444; color: #fff; }
+  header.top .nav-routes .current { color: #fff; font-weight: 600; padding: 2px 8px; }
+  main { padding: 16px; max-width: 100%; }
+  section.route {
+    margin-bottom: 32px; background: #fff; border-radius: 6px;
+    padding: 12px 16px 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  section.route h2 {
+    font-size: 18px; margin: 0 0 12px; padding-bottom: 6px;
+    border-bottom: 1px solid #e5e5e5;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+  .component-row {
+    display: grid; grid-template-columns: 180px repeat(4, 1fr);
+    gap: var(--col-gap); margin-bottom: var(--row-gap);
+    align-items: start;
+  }
+  .component-row .label {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px; color: #555; padding-top: 28px; line-height: 1.3;
+    word-break: break-word;
+  }
+  .cell {
+    border: 1px solid #e5e5e5; border-radius: 4px; overflow: hidden;
+    background: #f3f4f6; position: relative; min-height: 100px;
+    display: flex; flex-direction: column;
+  }
+  .cell .header {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.04em; padding: 4px 8px; color: #fff;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .cell.develop .header { background: #6b7280; }
+  .cell.ds3 .header { background: #4338ca; }
+  .cell.ds1 .header { background: #92400e; }
+  .cell.ds2 .header { background: #166534; }
+  .cell img {
+    display: block; width: auto; max-width: 100%; height: auto;
+    cursor: zoom-in; background: #fff; align-self: flex-start;
+  }
+  body.fit-cell .cell img { width: 100%; max-width: 100%; }
+  .cell.empty {
+    display: flex; align-items: center; justify-content: center;
+    color: #999; font-size: 12px; padding: 24px; background: #f9f9f9;
+  }
+  .cell.empty::after { content: "(not captured)"; }
+
+  /* Lightbox */
+  #lightbox {
+    display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.92);
+    z-index: 1000; align-items: center; justify-content: center; cursor: zoom-out;
+  }
+  #lightbox.open { display: flex; }
+  #lightbox img { max-width: 96vw; max-height: 96vh; box-shadow: 0 4px 24px rgba(0,0,0,0.5); }
+
+  .controls { display: flex; gap: 12px; align-items: center; font-size: 12px; flex-wrap: wrap; }
+  .controls label { display: flex; align-items: center; gap: 4px; cursor: pointer; }
+  .controls input[type=checkbox] { margin: 0; }
+
+  .state-chips { display: inline-flex; gap: 4px; align-items: center; }
+  .state-chip {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .state-chip.active { background: #2563eb; border-color: #1d4ed8; }
+  .state-chip:hover { background: #4b5563; }
+  .state-chip.active:hover { background: #1d4ed8; }
+
+  body.hide-empty .component-row.all-empty,
+  body.hide-empty .cell.empty { display: none; }
+  body.compact .cell img { max-height: 360px; object-fit: cover; object-position: top; }
+
+  .cell .mark-btn {
+    margin-left: auto; background: rgba(255,255,255,0.18);
+    color: #fff; border: 1px solid rgba(255,255,255,0.35);
+    border-radius: 3px; font-size: 10px; font-weight: 600;
+    padding: 2px 6px; cursor: pointer;
+    text-transform: none; letter-spacing: 0; line-height: 1.2;
+  }
+  .cell .mark-btn:hover { background: rgba(255,255,255,0.28); }
+  .cell.marked { border: 3px solid #dc2626; }
+  .cell.marked .mark-btn { background: #dc2626; border-color: #b91c1c; color: #fff; }
+  .cell.marked .mark-btn::before { content: "x "; }
+  .cell.pending-recapture { animation: cellPulse 2s ease-out; }
+  @keyframes cellPulse {
+    0%   { box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.9); border-color: #7c3aed; }
+    100% { box-shadow: 0 0 0 8px rgba(124, 58, 237, 0); }
+  }
+  .cell .toolbar {
+    display: none;
+    padding: 6px 8px; background: #fef2f2; border-top: 1px solid #fecaca;
+    font-size: 11px;
+  }
+  .cell.marked .toolbar { display: block; }
+  .cell .toolbar input[type=text],
+  .cell .toolbar textarea {
+    width: 100%; box-sizing: border-box;
+    border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 4px 6px; font-size: 12px; font-family: inherit;
+    background: #fff;
+  }
+  .cell .toolbar input[type=text]:focus,
+  .cell .toolbar textarea:focus { outline: 2px solid #dc2626; outline-offset: -1px; }
+  .cell .toolbar .field { margin-bottom: 6px; }
+  .cell .toolbar .field-label {
+    display: block; font-size: 10px; font-weight: 600;
+    color: #7f1d1d; text-transform: uppercase; letter-spacing: 0.04em;
+    margin-bottom: 2px;
+  }
+  .cell .toolbar .cat-chips { display: flex; gap: 4px; flex-wrap: wrap; }
+  .cell .toolbar .cat-chip {
+    background: #fff; border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 2px 8px; font-size: 11px; cursor: pointer; font-family: inherit;
+    color: #7f1d1d;
+  }
+  .cell .toolbar .cat-chip.active { background: #7f1d1d; color: #fff; border-color: #7f1d1d; }
+  .cell .toolbar .cat-chip[data-cat="needs-design"].active { background: #6d28d9; border-color: #6d28d9; }
+  .cell .toolbar .cat-chip[data-cat="bug"].active        { background: #b91c1c; border-color: #b91c1c; }
+  .cell .toolbar .cat-chip[data-cat="tooling"].active    { background: #b45309; border-color: #b45309; }
+  .cell .toolbar .cat-chip[data-cat="intentional"].active{ background: #15803d; border-color: #15803d; }
+  .cell .toolbar .cat-chip[data-cat="unclear"].active    { background: #6b7280; border-color: #6b7280; }
+  .cell .toolbar .recapture-btn {
+    background: #1d4ed8; color: #fff; border: 0; border-radius: 3px;
+    padding: 4px 10px; font-size: 11px; cursor: pointer;
+    font-family: inherit; font-weight: 600;
+  }
+  .cell .toolbar .recapture-btn:hover { background: #1e40af; }
+  .cell .toolbar textarea { min-height: 32px; resize: vertical; font-size: 11px; }
+  .cell.cat-needs-design { border-color: #6d28d9; }
+  .cell.cat-bug         { border-color: #b91c1c; }
+  .cell.cat-tooling     { border-color: #b45309; }
+  .cell.cat-intentional { border-color: #15803d; }
+  .cell.cat-unclear     { border-color: #6b7280; }
+
+  .marks-cluster {
+    display: flex; align-items: center; gap: 8px;
+    border-left: 1px solid #444; padding-left: 12px; margin-left: 4px;
+    font-size: 12px;
+  }
+  .marks-cluster .count {
+    background: #dc2626; color: #fff; border-radius: 10px;
+    padding: 2px 8px; font-weight: 600; min-width: 18px; text-align: center;
+  }
+  .marks-cluster button {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .marks-cluster button:hover { background: #4b5563; }
+  .marks-cluster button.danger { background: #7f1d1d; border-color: #991b1b; }
+  .marks-cluster button.danger:hover { background: #991b1b; }
+
+  body.only-marked .component-row:not(.has-marked) { display: none; }
+  body.only-marked section.route:not(.has-marked) { display: none; }
+
+  .component-row.suppressed { display: none; }
+  body.show-suppressed .component-row.suppressed { display: grid; }
+  .component-row.suppressed .label::after { content: " (hidden)"; color: #b91c1c; font-style: italic; }
+
+  .component-row .label[data-mapped] { color: #1d4ed8; }
+  .component-row .label[data-mapped]::after { content: " *"; }
+  .mapped-tooltip {
+    display: inline-block; margin-left: 4px;
+    font-size: 10px; color: #6b7280; cursor: help; vertical-align: super;
+  }
+
+  .vp-badge, .state-badge {
+    display: inline-block; font-size: 9px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.05em;
+    padding: 1px 6px; border-radius: 8px; margin-top: 2px;
+  }
+  .vp-badge.desktop { background: #dbeafe; color: #1e3a8a; border: 1px solid #93c5fd; margin-right: 4px; }
+  .vp-badge.mobile  { background: #fef3c7; color: #78350f; border: 1px solid #fcd34d; margin-right: 4px; }
+  .state-badge.empty       { background: #f3f4f6; color: #374151; border: 1px solid #d1d5db; }
+  .state-badge.seeded      { background: #dcfce7; color: #14532d; border: 1px solid #86efac; }
+  .state-badge.mid-session { background: #ede9fe; color: #4c1d95; border: 1px solid #c4b5fd; }
+
+  .component-row.vp-mobile { background: #fffbeb; padding: 4px; border-radius: 4px; }
+  body.hide-desktop .component-row.vp-desktop { display: none; }
+  body.hide-mobile .component-row.vp-mobile { display: none; }
+
+  body.hide-state-empty       .component-row.state-empty       { display: none; }
+  body.hide-state-seeded      .component-row.state-seeded      { display: none; }
+  body.hide-state-mid-session .component-row.state-mid-session { display: none; }
+
+  .overlay {
+    display: none; position: fixed; inset: 0; z-index: 1100;
+    background: rgba(0,0,0,0.6); align-items: center; justify-content: center;
+  }
+  .overlay.open { display: flex; }
+  .overlay .panel {
+    background: #fff; border-radius: 6px; width: min(720px, 92vw);
+    max-height: 80vh; padding: 16px; display: flex; flex-direction: column; gap: 8px;
+  }
+  .overlay h3 { margin: 0; font-size: 14px; }
+  .overlay textarea {
+    flex: 1; min-height: 320px; font-family: ui-monospace, monospace; font-size: 12px;
+    border: 1px solid #ddd; border-radius: 4px; padding: 8px; resize: vertical;
+  }
+  .overlay .actions { display: flex; gap: 8px; justify-content: flex-end; }
+  .overlay button {
+    background: #1a1a1a; color: #fff; border: 0; border-radius: 3px;
+    padding: 6px 12px; font-size: 12px; cursor: pointer;
+  }
+  .overlay .hint { font-size: 11px; color: #555; }
+  .overlay .err  { font-size: 12px; color: #b91c1c; min-height: 16px; }
+
+  /* Index-page table */
+  table.routes-index {
+    width: 100%; border-collapse: collapse; background: #fff;
+    border-radius: 6px; overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  table.routes-index th, table.routes-index td {
+    padding: 8px 12px; text-align: left; font-size: 13px;
+    border-bottom: 1px solid #eee;
+  }
+  table.routes-index th { background: #f3f4f6; font-weight: 600; }
+  table.routes-index td a {
+    color: #1d4ed8; text-decoration: none; font-family: ui-monospace, monospace;
+  }
+  table.routes-index td a:hover { text-decoration: underline; }
+  table.routes-index td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  table.routes-index .marked-count.has-marks { color: #b91c1c; font-weight: 600; }
+  table.routes-index .unresolved-count.has-unresolved { color: #b45309; font-weight: 600; }
+  table.routes-index .breakdown {
+    font-size: 11px; color: #555; margin-left: 6px; font-variant-numeric: tabular-nums;
+  }
+"""
+
+
+# JS shared by all pages: mark schema, migration, persistence, helpers.
+# Note: Python format strings would conflict with the JS template literals,
+# so we use plain string concatenation and inject only via .replace() below.
+SHARED_JS_PRELUDE = r"""
+  const STORAGE_KEY = 'narraitor-audit-marks-v3';
+  const STORAGE_KEY_V2 = 'narraitor-audit-marks-v2';
+  const STORAGE_KEY_V1 = 'narraitor-audit-marks-v1';
+  // Tracks which routes have had their DS cells auto-prefilled as needs-design.
+  // Once a route is in here, the auto-prefill on page load is skipped.
+  const PREFILLED_KEY = 'narraitor-audit-prefilled-v1';
+  const STATES = ['empty', 'seeded'];
+  const VALID_CATEGORIES = ['needs-design','bug','tooling','intentional','unclear'];
+  const ROUTE_ORDER = __ROUTE_ORDER__;
+  const COMPONENT_ORDER = {"page":0,"header":1,"nav":2,"form":3,"main":4};
+  const THEME_ORDER = ["DS3","DS1","DS2","develop"];
+  const BRANCH_META = __BRANCH_META__;
+
+  function componentSortKey(c) {
+    if (c in COMPONENT_ORDER) return [COMPONENT_ORDER[c], 0];
+    if (c.startsWith("main-section-")) {
+      const n = parseInt(c.replace("main-section-",""), 10);
+      return [5, isNaN(n) ? 0 : n];
+    }
+    return [9, c];
+  }
+
+  // Pre-v3 ID migration: v1 (4 segments) -> v2 (5 segments) by inserting __seeded.
+  function migrateLegacyId(id) {
+    const parts = id.split('__');
+    if (parts.length < 4) return id;
+    const last = parts[parts.length - 1];
+    const second = parts[parts.length - 2];
+    const third = parts[parts.length - 3];
+    const isTheme = ['DS1','DS2','DS3','develop'].includes(last);
+    const isViewport = ['desktop','mobile'].includes(second);
+    const alreadyHasState = STATES.includes(third);
+    if (isTheme && isViewport && !alreadyHasState) {
+      const head = parts.slice(0, parts.length - 1).join('__');
+      return head + '__seeded__' + last;
+    }
+    return id;
+  }
+
+  function migrateMarksV1ToV2(input) {
+    const out = {};
+    let migrated = 0;
+    for (const [id, m] of Object.entries(input || {})) {
+      const newId = migrateLegacyId(id);
+      if (newId !== id) migrated++;
+      out[newId] = m;
+    }
+    return { marks: out, migrated };
+  }
+
+  // v2 -> v3: add category, why, updatedAt; preserve marked + note.
+  function upgradeV2ValueToV3(v) {
+    if (!v || typeof v !== 'object') return null;
+    return {
+      marked: !!v.marked,
+      note: typeof v.note === 'string' ? v.note : '',
+      category: v.category && VALID_CATEGORIES.includes(v.category) ? v.category : null,
+      why: typeof v.why === 'string' ? v.why : '',
+      updatedAt: v.updatedAt || new Date().toISOString(),
+    };
+  }
+
+  function migrateV2ObjectToV3(v2obj) {
+    const out = {};
+    for (const [id, m] of Object.entries(v2obj || {})) {
+      out[id] = upgradeV2ValueToV3(m);
+    }
+    return out;
+  }
+
+  function loadMarks() {
+    try {
+      const v3 = localStorage.getItem(STORAGE_KEY);
+      if (v3) return JSON.parse(v3);
+      // No v3 yet — try v2 (lazy migrate; leave v2 untouched for rollback).
+      const v2raw = localStorage.getItem(STORAGE_KEY_V2);
+      if (v2raw) {
+        const v3marks = migrateV2ObjectToV3(JSON.parse(v2raw));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + Object.keys(v3marks).length + ' v2 marks to v3 (v2 untouched).');
+        return v3marks;
+      }
+      // No v3 or v2 — try v1 and migrate v1 -> v2 -> v3 in one pass.
+      const v1raw = localStorage.getItem(STORAGE_KEY_V1);
+      if (v1raw) {
+        const { marks: v2marks, migrated } = migrateMarksV1ToV2(JSON.parse(v1raw));
+        const v3marks = migrateV2ObjectToV3(v2marks);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + migrated + ' v1 IDs through to v3.');
+        return v3marks;
+      }
+    } catch (e) { console.warn(e); }
+    return {};
+  }
+
+  function saveMarks(m) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(m)); } catch (e) {}
+  }
+"""
+
+
+def _shared_js_prelude():
+    return (
+        SHARED_JS_PRELUDE
+        .replace("__ROUTE_ORDER__", json.dumps(ROUTE_ORDER))
+        .replace("__BRANCH_META__", json.dumps(BRANCH_META))
+    )
+
+
+def html_head(title, extra_css=""):
+    return (
+        "<!DOCTYPE html>\n"
+        "<html lang=\"en\">\n"
+        "<head>\n"
+        "<meta charset=\"utf-8\">\n"
+        f"<title>{title}</title>\n"
+        f"<style>\n{SHARED_CSS}\n{extra_css}\n</style>\n"
+        "</head>\n"
+        "<body>\n"
+    )
+
+
+def render_route_section(route, components, branches_seen):
+    """Return the HTML for a single route section (the cell grid)."""
+    parts = [f'<section class="route" id="route-{route}">\n  <h2>{route}</h2>\n']
+
+    def render_row(label_text, branch_to_component, viewport, state,
+                   suppressed=False, mapped=False, tooltip=""):
+        row_classes = (
+            f'component-row vp-{viewport} state-{state}'
+            + (' suppressed' if suppressed else '')
+        )
+        out = [f'  <div class="{row_classes}" data-viewport="{viewport}" data-state="{state}">\n']
+        label_attrs = ' data-mapped="1"' if mapped else ''
+        tip_html = f'<span class="mapped-tooltip" title="{tooltip}">i</span>' if tooltip else ''
+        vp_badge = f'<span class="vp-badge {viewport}">{viewport}</span>'
+        state_badge = f'<span class="state-badge {state}">{state}</span>'
+        out.append(
+            f'    <div class="label"{label_attrs}>{label_text}{tip_html}'
+            f'<br>{vp_badge}{state_badge}</div>\n'
+        )
+        for theme_key, subdir in DIRS.items():
+            theme_class = theme_key.lower()
+            src_component = branch_to_component.get(theme_key)
+            if src_component is None:
+                out.append('    <div class="cell empty"></div>\n')
+                continue
+            abs_path = absolute_capture_path(subdir, viewport, state, route, src_component)
+            if abs_path.exists():
+                rel = rel_capture_path(subdir, viewport, state, route, src_component)
+                cid = cell_id(route, label_text, viewport, state, theme_key)
+                caption = (
+                    f'{theme_key} -- {route}/{label_text} '
+                    f'({viewport}/{state}; src: {src_component})'
+                )
+                img_scale = '2' if src_component == 'page' else '1'
+                out.append(
+                    f'    <div class="cell {theme_class}" data-cell-id="{cid}" '
+                    f'data-route="{route}" data-component="{label_text}" '
+                    f'data-viewport="{viewport}" data-state="{state}" '
+                    f'data-theme="{theme_key}" data-img-scale="{img_scale}">\n'
+                )
+                out.append(
+                    f'      <div class="header"><span>{theme_key}</span>'
+                    f'<button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>\n'
+                )
+                out.append(
+                    f'      <img src="{rel}" alt="{theme_key} {route}/{label_text}/{viewport}/{state}" '
+                    f'data-caption="{caption}" loading="lazy">\n'
+                )
+                # New v3 toolbar: category chips, why, note, copy re-capture command
+                out.append(
+                    '      <div class="toolbar">\n'
+                    '        <div class="field">\n'
+                    '          <span class="field-label">Category</span>\n'
+                    '          <div class="cat-chips" data-action="cat-chips">\n'
+                    '            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>\n'
+                    '            <button type="button" class="cat-chip" data-cat="bug">bug</button>\n'
+                    '            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>\n'
+                    '            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>\n'
+                    '            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>\n'
+                    '          </div>\n'
+                    '        </div>\n'
+                    '        <div class="field">\n'
+                    '          <span class="field-label">Why (one-line summary)</span>\n'
+                    '          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">\n'
+                    '        </div>\n'
+                    '        <div class="field">\n'
+                    '          <span class="field-label">Note (freeform scratchpad)</span>\n'
+                    '          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>\n'
+                    '        </div>\n'
+                    '        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">\n'
+                    '          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>\n'
+                    '        </div>\n'
+                    '      </div>\n'
+                )
+                out.append('    </div>\n')
+            else:
+                out.append('    <div class="cell empty"></div>\n')
+        out.append('  </div>\n')
+        return ''.join(out)
+
+    for state in STATES:
+        for logical_label, branch_map in MAPPED_COMPONENTS.items():
+            any_present = any(
+                absolute_capture_path(DIRS[bk], "desktop", state, route, src).exists()
+                for bk, src in branch_map.items()
+            )
+            if any_present:
+                tip = "Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar."
+                parts.append(render_row(
+                    logical_label, branch_map, "desktop", state,
+                    mapped=True, tooltip=tip,
+                ))
+
+        for c in components:
+            same = {bk: c for bk in DIRS.keys()}
+            is_suppressed = c in SUPPRESSED_COMPONENTS
+            if any(absolute_capture_path(DIRS[bk], "desktop", state, route, c).exists() for bk in DIRS):
+                parts.append(render_row(c, same, "desktop", state, suppressed=is_suppressed))
+            if c == "page" and any(
+                absolute_capture_path(DIRS[bk], "mobile", state, route, c).exists() for bk in DIRS
+            ):
+                parts.append(render_row(c, same, "mobile", state, suppressed=is_suppressed))
+
+    parts.append('</section>\n')
+    return ''.join(parts)
+
+
+def render_route_page(route, components, branches_seen, sorted_routes):
+    """Return the full HTML for one per-route page."""
+    title = f'Cross-Theme Audit (#1129) — {route}'
+
+    idx = sorted_routes.index(route)
+    prev_route = sorted_routes[idx - 1] if idx > 0 else None
+    next_route = sorted_routes[idx + 1] if idx < len(sorted_routes) - 1 else None
+
+    head = html_head(title)
+    body_open = '<div class="sticky-shell">\n<header class="top">\n'
+    body_open += f'  <a class="back" href="index.html">&larr; Index</a>\n'
+    body_open += f'  <h1>{route}</h1>\n'
+    body_open += '  <div class="legend">\n'
+    body_open += '    <span class="col develop">develop</span>\n'
+    body_open += '    <span class="col ds3">DS3</span>\n'
+    body_open += '    <span class="col ds1">DS1</span>\n'
+    body_open += '    <span class="col ds2">DS2</span>\n'
+    body_open += '  </div>\n'
+    body_open += '  <div class="controls">\n'
+    body_open += '    <span class="state-chips" role="group" aria-label="State filter">\n'
+    body_open += '      <span style="font-size: 11px; color: #aaa;">State:</span>\n'
+    for s in STATES:
+        active = ' active' if s == 'seeded' else ''
+        body_open += f'      <button type="button" class="state-chip{active}" data-state="{s}">{s}</button>\n'
+    body_open += '    </span>\n'
+    body_open += '    <label><input type="checkbox" id="hide-empty"> Hide missing</label>\n'
+    body_open += '    <label><input type="checkbox" id="compact"> Compact</label>\n'
+    body_open += '    <label title="Stretch images to cell width"><input type="checkbox" id="fit-cell"> Fit to cell</label>\n'
+    body_open += '    <label><input type="checkbox" id="only-marked"> Only marked</label>\n'
+    body_open += '    <label><input type="checkbox" id="show-suppressed"> Show hidden rows</label>\n'
+    body_open += '    <label><input type="checkbox" id="hide-desktop"> Hide desktop</label>\n'
+    body_open += '    <label><input type="checkbox" id="hide-mobile"> Hide mobile</label>\n'
+    body_open += '  </div>\n'
+    body_open += '  <div class="marks-cluster">\n'
+    body_open += '    <span>Marked (route):</span>\n'
+    body_open += '    <span class="count" id="mark-count">0</span>\n'
+    body_open += '    <button id="prefill-ds-btn" type="button" title="Mark every DS cell that has no mark yet as needs-design (gap-fill, never overwrites your existing marks)">Fill DS gaps</button>\n'
+    body_open += '    <button id="export-md-btn" type="button">Export markdown</button>\n'
+    body_open += '    <button id="export-json-btn" type="button">Export JSON</button>\n'
+    body_open += '    <button id="import-json-btn" type="button">Import JSON</button>\n'
+    body_open += '    <button id="clear-route-btn" type="button" class="danger">Clear (route)</button>\n'
+    body_open += '  </div>\n'
+    body_open += '</header>\n'
+
+    # prev/next nav row
+    body_open += '<nav class="toc" style="background:#2a2a2a;color:#ccc;padding:6px 16px;font-size:12px;display:flex;gap:8px;align-items:center;border-top:1px solid #444;">\n'
+    body_open += '  <span class="nav-routes">\n'
+    if prev_route:
+        body_open += f'    <a href="{prev_route}.html">&larr; {prev_route}</a>\n'
+    body_open += f'    <span class="current">{route}</span>\n'
+    if next_route:
+        body_open += f'    <a href="{next_route}.html">{next_route} &rarr;</a>\n'
+    body_open += '  </span>\n'
+    body_open += '</nav>\n'
+    body_open += '</div>\n<main>\n'
+
+    section_html = render_route_section(route, components, branches_seen)
+
+    overlays = """</main>
+
+<div id="lightbox" class="overlay">
+  <img id="lightbox-img" src="" alt="">
+  <div id="lightbox-caption" style="position: fixed; top: 12px; left: 50%; transform: translateX(-50%); color: #fff; font-family: ui-monospace, monospace; font-size: 13px; background: rgba(0,0,0,0.6); padding: 6px 12px; border-radius: 4px;"></div>
+</div>
+
+<div id="md-overlay" class="overlay">
+  <div class="panel">
+    <h3>Audit marks (markdown) -- this route only</h3>
+    <textarea id="md-text" readonly></textarea>
+    <div class="actions">
+      <button id="md-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="md-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-export-overlay" class="overlay">
+  <div class="panel">
+    <h3>Marks (raw JSON) -- all routes</h3>
+    <textarea id="json-export-text" readonly></textarea>
+    <div class="actions">
+      <button id="json-export-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="json-export-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-import-overlay" class="overlay">
+  <div class="panel">
+    <h3>Import marks (paste raw JSON)</h3>
+    <p class="hint">Paste JSON exported from another instance. Legacy IDs without a state segment are migrated to <code>__seeded</code>; v2 values are upgraded to v3 (category=null, why="", updatedAt=now). Existing marks with the same ID are overwritten.</p>
+    <textarea id="json-import-text" placeholder='{"home__page__desktop__seeded__DS3":{"marked":true,"note":"...","category":"bug","why":"...","updatedAt":"..."}}'></textarea>
+    <div class="err" id="json-import-err"></div>
+    <div class="actions">
+      <button id="json-import-apply" type="button">Apply</button>
+      <button class="overlay-close" data-overlay="json-import-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+"""
+
+    js = f"""<script>
+{_shared_js_prelude()}
+
+  const ROUTE = {json.dumps(route)};
+  let marks = loadMarks();
+
+  function applyMarkState(cell) {{
+    const id = cell.dataset.cellId;
+    const m = marks[id];
+    const noteInput = cell.querySelector('textarea[data-action="note"]');
+    const whyInput = cell.querySelector('input[data-action="why"]');
+    const chips = cell.querySelectorAll('.cat-chip');
+    cell.classList.remove('cat-bug','cat-tooling','cat-intentional','cat-unclear');
+    chips.forEach(c => c.classList.remove('active'));
+    if (m && m.marked) {{
+      cell.classList.add('marked');
+      if (noteInput) noteInput.value = m.note || '';
+      if (whyInput) whyInput.value = m.why || '';
+      if (m.category) {{
+        cell.classList.add('cat-' + m.category);
+        const chip = cell.querySelector('.cat-chip[data-cat="' + m.category + '"]');
+        if (chip) chip.classList.add('active');
+      }}
+    }} else {{
+      cell.classList.remove('marked');
+      if (noteInput) noteInput.value = '';
+      if (whyInput) whyInput.value = '';
+    }}
+  }}
+
+  function updateRowSectionFlags() {{
+    document.querySelectorAll('.component-row').forEach(row => {{
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    }});
+    document.querySelectorAll('section.route').forEach(sec => {{
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+    }});
+  }}
+
+  function updateCount() {{
+    const n = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).length;
+    document.getElementById('mark-count').textContent = n;
+  }}
+
+  function writeMark(id, partial) {{
+    const existing = marks[id] || {{ marked: false, note: '', category: null, why: '', updatedAt: null }};
+    const next = Object.assign({{}}, existing, partial, {{ updatedAt: new Date().toISOString() }});
+    if (!next.marked && !next.note && !next.why && !next.category) {{
+      delete marks[id];
+    }} else {{
+      marks[id] = next;
+    }}
+    saveMarks(marks);
+    updateCount();
+  }}
+
+  function buildRecaptureCommand(cell) {{
+    const route = cell.dataset.route;
+    const viewport = cell.dataset.viewport;
+    const state = cell.dataset.state;
+    const themeKey = cell.dataset.theme;
+    const meta = BRANCH_META[themeKey];
+    if (!meta) return null;
+    return 'npx tsx scripts/audit/playwright-crawl.ts'
+      + ' --branch ' + meta.branchArg
+      + ' --viewport ' + viewport
+      + ' --state ' + state
+      + ' --theme ' + meta.theme
+      + ' --mode ' + meta.mode
+      + ' --route ' + route;
+  }}
+
+  function loadPrefilledFlags() {{
+    try {{ return JSON.parse(localStorage.getItem(PREFILLED_KEY) || '{{}}'); }}
+    catch (e) {{ return {{}}; }}
+  }}
+  function savePrefilledFlags(f) {{
+    try {{ localStorage.setItem(PREFILLED_KEY, JSON.stringify(f)); }} catch (e) {{}}
+  }}
+
+  // Gap-fill: only adds entries for DS cells that have no existing mark.
+  // Returns the count of cells filled. Develop is excluded (it's the baseline).
+  function prefillDsCellsAsNeedsDesign() {{
+    const dsCells = Array.from(document.querySelectorAll('.cell[data-cell-id]'))
+      .filter(c => ['DS1','DS2','DS3'].includes(c.dataset.theme));
+    let added = 0;
+    const ts = new Date().toISOString();
+    for (const cell of dsCells) {{
+      const id = cell.dataset.cellId;
+      if (!marks[id]) {{
+        marks[id] = {{ marked: true, note: '', category: 'needs-design', why: '', updatedAt: ts }};
+        added++;
+      }}
+    }}
+    if (added > 0) saveMarks(marks);
+    return added;
+  }}
+
+  // Auto-prefill on first visit per route.
+  const prefillFlags = loadPrefilledFlags();
+  if (!prefillFlags[ROUTE]) {{
+    const added = prefillDsCellsAsNeedsDesign();
+    prefillFlags[ROUTE] = true;
+    savePrefilledFlags(prefillFlags);
+    if (added > 0) console.info('[audit] auto-prefilled ' + added + ' DS cells for ' + ROUTE + ' as needs-design.');
+  }}
+
+  document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+  updateRowSectionFlags();
+  updateCount();
+
+  // Lightbox
+  const lb = document.getElementById('lightbox');
+  const lbImg = document.getElementById('lightbox-img');
+  const lbCap = document.getElementById('lightbox-caption');
+  document.querySelectorAll('.cell img').forEach(img => {{
+    img.addEventListener('click', () => {{
+      lbImg.src = img.src;
+      lbCap.textContent = img.dataset.caption || '';
+      lb.classList.add('open');
+    }});
+  }});
+  lb.addEventListener('click', () => lb.classList.remove('open'));
+  document.addEventListener('keydown', e => {{
+    if (e.key === 'Escape') document.querySelectorAll('.overlay.open').forEach(o => o.classList.remove('open'));
+  }});
+
+  // Mark toggle
+  document.querySelectorAll('button[data-action="toggle-mark"]').forEach(btn => {{
+    btn.addEventListener('click', e => {{
+      e.stopPropagation();
+      const cell = btn.closest('.cell');
+      const id = cell.dataset.cellId;
+      const isMarked = !cell.classList.contains('marked');
+      writeMark(id, {{ marked: isMarked }});
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      const sec = cell.closest('section.route');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+      if (isMarked) {{
+        const why = cell.querySelector('input[data-action="why"]');
+        if (why) setTimeout(() => why.focus(), 0);
+      }}
+    }});
+  }});
+
+  // Why / note inputs (debounced save)
+  let saveTimer = null;
+  function bindInput(sel, field) {{
+    document.querySelectorAll(sel).forEach(inp => {{
+      const handler = () => {{
+        const cell = inp.closest('.cell');
+        if (!cell.classList.contains('marked')) return;
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(() => {{
+          writeMark(cell.dataset.cellId, {{ [field]: inp.value }});
+        }}, 250);
+      }};
+      inp.addEventListener('input', handler);
+      inp.addEventListener('blur', () => {{
+        const cell = inp.closest('.cell');
+        if (cell.classList.contains('marked')) writeMark(cell.dataset.cellId, {{ [field]: inp.value }});
+      }});
+    }});
+  }}
+  bindInput('input[data-action="why"]', 'why');
+  bindInput('textarea[data-action="note"]', 'note');
+
+  // Category chips
+  document.querySelectorAll('.cat-chip').forEach(chip => {{
+    chip.addEventListener('click', () => {{
+      const cell = chip.closest('.cell');
+      if (!cell.classList.contains('marked')) {{
+        // Mark the cell first so the category sticks
+        writeMark(cell.dataset.cellId, {{ marked: true }});
+      }}
+      const cat = chip.dataset.cat;
+      const isActive = chip.classList.contains('active');
+      writeMark(cell.dataset.cellId, {{ category: isActive ? null : cat }});
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    }});
+  }});
+
+  // Re-capture command (copy to clipboard, flash purple)
+  document.querySelectorAll('button[data-action="recapture"]').forEach(btn => {{
+    btn.addEventListener('click', async () => {{
+      const cell = btn.closest('.cell');
+      const cmd = buildRecaptureCommand(cell);
+      if (!cmd) return;
+      try {{
+        await navigator.clipboard.writeText(cmd);
+        btn.textContent = 'Copied!';
+        setTimeout(() => {{ btn.textContent = 'Copy re-capture command'; }}, 1500);
+      }} catch (e) {{
+        prompt('Copy this command:', cmd);
+      }}
+      cell.classList.remove('pending-recapture');
+      void cell.offsetWidth; // force reflow so the animation restarts
+      cell.classList.add('pending-recapture');
+    }});
+  }});
+
+  // Toggles
+  document.getElementById('hide-empty').addEventListener('change', e => document.body.classList.toggle('hide-empty', e.target.checked));
+  document.getElementById('compact').addEventListener('change', e => document.body.classList.toggle('compact', e.target.checked));
+  document.getElementById('fit-cell').addEventListener('change', e => document.body.classList.toggle('fit-cell', e.target.checked));
+  document.getElementById('only-marked').addEventListener('change', e => document.body.classList.toggle('only-marked', e.target.checked));
+  document.getElementById('show-suppressed').addEventListener('change', e => document.body.classList.toggle('show-suppressed', e.target.checked));
+  document.getElementById('hide-desktop').addEventListener('change', e => document.body.classList.toggle('hide-desktop', e.target.checked));
+  document.getElementById('hide-mobile').addEventListener('change', e => document.body.classList.toggle('hide-mobile', e.target.checked));
+
+  // True-scale rendering (1x for selector captures, 0.5x for retina full-page).
+  const RETINA_THRESHOLD = 1500;
+  function applyTrueScale(img) {{
+    if (!img.naturalWidth) return;
+    const cssWidth = img.naturalWidth > RETINA_THRESHOLD
+      ? Math.round(img.naturalWidth / 2)
+      : img.naturalWidth;
+    img.style.maxWidth = 'min(100%, ' + cssWidth + 'px)';
+  }}
+  document.querySelectorAll('.cell img').forEach(img => {{
+    if (img.complete && img.naturalWidth > 0) applyTrueScale(img);
+    else img.addEventListener('load', () => applyTrueScale(img), {{ once: true }});
+  }});
+
+  // State chips
+  document.querySelectorAll('.state-chip').forEach(chip => {{
+    chip.addEventListener('click', () => {{
+      const state = chip.dataset.state;
+      chip.classList.toggle('active');
+      document.body.classList.toggle('hide-state-' + state, !chip.classList.contains('active'));
+    }});
+  }});
+  STATES.forEach(s => {{
+    const chip = document.querySelector('.state-chip[data-state="' + s + '"]');
+    if (chip && !chip.classList.contains('active')) document.body.classList.add('hide-state-' + s);
+  }});
+
+  // Manual top-up: fill any DS cells that don't have a mark yet
+  document.getElementById('prefill-ds-btn').addEventListener('click', () => {{
+    const added = prefillDsCellsAsNeedsDesign();
+    if (added > 0) {{
+      document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+      updateRowSectionFlags();
+      updateCount();
+      alert('Filled ' + added + ' missing DS cells as needs-design.');
+    }} else {{
+      alert('All DS cells in this route already have marks.');
+    }}
+  }});
+
+  // Clear-route. Also resets the prefilled flag so a reload re-triggers auto-prefill.
+  document.getElementById('clear-route-btn').addEventListener('click', () => {{
+    const ids = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).map(([id]) => id);
+    if (!ids.length) {{ alert('No marks for this route.'); return; }}
+    if (!confirm('Clear ' + ids.length + ' marks for route ' + ROUTE + '?\\n\\nReloading the page will re-prefill all DS cells as needs-design.')) return;
+    ids.forEach(id => delete marks[id]);
+    saveMarks(marks);
+    const flags = loadPrefilledFlags();
+    delete flags[ROUTE];
+    savePrefilledFlags(flags);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+  }});
+
+  function buildMarkdown() {{
+    const items = [];
+    Object.entries(marks).forEach(([id, m]) => {{
+      if (!m || !m.marked) return;
+      if (!id.startsWith(ROUTE + '__')) return;
+      const parts = id.split('__');
+      const themeKey = parts[parts.length - 1];
+      const state = parts[parts.length - 2];
+      const viewport = parts[parts.length - 3];
+      const route = parts[0];
+      const component = parts.slice(1, parts.length - 3).join('__');
+      items.push({{ component, viewport, state, theme: themeKey,
+                   note: m.note || '', why: m.why || '', category: m.category || '' }});
+    }});
+    items.sort((a, b) => {{
+      const ak = componentSortKey(a.component);
+      const bk = componentSortKey(b.component);
+      if (ak[0] !== bk[0]) return ak[0] - bk[0];
+      if (ak[1] !== bk[1]) return ak[1] < bk[1] ? -1 : 1;
+      const sd = STATES.indexOf(a.state) - STATES.indexOf(b.state);
+      if (sd !== 0) return sd;
+      const td = THEME_ORDER.indexOf(a.theme) - THEME_ORDER.indexOf(b.theme);
+      if (td !== 0) return td;
+      return a.viewport === b.viewport ? 0 : (a.viewport === 'desktop' ? -1 : 1);
+    }});
+    const date = new Date().toISOString().split('T')[0];
+    const lines = ['# Audit marks -- ' + ROUTE + ' -- ' + items.length + ' items -- ' + date, ''];
+    items.forEach(it => {{
+      const catTag = it.category ? ' [' + it.category + ']' : '';
+      const whyTxt = it.why ? ': ' + it.why : '';
+      const noteTxt = it.note ? '  -- ' + it.note : '';
+      lines.push('- [ ] **' + it.theme + ' ' + it.component + '** [' + it.viewport + '/' + it.state + ']' + catTag + whyTxt + noteTxt);
+    }});
+    return lines.join('\\n');
+  }}
+
+  function openOverlay(id) {{ document.getElementById(id).classList.add('open'); }}
+  function closeOverlay(id) {{ document.getElementById(id).classList.remove('open'); }}
+  document.querySelectorAll('.overlay-close').forEach(b => b.addEventListener('click', () => closeOverlay(b.dataset.overlay)));
+  document.querySelectorAll('.overlay').forEach(o => {{
+    o.addEventListener('click', e => {{ if (e.target === o) o.classList.remove('open'); }});
+  }});
+
+  document.getElementById('export-md-btn').addEventListener('click', async () => {{
+    const md = buildMarkdown();
+    const ta = document.getElementById('md-text');
+    ta.value = md;
+    openOverlay('md-overlay');
+    try {{ await navigator.clipboard.writeText(md); document.getElementById('md-copy').textContent = 'Copied!'; setTimeout(()=>{{document.getElementById('md-copy').textContent='Copy';}},1500);}}
+    catch (e) {{ ta.focus(); ta.select(); }}
+  }});
+  document.getElementById('md-copy').addEventListener('click', async () => {{
+    const ta = document.getElementById('md-text');
+    try {{ await navigator.clipboard.writeText(ta.value); document.getElementById('md-copy').textContent='Copied!'; setTimeout(()=>{{document.getElementById('md-copy').textContent='Copy';}},1500);}}
+    catch (e) {{ ta.focus(); ta.select(); }}
+  }});
+
+  document.getElementById('export-json-btn').addEventListener('click', () => {{
+    const ta = document.getElementById('json-export-text');
+    ta.value = JSON.stringify(marks, null, 2);
+    openOverlay('json-export-overlay');
+  }});
+  document.getElementById('json-export-copy').addEventListener('click', async () => {{
+    const ta = document.getElementById('json-export-text');
+    try {{ await navigator.clipboard.writeText(ta.value); document.getElementById('json-export-copy').textContent='Copied!'; setTimeout(()=>{{document.getElementById('json-export-copy').textContent='Copy';}},1500);}}
+    catch (e) {{ ta.focus(); ta.select(); }}
+  }});
+
+  document.getElementById('import-json-btn').addEventListener('click', () => {{
+    document.getElementById('json-import-text').value = '';
+    document.getElementById('json-import-err').textContent = '';
+    openOverlay('json-import-overlay');
+  }});
+  document.getElementById('json-import-apply').addEventListener('click', () => {{
+    const ta = document.getElementById('json-import-text');
+    const err = document.getElementById('json-import-err');
+    err.textContent = '';
+    let parsed;
+    try {{ parsed = JSON.parse(ta.value); }}
+    catch (e) {{ err.textContent = 'Invalid JSON: ' + e.message; return; }}
+    if (!parsed || typeof parsed !== 'object') {{ err.textContent = 'Expected an object.'; return; }}
+    // First migrate v1 IDs (4 segments) -> v2 IDs (5 segments)
+    const {{ marks: idMigrated, migrated }} = migrateMarksV1ToV2(parsed);
+    // Then upgrade each value v2 -> v3 (preserves marked + note, fills new fields)
+    Object.entries(idMigrated).forEach(([id, m]) => {{
+      marks[id] = upgradeV2ValueToV3(m);
+    }});
+    saveMarks(marks);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+    closeOverlay('json-import-overlay');
+    alert('Imported ' + Object.keys(idMigrated).length + ' marks (' + migrated + ' legacy IDs migrated to __seeded; values upgraded to v3).');
+  }});
+</script>
+</body>
+</html>
+"""
+
+    return head + body_open + section_html + overlays + js
+
+
+def render_index_page(sorted_routes, route_to_components, branches_seen):
+    """Return the index page HTML."""
+    title = 'Cross-Theme Audit (#1129) — Index'
+    head = html_head(title)
+
+    # Compute static cell counts per route (used for the 'Cells' column).
+    # A cell exists if there's at least one capture for (route, component, viewport, state, branch).
+    cell_counts = {}
+    for r in sorted_routes:
+        components = sorted(route_to_components[r], key=component_sort_key)
+        n = 0
+        for state in STATES:
+            for branch_label in DIRS:
+                # mapped (global-nav) — desktop only
+                for logical_label, branch_map in MAPPED_COMPONENTS.items():
+                    src = branch_map.get(branch_label)
+                    if src and absolute_capture_path(DIRS[branch_label], "desktop", state, r, src).exists():
+                        n += 1
+            for c in components:
+                for branch_label in DIRS:
+                    if absolute_capture_path(DIRS[branch_label], "desktop", state, r, c).exists():
+                        n += 1
+                if c == "page":
+                    for branch_label in DIRS:
+                        if absolute_capture_path(DIRS[branch_label], "mobile", state, r, c).exists():
+                            n += 1
+        cell_counts[r] = n
+
+    body = '<div class="sticky-shell">\n<header class="top">\n'
+    body += '  <h1>Narraitor Cross-Theme Audit (#1129) -- Index</h1>\n'
+    body += '  <div class="legend">\n'
+    body += '    <span class="col develop">develop (baseline)</span>\n'
+    body += '    <span class="col ds3">DS3</span>\n'
+    body += '    <span class="col ds1">DS1</span>\n'
+    body += '    <span class="col ds2">DS2</span>\n'
+    body += '  </div>\n'
+    body += '  <div class="marks-cluster">\n'
+    body += '    <span>Total marked:</span>\n'
+    body += '    <span class="count" id="total-marked">0</span>\n'
+    body += '    <button id="export-json-btn" type="button">Export JSON</button>\n'
+    body += '    <button id="import-json-btn" type="button">Import JSON</button>\n'
+    body += '    <button id="clear-all-btn" type="button" class="danger">Clear all</button>\n'
+    body += '  </div>\n'
+    body += '</header>\n'
+    body += '</div>\n<main>\n'
+
+    body += '<table class="routes-index">\n'
+    body += '  <thead><tr>\n'
+    body += '    <th>Route</th><th class="num">Cells</th><th class="num">Marked</th>'
+    body += '<th class="num">Unresolved</th><th>Categories</th>\n'
+    body += '  </tr></thead>\n  <tbody>\n'
+    for r in sorted_routes:
+        n = cell_counts[r]
+        body += f'    <tr data-route="{r}">\n'
+        body += f'      <td><a href="{r}.html">{r}</a></td>\n'
+        body += f'      <td class="num cells-count">{n}</td>\n'
+        body += f'      <td class="num marked-count">0</td>\n'
+        body += f'      <td class="num unresolved-count">0</td>\n'
+        body += f'      <td class="cat-breakdown" style="font-family:ui-monospace,monospace;font-size:11px;color:#555;"></td>\n'
+        body += f'    </tr>\n'
+    body += '  </tbody>\n</table>\n'
+    body += '<p style="margin-top:16px;font-size:12px;color:#555;">Marked counts read from <code>narraitor-audit-marks-v3</code> in this browser. Unresolved = marked cells with no category set or category=unclear.</p>\n'
+
+    overlays = """</main>
+
+<div id="json-export-overlay" class="overlay">
+  <div class="panel">
+    <h3>Marks (raw JSON) -- all routes</h3>
+    <textarea id="json-export-text" readonly></textarea>
+    <div class="actions">
+      <button id="json-export-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="json-export-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-import-overlay" class="overlay">
+  <div class="panel">
+    <h3>Import marks (paste raw JSON)</h3>
+    <p class="hint">Legacy IDs without state segments are migrated to <code>__seeded</code>; v2 values are upgraded to v3.</p>
+    <textarea id="json-import-text"></textarea>
+    <div class="err" id="json-import-err"></div>
+    <div class="actions">
+      <button id="json-import-apply" type="button">Apply</button>
+      <button class="overlay-close" data-overlay="json-import-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+"""
+
+    js = f"""<script>
+{_shared_js_prelude()}
+
+  let marks = loadMarks();
+
+  function recompute() {{
+    const perRoute = {{}};
+    let total = 0;
+    Object.entries(marks).forEach(([id, m]) => {{
+      if (!m || !m.marked) return;
+      total++;
+      const route = id.split('__')[0];
+      if (!perRoute[route]) perRoute[route] = {{ marked: 0, unresolved: 0, cats: {{}} }};
+      perRoute[route].marked++;
+      const cat = m.category;
+      if (!cat || cat === 'unclear') perRoute[route].unresolved++;
+      const key = cat || 'unset';
+      perRoute[route].cats[key] = (perRoute[route].cats[key] || 0) + 1;
+    }});
+    document.getElementById('total-marked').textContent = total;
+    document.querySelectorAll('tr[data-route]').forEach(tr => {{
+      const route = tr.dataset.route;
+      const r = perRoute[route] || {{ marked: 0, unresolved: 0, cats: {{}} }};
+      const mc = tr.querySelector('.marked-count');
+      const uc = tr.querySelector('.unresolved-count');
+      const cb = tr.querySelector('.cat-breakdown');
+      mc.textContent = r.marked;
+      mc.classList.toggle('has-marks', r.marked > 0);
+      uc.textContent = r.unresolved;
+      uc.classList.toggle('has-unresolved', r.unresolved > 0);
+      const catParts = [];
+      ['needs-design','bug','tooling','intentional','unclear','unset'].forEach(c => {{
+        if (r.cats[c]) catParts.push(c + ':' + r.cats[c]);
+      }});
+      cb.textContent = catParts.join('  ');
+    }});
+  }}
+
+  recompute();
+  // Recompute when localStorage changes in another tab (per-route page edits).
+  window.addEventListener('storage', e => {{
+    if (e.key === STORAGE_KEY) {{
+      marks = loadMarks();
+      recompute();
+    }}
+  }});
+  // Manual refresh on focus (same tab can't get a 'storage' event for itself).
+  window.addEventListener('focus', () => {{
+    marks = loadMarks();
+    recompute();
+  }});
+
+  function openOverlay(id) {{ document.getElementById(id).classList.add('open'); }}
+  function closeOverlay(id) {{ document.getElementById(id).classList.remove('open'); }}
+  document.querySelectorAll('.overlay-close').forEach(b => b.addEventListener('click', () => closeOverlay(b.dataset.overlay)));
+  document.querySelectorAll('.overlay').forEach(o => {{
+    o.addEventListener('click', e => {{ if (e.target === o) o.classList.remove('open'); }});
+  }});
+
+  document.getElementById('export-json-btn').addEventListener('click', () => {{
+    document.getElementById('json-export-text').value = JSON.stringify(marks, null, 2);
+    openOverlay('json-export-overlay');
+  }});
+  document.getElementById('json-export-copy').addEventListener('click', async () => {{
+    const ta = document.getElementById('json-export-text');
+    try {{ await navigator.clipboard.writeText(ta.value); document.getElementById('json-export-copy').textContent='Copied!'; setTimeout(()=>{{document.getElementById('json-export-copy').textContent='Copy';}},1500);}}
+    catch (e) {{ ta.focus(); ta.select(); }}
+  }});
+
+  document.getElementById('import-json-btn').addEventListener('click', () => {{
+    document.getElementById('json-import-text').value = '';
+    document.getElementById('json-import-err').textContent = '';
+    openOverlay('json-import-overlay');
+  }});
+  document.getElementById('json-import-apply').addEventListener('click', () => {{
+    const ta = document.getElementById('json-import-text');
+    const err = document.getElementById('json-import-err');
+    err.textContent = '';
+    let parsed;
+    try {{ parsed = JSON.parse(ta.value); }}
+    catch (e) {{ err.textContent = 'Invalid JSON: ' + e.message; return; }}
+    if (!parsed || typeof parsed !== 'object') {{ err.textContent = 'Expected an object.'; return; }}
+    const {{ marks: idMigrated, migrated }} = migrateMarksV1ToV2(parsed);
+    Object.entries(idMigrated).forEach(([id, m]) => {{ marks[id] = upgradeV2ValueToV3(m); }});
+    saveMarks(marks);
+    recompute();
+    closeOverlay('json-import-overlay');
+    alert('Imported ' + Object.keys(idMigrated).length + ' marks (' + migrated + ' legacy IDs migrated; values upgraded to v3).');
+  }});
+
+  document.getElementById('clear-all-btn').addEventListener('click', () => {{
+    const n = Object.values(marks).filter(m => m && m.marked).length;
+    if (!n) {{ alert('No marks to clear.'); return; }}
+    if (!confirm('Clear all ' + n + ' marks across every route? This cannot be undone.')) return;
+    marks = {{}};
+    saveMarks(marks);
+    recompute();
+  }});
+</script>
+</body>
+</html>
+"""
+
+    return head + body + overlays + js
+
+
+def render_legacy_redirect():
+    return """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Audit review moved</title>
+<meta http-equiv="refresh" content="0; url=review/index.html">
+<style>body{font-family:-apple-system,system-ui,sans-serif;padding:24px;}</style>
+</head>
+<body>
+<h1>Moved</h1>
+<p>The audit review now lives at <a href="review/index.html">review/index.html</a>.</p>
+</body>
+</html>
+"""
+
+
+def render_html():
+    pairs, branches_seen = discover()
+
+    routes = defaultdict(set)
+    for (route, component), states in pairs.items():
+        routes[route].add(component)
+
+    sorted_routes = sorted(routes.keys(), key=route_sort_key)
+
+    REVIEW_DIR.mkdir(exist_ok=True)
+
+    # Per-route pages
+    for r in sorted_routes:
+        components = sorted(routes[r], key=component_sort_key)
+        page = render_route_page(r, components, branches_seen, sorted_routes)
+        (REVIEW_DIR / f"{r}.html").write_text(page)
+
+    # Index page
+    index_html = render_index_page(sorted_routes, routes, branches_seen)
+    (REVIEW_DIR / "index.html").write_text(index_html)
+
+    # Legacy redirect stub at the old review.html path
+    LEGACY_OUTPUT_PATH.write_text(render_legacy_redirect())
+
+    print(f"Wrote {REVIEW_DIR}/ ({len(sorted_routes)} per-route pages + index.html)")
+    print(f"Branches discovered: {sorted(branches_seen)}")
+    print(f"Legacy stub at: {LEGACY_OUTPUT_PATH}")
+
+
+if __name__ == '__main__':
+    render_html()

--- a/scripts/audit/build-seed.ts
+++ b/scripts/audit/build-seed.ts
@@ -1,0 +1,184 @@
+/**
+ * Per-state seed builder for the cross-theme audit (#1129).
+ *
+ * Emits a JSON map of `{ "<persist-key>": "<json-string>" }` that downstream
+ * crawl scripts inject into IndexedDB + localStorage via `bdg dom eval`.
+ *
+ * States:
+ *   empty        — no worlds, no characters, no sessions; tutorialProgress all false
+ *   seeded       — SAMPLE_WORLDS + SAMPLE_CHARACTERS + SAMPLE_GAME_SESSIONS, no active session
+ *   mid-session  — seeded + currentSessionId set + segments + decisions + journal entries
+ *
+ * Usage:
+ *   npx tsx scripts/audit/build-seed.ts --state empty       > scripts/audit/seeds/empty.json
+ *   npx tsx scripts/audit/build-seed.ts --state seeded      > scripts/audit/seeds/seeded.json
+ *   npx tsx scripts/audit/build-seed.ts --state mid-session > scripts/audit/seeds/mid-session.json
+ *
+ * Persist versions are read from src/state/<store>.ts and must be kept in sync
+ * if any store bumps its persist version.
+ */
+import {
+  SAMPLE_WORLDS,
+  SAMPLE_CHARACTERS,
+  SAMPLE_GAME_SESSIONS,
+  SAMPLE_NARRATIVE_SEGMENTS,
+  SAMPLE_DECISIONS,
+  SAMPLE_JOURNAL_ENTRIES,
+} from '../../tests/fixtures';
+
+type State = 'empty' | 'seeded' | 'mid-session';
+
+const VERSIONS = {
+  world: 5,
+  character: 3,
+  session: 4,
+  narrative: 1,
+  journal: 1,
+  npc: 2,
+} as const;
+
+const PHASES_DONE = {
+  intro: { completed: true, skipped: false },
+  worldCreation: { completed: true, skipped: false, lastStep: 999 },
+  worldGeneration: { completed: true, skipped: false, lastStep: 0 },
+  characterCreation: { completed: true, skipped: false, lastStep: 5 },
+  firstPlay: { completed: true, skipped: false },
+};
+
+const PHASES_EMPTY = {
+  intro: { completed: false, skipped: false },
+  worldCreation: { completed: false, skipped: false, lastStep: 0 },
+  worldGeneration: { completed: false, skipped: false, lastStep: 0 },
+  characterCreation: { completed: false, skipped: false, lastStep: 0 },
+  firstPlay: { completed: false, skipped: false },
+};
+
+function byId<T extends { id: string }>(arr: readonly T[]): Record<string, T> {
+  return Object.fromEntries(arr.map((x) => [x.id, x]));
+}
+
+function buildSeed(state: State): Record<string, string> {
+  const isEmpty = state === 'empty';
+  const isMid = state === 'mid-session';
+
+  const worlds = isEmpty ? {} : byId(SAMPLE_WORLDS);
+  const characters = isEmpty ? {} : byId(SAMPLE_CHARACTERS);
+  const sessions = isEmpty ? {} : byId(SAMPLE_GAME_SESSIONS);
+  const firstSession = isEmpty ? null : SAMPLE_GAME_SESSIONS[0];
+
+  const segments = isMid ? byId(SAMPLE_NARRATIVE_SEGMENTS) : {};
+  const decisions = isMid ? byId(SAMPLE_DECISIONS) : {};
+  const journalEntries = isMid ? byId(SAMPLE_JOURNAL_ENTRIES) : {};
+
+  const sessionSegments: Record<string, string[]> = {};
+  const sessionDecisions: Record<string, string[]> = {};
+  const sessionJournal: Record<string, string[]> = {};
+  if (isMid && firstSession) {
+    sessionSegments[firstSession.id] = Object.keys(segments).filter(
+      (id) => (segments as Record<string, { sessionId?: string }>)[id]?.sessionId === firstSession.id,
+    );
+    sessionDecisions[firstSession.id] = Object.keys(decisions);
+    sessionJournal[firstSession.id] = Object.keys(journalEntries);
+  }
+
+  const savedSessions = isEmpty
+    ? {}
+    : SAMPLE_GAME_SESSIONS.reduce<Record<string, unknown>>((acc, s) => {
+        acc[s.id] = {
+          id: s.id,
+          worldId: s.worldId,
+          characterId: s.characterId,
+          lastPlayed: (s as { lastPlayedAt?: string }).lastPlayedAt ?? null,
+          narrativeCount: (s as { totalTurns?: number }).totalTurns ?? 0,
+        };
+        return acc;
+      }, {});
+
+  const stores = {
+    world: {
+      state: {
+        worlds,
+        currentWorldId: isEmpty ? null : SAMPLE_WORLDS[0]?.id ?? null,
+        error: null,
+        loading: false,
+      },
+      version: VERSIONS.world,
+    },
+    character: {
+      state: {
+        characters,
+        currentCharacterId: isEmpty ? null : SAMPLE_CHARACTERS[0]?.id ?? null,
+        error: null,
+        loading: false,
+      },
+      version: VERSIONS.character,
+    },
+    session: {
+      state: {
+        sessions,
+        currentSessionId: isMid && firstSession ? firstSession.id : null,
+        id: isMid && firstSession ? firstSession.id : null,
+        status: isMid ? ('active' as const) : ('idle' as const),
+        worldId: isMid && firstSession ? firstSession.worldId : null,
+        characterId: isMid && firstSession ? firstSession.characterId : null,
+        savedSessions,
+        tutorialProgress: {
+          phases: isEmpty ? PHASES_EMPTY : PHASES_DONE,
+          dismissedHints: [],
+          lastActiveStep: null,
+        },
+        error: null,
+        loading: false,
+      },
+      version: VERSIONS.session,
+    },
+    narrative: {
+      state: {
+        segments,
+        sessionSegments,
+        decisions,
+        sessionDecisions,
+        endedSessions: {},
+        currentEnding: null,
+        isGeneratingEnding: false,
+        endingError: null,
+        error: null,
+        loading: false,
+      },
+      version: VERSIONS.narrative,
+    },
+    journal: {
+      state: {
+        entries: journalEntries,
+        sessionEntries: sessionJournal,
+      },
+      version: VERSIONS.journal,
+    },
+    npc: {
+      state: { npcs: {}, error: null, loading: false },
+      version: VERSIONS.npc,
+    },
+  } as const;
+
+  return {
+    'narraitor-world-store': JSON.stringify(stores.world),
+    'narraitor-character-store': JSON.stringify(stores.character),
+    'narraitor-session-store': JSON.stringify(stores.session),
+    'narraitor-narrative-store': JSON.stringify(stores.narrative),
+    'narraitor-journal-store': JSON.stringify(stores.journal),
+    'narraitor-npc-store': JSON.stringify(stores.npc),
+  };
+}
+
+function parseStateArg(): State {
+  const idx = process.argv.indexOf('--state');
+  const value = idx >= 0 ? process.argv[idx + 1] : 'seeded';
+  if (value !== 'empty' && value !== 'seeded' && value !== 'mid-session') {
+    console.error(`Invalid --state '${value}'. Expected: empty | seeded | mid-session`);
+    process.exit(1);
+  }
+  return value;
+}
+
+const state = parseStateArg();
+process.stdout.write(JSON.stringify(buildSeed(state), null, 2));

--- a/scripts/audit/component-crawl-mobile.sh
+++ b/scripts/audit/component-crawl-mobile.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# Mobile full-page capture for the cross-theme audit (#1129).
+#
+# Mobile uses full-page captures only. bdg's `--selector` mode produces clipped
+# images at mobile viewport (deviceScaleFactor artifact); per-component
+# selector captures are unreliable, so we skip them on mobile.
+#
+# Usage:
+#   scripts/audit/component-crawl-mobile.sh \
+#     --theme <ds3|ds1|ds2|default> \
+#     --mode <light|dark> \
+#     --state <empty|seeded|mid-session> \
+#     --branch <branch-label> \
+#     [--base-url http://localhost:3000]
+#
+# Output: scripts/audit/captures/comp-<branch>/mobile/<state>/<route>__page.png
+
+# NOTE: do NOT use `set -e`. bdg returns non-zero on selector misses; we want the loop to continue.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_DIR="${REPO_ROOT}/scripts/audit"
+
+THEME=""
+MODE="light"
+STATE="seeded"
+BRANCH=""
+BASE_URL="http://localhost:3000"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --theme) THEME="$2"; shift 2 ;;
+    --mode) MODE="$2"; shift 2 ;;
+    --state) STATE="$2"; shift 2 ;;
+    --branch) BRANCH="$2"; shift 2 ;;
+    --base-url) BASE_URL="$2"; shift 2 ;;
+    -h|--help)
+      grep -E "^# " "$0" | sed 's/^# \{0,1\}//' >&2
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$THEME" || -z "$BRANCH" ]]; then
+  echo "Required: --theme <name> --branch <label>" >&2
+  exit 1
+fi
+
+case "$STATE" in
+  empty|seeded|mid-session) ;;
+  *) echo "Invalid --state '$STATE' (expected: empty|seeded|mid-session)" >&2; exit 1 ;;
+esac
+
+OUTDIR="${SCRIPT_DIR}/captures/comp-${BRANCH}/mobile/${STATE}"
+SEED_FILE="${SCRIPT_DIR}/seeds/${STATE}.json"
+
+if [[ ! -f "$SEED_FILE" ]]; then
+  echo "Seed file not found: $SEED_FILE" >&2
+  echo "Generate it first: npx tsx scripts/audit/build-seed.ts --state ${STATE} > ${SEED_FILE}" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTDIR"
+echo "Output: $OUTDIR"
+echo "Seed:   $SEED_FILE  (state: $STATE)"
+
+SEED_JSON=$(cat "$SEED_FILE")
+INJECT_SCRIPT=$(cat <<'EOF'
+async function inject(payload) {
+  const data = JSON.parse(payload);
+  for (const [k, v] of Object.entries(data)) localStorage.setItem(k, v);
+  await new Promise((resolve) => {
+    const req = indexedDB.open('narraitor-state', 1);
+    req.onupgradeneeded = (e) => {
+      const db = e.target.result;
+      if (!db.objectStoreNames.contains('narraitor-store')) db.createObjectStore('narraitor-store');
+    };
+    req.onsuccess = (e) => {
+      const db = e.target.result;
+      const tx = db.transaction(['narraitor-store'], 'readwrite');
+      const store = tx.objectStore('narraitor-store');
+      for (const [k, v] of Object.entries(data)) store.put({ id: k, value: JSON.parse(v) }, k);
+      tx.oncomplete = () => resolve('ok');
+      tx.onerror = () => resolve('err');
+    };
+    req.onerror = () => resolve('err');
+  });
+  return 'seeded';
+}
+EOF
+)
+
+if [[ "$THEME" != "default" ]]; then
+  bdg dom eval "localStorage.setItem('narraitor-theme','${THEME}'); localStorage.setItem('narraitor-color-scheme','${MODE}'); 'set'" > /dev/null
+fi
+
+ESCAPED_SEED=$(printf '%s' "$SEED_JSON" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
+bdg dom eval "(${INJECT_SCRIPT})(${ESCAPED_SEED})" > /dev/null
+
+bdg cdp Page.reload --params '{"ignoreCache":true}' > /dev/null 2>&1
+/bin/sleep 3
+
+HIDE_CSS_SCRIPT="(()=>{ if(document.getElementById('audit-hide-css')) return 'present'; const s=document.createElement('style'); s.id='audit-hide-css'; s.textContent='[data-testid=\"devtools-panel-container\"],[data-testid^=\"devtools-panel-\"]{display:none !important;}'; document.head.appendChild(s); return 'injected'; })()"
+
+ROUTES=(
+  "home:/"
+  "about:/about"
+  "worlds:/worlds"
+  "worlds-detail:/worlds/world-cyberpunk-2077"
+  "worlds-edit:/worlds/world-cyberpunk-2077/edit"
+  "worlds-create:/worlds/create"
+  "worlds-play:/worlds/world-cyberpunk-2077/play"
+  "worlds-play-journal:/worlds/world-cyberpunk-2077/play/journal"
+  "characters:/characters"
+  "characters-detail:/characters/char-cyberpunk-hacker"
+  "characters-edit:/characters/char-cyberpunk-hacker/edit"
+  "characters-create:/characters/create"
+  "play:/play"
+  "settings:/settings"
+)
+
+VIEWPORT_W=390
+VIEWPORT_H=844
+# deviceScaleFactor=1: keep capture widths at CSS-pixel parity (see note in
+# component-crawl.sh).
+VIEWPORT_PARAMS="{\"width\":${VIEWPORT_W},\"height\":${VIEWPORT_H},\"deviceScaleFactor\":1,\"mobile\":true}"
+
+bdg cdp Emulation.setDeviceMetricsOverride --params "$VIEWPORT_PARAMS" > /dev/null 2>&1
+/bin/sleep 1
+
+for route_pair in "${ROUTES[@]}"; do
+  slug="${route_pair%%:*}"
+  path="${route_pair#*:}"
+  echo "=== ${slug} (${STATE}) ==="
+
+  # Re-apply viewport override before each navigation
+  bdg cdp Emulation.setDeviceMetricsOverride --params "$VIEWPORT_PARAMS" > /dev/null 2>&1
+  bdg cdp Page.navigate --params "{\"url\":\"${BASE_URL}${path}\"}" > /dev/null 2>&1
+  /bin/sleep 4
+
+  measured=$(bdg dom eval "window.innerWidth + 'x' + window.innerHeight" 2>/dev/null | tr -d '"' | tr -d ' ')
+  if [[ "$measured" != "${VIEWPORT_W}x${VIEWPORT_H}" ]]; then
+    echo "  WARN: viewport is $measured (expected ${VIEWPORT_W}x${VIEWPORT_H})"
+  fi
+
+  bdg dom eval "$HIDE_CSS_SCRIPT" > /dev/null 2>&1
+
+  # --no-resize keeps PNG dims = CSS-px x dpr (mobile dpr 2 -> 780 wide).
+  bdg dom screenshot --no-resize "${OUTDIR}/${slug}__page.png" > /dev/null 2>&1
+done
+
+bdg cdp Emulation.clearDeviceMetricsOverride > /dev/null 2>&1
+echo "Total mobile captures in ${OUTDIR}: $(/bin/ls "$OUTDIR" | /usr/bin/wc -l | tr -d ' ')"

--- a/scripts/audit/component-crawl.sh
+++ b/scripts/audit/component-crawl.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+# Desktop component-level capture for the cross-theme audit (#1129).
+# Captures full-page + per-component (header/nav/main/form/dialog) + main-section-N
+# at 1280x1200 desktop viewport.
+#
+# Usage:
+#   scripts/audit/component-crawl.sh \
+#     --theme <ds3|ds1|ds2|default> \
+#     --mode <light|dark> \
+#     --state <empty|seeded|mid-session> \
+#     --branch <branch-label> \
+#     [--base-url http://localhost:3000]
+#
+# Output: scripts/audit/captures/comp-<branch>/desktop/<state>/<route>__<component>.png
+#
+# Requires `bdg` (browser-debugger-cli) running against an open Chromium tab on
+# the target dev server. Seed JSON is built via `npx tsx scripts/audit/build-seed.ts`.
+
+# NOTE: do NOT use `set -e`. bdg returns non-zero when a selector misses (e.g.
+# capturing `form` on a route without one), and we want the loop to continue.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_DIR="${REPO_ROOT}/scripts/audit"
+
+THEME=""
+MODE="light"
+STATE="seeded"
+BRANCH=""
+BASE_URL="http://localhost:3000"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --theme) THEME="$2"; shift 2 ;;
+    --mode) MODE="$2"; shift 2 ;;
+    --state) STATE="$2"; shift 2 ;;
+    --branch) BRANCH="$2"; shift 2 ;;
+    --base-url) BASE_URL="$2"; shift 2 ;;
+    -h|--help)
+      grep -E "^# " "$0" | sed 's/^# \{0,1\}//' >&2
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$THEME" || -z "$BRANCH" ]]; then
+  echo "Required: --theme <name> --branch <label>" >&2
+  exit 1
+fi
+
+case "$STATE" in
+  empty|seeded|mid-session) ;;
+  *) echo "Invalid --state '$STATE' (expected: empty|seeded|mid-session)" >&2; exit 1 ;;
+esac
+
+OUTDIR="${SCRIPT_DIR}/captures/comp-${BRANCH}/desktop/${STATE}"
+SEED_FILE="${SCRIPT_DIR}/seeds/${STATE}.json"
+
+if [[ ! -f "$SEED_FILE" ]]; then
+  echo "Seed file not found: $SEED_FILE" >&2
+  echo "Generate it first: npx tsx scripts/audit/build-seed.ts --state ${STATE} > ${SEED_FILE}" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTDIR"
+echo "Output: $OUTDIR"
+echo "Seed:   $SEED_FILE  (state: $STATE)"
+
+# Inject seed into IndexedDB + localStorage
+SEED_JSON=$(cat "$SEED_FILE")
+INJECT_SCRIPT=$(cat <<'EOF'
+async function inject(payload) {
+  const data = JSON.parse(payload);
+  // localStorage fallback
+  for (const [k, v] of Object.entries(data)) localStorage.setItem(k, v);
+  // IndexedDB primary
+  await new Promise((resolve) => {
+    const req = indexedDB.open('narraitor-state', 1);
+    req.onupgradeneeded = (e) => {
+      const db = e.target.result;
+      if (!db.objectStoreNames.contains('narraitor-store')) db.createObjectStore('narraitor-store');
+    };
+    req.onsuccess = (e) => {
+      const db = e.target.result;
+      const tx = db.transaction(['narraitor-store'], 'readwrite');
+      const store = tx.objectStore('narraitor-store');
+      for (const [k, v] of Object.entries(data)) store.put({ id: k, value: JSON.parse(v) }, k);
+      tx.oncomplete = () => resolve('ok');
+      tx.onerror = () => resolve('err');
+    };
+    req.onerror = () => resolve('err');
+  });
+  return 'seeded';
+}
+EOF
+)
+
+# Set theme + color scheme on integration branches; skip on develop
+if [[ "$THEME" != "default" ]]; then
+  bdg dom eval "localStorage.setItem('narraitor-theme','${THEME}'); localStorage.setItem('narraitor-color-scheme','${MODE}'); 'set'" > /dev/null
+fi
+
+# Inject seed (escape backticks/dollars for the eval payload)
+ESCAPED_SEED=$(printf '%s' "$SEED_JSON" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
+bdg dom eval "(${INJECT_SCRIPT})(${ESCAPED_SEED})" > /dev/null
+
+# Reload to pick up the new state
+bdg cdp Page.reload --params '{"ignoreCache":true}' > /dev/null 2>&1
+/bin/sleep 3
+
+# CSS injected before each capture to hide visual noise (dev panel, etc.)
+HIDE_CSS_SCRIPT="(()=>{ if(document.getElementById('audit-hide-css')) return 'present'; const s=document.createElement('style'); s.id='audit-hide-css'; s.textContent='[data-testid=\"devtools-panel-container\"],[data-testid^=\"devtools-panel-\"]{display:none !important;}'; document.head.appendChild(s); return 'injected'; })()"
+
+# 14 production routes
+ROUTES=(
+  "home:/"
+  "about:/about"
+  "worlds:/worlds"
+  "worlds-detail:/worlds/world-cyberpunk-2077"
+  "worlds-edit:/worlds/world-cyberpunk-2077/edit"
+  "worlds-create:/worlds/create"
+  "worlds-play:/worlds/world-cyberpunk-2077/play"
+  "worlds-play-journal:/worlds/world-cyberpunk-2077/play/journal"
+  "characters:/characters"
+  "characters-detail:/characters/char-cyberpunk-hacker"
+  "characters-edit:/characters/char-cyberpunk-hacker/edit"
+  "characters-create:/characters/create"
+  "play:/play"
+  "settings:/settings"
+)
+
+SELECTORS=(
+  "header:header"
+  "nav:nav"
+  "main:main"
+  "form:form"
+  "dialog:[role=\"dialog\"]"
+)
+
+VIEWPORT_W=1320
+VIEWPORT_H=900
+# deviceScaleFactor=1: full-page and selector captures both render at 1:1 with
+# CSS pixels. With dsf=2, full-page would be 2x retina but selector captures
+# stay at 1x — mixed regimes that complicate the review page.
+VIEWPORT_PARAMS="{\"width\":${VIEWPORT_W},\"height\":${VIEWPORT_H},\"deviceScaleFactor\":1,\"mobile\":false}"
+
+bdg cdp Emulation.setDeviceMetricsOverride --params "$VIEWPORT_PARAMS" > /dev/null 2>&1
+/bin/sleep 1
+
+for route_pair in "${ROUTES[@]}"; do
+  slug="${route_pair%%:*}"
+  path="${route_pair#*:}"
+  echo "=== ${slug} (${STATE}) ==="
+
+  # Re-apply viewport override before each navigation. CDP can drop it across nav.
+  bdg cdp Emulation.setDeviceMetricsOverride --params "$VIEWPORT_PARAMS" > /dev/null 2>&1
+  bdg cdp Page.navigate --params "{\"url\":\"${BASE_URL}${path}\"}" > /dev/null 2>&1
+  /bin/sleep 4
+
+  # Verify the viewport landed where we expected
+  measured=$(bdg dom eval "window.innerWidth + 'x' + window.innerHeight" 2>/dev/null | tr -d '"' | tr -d ' ')
+  if [[ "$measured" != "${VIEWPORT_W}x${VIEWPORT_H}" ]]; then
+    echo "  WARN: viewport is $measured (expected ${VIEWPORT_W}x${VIEWPORT_H})"
+  fi
+
+  # Hide DevTools panel + similar visual-noise widgets via injected CSS
+  bdg dom eval "$HIDE_CSS_SCRIPT" > /dev/null 2>&1
+
+  # --no-resize: skip bdg's auto-resize so widths match CSS-px x dpr exactly.
+  # Full-page / viewport captures are at 2x retina; selector captures are at 1x.
+  bdg dom screenshot --no-resize "${OUTDIR}/${slug}__page.png" > /dev/null 2>&1
+
+  for sel_pair in "${SELECTORS[@]}"; do
+    name="${sel_pair%%:*}"
+    selector="${sel_pair#*:}"
+    OUT="${OUTDIR}/${slug}__${name}.png"
+    bdg dom screenshot --no-resize --selector "$selector" "$OUT" > /dev/null 2>&1
+    if [[ -f "$OUT" ]] && [[ $(/usr/bin/stat -f%z "$OUT" 2>/dev/null || /bin/stat --printf='%s' "$OUT" 2>/dev/null) -gt 1000 ]]; then
+      echo "  ${name} -> captured"
+    else
+      /bin/rm -f "$OUT"
+    fi
+  done
+
+  IDX=0
+  while [[ $IDX -lt 8 ]]; do
+    OUT="${OUTDIR}/${slug}__main-section-${IDX}.png"
+    bdg dom screenshot --no-resize --selector "main > *:nth-child($((IDX + 1)))" "$OUT" > /dev/null 2>&1
+    if [[ -f "$OUT" ]] && [[ $(/usr/bin/stat -f%z "$OUT" 2>/dev/null || /bin/stat --printf='%s' "$OUT" 2>/dev/null) -gt 1000 ]]; then
+      IDX=$((IDX + 1))
+    else
+      /bin/rm -f "$OUT"
+      break
+    fi
+  done
+done
+
+bdg cdp Emulation.clearDeviceMetricsOverride > /dev/null 2>&1
+echo "Total captures in ${OUTDIR}: $(/bin/ls "$OUTDIR" | /usr/bin/wc -l | tr -d ' ')"

--- a/scripts/audit/playwright-crawl.ts
+++ b/scripts/audit/playwright-crawl.ts
@@ -1,0 +1,372 @@
+/**
+ * Playwright-based capture crawler for the cross-theme audit (#1129).
+ *
+ * Replaces the bdg-based bash scripts. Playwright sessions are stable across
+ * long runs, so this can do the full 14-route x 3-state x 4-branch x 2-viewport
+ * sweep without midway crashes.
+ *
+ * Usage (single batch):
+ *   npx tsx scripts/audit/playwright-crawl.ts \
+ *     --theme ds3 --mode light --state empty \
+ *     --branch integration-ds3-light --viewport desktop
+ *
+ * Output: scripts/audit/captures/comp-<branch>/<viewport>/<state>/<route>__*.png
+ */
+import { chromium, type Browser, type Page } from '@playwright/test';
+import { mkdir, writeFile, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  SAMPLE_WORLDS,
+  SAMPLE_CHARACTERS,
+  SAMPLE_GAME_SESSIONS,
+  SAMPLE_NARRATIVE_SEGMENTS,
+  SAMPLE_DECISIONS,
+  SAMPLE_JOURNAL_ENTRIES,
+} from '../../tests/fixtures';
+
+type State = 'empty' | 'seeded' | 'mid-session';
+type Theme = 'ds3' | 'ds1' | 'ds2' | 'default';
+type Mode = 'light' | 'dark';
+type Viewport = 'desktop' | 'mobile';
+
+const ROUTES: Array<[string, string]> = [
+  ['home', '/'],
+  ['about', '/about'],
+  ['worlds', '/worlds'],
+  ['worlds-detail', '/worlds/world-cyberpunk-2077'],
+  ['worlds-edit', '/worlds/world-cyberpunk-2077/edit'],
+  ['worlds-create', '/worlds/create'],
+  ['worlds-play', '/worlds/world-cyberpunk-2077/play'],
+  ['worlds-play-journal', '/worlds/world-cyberpunk-2077/play/journal'],
+  ['characters', '/characters'],
+  ['characters-detail', '/characters/char-cyberpunk-hacker'],
+  ['characters-edit', '/characters/char-cyberpunk-hacker/edit'],
+  ['characters-create', '/characters/create'],
+  ['play', '/play'],
+  ['settings', '/settings'],
+];
+
+const SELECTORS: Array<[string, string]> = [
+  ['header', 'header'],
+  ['nav', 'nav'],
+  ['main', 'main'],
+  ['form', 'form'],
+  ['dialog', '[role="dialog"]'],
+];
+
+const VERSIONS = { world: 5, character: 3, session: 4, narrative: 1, journal: 1, npc: 2 } as const;
+
+const PHASES_DONE = {
+  intro: { completed: true, skipped: false },
+  worldCreation: { completed: true, skipped: false, lastStep: 999 },
+  worldGeneration: { completed: true, skipped: false, lastStep: 0 },
+  characterCreation: { completed: true, skipped: false, lastStep: 5 },
+  firstPlay: { completed: true, skipped: false },
+};
+const PHASES_EMPTY = {
+  intro: { completed: false, skipped: false },
+  worldCreation: { completed: false, skipped: false, lastStep: 0 },
+  worldGeneration: { completed: false, skipped: false, lastStep: 0 },
+  characterCreation: { completed: false, skipped: false, lastStep: 0 },
+  firstPlay: { completed: false, skipped: false },
+};
+
+function byId<T extends { id: string }>(arr: readonly T[]): Record<string, T> {
+  return Object.fromEntries(arr.map((x) => [x.id, x]));
+}
+
+function buildSeed(state: State): Record<string, string> {
+  const isEmpty = state === 'empty';
+  const isMid = state === 'mid-session';
+
+  const worlds = isEmpty ? {} : byId(SAMPLE_WORLDS);
+  const characters = isEmpty ? {} : byId(SAMPLE_CHARACTERS);
+  const sessions = isEmpty ? {} : byId(SAMPLE_GAME_SESSIONS);
+  const firstSession = isEmpty ? null : SAMPLE_GAME_SESSIONS[0];
+
+  const segments = isMid ? byId(SAMPLE_NARRATIVE_SEGMENTS) : {};
+  const decisions = isMid ? byId(SAMPLE_DECISIONS) : {};
+  const journalEntries = isMid ? byId(SAMPLE_JOURNAL_ENTRIES) : {};
+
+  const sessionSegments: Record<string, string[]> = {};
+  const sessionDecisions: Record<string, string[]> = {};
+  const sessionJournal: Record<string, string[]> = {};
+  if (isMid && firstSession) {
+    sessionSegments[firstSession.id] = Object.keys(segments).filter(
+      (id) => (segments as Record<string, { sessionId?: string }>)[id]?.sessionId === firstSession.id,
+    );
+    sessionDecisions[firstSession.id] = Object.keys(decisions);
+    sessionJournal[firstSession.id] = Object.keys(journalEntries);
+  }
+
+  const savedSessions = isEmpty
+    ? {}
+    : SAMPLE_GAME_SESSIONS.reduce<Record<string, unknown>>((acc, s) => {
+        acc[s.id] = {
+          id: s.id,
+          worldId: s.worldId,
+          characterId: s.characterId,
+          lastPlayed: (s as { lastPlayedAt?: string }).lastPlayedAt ?? null,
+          narrativeCount: (s as { totalTurns?: number }).totalTurns ?? 0,
+        };
+        return acc;
+      }, {});
+
+  return {
+    'narraitor-world-store': JSON.stringify({
+      state: { worlds, currentWorldId: isEmpty ? null : SAMPLE_WORLDS[0]?.id ?? null, error: null, loading: false },
+      version: VERSIONS.world,
+    }),
+    'narraitor-character-store': JSON.stringify({
+      state: {
+        characters,
+        currentCharacterId: isEmpty ? null : SAMPLE_CHARACTERS[0]?.id ?? null,
+        error: null,
+        loading: false,
+      },
+      version: VERSIONS.character,
+    }),
+    'narraitor-session-store': JSON.stringify({
+      state: {
+        sessions,
+        currentSessionId: isMid && firstSession ? firstSession.id : null,
+        id: isMid && firstSession ? firstSession.id : null,
+        status: isMid ? 'active' : 'idle',
+        worldId: isMid && firstSession ? firstSession.worldId : null,
+        characterId: isMid && firstSession ? firstSession.characterId : null,
+        savedSessions,
+        tutorialProgress: {
+          phases: isEmpty ? PHASES_EMPTY : PHASES_DONE,
+          dismissedHints: [],
+          lastActiveStep: null,
+        },
+        error: null,
+        loading: false,
+      },
+      version: VERSIONS.session,
+    }),
+    'narraitor-narrative-store': JSON.stringify({
+      state: {
+        segments,
+        sessionSegments,
+        decisions,
+        sessionDecisions,
+        endedSessions: {},
+        currentEnding: null,
+        isGeneratingEnding: false,
+        endingError: null,
+        error: null,
+        loading: false,
+      },
+      version: VERSIONS.narrative,
+    }),
+    'narraitor-journal-store': JSON.stringify({
+      state: { entries: journalEntries, sessionEntries: sessionJournal },
+      version: VERSIONS.journal,
+    }),
+    'narraitor-npc-store': JSON.stringify({
+      state: { npcs: {}, error: null, loading: false },
+      version: VERSIONS.npc,
+    }),
+  };
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const get = (name: string, def?: string): string => {
+    const i = args.indexOf(`--${name}`);
+    if (i < 0) return def ?? '';
+    return args[i + 1] ?? '';
+  };
+  const theme = (get('theme', 'default') as Theme);
+  const mode = (get('mode', 'light') as Mode);
+  const state = (get('state', 'seeded') as State);
+  const branch = get('branch');
+  const viewport = (get('viewport', 'desktop') as Viewport);
+  const baseUrl = get('base-url', 'http://localhost:3000');
+  const route = get('route', '');
+  if (!branch) {
+    console.error('Required: --branch <label>');
+    process.exit(1);
+  }
+  if (!['empty', 'seeded', 'mid-session'].includes(state)) {
+    console.error(`Invalid --state '${state}'`);
+    process.exit(1);
+  }
+  if (route && !ROUTES.some(([slug]) => slug === route)) {
+    console.error(`Unknown --route '${route}'. Known routes: ${ROUTES.map(([s]) => s).join(', ')}`);
+    process.exit(1);
+  }
+  return { theme, mode, state, branch, viewport, baseUrl, route };
+}
+
+async function captureRoute(
+  page: Page,
+  routeSlug: string,
+  routePath: string,
+  outDir: string,
+  viewport: Viewport,
+  baseUrl: string,
+) {
+  console.log(`=== ${routeSlug} ===`);
+  await page.goto(`${baseUrl}${routePath}`, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await page.waitForTimeout(1500); // let lazy widgets / fonts settle
+
+  // Hide DevTools panel + similar visual noise
+  await page.addStyleTag({
+    content: `[data-testid="devtools-panel-container"],[data-testid^="devtools-panel-"]{display:none !important;}`,
+  });
+
+  const pagePath = join(outDir, `${routeSlug}__page.png`);
+  await page.screenshot({ path: pagePath, fullPage: true });
+
+  if (viewport === 'mobile') {
+    // Mobile uses full-page only — selector captures are unreliable on narrow viewports
+    return;
+  }
+
+  for (const [name, selector] of SELECTORS) {
+    const elements = await page.locator(selector).all();
+    if (elements.length === 0) continue;
+    try {
+      const out = join(outDir, `${routeSlug}__${name}.png`);
+      await elements[0].screenshot({ path: out, timeout: 5000 });
+      console.log(`  ${name} -> captured`);
+    } catch {
+      // Element not visible / not screenshot-able — skip
+    }
+  }
+
+  // main > * children. Indices 0 and 1 are reliably page wrappers (header
+  // shells, container divs); skip them so triage isn't drowning in noise.
+  const mainChildren = await page.locator('main > *').all();
+  for (let i = 0; i < Math.min(mainChildren.length, 8); i++) {
+    if (i < 2) continue;
+    try {
+      const out = join(outDir, `${routeSlug}__main-section-${i}.png`);
+      await mainChildren[i].screenshot({ path: out, timeout: 5000 });
+    } catch {
+      break;
+    }
+  }
+}
+
+async function injectSeed(page: Page, seed: Record<string, string>) {
+  await page.evaluate(async (seedJson: string) => {
+    const data = JSON.parse(seedJson) as Record<string, string>;
+    for (const [k, v] of Object.entries(data)) localStorage.setItem(k, v);
+    await new Promise<void>((resolve) => {
+      const req = indexedDB.open('narraitor-state', 1);
+      req.onupgradeneeded = (e) => {
+        const db = (e.target as IDBOpenDBRequest).result;
+        if (!db.objectStoreNames.contains('narraitor-store')) {
+          db.createObjectStore('narraitor-store');
+        }
+      };
+      req.onsuccess = (e) => {
+        const db = (e.target as IDBOpenDBRequest).result;
+        const tx = db.transaction(['narraitor-store'], 'readwrite');
+        const store = tx.objectStore('narraitor-store');
+        for (const [k, v] of Object.entries(data)) {
+          store.put({ id: k, value: JSON.parse(v) }, k);
+        }
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => resolve();
+      };
+      req.onerror = () => resolve();
+    });
+  }, JSON.stringify(seed));
+}
+
+async function main() {
+  const { theme, mode, state, branch, viewport, baseUrl, route } = parseArgs();
+
+  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+  const outDir = join(
+    repoRoot,
+    'scripts',
+    'audit',
+    'captures',
+    `comp-${branch}`,
+    viewport,
+    state,
+  );
+  // Clean before each run so stale files from a previous tool/viewport/state
+  // don't contaminate the directory. When --route is set, only delete that
+  // route's files so the rest of the cell's captures aren't wiped.
+  if (route) {
+    await mkdir(outDir, { recursive: true });
+    if (existsSync(outDir)) {
+      const { readdir, unlink } = await import('node:fs/promises');
+      const files = await readdir(outDir);
+      for (const f of files) {
+        if (f.startsWith(`${route}__`) && f.endsWith('.png')) {
+          await unlink(join(outDir, f));
+        }
+      }
+    }
+  } else {
+    if (existsSync(outDir)) {
+      await rm(outDir, { recursive: true, force: true });
+    }
+    await mkdir(outDir, { recursive: true });
+  }
+
+  const seed = buildSeed(state);
+
+  const browser: Browser = await chromium.launch({ headless: true });
+  // NOTE: not setting isMobile — it forces deviceScaleFactor to 2 and creates
+  // retina captures with empty right-half. We only need the viewport size for
+  // layout audit purposes.
+  const ctx = await browser.newContext({
+    viewport:
+      viewport === 'mobile'
+        ? { width: 390, height: 844 }
+        : { width: 1320, height: 900 },
+    deviceScaleFactor: 1,
+  });
+  const page = await ctx.newPage();
+
+  // Prime origin so localStorage + IDB injects are accepted
+  await page.goto(baseUrl, { waitUntil: 'domcontentloaded' });
+
+  // Set theme + scheme on integration branches
+  if (theme !== 'default') {
+    await page.evaluate(
+      ({ t, m }: { t: string; m: string }) => {
+        localStorage.setItem('narraitor-theme', t);
+        localStorage.setItem('narraitor-color-scheme', m);
+      },
+      { t: theme, m: mode },
+    );
+  }
+
+  await injectSeed(page, seed);
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(1500);
+
+  const routesToRun = route ? ROUTES.filter(([slug]) => slug === route) : ROUTES;
+
+  console.log(`Output:   ${outDir}`);
+  console.log(`Viewport: ${viewport}  Theme: ${theme}/${mode}  State: ${state}  Branch: ${branch}`);
+  console.log(`Total routes: ${routesToRun.length}${route ? ` (filtered to '${route}')` : ''}`);
+
+  for (const [slug, path] of routesToRun) {
+    try {
+      await captureRoute(page, slug, path, outDir, viewport, baseUrl);
+    } catch (err) {
+      console.error(`  ERROR on ${slug}: ${(err as Error).message}`);
+    }
+  }
+
+  await browser.close();
+  console.log('done');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/audit/review.html
+++ b/scripts/audit/review.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Audit review moved</title>
+<meta http-equiv="refresh" content="0; url=review/index.html">
+<style>body{font-family:-apple-system,system-ui,sans-serif;padding:24px;}</style>
+</head>
+<body>
+<h1>Moved</h1>
+<p>The audit review now lives at <a href="review/index.html">review/index.html</a>.</p>
+</body>
+</html>

--- a/scripts/audit/review/about.html
+++ b/scripts/audit/review/about.html
@@ -1,0 +1,2143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Cross-Theme Audit (#1129) — about</title>
+<style>
+
+  :root { --col-gap: 8px; --row-gap: 16px; }
+  html, body { margin: 0; padding: 0; font-family: -apple-system, system-ui, sans-serif; background: #fafafa; color: #222; }
+  .sticky-shell { position: sticky; top: 0; z-index: 100; border-bottom: 1px solid #444; }
+  header.top {
+    background: #1a1a1a; color: #fff; padding: 12px 16px;
+    display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+  }
+  header.top h1 { font-size: 14px; margin: 0; font-weight: 600; }
+  header.top .legend { display: flex; gap: 12px; font-size: 12px; }
+  header.top .legend .col { padding: 2px 8px; border-radius: 3px; }
+  header.top .legend .develop { background: #6b7280; }
+  header.top .legend .ds3 { background: #4338ca; }
+  header.top .legend .ds1 { background: #92400e; }
+  header.top .legend .ds2 { background: #166534; }
+  header.top a.back { color: #9cf; font-size: 12px; text-decoration: none; padding: 2px 6px; border-radius: 2px; }
+  header.top a.back:hover { background: #444; color: #fff; }
+  header.top .nav-routes { display: flex; gap: 4px; align-items: center; font-size: 12px; }
+  header.top .nav-routes a { color: #9cf; text-decoration: none; padding: 2px 8px; border-radius: 2px; background: #2a2a2a; }
+  header.top .nav-routes a:hover { background: #444; color: #fff; }
+  header.top .nav-routes .current { color: #fff; font-weight: 600; padding: 2px 8px; }
+  main { padding: 16px; max-width: 100%; }
+  section.route {
+    margin-bottom: 32px; background: #fff; border-radius: 6px;
+    padding: 12px 16px 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  section.route h2 {
+    font-size: 18px; margin: 0 0 12px; padding-bottom: 6px;
+    border-bottom: 1px solid #e5e5e5;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+  .component-row {
+    display: grid; grid-template-columns: 180px repeat(4, 1fr);
+    gap: var(--col-gap); margin-bottom: var(--row-gap);
+    align-items: start;
+  }
+  .component-row .label {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px; color: #555; padding-top: 28px; line-height: 1.3;
+    word-break: break-word;
+  }
+  .cell {
+    border: 1px solid #e5e5e5; border-radius: 4px; overflow: hidden;
+    background: #f3f4f6; position: relative; min-height: 100px;
+    display: flex; flex-direction: column;
+  }
+  .cell .header {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.04em; padding: 4px 8px; color: #fff;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .cell.develop .header { background: #6b7280; }
+  .cell.ds3 .header { background: #4338ca; }
+  .cell.ds1 .header { background: #92400e; }
+  .cell.ds2 .header { background: #166534; }
+  .cell img {
+    display: block; width: auto; max-width: 100%; height: auto;
+    cursor: zoom-in; background: #fff; align-self: flex-start;
+  }
+  body.fit-cell .cell img { width: 100%; max-width: 100%; }
+  .cell.empty {
+    display: flex; align-items: center; justify-content: center;
+    color: #999; font-size: 12px; padding: 24px; background: #f9f9f9;
+  }
+  .cell.empty::after { content: "(not captured)"; }
+
+  /* Lightbox */
+  #lightbox {
+    display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.92);
+    z-index: 1000; align-items: center; justify-content: center; cursor: zoom-out;
+  }
+  #lightbox.open { display: flex; }
+  #lightbox img { max-width: 96vw; max-height: 96vh; box-shadow: 0 4px 24px rgba(0,0,0,0.5); }
+
+  .controls { display: flex; gap: 12px; align-items: center; font-size: 12px; flex-wrap: wrap; }
+  .controls label { display: flex; align-items: center; gap: 4px; cursor: pointer; }
+  .controls input[type=checkbox] { margin: 0; }
+
+  .state-chips { display: inline-flex; gap: 4px; align-items: center; }
+  .state-chip {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .state-chip.active { background: #2563eb; border-color: #1d4ed8; }
+  .state-chip:hover { background: #4b5563; }
+  .state-chip.active:hover { background: #1d4ed8; }
+
+  body.hide-empty .component-row.all-empty,
+  body.hide-empty .cell.empty { display: none; }
+  body.compact .cell img { max-height: 360px; object-fit: cover; object-position: top; }
+
+  .cell .mark-btn {
+    margin-left: auto; background: rgba(255,255,255,0.18);
+    color: #fff; border: 1px solid rgba(255,255,255,0.35);
+    border-radius: 3px; font-size: 10px; font-weight: 600;
+    padding: 2px 6px; cursor: pointer;
+    text-transform: none; letter-spacing: 0; line-height: 1.2;
+  }
+  .cell .mark-btn:hover { background: rgba(255,255,255,0.28); }
+  .cell.marked { border: 3px solid #dc2626; }
+  .cell.marked .mark-btn { background: #dc2626; border-color: #b91c1c; color: #fff; }
+  .cell.marked .mark-btn::before { content: "x "; }
+  .cell.pending-recapture { animation: cellPulse 2s ease-out; }
+  @keyframes cellPulse {
+    0%   { box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.9); border-color: #7c3aed; }
+    100% { box-shadow: 0 0 0 8px rgba(124, 58, 237, 0); }
+  }
+  .cell .toolbar {
+    display: none;
+    padding: 6px 8px; background: #fef2f2; border-top: 1px solid #fecaca;
+    font-size: 11px;
+  }
+  .cell.marked .toolbar { display: block; }
+  .cell .toolbar input[type=text],
+  .cell .toolbar textarea {
+    width: 100%; box-sizing: border-box;
+    border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 4px 6px; font-size: 12px; font-family: inherit;
+    background: #fff;
+  }
+  .cell .toolbar input[type=text]:focus,
+  .cell .toolbar textarea:focus { outline: 2px solid #dc2626; outline-offset: -1px; }
+  .cell .toolbar .field { margin-bottom: 6px; }
+  .cell .toolbar .field-label {
+    display: block; font-size: 10px; font-weight: 600;
+    color: #7f1d1d; text-transform: uppercase; letter-spacing: 0.04em;
+    margin-bottom: 2px;
+  }
+  .cell .toolbar .cat-chips { display: flex; gap: 4px; flex-wrap: wrap; }
+  .cell .toolbar .cat-chip {
+    background: #fff; border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 2px 8px; font-size: 11px; cursor: pointer; font-family: inherit;
+    color: #7f1d1d;
+  }
+  .cell .toolbar .cat-chip.active { background: #7f1d1d; color: #fff; border-color: #7f1d1d; }
+  .cell .toolbar .cat-chip[data-cat="needs-design"].active { background: #6d28d9; border-color: #6d28d9; }
+  .cell .toolbar .cat-chip[data-cat="bug"].active        { background: #b91c1c; border-color: #b91c1c; }
+  .cell .toolbar .cat-chip[data-cat="tooling"].active    { background: #b45309; border-color: #b45309; }
+  .cell .toolbar .cat-chip[data-cat="intentional"].active{ background: #15803d; border-color: #15803d; }
+  .cell .toolbar .cat-chip[data-cat="unclear"].active    { background: #6b7280; border-color: #6b7280; }
+  .cell .toolbar .recapture-btn {
+    background: #1d4ed8; color: #fff; border: 0; border-radius: 3px;
+    padding: 4px 10px; font-size: 11px; cursor: pointer;
+    font-family: inherit; font-weight: 600;
+  }
+  .cell .toolbar .recapture-btn:hover { background: #1e40af; }
+  .cell .toolbar textarea { min-height: 32px; resize: vertical; font-size: 11px; }
+  .cell.cat-needs-design { border-color: #6d28d9; }
+  .cell.cat-bug         { border-color: #b91c1c; }
+  .cell.cat-tooling     { border-color: #b45309; }
+  .cell.cat-intentional { border-color: #15803d; }
+  .cell.cat-unclear     { border-color: #6b7280; }
+
+  .marks-cluster {
+    display: flex; align-items: center; gap: 8px;
+    border-left: 1px solid #444; padding-left: 12px; margin-left: 4px;
+    font-size: 12px;
+  }
+  .marks-cluster .count {
+    background: #dc2626; color: #fff; border-radius: 10px;
+    padding: 2px 8px; font-weight: 600; min-width: 18px; text-align: center;
+  }
+  .marks-cluster button {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .marks-cluster button:hover { background: #4b5563; }
+  .marks-cluster button.danger { background: #7f1d1d; border-color: #991b1b; }
+  .marks-cluster button.danger:hover { background: #991b1b; }
+
+  body.only-marked .component-row:not(.has-marked) { display: none; }
+  body.only-marked section.route:not(.has-marked) { display: none; }
+
+  .component-row.suppressed { display: none; }
+  body.show-suppressed .component-row.suppressed { display: grid; }
+  .component-row.suppressed .label::after { content: " (hidden)"; color: #b91c1c; font-style: italic; }
+
+  .component-row .label[data-mapped] { color: #1d4ed8; }
+  .component-row .label[data-mapped]::after { content: " *"; }
+  .mapped-tooltip {
+    display: inline-block; margin-left: 4px;
+    font-size: 10px; color: #6b7280; cursor: help; vertical-align: super;
+  }
+
+  .vp-badge, .state-badge {
+    display: inline-block; font-size: 9px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.05em;
+    padding: 1px 6px; border-radius: 8px; margin-top: 2px;
+  }
+  .vp-badge.desktop { background: #dbeafe; color: #1e3a8a; border: 1px solid #93c5fd; margin-right: 4px; }
+  .vp-badge.mobile  { background: #fef3c7; color: #78350f; border: 1px solid #fcd34d; margin-right: 4px; }
+  .state-badge.empty       { background: #f3f4f6; color: #374151; border: 1px solid #d1d5db; }
+  .state-badge.seeded      { background: #dcfce7; color: #14532d; border: 1px solid #86efac; }
+  .state-badge.mid-session { background: #ede9fe; color: #4c1d95; border: 1px solid #c4b5fd; }
+
+  .component-row.vp-mobile { background: #fffbeb; padding: 4px; border-radius: 4px; }
+  body.hide-desktop .component-row.vp-desktop { display: none; }
+  body.hide-mobile .component-row.vp-mobile { display: none; }
+
+  body.hide-state-empty       .component-row.state-empty       { display: none; }
+  body.hide-state-seeded      .component-row.state-seeded      { display: none; }
+  body.hide-state-mid-session .component-row.state-mid-session { display: none; }
+
+  .overlay {
+    display: none; position: fixed; inset: 0; z-index: 1100;
+    background: rgba(0,0,0,0.6); align-items: center; justify-content: center;
+  }
+  .overlay.open { display: flex; }
+  .overlay .panel {
+    background: #fff; border-radius: 6px; width: min(720px, 92vw);
+    max-height: 80vh; padding: 16px; display: flex; flex-direction: column; gap: 8px;
+  }
+  .overlay h3 { margin: 0; font-size: 14px; }
+  .overlay textarea {
+    flex: 1; min-height: 320px; font-family: ui-monospace, monospace; font-size: 12px;
+    border: 1px solid #ddd; border-radius: 4px; padding: 8px; resize: vertical;
+  }
+  .overlay .actions { display: flex; gap: 8px; justify-content: flex-end; }
+  .overlay button {
+    background: #1a1a1a; color: #fff; border: 0; border-radius: 3px;
+    padding: 6px 12px; font-size: 12px; cursor: pointer;
+  }
+  .overlay .hint { font-size: 11px; color: #555; }
+  .overlay .err  { font-size: 12px; color: #b91c1c; min-height: 16px; }
+
+  /* Index-page table */
+  table.routes-index {
+    width: 100%; border-collapse: collapse; background: #fff;
+    border-radius: 6px; overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  table.routes-index th, table.routes-index td {
+    padding: 8px 12px; text-align: left; font-size: 13px;
+    border-bottom: 1px solid #eee;
+  }
+  table.routes-index th { background: #f3f4f6; font-weight: 600; }
+  table.routes-index td a {
+    color: #1d4ed8; text-decoration: none; font-family: ui-monospace, monospace;
+  }
+  table.routes-index td a:hover { text-decoration: underline; }
+  table.routes-index td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  table.routes-index .marked-count.has-marks { color: #b91c1c; font-weight: 600; }
+  table.routes-index .unresolved-count.has-unresolved { color: #b45309; font-weight: 600; }
+  table.routes-index .breakdown {
+    font-size: 11px; color: #555; margin-left: 6px; font-variant-numeric: tabular-nums;
+  }
+
+
+</style>
+</head>
+<body>
+<div class="sticky-shell">
+<header class="top">
+  <a class="back" href="index.html">&larr; Index</a>
+  <h1>about</h1>
+  <div class="legend">
+    <span class="col develop">develop</span>
+    <span class="col ds3">DS3</span>
+    <span class="col ds1">DS1</span>
+    <span class="col ds2">DS2</span>
+  </div>
+  <div class="controls">
+    <span class="state-chips" role="group" aria-label="State filter">
+      <span style="font-size: 11px; color: #aaa;">State:</span>
+      <button type="button" class="state-chip" data-state="empty">empty</button>
+      <button type="button" class="state-chip active" data-state="seeded">seeded</button>
+    </span>
+    <label><input type="checkbox" id="hide-empty"> Hide missing</label>
+    <label><input type="checkbox" id="compact"> Compact</label>
+    <label title="Stretch images to cell width"><input type="checkbox" id="fit-cell"> Fit to cell</label>
+    <label><input type="checkbox" id="only-marked"> Only marked</label>
+    <label><input type="checkbox" id="show-suppressed"> Show hidden rows</label>
+    <label><input type="checkbox" id="hide-desktop"> Hide desktop</label>
+    <label><input type="checkbox" id="hide-mobile"> Hide mobile</label>
+  </div>
+  <div class="marks-cluster">
+    <span>Marked (route):</span>
+    <span class="count" id="mark-count">0</span>
+    <button id="prefill-ds-btn" type="button" title="Mark every DS cell that has no mark yet as needs-design (gap-fill, never overwrites your existing marks)">Fill DS gaps</button>
+    <button id="export-md-btn" type="button">Export markdown</button>
+    <button id="export-json-btn" type="button">Export JSON</button>
+    <button id="import-json-btn" type="button">Import JSON</button>
+    <button id="clear-route-btn" type="button" class="danger">Clear (route)</button>
+  </div>
+</header>
+<nav class="toc" style="background:#2a2a2a;color:#ccc;padding:6px 16px;font-size:12px;display:flex;gap:8px;align-items:center;border-top:1px solid #444;">
+  <span class="nav-routes">
+    <a href="home.html">&larr; home</a>
+    <span class="current">about</span>
+    <a href="worlds.html">worlds &rarr;</a>
+  </span>
+</nav>
+</div>
+<main>
+<section class="route" id="route-about">
+  <h2>about</h2>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="about__global-nav__desktop__empty__develop" data-route="about" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/about__nav.png" alt="develop about/global-nav/desktop/empty" data-caption="develop -- about/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="about__global-nav__desktop__empty__DS3" data-route="about" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/about__nav.png" alt="DS3 about/global-nav/desktop/empty" data-caption="DS3 -- about/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="about__global-nav__desktop__empty__DS1" data-route="about" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/about__nav.png" alt="DS1 about/global-nav/desktop/empty" data-caption="DS1 -- about/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="about__global-nav__desktop__empty__DS2" data-route="about" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/about__nav.png" alt="DS2 about/global-nav/desktop/empty" data-caption="DS2 -- about/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="about__page__desktop__empty__develop" data-route="about" data-component="page" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/about__page.png" alt="develop about/page/desktop/empty" data-caption="develop -- about/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="about__page__desktop__empty__DS3" data-route="about" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/about__page.png" alt="DS3 about/page/desktop/empty" data-caption="DS3 -- about/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="about__page__desktop__empty__DS1" data-route="about" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/about__page.png" alt="DS1 about/page/desktop/empty" data-caption="DS1 -- about/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="about__page__desktop__empty__DS2" data-route="about" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/about__page.png" alt="DS2 about/page/desktop/empty" data-caption="DS2 -- about/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-empty" data-viewport="mobile" data-state="empty">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="about__page__mobile__empty__develop" data-route="about" data-component="page" data-viewport="mobile" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/empty/about__page.png" alt="develop about/page/mobile/empty" data-caption="develop -- about/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="about__page__mobile__empty__DS3" data-route="about" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/empty/about__page.png" alt="DS3 about/page/mobile/empty" data-caption="DS3 -- about/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="about__page__mobile__empty__DS1" data-route="about" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/empty/about__page.png" alt="DS1 about/page/mobile/empty" data-caption="DS1 -- about/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="about__page__mobile__empty__DS2" data-route="about" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/empty/about__page.png" alt="DS2 about/page/mobile/empty" data-caption="DS2 -- about/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="about__header__desktop__empty__develop" data-route="about" data-component="header" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/about__header.png" alt="develop about/header/desktop/empty" data-caption="develop -- about/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="about__header__desktop__empty__DS3" data-route="about" data-component="header" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/about__header.png" alt="DS3 about/header/desktop/empty" data-caption="DS3 -- about/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="about__header__desktop__empty__DS1" data-route="about" data-component="header" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/about__header.png" alt="DS1 about/header/desktop/empty" data-caption="DS1 -- about/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="about__header__desktop__empty__DS2" data-route="about" data-component="header" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/about__header.png" alt="DS2 about/header/desktop/empty" data-caption="DS2 -- about/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="about__nav__desktop__empty__develop" data-route="about" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/about__nav.png" alt="develop about/nav/desktop/empty" data-caption="develop -- about/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="about__nav__desktop__empty__DS3" data-route="about" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/about__nav.png" alt="DS3 about/nav/desktop/empty" data-caption="DS3 -- about/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="about__nav__desktop__empty__DS1" data-route="about" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/about__nav.png" alt="DS1 about/nav/desktop/empty" data-caption="DS1 -- about/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="about__nav__desktop__empty__DS2" data-route="about" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/about__nav.png" alt="DS2 about/nav/desktop/empty" data-caption="DS2 -- about/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="about__main__desktop__empty__develop" data-route="about" data-component="main" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/about__main.png" alt="develop about/main/desktop/empty" data-caption="develop -- about/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="about__main__desktop__empty__DS3" data-route="about" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/about__main.png" alt="DS3 about/main/desktop/empty" data-caption="DS3 -- about/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="about__main__desktop__empty__DS1" data-route="about" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/about__main.png" alt="DS1 about/main/desktop/empty" data-caption="DS1 -- about/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="about__main__desktop__empty__DS2" data-route="about" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/about__main.png" alt="DS2 about/main/desktop/empty" data-caption="DS2 -- about/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="about__global-nav__desktop__seeded__develop" data-route="about" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/about__nav.png" alt="develop about/global-nav/desktop/seeded" data-caption="develop -- about/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="about__global-nav__desktop__seeded__DS3" data-route="about" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/about__nav.png" alt="DS3 about/global-nav/desktop/seeded" data-caption="DS3 -- about/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="about__global-nav__desktop__seeded__DS1" data-route="about" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/about__nav.png" alt="DS1 about/global-nav/desktop/seeded" data-caption="DS1 -- about/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="about__global-nav__desktop__seeded__DS2" data-route="about" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/about__nav.png" alt="DS2 about/global-nav/desktop/seeded" data-caption="DS2 -- about/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="about__page__desktop__seeded__develop" data-route="about" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/about__page.png" alt="develop about/page/desktop/seeded" data-caption="develop -- about/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="about__page__desktop__seeded__DS3" data-route="about" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/about__page.png" alt="DS3 about/page/desktop/seeded" data-caption="DS3 -- about/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="about__page__desktop__seeded__DS1" data-route="about" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/about__page.png" alt="DS1 about/page/desktop/seeded" data-caption="DS1 -- about/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="about__page__desktop__seeded__DS2" data-route="about" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/about__page.png" alt="DS2 about/page/desktop/seeded" data-caption="DS2 -- about/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-seeded" data-viewport="mobile" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="about__page__mobile__seeded__develop" data-route="about" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/seeded/about__page.png" alt="develop about/page/mobile/seeded" data-caption="develop -- about/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="about__page__mobile__seeded__DS3" data-route="about" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/seeded/about__page.png" alt="DS3 about/page/mobile/seeded" data-caption="DS3 -- about/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="about__page__mobile__seeded__DS1" data-route="about" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/seeded/about__page.png" alt="DS1 about/page/mobile/seeded" data-caption="DS1 -- about/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="about__page__mobile__seeded__DS2" data-route="about" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/seeded/about__page.png" alt="DS2 about/page/mobile/seeded" data-caption="DS2 -- about/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="about__header__desktop__seeded__develop" data-route="about" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/about__header.png" alt="develop about/header/desktop/seeded" data-caption="develop -- about/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="about__header__desktop__seeded__DS3" data-route="about" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/about__header.png" alt="DS3 about/header/desktop/seeded" data-caption="DS3 -- about/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="about__header__desktop__seeded__DS1" data-route="about" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/about__header.png" alt="DS1 about/header/desktop/seeded" data-caption="DS1 -- about/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="about__header__desktop__seeded__DS2" data-route="about" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/about__header.png" alt="DS2 about/header/desktop/seeded" data-caption="DS2 -- about/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="about__nav__desktop__seeded__develop" data-route="about" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/about__nav.png" alt="develop about/nav/desktop/seeded" data-caption="develop -- about/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="about__nav__desktop__seeded__DS3" data-route="about" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/about__nav.png" alt="DS3 about/nav/desktop/seeded" data-caption="DS3 -- about/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="about__nav__desktop__seeded__DS1" data-route="about" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/about__nav.png" alt="DS1 about/nav/desktop/seeded" data-caption="DS1 -- about/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="about__nav__desktop__seeded__DS2" data-route="about" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/about__nav.png" alt="DS2 about/nav/desktop/seeded" data-caption="DS2 -- about/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="about__main__desktop__seeded__develop" data-route="about" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/about__main.png" alt="develop about/main/desktop/seeded" data-caption="develop -- about/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="about__main__desktop__seeded__DS3" data-route="about" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/about__main.png" alt="DS3 about/main/desktop/seeded" data-caption="DS3 -- about/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="about__main__desktop__seeded__DS1" data-route="about" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/about__main.png" alt="DS1 about/main/desktop/seeded" data-caption="DS1 -- about/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="about__main__desktop__seeded__DS2" data-route="about" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/about__main.png" alt="DS2 about/main/desktop/seeded" data-caption="DS2 -- about/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+</main>
+
+<div id="lightbox" class="overlay">
+  <img id="lightbox-img" src="" alt="">
+  <div id="lightbox-caption" style="position: fixed; top: 12px; left: 50%; transform: translateX(-50%); color: #fff; font-family: ui-monospace, monospace; font-size: 13px; background: rgba(0,0,0,0.6); padding: 6px 12px; border-radius: 4px;"></div>
+</div>
+
+<div id="md-overlay" class="overlay">
+  <div class="panel">
+    <h3>Audit marks (markdown) -- this route only</h3>
+    <textarea id="md-text" readonly></textarea>
+    <div class="actions">
+      <button id="md-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="md-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-export-overlay" class="overlay">
+  <div class="panel">
+    <h3>Marks (raw JSON) -- all routes</h3>
+    <textarea id="json-export-text" readonly></textarea>
+    <div class="actions">
+      <button id="json-export-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="json-export-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-import-overlay" class="overlay">
+  <div class="panel">
+    <h3>Import marks (paste raw JSON)</h3>
+    <p class="hint">Paste JSON exported from another instance. Legacy IDs without a state segment are migrated to <code>__seeded</code>; v2 values are upgraded to v3 (category=null, why="", updatedAt=now). Existing marks with the same ID are overwritten.</p>
+    <textarea id="json-import-text" placeholder='{"home__page__desktop__seeded__DS3":{"marked":true,"note":"...","category":"bug","why":"...","updatedAt":"..."}}'></textarea>
+    <div class="err" id="json-import-err"></div>
+    <div class="actions">
+      <button id="json-import-apply" type="button">Apply</button>
+      <button class="overlay-close" data-overlay="json-import-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+<script>
+
+  const STORAGE_KEY = 'narraitor-audit-marks-v3';
+  const STORAGE_KEY_V2 = 'narraitor-audit-marks-v2';
+  const STORAGE_KEY_V1 = 'narraitor-audit-marks-v1';
+  // Tracks which routes have had their DS cells auto-prefilled as needs-design.
+  // Once a route is in here, the auto-prefill on page load is skipped.
+  const PREFILLED_KEY = 'narraitor-audit-prefilled-v1';
+  const STATES = ['empty', 'seeded'];
+  const VALID_CATEGORIES = ['needs-design','bug','tooling','intentional','unclear'];
+  const ROUTE_ORDER = ["home", "about", "worlds", "worlds-detail", "worlds-edit", "worlds-create", "worlds-play", "worlds-play-journal", "characters", "characters-detail", "characters-edit", "characters-create", "play", "settings"];
+  const COMPONENT_ORDER = {"page":0,"header":1,"nav":2,"form":3,"main":4};
+  const THEME_ORDER = ["DS3","DS1","DS2","develop"];
+  const BRANCH_META = {"develop": {"theme": "default", "mode": "light", "branchArg": "develop-default"}, "DS3": {"theme": "ds3", "mode": "light", "branchArg": "integration-ds3-light"}, "DS1": {"theme": "ds1", "mode": "light", "branchArg": "integration-ds1-light"}, "DS2": {"theme": "ds2", "mode": "light", "branchArg": "integration-ds2-light"}};
+
+  function componentSortKey(c) {
+    if (c in COMPONENT_ORDER) return [COMPONENT_ORDER[c], 0];
+    if (c.startsWith("main-section-")) {
+      const n = parseInt(c.replace("main-section-",""), 10);
+      return [5, isNaN(n) ? 0 : n];
+    }
+    return [9, c];
+  }
+
+  // Pre-v3 ID migration: v1 (4 segments) -> v2 (5 segments) by inserting __seeded.
+  function migrateLegacyId(id) {
+    const parts = id.split('__');
+    if (parts.length < 4) return id;
+    const last = parts[parts.length - 1];
+    const second = parts[parts.length - 2];
+    const third = parts[parts.length - 3];
+    const isTheme = ['DS1','DS2','DS3','develop'].includes(last);
+    const isViewport = ['desktop','mobile'].includes(second);
+    const alreadyHasState = STATES.includes(third);
+    if (isTheme && isViewport && !alreadyHasState) {
+      const head = parts.slice(0, parts.length - 1).join('__');
+      return head + '__seeded__' + last;
+    }
+    return id;
+  }
+
+  function migrateMarksV1ToV2(input) {
+    const out = {};
+    let migrated = 0;
+    for (const [id, m] of Object.entries(input || {})) {
+      const newId = migrateLegacyId(id);
+      if (newId !== id) migrated++;
+      out[newId] = m;
+    }
+    return { marks: out, migrated };
+  }
+
+  // v2 -> v3: add category, why, updatedAt; preserve marked + note.
+  function upgradeV2ValueToV3(v) {
+    if (!v || typeof v !== 'object') return null;
+    return {
+      marked: !!v.marked,
+      note: typeof v.note === 'string' ? v.note : '',
+      category: v.category && VALID_CATEGORIES.includes(v.category) ? v.category : null,
+      why: typeof v.why === 'string' ? v.why : '',
+      updatedAt: v.updatedAt || new Date().toISOString(),
+    };
+  }
+
+  function migrateV2ObjectToV3(v2obj) {
+    const out = {};
+    for (const [id, m] of Object.entries(v2obj || {})) {
+      out[id] = upgradeV2ValueToV3(m);
+    }
+    return out;
+  }
+
+  function loadMarks() {
+    try {
+      const v3 = localStorage.getItem(STORAGE_KEY);
+      if (v3) return JSON.parse(v3);
+      // No v3 yet — try v2 (lazy migrate; leave v2 untouched for rollback).
+      const v2raw = localStorage.getItem(STORAGE_KEY_V2);
+      if (v2raw) {
+        const v3marks = migrateV2ObjectToV3(JSON.parse(v2raw));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + Object.keys(v3marks).length + ' v2 marks to v3 (v2 untouched).');
+        return v3marks;
+      }
+      // No v3 or v2 — try v1 and migrate v1 -> v2 -> v3 in one pass.
+      const v1raw = localStorage.getItem(STORAGE_KEY_V1);
+      if (v1raw) {
+        const { marks: v2marks, migrated } = migrateMarksV1ToV2(JSON.parse(v1raw));
+        const v3marks = migrateV2ObjectToV3(v2marks);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + migrated + ' v1 IDs through to v3.');
+        return v3marks;
+      }
+    } catch (e) { console.warn(e); }
+    return {};
+  }
+
+  function saveMarks(m) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(m)); } catch (e) {}
+  }
+
+
+  const ROUTE = "about";
+  let marks = loadMarks();
+
+  function applyMarkState(cell) {
+    const id = cell.dataset.cellId;
+    const m = marks[id];
+    const noteInput = cell.querySelector('textarea[data-action="note"]');
+    const whyInput = cell.querySelector('input[data-action="why"]');
+    const chips = cell.querySelectorAll('.cat-chip');
+    cell.classList.remove('cat-bug','cat-tooling','cat-intentional','cat-unclear');
+    chips.forEach(c => c.classList.remove('active'));
+    if (m && m.marked) {
+      cell.classList.add('marked');
+      if (noteInput) noteInput.value = m.note || '';
+      if (whyInput) whyInput.value = m.why || '';
+      if (m.category) {
+        cell.classList.add('cat-' + m.category);
+        const chip = cell.querySelector('.cat-chip[data-cat="' + m.category + '"]');
+        if (chip) chip.classList.add('active');
+      }
+    } else {
+      cell.classList.remove('marked');
+      if (noteInput) noteInput.value = '';
+      if (whyInput) whyInput.value = '';
+    }
+  }
+
+  function updateRowSectionFlags() {
+    document.querySelectorAll('.component-row').forEach(row => {
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+    document.querySelectorAll('section.route').forEach(sec => {
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+    });
+  }
+
+  function updateCount() {
+    const n = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).length;
+    document.getElementById('mark-count').textContent = n;
+  }
+
+  function writeMark(id, partial) {
+    const existing = marks[id] || { marked: false, note: '', category: null, why: '', updatedAt: null };
+    const next = Object.assign({}, existing, partial, { updatedAt: new Date().toISOString() });
+    if (!next.marked && !next.note && !next.why && !next.category) {
+      delete marks[id];
+    } else {
+      marks[id] = next;
+    }
+    saveMarks(marks);
+    updateCount();
+  }
+
+  function buildRecaptureCommand(cell) {
+    const route = cell.dataset.route;
+    const viewport = cell.dataset.viewport;
+    const state = cell.dataset.state;
+    const themeKey = cell.dataset.theme;
+    const meta = BRANCH_META[themeKey];
+    if (!meta) return null;
+    return 'npx tsx scripts/audit/playwright-crawl.ts'
+      + ' --branch ' + meta.branchArg
+      + ' --viewport ' + viewport
+      + ' --state ' + state
+      + ' --theme ' + meta.theme
+      + ' --mode ' + meta.mode
+      + ' --route ' + route;
+  }
+
+  function loadPrefilledFlags() {
+    try { return JSON.parse(localStorage.getItem(PREFILLED_KEY) || '{}'); }
+    catch (e) { return {}; }
+  }
+  function savePrefilledFlags(f) {
+    try { localStorage.setItem(PREFILLED_KEY, JSON.stringify(f)); } catch (e) {}
+  }
+
+  // Gap-fill: only adds entries for DS cells that have no existing mark.
+  // Returns the count of cells filled. Develop is excluded (it's the baseline).
+  function prefillDsCellsAsNeedsDesign() {
+    const dsCells = Array.from(document.querySelectorAll('.cell[data-cell-id]'))
+      .filter(c => ['DS1','DS2','DS3'].includes(c.dataset.theme));
+    let added = 0;
+    const ts = new Date().toISOString();
+    for (const cell of dsCells) {
+      const id = cell.dataset.cellId;
+      if (!marks[id]) {
+        marks[id] = { marked: true, note: '', category: 'needs-design', why: '', updatedAt: ts };
+        added++;
+      }
+    }
+    if (added > 0) saveMarks(marks);
+    return added;
+  }
+
+  // Auto-prefill on first visit per route.
+  const prefillFlags = loadPrefilledFlags();
+  if (!prefillFlags[ROUTE]) {
+    const added = prefillDsCellsAsNeedsDesign();
+    prefillFlags[ROUTE] = true;
+    savePrefilledFlags(prefillFlags);
+    if (added > 0) console.info('[audit] auto-prefilled ' + added + ' DS cells for ' + ROUTE + ' as needs-design.');
+  }
+
+  document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+  updateRowSectionFlags();
+  updateCount();
+
+  // Lightbox
+  const lb = document.getElementById('lightbox');
+  const lbImg = document.getElementById('lightbox-img');
+  const lbCap = document.getElementById('lightbox-caption');
+  document.querySelectorAll('.cell img').forEach(img => {
+    img.addEventListener('click', () => {
+      lbImg.src = img.src;
+      lbCap.textContent = img.dataset.caption || '';
+      lb.classList.add('open');
+    });
+  });
+  lb.addEventListener('click', () => lb.classList.remove('open'));
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') document.querySelectorAll('.overlay.open').forEach(o => o.classList.remove('open'));
+  });
+
+  // Mark toggle
+  document.querySelectorAll('button[data-action="toggle-mark"]').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      const cell = btn.closest('.cell');
+      const id = cell.dataset.cellId;
+      const isMarked = !cell.classList.contains('marked');
+      writeMark(id, { marked: isMarked });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      const sec = cell.closest('section.route');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+      if (isMarked) {
+        const why = cell.querySelector('input[data-action="why"]');
+        if (why) setTimeout(() => why.focus(), 0);
+      }
+    });
+  });
+
+  // Why / note inputs (debounced save)
+  let saveTimer = null;
+  function bindInput(sel, field) {
+    document.querySelectorAll(sel).forEach(inp => {
+      const handler = () => {
+        const cell = inp.closest('.cell');
+        if (!cell.classList.contains('marked')) return;
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(() => {
+          writeMark(cell.dataset.cellId, { [field]: inp.value });
+        }, 250);
+      };
+      inp.addEventListener('input', handler);
+      inp.addEventListener('blur', () => {
+        const cell = inp.closest('.cell');
+        if (cell.classList.contains('marked')) writeMark(cell.dataset.cellId, { [field]: inp.value });
+      });
+    });
+  }
+  bindInput('input[data-action="why"]', 'why');
+  bindInput('textarea[data-action="note"]', 'note');
+
+  // Category chips
+  document.querySelectorAll('.cat-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const cell = chip.closest('.cell');
+      if (!cell.classList.contains('marked')) {
+        // Mark the cell first so the category sticks
+        writeMark(cell.dataset.cellId, { marked: true });
+      }
+      const cat = chip.dataset.cat;
+      const isActive = chip.classList.contains('active');
+      writeMark(cell.dataset.cellId, { category: isActive ? null : cat });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+  });
+
+  // Re-capture command (copy to clipboard, flash purple)
+  document.querySelectorAll('button[data-action="recapture"]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const cell = btn.closest('.cell');
+      const cmd = buildRecaptureCommand(cell);
+      if (!cmd) return;
+      try {
+        await navigator.clipboard.writeText(cmd);
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Copy re-capture command'; }, 1500);
+      } catch (e) {
+        prompt('Copy this command:', cmd);
+      }
+      cell.classList.remove('pending-recapture');
+      void cell.offsetWidth; // force reflow so the animation restarts
+      cell.classList.add('pending-recapture');
+    });
+  });
+
+  // Toggles
+  document.getElementById('hide-empty').addEventListener('change', e => document.body.classList.toggle('hide-empty', e.target.checked));
+  document.getElementById('compact').addEventListener('change', e => document.body.classList.toggle('compact', e.target.checked));
+  document.getElementById('fit-cell').addEventListener('change', e => document.body.classList.toggle('fit-cell', e.target.checked));
+  document.getElementById('only-marked').addEventListener('change', e => document.body.classList.toggle('only-marked', e.target.checked));
+  document.getElementById('show-suppressed').addEventListener('change', e => document.body.classList.toggle('show-suppressed', e.target.checked));
+  document.getElementById('hide-desktop').addEventListener('change', e => document.body.classList.toggle('hide-desktop', e.target.checked));
+  document.getElementById('hide-mobile').addEventListener('change', e => document.body.classList.toggle('hide-mobile', e.target.checked));
+
+  // True-scale rendering (1x for selector captures, 0.5x for retina full-page).
+  const RETINA_THRESHOLD = 1500;
+  function applyTrueScale(img) {
+    if (!img.naturalWidth) return;
+    const cssWidth = img.naturalWidth > RETINA_THRESHOLD
+      ? Math.round(img.naturalWidth / 2)
+      : img.naturalWidth;
+    img.style.maxWidth = 'min(100%, ' + cssWidth + 'px)';
+  }
+  document.querySelectorAll('.cell img').forEach(img => {
+    if (img.complete && img.naturalWidth > 0) applyTrueScale(img);
+    else img.addEventListener('load', () => applyTrueScale(img), { once: true });
+  });
+
+  // State chips
+  document.querySelectorAll('.state-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const state = chip.dataset.state;
+      chip.classList.toggle('active');
+      document.body.classList.toggle('hide-state-' + state, !chip.classList.contains('active'));
+    });
+  });
+  STATES.forEach(s => {
+    const chip = document.querySelector('.state-chip[data-state="' + s + '"]');
+    if (chip && !chip.classList.contains('active')) document.body.classList.add('hide-state-' + s);
+  });
+
+  // Manual top-up: fill any DS cells that don't have a mark yet
+  document.getElementById('prefill-ds-btn').addEventListener('click', () => {
+    const added = prefillDsCellsAsNeedsDesign();
+    if (added > 0) {
+      document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+      updateRowSectionFlags();
+      updateCount();
+      alert('Filled ' + added + ' missing DS cells as needs-design.');
+    } else {
+      alert('All DS cells in this route already have marks.');
+    }
+  });
+
+  // Clear-route. Also resets the prefilled flag so a reload re-triggers auto-prefill.
+  document.getElementById('clear-route-btn').addEventListener('click', () => {
+    const ids = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).map(([id]) => id);
+    if (!ids.length) { alert('No marks for this route.'); return; }
+    if (!confirm('Clear ' + ids.length + ' marks for route ' + ROUTE + '?\n\nReloading the page will re-prefill all DS cells as needs-design.')) return;
+    ids.forEach(id => delete marks[id]);
+    saveMarks(marks);
+    const flags = loadPrefilledFlags();
+    delete flags[ROUTE];
+    savePrefilledFlags(flags);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+  });
+
+  function buildMarkdown() {
+    const items = [];
+    Object.entries(marks).forEach(([id, m]) => {
+      if (!m || !m.marked) return;
+      if (!id.startsWith(ROUTE + '__')) return;
+      const parts = id.split('__');
+      const themeKey = parts[parts.length - 1];
+      const state = parts[parts.length - 2];
+      const viewport = parts[parts.length - 3];
+      const route = parts[0];
+      const component = parts.slice(1, parts.length - 3).join('__');
+      items.push({ component, viewport, state, theme: themeKey,
+                   note: m.note || '', why: m.why || '', category: m.category || '' });
+    });
+    items.sort((a, b) => {
+      const ak = componentSortKey(a.component);
+      const bk = componentSortKey(b.component);
+      if (ak[0] !== bk[0]) return ak[0] - bk[0];
+      if (ak[1] !== bk[1]) return ak[1] < bk[1] ? -1 : 1;
+      const sd = STATES.indexOf(a.state) - STATES.indexOf(b.state);
+      if (sd !== 0) return sd;
+      const td = THEME_ORDER.indexOf(a.theme) - THEME_ORDER.indexOf(b.theme);
+      if (td !== 0) return td;
+      return a.viewport === b.viewport ? 0 : (a.viewport === 'desktop' ? -1 : 1);
+    });
+    const date = new Date().toISOString().split('T')[0];
+    const lines = ['# Audit marks -- ' + ROUTE + ' -- ' + items.length + ' items -- ' + date, ''];
+    items.forEach(it => {
+      const catTag = it.category ? ' [' + it.category + ']' : '';
+      const whyTxt = it.why ? ': ' + it.why : '';
+      const noteTxt = it.note ? '  -- ' + it.note : '';
+      lines.push('- [ ] **' + it.theme + ' ' + it.component + '** [' + it.viewport + '/' + it.state + ']' + catTag + whyTxt + noteTxt);
+    });
+    return lines.join('\n');
+  }
+
+  function openOverlay(id) { document.getElementById(id).classList.add('open'); }
+  function closeOverlay(id) { document.getElementById(id).classList.remove('open'); }
+  document.querySelectorAll('.overlay-close').forEach(b => b.addEventListener('click', () => closeOverlay(b.dataset.overlay)));
+  document.querySelectorAll('.overlay').forEach(o => {
+    o.addEventListener('click', e => { if (e.target === o) o.classList.remove('open'); });
+  });
+
+  document.getElementById('export-md-btn').addEventListener('click', async () => {
+    const md = buildMarkdown();
+    const ta = document.getElementById('md-text');
+    ta.value = md;
+    openOverlay('md-overlay');
+    try { await navigator.clipboard.writeText(md); document.getElementById('md-copy').textContent = 'Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+  document.getElementById('md-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('md-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('md-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('export-json-btn').addEventListener('click', () => {
+    const ta = document.getElementById('json-export-text');
+    ta.value = JSON.stringify(marks, null, 2);
+    openOverlay('json-export-overlay');
+  });
+  document.getElementById('json-export-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('json-export-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('json-export-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('json-export-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('import-json-btn').addEventListener('click', () => {
+    document.getElementById('json-import-text').value = '';
+    document.getElementById('json-import-err').textContent = '';
+    openOverlay('json-import-overlay');
+  });
+  document.getElementById('json-import-apply').addEventListener('click', () => {
+    const ta = document.getElementById('json-import-text');
+    const err = document.getElementById('json-import-err');
+    err.textContent = '';
+    let parsed;
+    try { parsed = JSON.parse(ta.value); }
+    catch (e) { err.textContent = 'Invalid JSON: ' + e.message; return; }
+    if (!parsed || typeof parsed !== 'object') { err.textContent = 'Expected an object.'; return; }
+    // First migrate v1 IDs (4 segments) -> v2 IDs (5 segments)
+    const { marks: idMigrated, migrated } = migrateMarksV1ToV2(parsed);
+    // Then upgrade each value v2 -> v3 (preserves marked + note, fills new fields)
+    Object.entries(idMigrated).forEach(([id, m]) => {
+      marks[id] = upgradeV2ValueToV3(m);
+    });
+    saveMarks(marks);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+    closeOverlay('json-import-overlay');
+    alert('Imported ' + Object.keys(idMigrated).length + ' marks (' + migrated + ' legacy IDs migrated to __seeded; values upgraded to v3).');
+  });
+</script>
+</body>
+</html>

--- a/scripts/audit/review/characters-create.html
+++ b/scripts/audit/review/characters-create.html
@@ -1,0 +1,2065 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Cross-Theme Audit (#1129) — characters-create</title>
+<style>
+
+  :root { --col-gap: 8px; --row-gap: 16px; }
+  html, body { margin: 0; padding: 0; font-family: -apple-system, system-ui, sans-serif; background: #fafafa; color: #222; }
+  .sticky-shell { position: sticky; top: 0; z-index: 100; border-bottom: 1px solid #444; }
+  header.top {
+    background: #1a1a1a; color: #fff; padding: 12px 16px;
+    display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+  }
+  header.top h1 { font-size: 14px; margin: 0; font-weight: 600; }
+  header.top .legend { display: flex; gap: 12px; font-size: 12px; }
+  header.top .legend .col { padding: 2px 8px; border-radius: 3px; }
+  header.top .legend .develop { background: #6b7280; }
+  header.top .legend .ds3 { background: #4338ca; }
+  header.top .legend .ds1 { background: #92400e; }
+  header.top .legend .ds2 { background: #166534; }
+  header.top a.back { color: #9cf; font-size: 12px; text-decoration: none; padding: 2px 6px; border-radius: 2px; }
+  header.top a.back:hover { background: #444; color: #fff; }
+  header.top .nav-routes { display: flex; gap: 4px; align-items: center; font-size: 12px; }
+  header.top .nav-routes a { color: #9cf; text-decoration: none; padding: 2px 8px; border-radius: 2px; background: #2a2a2a; }
+  header.top .nav-routes a:hover { background: #444; color: #fff; }
+  header.top .nav-routes .current { color: #fff; font-weight: 600; padding: 2px 8px; }
+  main { padding: 16px; max-width: 100%; }
+  section.route {
+    margin-bottom: 32px; background: #fff; border-radius: 6px;
+    padding: 12px 16px 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  section.route h2 {
+    font-size: 18px; margin: 0 0 12px; padding-bottom: 6px;
+    border-bottom: 1px solid #e5e5e5;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+  .component-row {
+    display: grid; grid-template-columns: 180px repeat(4, 1fr);
+    gap: var(--col-gap); margin-bottom: var(--row-gap);
+    align-items: start;
+  }
+  .component-row .label {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px; color: #555; padding-top: 28px; line-height: 1.3;
+    word-break: break-word;
+  }
+  .cell {
+    border: 1px solid #e5e5e5; border-radius: 4px; overflow: hidden;
+    background: #f3f4f6; position: relative; min-height: 100px;
+    display: flex; flex-direction: column;
+  }
+  .cell .header {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.04em; padding: 4px 8px; color: #fff;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .cell.develop .header { background: #6b7280; }
+  .cell.ds3 .header { background: #4338ca; }
+  .cell.ds1 .header { background: #92400e; }
+  .cell.ds2 .header { background: #166534; }
+  .cell img {
+    display: block; width: auto; max-width: 100%; height: auto;
+    cursor: zoom-in; background: #fff; align-self: flex-start;
+  }
+  body.fit-cell .cell img { width: 100%; max-width: 100%; }
+  .cell.empty {
+    display: flex; align-items: center; justify-content: center;
+    color: #999; font-size: 12px; padding: 24px; background: #f9f9f9;
+  }
+  .cell.empty::after { content: "(not captured)"; }
+
+  /* Lightbox */
+  #lightbox {
+    display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.92);
+    z-index: 1000; align-items: center; justify-content: center; cursor: zoom-out;
+  }
+  #lightbox.open { display: flex; }
+  #lightbox img { max-width: 96vw; max-height: 96vh; box-shadow: 0 4px 24px rgba(0,0,0,0.5); }
+
+  .controls { display: flex; gap: 12px; align-items: center; font-size: 12px; flex-wrap: wrap; }
+  .controls label { display: flex; align-items: center; gap: 4px; cursor: pointer; }
+  .controls input[type=checkbox] { margin: 0; }
+
+  .state-chips { display: inline-flex; gap: 4px; align-items: center; }
+  .state-chip {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .state-chip.active { background: #2563eb; border-color: #1d4ed8; }
+  .state-chip:hover { background: #4b5563; }
+  .state-chip.active:hover { background: #1d4ed8; }
+
+  body.hide-empty .component-row.all-empty,
+  body.hide-empty .cell.empty { display: none; }
+  body.compact .cell img { max-height: 360px; object-fit: cover; object-position: top; }
+
+  .cell .mark-btn {
+    margin-left: auto; background: rgba(255,255,255,0.18);
+    color: #fff; border: 1px solid rgba(255,255,255,0.35);
+    border-radius: 3px; font-size: 10px; font-weight: 600;
+    padding: 2px 6px; cursor: pointer;
+    text-transform: none; letter-spacing: 0; line-height: 1.2;
+  }
+  .cell .mark-btn:hover { background: rgba(255,255,255,0.28); }
+  .cell.marked { border: 3px solid #dc2626; }
+  .cell.marked .mark-btn { background: #dc2626; border-color: #b91c1c; color: #fff; }
+  .cell.marked .mark-btn::before { content: "x "; }
+  .cell.pending-recapture { animation: cellPulse 2s ease-out; }
+  @keyframes cellPulse {
+    0%   { box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.9); border-color: #7c3aed; }
+    100% { box-shadow: 0 0 0 8px rgba(124, 58, 237, 0); }
+  }
+  .cell .toolbar {
+    display: none;
+    padding: 6px 8px; background: #fef2f2; border-top: 1px solid #fecaca;
+    font-size: 11px;
+  }
+  .cell.marked .toolbar { display: block; }
+  .cell .toolbar input[type=text],
+  .cell .toolbar textarea {
+    width: 100%; box-sizing: border-box;
+    border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 4px 6px; font-size: 12px; font-family: inherit;
+    background: #fff;
+  }
+  .cell .toolbar input[type=text]:focus,
+  .cell .toolbar textarea:focus { outline: 2px solid #dc2626; outline-offset: -1px; }
+  .cell .toolbar .field { margin-bottom: 6px; }
+  .cell .toolbar .field-label {
+    display: block; font-size: 10px; font-weight: 600;
+    color: #7f1d1d; text-transform: uppercase; letter-spacing: 0.04em;
+    margin-bottom: 2px;
+  }
+  .cell .toolbar .cat-chips { display: flex; gap: 4px; flex-wrap: wrap; }
+  .cell .toolbar .cat-chip {
+    background: #fff; border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 2px 8px; font-size: 11px; cursor: pointer; font-family: inherit;
+    color: #7f1d1d;
+  }
+  .cell .toolbar .cat-chip.active { background: #7f1d1d; color: #fff; border-color: #7f1d1d; }
+  .cell .toolbar .cat-chip[data-cat="needs-design"].active { background: #6d28d9; border-color: #6d28d9; }
+  .cell .toolbar .cat-chip[data-cat="bug"].active        { background: #b91c1c; border-color: #b91c1c; }
+  .cell .toolbar .cat-chip[data-cat="tooling"].active    { background: #b45309; border-color: #b45309; }
+  .cell .toolbar .cat-chip[data-cat="intentional"].active{ background: #15803d; border-color: #15803d; }
+  .cell .toolbar .cat-chip[data-cat="unclear"].active    { background: #6b7280; border-color: #6b7280; }
+  .cell .toolbar .recapture-btn {
+    background: #1d4ed8; color: #fff; border: 0; border-radius: 3px;
+    padding: 4px 10px; font-size: 11px; cursor: pointer;
+    font-family: inherit; font-weight: 600;
+  }
+  .cell .toolbar .recapture-btn:hover { background: #1e40af; }
+  .cell .toolbar textarea { min-height: 32px; resize: vertical; font-size: 11px; }
+  .cell.cat-needs-design { border-color: #6d28d9; }
+  .cell.cat-bug         { border-color: #b91c1c; }
+  .cell.cat-tooling     { border-color: #b45309; }
+  .cell.cat-intentional { border-color: #15803d; }
+  .cell.cat-unclear     { border-color: #6b7280; }
+
+  .marks-cluster {
+    display: flex; align-items: center; gap: 8px;
+    border-left: 1px solid #444; padding-left: 12px; margin-left: 4px;
+    font-size: 12px;
+  }
+  .marks-cluster .count {
+    background: #dc2626; color: #fff; border-radius: 10px;
+    padding: 2px 8px; font-weight: 600; min-width: 18px; text-align: center;
+  }
+  .marks-cluster button {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .marks-cluster button:hover { background: #4b5563; }
+  .marks-cluster button.danger { background: #7f1d1d; border-color: #991b1b; }
+  .marks-cluster button.danger:hover { background: #991b1b; }
+
+  body.only-marked .component-row:not(.has-marked) { display: none; }
+  body.only-marked section.route:not(.has-marked) { display: none; }
+
+  .component-row.suppressed { display: none; }
+  body.show-suppressed .component-row.suppressed { display: grid; }
+  .component-row.suppressed .label::after { content: " (hidden)"; color: #b91c1c; font-style: italic; }
+
+  .component-row .label[data-mapped] { color: #1d4ed8; }
+  .component-row .label[data-mapped]::after { content: " *"; }
+  .mapped-tooltip {
+    display: inline-block; margin-left: 4px;
+    font-size: 10px; color: #6b7280; cursor: help; vertical-align: super;
+  }
+
+  .vp-badge, .state-badge {
+    display: inline-block; font-size: 9px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.05em;
+    padding: 1px 6px; border-radius: 8px; margin-top: 2px;
+  }
+  .vp-badge.desktop { background: #dbeafe; color: #1e3a8a; border: 1px solid #93c5fd; margin-right: 4px; }
+  .vp-badge.mobile  { background: #fef3c7; color: #78350f; border: 1px solid #fcd34d; margin-right: 4px; }
+  .state-badge.empty       { background: #f3f4f6; color: #374151; border: 1px solid #d1d5db; }
+  .state-badge.seeded      { background: #dcfce7; color: #14532d; border: 1px solid #86efac; }
+  .state-badge.mid-session { background: #ede9fe; color: #4c1d95; border: 1px solid #c4b5fd; }
+
+  .component-row.vp-mobile { background: #fffbeb; padding: 4px; border-radius: 4px; }
+  body.hide-desktop .component-row.vp-desktop { display: none; }
+  body.hide-mobile .component-row.vp-mobile { display: none; }
+
+  body.hide-state-empty       .component-row.state-empty       { display: none; }
+  body.hide-state-seeded      .component-row.state-seeded      { display: none; }
+  body.hide-state-mid-session .component-row.state-mid-session { display: none; }
+
+  .overlay {
+    display: none; position: fixed; inset: 0; z-index: 1100;
+    background: rgba(0,0,0,0.6); align-items: center; justify-content: center;
+  }
+  .overlay.open { display: flex; }
+  .overlay .panel {
+    background: #fff; border-radius: 6px; width: min(720px, 92vw);
+    max-height: 80vh; padding: 16px; display: flex; flex-direction: column; gap: 8px;
+  }
+  .overlay h3 { margin: 0; font-size: 14px; }
+  .overlay textarea {
+    flex: 1; min-height: 320px; font-family: ui-monospace, monospace; font-size: 12px;
+    border: 1px solid #ddd; border-radius: 4px; padding: 8px; resize: vertical;
+  }
+  .overlay .actions { display: flex; gap: 8px; justify-content: flex-end; }
+  .overlay button {
+    background: #1a1a1a; color: #fff; border: 0; border-radius: 3px;
+    padding: 6px 12px; font-size: 12px; cursor: pointer;
+  }
+  .overlay .hint { font-size: 11px; color: #555; }
+  .overlay .err  { font-size: 12px; color: #b91c1c; min-height: 16px; }
+
+  /* Index-page table */
+  table.routes-index {
+    width: 100%; border-collapse: collapse; background: #fff;
+    border-radius: 6px; overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  table.routes-index th, table.routes-index td {
+    padding: 8px 12px; text-align: left; font-size: 13px;
+    border-bottom: 1px solid #eee;
+  }
+  table.routes-index th { background: #f3f4f6; font-weight: 600; }
+  table.routes-index td a {
+    color: #1d4ed8; text-decoration: none; font-family: ui-monospace, monospace;
+  }
+  table.routes-index td a:hover { text-decoration: underline; }
+  table.routes-index td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  table.routes-index .marked-count.has-marks { color: #b91c1c; font-weight: 600; }
+  table.routes-index .unresolved-count.has-unresolved { color: #b45309; font-weight: 600; }
+  table.routes-index .breakdown {
+    font-size: 11px; color: #555; margin-left: 6px; font-variant-numeric: tabular-nums;
+  }
+
+
+</style>
+</head>
+<body>
+<div class="sticky-shell">
+<header class="top">
+  <a class="back" href="index.html">&larr; Index</a>
+  <h1>characters-create</h1>
+  <div class="legend">
+    <span class="col develop">develop</span>
+    <span class="col ds3">DS3</span>
+    <span class="col ds1">DS1</span>
+    <span class="col ds2">DS2</span>
+  </div>
+  <div class="controls">
+    <span class="state-chips" role="group" aria-label="State filter">
+      <span style="font-size: 11px; color: #aaa;">State:</span>
+      <button type="button" class="state-chip" data-state="empty">empty</button>
+      <button type="button" class="state-chip active" data-state="seeded">seeded</button>
+    </span>
+    <label><input type="checkbox" id="hide-empty"> Hide missing</label>
+    <label><input type="checkbox" id="compact"> Compact</label>
+    <label title="Stretch images to cell width"><input type="checkbox" id="fit-cell"> Fit to cell</label>
+    <label><input type="checkbox" id="only-marked"> Only marked</label>
+    <label><input type="checkbox" id="show-suppressed"> Show hidden rows</label>
+    <label><input type="checkbox" id="hide-desktop"> Hide desktop</label>
+    <label><input type="checkbox" id="hide-mobile"> Hide mobile</label>
+  </div>
+  <div class="marks-cluster">
+    <span>Marked (route):</span>
+    <span class="count" id="mark-count">0</span>
+    <button id="prefill-ds-btn" type="button" title="Mark every DS cell that has no mark yet as needs-design (gap-fill, never overwrites your existing marks)">Fill DS gaps</button>
+    <button id="export-md-btn" type="button">Export markdown</button>
+    <button id="export-json-btn" type="button">Export JSON</button>
+    <button id="import-json-btn" type="button">Import JSON</button>
+    <button id="clear-route-btn" type="button" class="danger">Clear (route)</button>
+  </div>
+</header>
+<nav class="toc" style="background:#2a2a2a;color:#ccc;padding:6px 16px;font-size:12px;display:flex;gap:8px;align-items:center;border-top:1px solid #444;">
+  <span class="nav-routes">
+    <a href="characters-edit.html">&larr; characters-edit</a>
+    <span class="current">characters-create</span>
+    <a href="play.html">play &rarr;</a>
+  </span>
+</nav>
+</div>
+<main>
+<section class="route" id="route-characters-create">
+  <h2>characters-create</h2>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters-create__global-nav__desktop__empty__develop" data-route="characters-create" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/characters-create__nav.png" alt="develop characters-create/global-nav/desktop/empty" data-caption="develop -- characters-create/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-create__global-nav__desktop__empty__DS3" data-route="characters-create" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/characters-create__nav.png" alt="DS3 characters-create/global-nav/desktop/empty" data-caption="DS3 -- characters-create/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-create__global-nav__desktop__empty__DS1" data-route="characters-create" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/characters-create__nav.png" alt="DS1 characters-create/global-nav/desktop/empty" data-caption="DS1 -- characters-create/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-create__global-nav__desktop__empty__DS2" data-route="characters-create" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/characters-create__nav.png" alt="DS2 characters-create/global-nav/desktop/empty" data-caption="DS2 -- characters-create/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters-create__page__desktop__empty__develop" data-route="characters-create" data-component="page" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/characters-create__page.png" alt="develop characters-create/page/desktop/empty" data-caption="develop -- characters-create/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-create__page__desktop__empty__DS3" data-route="characters-create" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/characters-create__page.png" alt="DS3 characters-create/page/desktop/empty" data-caption="DS3 -- characters-create/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-create__page__desktop__empty__DS1" data-route="characters-create" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/characters-create__page.png" alt="DS1 characters-create/page/desktop/empty" data-caption="DS1 -- characters-create/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-create__page__desktop__empty__DS2" data-route="characters-create" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/characters-create__page.png" alt="DS2 characters-create/page/desktop/empty" data-caption="DS2 -- characters-create/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-empty" data-viewport="mobile" data-state="empty">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters-create__page__mobile__empty__develop" data-route="characters-create" data-component="page" data-viewport="mobile" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/empty/characters-create__page.png" alt="develop characters-create/page/mobile/empty" data-caption="develop -- characters-create/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-create__page__mobile__empty__DS3" data-route="characters-create" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/empty/characters-create__page.png" alt="DS3 characters-create/page/mobile/empty" data-caption="DS3 -- characters-create/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-create__page__mobile__empty__DS1" data-route="characters-create" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/empty/characters-create__page.png" alt="DS1 characters-create/page/mobile/empty" data-caption="DS1 -- characters-create/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-create__page__mobile__empty__DS2" data-route="characters-create" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/empty/characters-create__page.png" alt="DS2 characters-create/page/mobile/empty" data-caption="DS2 -- characters-create/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters-create__header__desktop__empty__develop" data-route="characters-create" data-component="header" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/characters-create__header.png" alt="develop characters-create/header/desktop/empty" data-caption="develop -- characters-create/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters-create__nav__desktop__empty__develop" data-route="characters-create" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/characters-create__nav.png" alt="develop characters-create/nav/desktop/empty" data-caption="develop -- characters-create/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-create__nav__desktop__empty__DS3" data-route="characters-create" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/characters-create__nav.png" alt="DS3 characters-create/nav/desktop/empty" data-caption="DS3 -- characters-create/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-create__nav__desktop__empty__DS1" data-route="characters-create" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/characters-create__nav.png" alt="DS1 characters-create/nav/desktop/empty" data-caption="DS1 -- characters-create/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-create__nav__desktop__empty__DS2" data-route="characters-create" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/characters-create__nav.png" alt="DS2 characters-create/nav/desktop/empty" data-caption="DS2 -- characters-create/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters-create__main__desktop__empty__develop" data-route="characters-create" data-component="main" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/characters-create__main.png" alt="develop characters-create/main/desktop/empty" data-caption="develop -- characters-create/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-create__main__desktop__empty__DS3" data-route="characters-create" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/characters-create__main.png" alt="DS3 characters-create/main/desktop/empty" data-caption="DS3 -- characters-create/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-create__main__desktop__empty__DS1" data-route="characters-create" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/characters-create__main.png" alt="DS1 characters-create/main/desktop/empty" data-caption="DS1 -- characters-create/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-create__main__desktop__empty__DS2" data-route="characters-create" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/characters-create__main.png" alt="DS2 characters-create/main/desktop/empty" data-caption="DS2 -- characters-create/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters-create__global-nav__desktop__seeded__develop" data-route="characters-create" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/characters-create__nav.png" alt="develop characters-create/global-nav/desktop/seeded" data-caption="develop -- characters-create/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-create__global-nav__desktop__seeded__DS3" data-route="characters-create" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/characters-create__nav.png" alt="DS3 characters-create/global-nav/desktop/seeded" data-caption="DS3 -- characters-create/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-create__global-nav__desktop__seeded__DS1" data-route="characters-create" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/characters-create__nav.png" alt="DS1 characters-create/global-nav/desktop/seeded" data-caption="DS1 -- characters-create/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-create__global-nav__desktop__seeded__DS2" data-route="characters-create" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/characters-create__nav.png" alt="DS2 characters-create/global-nav/desktop/seeded" data-caption="DS2 -- characters-create/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters-create__page__desktop__seeded__develop" data-route="characters-create" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/characters-create__page.png" alt="develop characters-create/page/desktop/seeded" data-caption="develop -- characters-create/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-create__page__desktop__seeded__DS3" data-route="characters-create" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/characters-create__page.png" alt="DS3 characters-create/page/desktop/seeded" data-caption="DS3 -- characters-create/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-create__page__desktop__seeded__DS1" data-route="characters-create" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/characters-create__page.png" alt="DS1 characters-create/page/desktop/seeded" data-caption="DS1 -- characters-create/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-create__page__desktop__seeded__DS2" data-route="characters-create" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/characters-create__page.png" alt="DS2 characters-create/page/desktop/seeded" data-caption="DS2 -- characters-create/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-seeded" data-viewport="mobile" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters-create__page__mobile__seeded__develop" data-route="characters-create" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/seeded/characters-create__page.png" alt="develop characters-create/page/mobile/seeded" data-caption="develop -- characters-create/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-create__page__mobile__seeded__DS3" data-route="characters-create" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/seeded/characters-create__page.png" alt="DS3 characters-create/page/mobile/seeded" data-caption="DS3 -- characters-create/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-create__page__mobile__seeded__DS1" data-route="characters-create" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/seeded/characters-create__page.png" alt="DS1 characters-create/page/mobile/seeded" data-caption="DS1 -- characters-create/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-create__page__mobile__seeded__DS2" data-route="characters-create" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/seeded/characters-create__page.png" alt="DS2 characters-create/page/mobile/seeded" data-caption="DS2 -- characters-create/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters-create__header__desktop__seeded__develop" data-route="characters-create" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/characters-create__header.png" alt="develop characters-create/header/desktop/seeded" data-caption="develop -- characters-create/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-create__header__desktop__seeded__DS3" data-route="characters-create" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/characters-create__header.png" alt="DS3 characters-create/header/desktop/seeded" data-caption="DS3 -- characters-create/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-create__header__desktop__seeded__DS1" data-route="characters-create" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/characters-create__header.png" alt="DS1 characters-create/header/desktop/seeded" data-caption="DS1 -- characters-create/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-create__header__desktop__seeded__DS2" data-route="characters-create" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/characters-create__header.png" alt="DS2 characters-create/header/desktop/seeded" data-caption="DS2 -- characters-create/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters-create__nav__desktop__seeded__develop" data-route="characters-create" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/characters-create__nav.png" alt="develop characters-create/nav/desktop/seeded" data-caption="develop -- characters-create/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-create__nav__desktop__seeded__DS3" data-route="characters-create" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/characters-create__nav.png" alt="DS3 characters-create/nav/desktop/seeded" data-caption="DS3 -- characters-create/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-create__nav__desktop__seeded__DS1" data-route="characters-create" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/characters-create__nav.png" alt="DS1 characters-create/nav/desktop/seeded" data-caption="DS1 -- characters-create/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-create__nav__desktop__seeded__DS2" data-route="characters-create" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/characters-create__nav.png" alt="DS2 characters-create/nav/desktop/seeded" data-caption="DS2 -- characters-create/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters-create__main__desktop__seeded__develop" data-route="characters-create" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/characters-create__main.png" alt="develop characters-create/main/desktop/seeded" data-caption="develop -- characters-create/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-create__main__desktop__seeded__DS3" data-route="characters-create" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/characters-create__main.png" alt="DS3 characters-create/main/desktop/seeded" data-caption="DS3 -- characters-create/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-create__main__desktop__seeded__DS1" data-route="characters-create" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/characters-create__main.png" alt="DS1 characters-create/main/desktop/seeded" data-caption="DS1 -- characters-create/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-create__main__desktop__seeded__DS2" data-route="characters-create" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/characters-create__main.png" alt="DS2 characters-create/main/desktop/seeded" data-caption="DS2 -- characters-create/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+</main>
+
+<div id="lightbox" class="overlay">
+  <img id="lightbox-img" src="" alt="">
+  <div id="lightbox-caption" style="position: fixed; top: 12px; left: 50%; transform: translateX(-50%); color: #fff; font-family: ui-monospace, monospace; font-size: 13px; background: rgba(0,0,0,0.6); padding: 6px 12px; border-radius: 4px;"></div>
+</div>
+
+<div id="md-overlay" class="overlay">
+  <div class="panel">
+    <h3>Audit marks (markdown) -- this route only</h3>
+    <textarea id="md-text" readonly></textarea>
+    <div class="actions">
+      <button id="md-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="md-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-export-overlay" class="overlay">
+  <div class="panel">
+    <h3>Marks (raw JSON) -- all routes</h3>
+    <textarea id="json-export-text" readonly></textarea>
+    <div class="actions">
+      <button id="json-export-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="json-export-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-import-overlay" class="overlay">
+  <div class="panel">
+    <h3>Import marks (paste raw JSON)</h3>
+    <p class="hint">Paste JSON exported from another instance. Legacy IDs without a state segment are migrated to <code>__seeded</code>; v2 values are upgraded to v3 (category=null, why="", updatedAt=now). Existing marks with the same ID are overwritten.</p>
+    <textarea id="json-import-text" placeholder='{"home__page__desktop__seeded__DS3":{"marked":true,"note":"...","category":"bug","why":"...","updatedAt":"..."}}'></textarea>
+    <div class="err" id="json-import-err"></div>
+    <div class="actions">
+      <button id="json-import-apply" type="button">Apply</button>
+      <button class="overlay-close" data-overlay="json-import-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+<script>
+
+  const STORAGE_KEY = 'narraitor-audit-marks-v3';
+  const STORAGE_KEY_V2 = 'narraitor-audit-marks-v2';
+  const STORAGE_KEY_V1 = 'narraitor-audit-marks-v1';
+  // Tracks which routes have had their DS cells auto-prefilled as needs-design.
+  // Once a route is in here, the auto-prefill on page load is skipped.
+  const PREFILLED_KEY = 'narraitor-audit-prefilled-v1';
+  const STATES = ['empty', 'seeded'];
+  const VALID_CATEGORIES = ['needs-design','bug','tooling','intentional','unclear'];
+  const ROUTE_ORDER = ["home", "about", "worlds", "worlds-detail", "worlds-edit", "worlds-create", "worlds-play", "worlds-play-journal", "characters", "characters-detail", "characters-edit", "characters-create", "play", "settings"];
+  const COMPONENT_ORDER = {"page":0,"header":1,"nav":2,"form":3,"main":4};
+  const THEME_ORDER = ["DS3","DS1","DS2","develop"];
+  const BRANCH_META = {"develop": {"theme": "default", "mode": "light", "branchArg": "develop-default"}, "DS3": {"theme": "ds3", "mode": "light", "branchArg": "integration-ds3-light"}, "DS1": {"theme": "ds1", "mode": "light", "branchArg": "integration-ds1-light"}, "DS2": {"theme": "ds2", "mode": "light", "branchArg": "integration-ds2-light"}};
+
+  function componentSortKey(c) {
+    if (c in COMPONENT_ORDER) return [COMPONENT_ORDER[c], 0];
+    if (c.startsWith("main-section-")) {
+      const n = parseInt(c.replace("main-section-",""), 10);
+      return [5, isNaN(n) ? 0 : n];
+    }
+    return [9, c];
+  }
+
+  // Pre-v3 ID migration: v1 (4 segments) -> v2 (5 segments) by inserting __seeded.
+  function migrateLegacyId(id) {
+    const parts = id.split('__');
+    if (parts.length < 4) return id;
+    const last = parts[parts.length - 1];
+    const second = parts[parts.length - 2];
+    const third = parts[parts.length - 3];
+    const isTheme = ['DS1','DS2','DS3','develop'].includes(last);
+    const isViewport = ['desktop','mobile'].includes(second);
+    const alreadyHasState = STATES.includes(third);
+    if (isTheme && isViewport && !alreadyHasState) {
+      const head = parts.slice(0, parts.length - 1).join('__');
+      return head + '__seeded__' + last;
+    }
+    return id;
+  }
+
+  function migrateMarksV1ToV2(input) {
+    const out = {};
+    let migrated = 0;
+    for (const [id, m] of Object.entries(input || {})) {
+      const newId = migrateLegacyId(id);
+      if (newId !== id) migrated++;
+      out[newId] = m;
+    }
+    return { marks: out, migrated };
+  }
+
+  // v2 -> v3: add category, why, updatedAt; preserve marked + note.
+  function upgradeV2ValueToV3(v) {
+    if (!v || typeof v !== 'object') return null;
+    return {
+      marked: !!v.marked,
+      note: typeof v.note === 'string' ? v.note : '',
+      category: v.category && VALID_CATEGORIES.includes(v.category) ? v.category : null,
+      why: typeof v.why === 'string' ? v.why : '',
+      updatedAt: v.updatedAt || new Date().toISOString(),
+    };
+  }
+
+  function migrateV2ObjectToV3(v2obj) {
+    const out = {};
+    for (const [id, m] of Object.entries(v2obj || {})) {
+      out[id] = upgradeV2ValueToV3(m);
+    }
+    return out;
+  }
+
+  function loadMarks() {
+    try {
+      const v3 = localStorage.getItem(STORAGE_KEY);
+      if (v3) return JSON.parse(v3);
+      // No v3 yet — try v2 (lazy migrate; leave v2 untouched for rollback).
+      const v2raw = localStorage.getItem(STORAGE_KEY_V2);
+      if (v2raw) {
+        const v3marks = migrateV2ObjectToV3(JSON.parse(v2raw));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + Object.keys(v3marks).length + ' v2 marks to v3 (v2 untouched).');
+        return v3marks;
+      }
+      // No v3 or v2 — try v1 and migrate v1 -> v2 -> v3 in one pass.
+      const v1raw = localStorage.getItem(STORAGE_KEY_V1);
+      if (v1raw) {
+        const { marks: v2marks, migrated } = migrateMarksV1ToV2(JSON.parse(v1raw));
+        const v3marks = migrateV2ObjectToV3(v2marks);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + migrated + ' v1 IDs through to v3.');
+        return v3marks;
+      }
+    } catch (e) { console.warn(e); }
+    return {};
+  }
+
+  function saveMarks(m) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(m)); } catch (e) {}
+  }
+
+
+  const ROUTE = "characters-create";
+  let marks = loadMarks();
+
+  function applyMarkState(cell) {
+    const id = cell.dataset.cellId;
+    const m = marks[id];
+    const noteInput = cell.querySelector('textarea[data-action="note"]');
+    const whyInput = cell.querySelector('input[data-action="why"]');
+    const chips = cell.querySelectorAll('.cat-chip');
+    cell.classList.remove('cat-bug','cat-tooling','cat-intentional','cat-unclear');
+    chips.forEach(c => c.classList.remove('active'));
+    if (m && m.marked) {
+      cell.classList.add('marked');
+      if (noteInput) noteInput.value = m.note || '';
+      if (whyInput) whyInput.value = m.why || '';
+      if (m.category) {
+        cell.classList.add('cat-' + m.category);
+        const chip = cell.querySelector('.cat-chip[data-cat="' + m.category + '"]');
+        if (chip) chip.classList.add('active');
+      }
+    } else {
+      cell.classList.remove('marked');
+      if (noteInput) noteInput.value = '';
+      if (whyInput) whyInput.value = '';
+    }
+  }
+
+  function updateRowSectionFlags() {
+    document.querySelectorAll('.component-row').forEach(row => {
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+    document.querySelectorAll('section.route').forEach(sec => {
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+    });
+  }
+
+  function updateCount() {
+    const n = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).length;
+    document.getElementById('mark-count').textContent = n;
+  }
+
+  function writeMark(id, partial) {
+    const existing = marks[id] || { marked: false, note: '', category: null, why: '', updatedAt: null };
+    const next = Object.assign({}, existing, partial, { updatedAt: new Date().toISOString() });
+    if (!next.marked && !next.note && !next.why && !next.category) {
+      delete marks[id];
+    } else {
+      marks[id] = next;
+    }
+    saveMarks(marks);
+    updateCount();
+  }
+
+  function buildRecaptureCommand(cell) {
+    const route = cell.dataset.route;
+    const viewport = cell.dataset.viewport;
+    const state = cell.dataset.state;
+    const themeKey = cell.dataset.theme;
+    const meta = BRANCH_META[themeKey];
+    if (!meta) return null;
+    return 'npx tsx scripts/audit/playwright-crawl.ts'
+      + ' --branch ' + meta.branchArg
+      + ' --viewport ' + viewport
+      + ' --state ' + state
+      + ' --theme ' + meta.theme
+      + ' --mode ' + meta.mode
+      + ' --route ' + route;
+  }
+
+  function loadPrefilledFlags() {
+    try { return JSON.parse(localStorage.getItem(PREFILLED_KEY) || '{}'); }
+    catch (e) { return {}; }
+  }
+  function savePrefilledFlags(f) {
+    try { localStorage.setItem(PREFILLED_KEY, JSON.stringify(f)); } catch (e) {}
+  }
+
+  // Gap-fill: only adds entries for DS cells that have no existing mark.
+  // Returns the count of cells filled. Develop is excluded (it's the baseline).
+  function prefillDsCellsAsNeedsDesign() {
+    const dsCells = Array.from(document.querySelectorAll('.cell[data-cell-id]'))
+      .filter(c => ['DS1','DS2','DS3'].includes(c.dataset.theme));
+    let added = 0;
+    const ts = new Date().toISOString();
+    for (const cell of dsCells) {
+      const id = cell.dataset.cellId;
+      if (!marks[id]) {
+        marks[id] = { marked: true, note: '', category: 'needs-design', why: '', updatedAt: ts };
+        added++;
+      }
+    }
+    if (added > 0) saveMarks(marks);
+    return added;
+  }
+
+  // Auto-prefill on first visit per route.
+  const prefillFlags = loadPrefilledFlags();
+  if (!prefillFlags[ROUTE]) {
+    const added = prefillDsCellsAsNeedsDesign();
+    prefillFlags[ROUTE] = true;
+    savePrefilledFlags(prefillFlags);
+    if (added > 0) console.info('[audit] auto-prefilled ' + added + ' DS cells for ' + ROUTE + ' as needs-design.');
+  }
+
+  document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+  updateRowSectionFlags();
+  updateCount();
+
+  // Lightbox
+  const lb = document.getElementById('lightbox');
+  const lbImg = document.getElementById('lightbox-img');
+  const lbCap = document.getElementById('lightbox-caption');
+  document.querySelectorAll('.cell img').forEach(img => {
+    img.addEventListener('click', () => {
+      lbImg.src = img.src;
+      lbCap.textContent = img.dataset.caption || '';
+      lb.classList.add('open');
+    });
+  });
+  lb.addEventListener('click', () => lb.classList.remove('open'));
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') document.querySelectorAll('.overlay.open').forEach(o => o.classList.remove('open'));
+  });
+
+  // Mark toggle
+  document.querySelectorAll('button[data-action="toggle-mark"]').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      const cell = btn.closest('.cell');
+      const id = cell.dataset.cellId;
+      const isMarked = !cell.classList.contains('marked');
+      writeMark(id, { marked: isMarked });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      const sec = cell.closest('section.route');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+      if (isMarked) {
+        const why = cell.querySelector('input[data-action="why"]');
+        if (why) setTimeout(() => why.focus(), 0);
+      }
+    });
+  });
+
+  // Why / note inputs (debounced save)
+  let saveTimer = null;
+  function bindInput(sel, field) {
+    document.querySelectorAll(sel).forEach(inp => {
+      const handler = () => {
+        const cell = inp.closest('.cell');
+        if (!cell.classList.contains('marked')) return;
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(() => {
+          writeMark(cell.dataset.cellId, { [field]: inp.value });
+        }, 250);
+      };
+      inp.addEventListener('input', handler);
+      inp.addEventListener('blur', () => {
+        const cell = inp.closest('.cell');
+        if (cell.classList.contains('marked')) writeMark(cell.dataset.cellId, { [field]: inp.value });
+      });
+    });
+  }
+  bindInput('input[data-action="why"]', 'why');
+  bindInput('textarea[data-action="note"]', 'note');
+
+  // Category chips
+  document.querySelectorAll('.cat-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const cell = chip.closest('.cell');
+      if (!cell.classList.contains('marked')) {
+        // Mark the cell first so the category sticks
+        writeMark(cell.dataset.cellId, { marked: true });
+      }
+      const cat = chip.dataset.cat;
+      const isActive = chip.classList.contains('active');
+      writeMark(cell.dataset.cellId, { category: isActive ? null : cat });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+  });
+
+  // Re-capture command (copy to clipboard, flash purple)
+  document.querySelectorAll('button[data-action="recapture"]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const cell = btn.closest('.cell');
+      const cmd = buildRecaptureCommand(cell);
+      if (!cmd) return;
+      try {
+        await navigator.clipboard.writeText(cmd);
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Copy re-capture command'; }, 1500);
+      } catch (e) {
+        prompt('Copy this command:', cmd);
+      }
+      cell.classList.remove('pending-recapture');
+      void cell.offsetWidth; // force reflow so the animation restarts
+      cell.classList.add('pending-recapture');
+    });
+  });
+
+  // Toggles
+  document.getElementById('hide-empty').addEventListener('change', e => document.body.classList.toggle('hide-empty', e.target.checked));
+  document.getElementById('compact').addEventListener('change', e => document.body.classList.toggle('compact', e.target.checked));
+  document.getElementById('fit-cell').addEventListener('change', e => document.body.classList.toggle('fit-cell', e.target.checked));
+  document.getElementById('only-marked').addEventListener('change', e => document.body.classList.toggle('only-marked', e.target.checked));
+  document.getElementById('show-suppressed').addEventListener('change', e => document.body.classList.toggle('show-suppressed', e.target.checked));
+  document.getElementById('hide-desktop').addEventListener('change', e => document.body.classList.toggle('hide-desktop', e.target.checked));
+  document.getElementById('hide-mobile').addEventListener('change', e => document.body.classList.toggle('hide-mobile', e.target.checked));
+
+  // True-scale rendering (1x for selector captures, 0.5x for retina full-page).
+  const RETINA_THRESHOLD = 1500;
+  function applyTrueScale(img) {
+    if (!img.naturalWidth) return;
+    const cssWidth = img.naturalWidth > RETINA_THRESHOLD
+      ? Math.round(img.naturalWidth / 2)
+      : img.naturalWidth;
+    img.style.maxWidth = 'min(100%, ' + cssWidth + 'px)';
+  }
+  document.querySelectorAll('.cell img').forEach(img => {
+    if (img.complete && img.naturalWidth > 0) applyTrueScale(img);
+    else img.addEventListener('load', () => applyTrueScale(img), { once: true });
+  });
+
+  // State chips
+  document.querySelectorAll('.state-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const state = chip.dataset.state;
+      chip.classList.toggle('active');
+      document.body.classList.toggle('hide-state-' + state, !chip.classList.contains('active'));
+    });
+  });
+  STATES.forEach(s => {
+    const chip = document.querySelector('.state-chip[data-state="' + s + '"]');
+    if (chip && !chip.classList.contains('active')) document.body.classList.add('hide-state-' + s);
+  });
+
+  // Manual top-up: fill any DS cells that don't have a mark yet
+  document.getElementById('prefill-ds-btn').addEventListener('click', () => {
+    const added = prefillDsCellsAsNeedsDesign();
+    if (added > 0) {
+      document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+      updateRowSectionFlags();
+      updateCount();
+      alert('Filled ' + added + ' missing DS cells as needs-design.');
+    } else {
+      alert('All DS cells in this route already have marks.');
+    }
+  });
+
+  // Clear-route. Also resets the prefilled flag so a reload re-triggers auto-prefill.
+  document.getElementById('clear-route-btn').addEventListener('click', () => {
+    const ids = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).map(([id]) => id);
+    if (!ids.length) { alert('No marks for this route.'); return; }
+    if (!confirm('Clear ' + ids.length + ' marks for route ' + ROUTE + '?\n\nReloading the page will re-prefill all DS cells as needs-design.')) return;
+    ids.forEach(id => delete marks[id]);
+    saveMarks(marks);
+    const flags = loadPrefilledFlags();
+    delete flags[ROUTE];
+    savePrefilledFlags(flags);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+  });
+
+  function buildMarkdown() {
+    const items = [];
+    Object.entries(marks).forEach(([id, m]) => {
+      if (!m || !m.marked) return;
+      if (!id.startsWith(ROUTE + '__')) return;
+      const parts = id.split('__');
+      const themeKey = parts[parts.length - 1];
+      const state = parts[parts.length - 2];
+      const viewport = parts[parts.length - 3];
+      const route = parts[0];
+      const component = parts.slice(1, parts.length - 3).join('__');
+      items.push({ component, viewport, state, theme: themeKey,
+                   note: m.note || '', why: m.why || '', category: m.category || '' });
+    });
+    items.sort((a, b) => {
+      const ak = componentSortKey(a.component);
+      const bk = componentSortKey(b.component);
+      if (ak[0] !== bk[0]) return ak[0] - bk[0];
+      if (ak[1] !== bk[1]) return ak[1] < bk[1] ? -1 : 1;
+      const sd = STATES.indexOf(a.state) - STATES.indexOf(b.state);
+      if (sd !== 0) return sd;
+      const td = THEME_ORDER.indexOf(a.theme) - THEME_ORDER.indexOf(b.theme);
+      if (td !== 0) return td;
+      return a.viewport === b.viewport ? 0 : (a.viewport === 'desktop' ? -1 : 1);
+    });
+    const date = new Date().toISOString().split('T')[0];
+    const lines = ['# Audit marks -- ' + ROUTE + ' -- ' + items.length + ' items -- ' + date, ''];
+    items.forEach(it => {
+      const catTag = it.category ? ' [' + it.category + ']' : '';
+      const whyTxt = it.why ? ': ' + it.why : '';
+      const noteTxt = it.note ? '  -- ' + it.note : '';
+      lines.push('- [ ] **' + it.theme + ' ' + it.component + '** [' + it.viewport + '/' + it.state + ']' + catTag + whyTxt + noteTxt);
+    });
+    return lines.join('\n');
+  }
+
+  function openOverlay(id) { document.getElementById(id).classList.add('open'); }
+  function closeOverlay(id) { document.getElementById(id).classList.remove('open'); }
+  document.querySelectorAll('.overlay-close').forEach(b => b.addEventListener('click', () => closeOverlay(b.dataset.overlay)));
+  document.querySelectorAll('.overlay').forEach(o => {
+    o.addEventListener('click', e => { if (e.target === o) o.classList.remove('open'); });
+  });
+
+  document.getElementById('export-md-btn').addEventListener('click', async () => {
+    const md = buildMarkdown();
+    const ta = document.getElementById('md-text');
+    ta.value = md;
+    openOverlay('md-overlay');
+    try { await navigator.clipboard.writeText(md); document.getElementById('md-copy').textContent = 'Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+  document.getElementById('md-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('md-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('md-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('export-json-btn').addEventListener('click', () => {
+    const ta = document.getElementById('json-export-text');
+    ta.value = JSON.stringify(marks, null, 2);
+    openOverlay('json-export-overlay');
+  });
+  document.getElementById('json-export-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('json-export-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('json-export-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('json-export-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('import-json-btn').addEventListener('click', () => {
+    document.getElementById('json-import-text').value = '';
+    document.getElementById('json-import-err').textContent = '';
+    openOverlay('json-import-overlay');
+  });
+  document.getElementById('json-import-apply').addEventListener('click', () => {
+    const ta = document.getElementById('json-import-text');
+    const err = document.getElementById('json-import-err');
+    err.textContent = '';
+    let parsed;
+    try { parsed = JSON.parse(ta.value); }
+    catch (e) { err.textContent = 'Invalid JSON: ' + e.message; return; }
+    if (!parsed || typeof parsed !== 'object') { err.textContent = 'Expected an object.'; return; }
+    // First migrate v1 IDs (4 segments) -> v2 IDs (5 segments)
+    const { marks: idMigrated, migrated } = migrateMarksV1ToV2(parsed);
+    // Then upgrade each value v2 -> v3 (preserves marked + note, fills new fields)
+    Object.entries(idMigrated).forEach(([id, m]) => {
+      marks[id] = upgradeV2ValueToV3(m);
+    });
+    saveMarks(marks);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+    closeOverlay('json-import-overlay');
+    alert('Imported ' + Object.keys(idMigrated).length + ' marks (' + migrated + ' legacy IDs migrated to __seeded; values upgraded to v3).');
+  });
+</script>
+</body>
+</html>

--- a/scripts/audit/review/characters-detail.html
+++ b/scripts/audit/review/characters-detail.html
@@ -1,0 +1,2065 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Cross-Theme Audit (#1129) — characters-detail</title>
+<style>
+
+  :root { --col-gap: 8px; --row-gap: 16px; }
+  html, body { margin: 0; padding: 0; font-family: -apple-system, system-ui, sans-serif; background: #fafafa; color: #222; }
+  .sticky-shell { position: sticky; top: 0; z-index: 100; border-bottom: 1px solid #444; }
+  header.top {
+    background: #1a1a1a; color: #fff; padding: 12px 16px;
+    display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+  }
+  header.top h1 { font-size: 14px; margin: 0; font-weight: 600; }
+  header.top .legend { display: flex; gap: 12px; font-size: 12px; }
+  header.top .legend .col { padding: 2px 8px; border-radius: 3px; }
+  header.top .legend .develop { background: #6b7280; }
+  header.top .legend .ds3 { background: #4338ca; }
+  header.top .legend .ds1 { background: #92400e; }
+  header.top .legend .ds2 { background: #166534; }
+  header.top a.back { color: #9cf; font-size: 12px; text-decoration: none; padding: 2px 6px; border-radius: 2px; }
+  header.top a.back:hover { background: #444; color: #fff; }
+  header.top .nav-routes { display: flex; gap: 4px; align-items: center; font-size: 12px; }
+  header.top .nav-routes a { color: #9cf; text-decoration: none; padding: 2px 8px; border-radius: 2px; background: #2a2a2a; }
+  header.top .nav-routes a:hover { background: #444; color: #fff; }
+  header.top .nav-routes .current { color: #fff; font-weight: 600; padding: 2px 8px; }
+  main { padding: 16px; max-width: 100%; }
+  section.route {
+    margin-bottom: 32px; background: #fff; border-radius: 6px;
+    padding: 12px 16px 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  section.route h2 {
+    font-size: 18px; margin: 0 0 12px; padding-bottom: 6px;
+    border-bottom: 1px solid #e5e5e5;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+  .component-row {
+    display: grid; grid-template-columns: 180px repeat(4, 1fr);
+    gap: var(--col-gap); margin-bottom: var(--row-gap);
+    align-items: start;
+  }
+  .component-row .label {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px; color: #555; padding-top: 28px; line-height: 1.3;
+    word-break: break-word;
+  }
+  .cell {
+    border: 1px solid #e5e5e5; border-radius: 4px; overflow: hidden;
+    background: #f3f4f6; position: relative; min-height: 100px;
+    display: flex; flex-direction: column;
+  }
+  .cell .header {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.04em; padding: 4px 8px; color: #fff;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .cell.develop .header { background: #6b7280; }
+  .cell.ds3 .header { background: #4338ca; }
+  .cell.ds1 .header { background: #92400e; }
+  .cell.ds2 .header { background: #166534; }
+  .cell img {
+    display: block; width: auto; max-width: 100%; height: auto;
+    cursor: zoom-in; background: #fff; align-self: flex-start;
+  }
+  body.fit-cell .cell img { width: 100%; max-width: 100%; }
+  .cell.empty {
+    display: flex; align-items: center; justify-content: center;
+    color: #999; font-size: 12px; padding: 24px; background: #f9f9f9;
+  }
+  .cell.empty::after { content: "(not captured)"; }
+
+  /* Lightbox */
+  #lightbox {
+    display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.92);
+    z-index: 1000; align-items: center; justify-content: center; cursor: zoom-out;
+  }
+  #lightbox.open { display: flex; }
+  #lightbox img { max-width: 96vw; max-height: 96vh; box-shadow: 0 4px 24px rgba(0,0,0,0.5); }
+
+  .controls { display: flex; gap: 12px; align-items: center; font-size: 12px; flex-wrap: wrap; }
+  .controls label { display: flex; align-items: center; gap: 4px; cursor: pointer; }
+  .controls input[type=checkbox] { margin: 0; }
+
+  .state-chips { display: inline-flex; gap: 4px; align-items: center; }
+  .state-chip {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .state-chip.active { background: #2563eb; border-color: #1d4ed8; }
+  .state-chip:hover { background: #4b5563; }
+  .state-chip.active:hover { background: #1d4ed8; }
+
+  body.hide-empty .component-row.all-empty,
+  body.hide-empty .cell.empty { display: none; }
+  body.compact .cell img { max-height: 360px; object-fit: cover; object-position: top; }
+
+  .cell .mark-btn {
+    margin-left: auto; background: rgba(255,255,255,0.18);
+    color: #fff; border: 1px solid rgba(255,255,255,0.35);
+    border-radius: 3px; font-size: 10px; font-weight: 600;
+    padding: 2px 6px; cursor: pointer;
+    text-transform: none; letter-spacing: 0; line-height: 1.2;
+  }
+  .cell .mark-btn:hover { background: rgba(255,255,255,0.28); }
+  .cell.marked { border: 3px solid #dc2626; }
+  .cell.marked .mark-btn { background: #dc2626; border-color: #b91c1c; color: #fff; }
+  .cell.marked .mark-btn::before { content: "x "; }
+  .cell.pending-recapture { animation: cellPulse 2s ease-out; }
+  @keyframes cellPulse {
+    0%   { box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.9); border-color: #7c3aed; }
+    100% { box-shadow: 0 0 0 8px rgba(124, 58, 237, 0); }
+  }
+  .cell .toolbar {
+    display: none;
+    padding: 6px 8px; background: #fef2f2; border-top: 1px solid #fecaca;
+    font-size: 11px;
+  }
+  .cell.marked .toolbar { display: block; }
+  .cell .toolbar input[type=text],
+  .cell .toolbar textarea {
+    width: 100%; box-sizing: border-box;
+    border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 4px 6px; font-size: 12px; font-family: inherit;
+    background: #fff;
+  }
+  .cell .toolbar input[type=text]:focus,
+  .cell .toolbar textarea:focus { outline: 2px solid #dc2626; outline-offset: -1px; }
+  .cell .toolbar .field { margin-bottom: 6px; }
+  .cell .toolbar .field-label {
+    display: block; font-size: 10px; font-weight: 600;
+    color: #7f1d1d; text-transform: uppercase; letter-spacing: 0.04em;
+    margin-bottom: 2px;
+  }
+  .cell .toolbar .cat-chips { display: flex; gap: 4px; flex-wrap: wrap; }
+  .cell .toolbar .cat-chip {
+    background: #fff; border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 2px 8px; font-size: 11px; cursor: pointer; font-family: inherit;
+    color: #7f1d1d;
+  }
+  .cell .toolbar .cat-chip.active { background: #7f1d1d; color: #fff; border-color: #7f1d1d; }
+  .cell .toolbar .cat-chip[data-cat="needs-design"].active { background: #6d28d9; border-color: #6d28d9; }
+  .cell .toolbar .cat-chip[data-cat="bug"].active        { background: #b91c1c; border-color: #b91c1c; }
+  .cell .toolbar .cat-chip[data-cat="tooling"].active    { background: #b45309; border-color: #b45309; }
+  .cell .toolbar .cat-chip[data-cat="intentional"].active{ background: #15803d; border-color: #15803d; }
+  .cell .toolbar .cat-chip[data-cat="unclear"].active    { background: #6b7280; border-color: #6b7280; }
+  .cell .toolbar .recapture-btn {
+    background: #1d4ed8; color: #fff; border: 0; border-radius: 3px;
+    padding: 4px 10px; font-size: 11px; cursor: pointer;
+    font-family: inherit; font-weight: 600;
+  }
+  .cell .toolbar .recapture-btn:hover { background: #1e40af; }
+  .cell .toolbar textarea { min-height: 32px; resize: vertical; font-size: 11px; }
+  .cell.cat-needs-design { border-color: #6d28d9; }
+  .cell.cat-bug         { border-color: #b91c1c; }
+  .cell.cat-tooling     { border-color: #b45309; }
+  .cell.cat-intentional { border-color: #15803d; }
+  .cell.cat-unclear     { border-color: #6b7280; }
+
+  .marks-cluster {
+    display: flex; align-items: center; gap: 8px;
+    border-left: 1px solid #444; padding-left: 12px; margin-left: 4px;
+    font-size: 12px;
+  }
+  .marks-cluster .count {
+    background: #dc2626; color: #fff; border-radius: 10px;
+    padding: 2px 8px; font-weight: 600; min-width: 18px; text-align: center;
+  }
+  .marks-cluster button {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .marks-cluster button:hover { background: #4b5563; }
+  .marks-cluster button.danger { background: #7f1d1d; border-color: #991b1b; }
+  .marks-cluster button.danger:hover { background: #991b1b; }
+
+  body.only-marked .component-row:not(.has-marked) { display: none; }
+  body.only-marked section.route:not(.has-marked) { display: none; }
+
+  .component-row.suppressed { display: none; }
+  body.show-suppressed .component-row.suppressed { display: grid; }
+  .component-row.suppressed .label::after { content: " (hidden)"; color: #b91c1c; font-style: italic; }
+
+  .component-row .label[data-mapped] { color: #1d4ed8; }
+  .component-row .label[data-mapped]::after { content: " *"; }
+  .mapped-tooltip {
+    display: inline-block; margin-left: 4px;
+    font-size: 10px; color: #6b7280; cursor: help; vertical-align: super;
+  }
+
+  .vp-badge, .state-badge {
+    display: inline-block; font-size: 9px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.05em;
+    padding: 1px 6px; border-radius: 8px; margin-top: 2px;
+  }
+  .vp-badge.desktop { background: #dbeafe; color: #1e3a8a; border: 1px solid #93c5fd; margin-right: 4px; }
+  .vp-badge.mobile  { background: #fef3c7; color: #78350f; border: 1px solid #fcd34d; margin-right: 4px; }
+  .state-badge.empty       { background: #f3f4f6; color: #374151; border: 1px solid #d1d5db; }
+  .state-badge.seeded      { background: #dcfce7; color: #14532d; border: 1px solid #86efac; }
+  .state-badge.mid-session { background: #ede9fe; color: #4c1d95; border: 1px solid #c4b5fd; }
+
+  .component-row.vp-mobile { background: #fffbeb; padding: 4px; border-radius: 4px; }
+  body.hide-desktop .component-row.vp-desktop { display: none; }
+  body.hide-mobile .component-row.vp-mobile { display: none; }
+
+  body.hide-state-empty       .component-row.state-empty       { display: none; }
+  body.hide-state-seeded      .component-row.state-seeded      { display: none; }
+  body.hide-state-mid-session .component-row.state-mid-session { display: none; }
+
+  .overlay {
+    display: none; position: fixed; inset: 0; z-index: 1100;
+    background: rgba(0,0,0,0.6); align-items: center; justify-content: center;
+  }
+  .overlay.open { display: flex; }
+  .overlay .panel {
+    background: #fff; border-radius: 6px; width: min(720px, 92vw);
+    max-height: 80vh; padding: 16px; display: flex; flex-direction: column; gap: 8px;
+  }
+  .overlay h3 { margin: 0; font-size: 14px; }
+  .overlay textarea {
+    flex: 1; min-height: 320px; font-family: ui-monospace, monospace; font-size: 12px;
+    border: 1px solid #ddd; border-radius: 4px; padding: 8px; resize: vertical;
+  }
+  .overlay .actions { display: flex; gap: 8px; justify-content: flex-end; }
+  .overlay button {
+    background: #1a1a1a; color: #fff; border: 0; border-radius: 3px;
+    padding: 6px 12px; font-size: 12px; cursor: pointer;
+  }
+  .overlay .hint { font-size: 11px; color: #555; }
+  .overlay .err  { font-size: 12px; color: #b91c1c; min-height: 16px; }
+
+  /* Index-page table */
+  table.routes-index {
+    width: 100%; border-collapse: collapse; background: #fff;
+    border-radius: 6px; overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  table.routes-index th, table.routes-index td {
+    padding: 8px 12px; text-align: left; font-size: 13px;
+    border-bottom: 1px solid #eee;
+  }
+  table.routes-index th { background: #f3f4f6; font-weight: 600; }
+  table.routes-index td a {
+    color: #1d4ed8; text-decoration: none; font-family: ui-monospace, monospace;
+  }
+  table.routes-index td a:hover { text-decoration: underline; }
+  table.routes-index td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  table.routes-index .marked-count.has-marks { color: #b91c1c; font-weight: 600; }
+  table.routes-index .unresolved-count.has-unresolved { color: #b45309; font-weight: 600; }
+  table.routes-index .breakdown {
+    font-size: 11px; color: #555; margin-left: 6px; font-variant-numeric: tabular-nums;
+  }
+
+
+</style>
+</head>
+<body>
+<div class="sticky-shell">
+<header class="top">
+  <a class="back" href="index.html">&larr; Index</a>
+  <h1>characters-detail</h1>
+  <div class="legend">
+    <span class="col develop">develop</span>
+    <span class="col ds3">DS3</span>
+    <span class="col ds1">DS1</span>
+    <span class="col ds2">DS2</span>
+  </div>
+  <div class="controls">
+    <span class="state-chips" role="group" aria-label="State filter">
+      <span style="font-size: 11px; color: #aaa;">State:</span>
+      <button type="button" class="state-chip" data-state="empty">empty</button>
+      <button type="button" class="state-chip active" data-state="seeded">seeded</button>
+    </span>
+    <label><input type="checkbox" id="hide-empty"> Hide missing</label>
+    <label><input type="checkbox" id="compact"> Compact</label>
+    <label title="Stretch images to cell width"><input type="checkbox" id="fit-cell"> Fit to cell</label>
+    <label><input type="checkbox" id="only-marked"> Only marked</label>
+    <label><input type="checkbox" id="show-suppressed"> Show hidden rows</label>
+    <label><input type="checkbox" id="hide-desktop"> Hide desktop</label>
+    <label><input type="checkbox" id="hide-mobile"> Hide mobile</label>
+  </div>
+  <div class="marks-cluster">
+    <span>Marked (route):</span>
+    <span class="count" id="mark-count">0</span>
+    <button id="prefill-ds-btn" type="button" title="Mark every DS cell that has no mark yet as needs-design (gap-fill, never overwrites your existing marks)">Fill DS gaps</button>
+    <button id="export-md-btn" type="button">Export markdown</button>
+    <button id="export-json-btn" type="button">Export JSON</button>
+    <button id="import-json-btn" type="button">Import JSON</button>
+    <button id="clear-route-btn" type="button" class="danger">Clear (route)</button>
+  </div>
+</header>
+<nav class="toc" style="background:#2a2a2a;color:#ccc;padding:6px 16px;font-size:12px;display:flex;gap:8px;align-items:center;border-top:1px solid #444;">
+  <span class="nav-routes">
+    <a href="characters.html">&larr; characters</a>
+    <span class="current">characters-detail</span>
+    <a href="characters-edit.html">characters-edit &rarr;</a>
+  </span>
+</nav>
+</div>
+<main>
+<section class="route" id="route-characters-detail">
+  <h2>characters-detail</h2>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters-detail__global-nav__desktop__empty__develop" data-route="characters-detail" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/characters-detail__nav.png" alt="develop characters-detail/global-nav/desktop/empty" data-caption="develop -- characters-detail/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-detail__global-nav__desktop__empty__DS3" data-route="characters-detail" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/characters-detail__nav.png" alt="DS3 characters-detail/global-nav/desktop/empty" data-caption="DS3 -- characters-detail/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-detail__global-nav__desktop__empty__DS1" data-route="characters-detail" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/characters-detail__nav.png" alt="DS1 characters-detail/global-nav/desktop/empty" data-caption="DS1 -- characters-detail/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-detail__global-nav__desktop__empty__DS2" data-route="characters-detail" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/characters-detail__nav.png" alt="DS2 characters-detail/global-nav/desktop/empty" data-caption="DS2 -- characters-detail/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters-detail__page__desktop__empty__develop" data-route="characters-detail" data-component="page" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/characters-detail__page.png" alt="develop characters-detail/page/desktop/empty" data-caption="develop -- characters-detail/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-detail__page__desktop__empty__DS3" data-route="characters-detail" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/characters-detail__page.png" alt="DS3 characters-detail/page/desktop/empty" data-caption="DS3 -- characters-detail/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-detail__page__desktop__empty__DS1" data-route="characters-detail" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/characters-detail__page.png" alt="DS1 characters-detail/page/desktop/empty" data-caption="DS1 -- characters-detail/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-detail__page__desktop__empty__DS2" data-route="characters-detail" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/characters-detail__page.png" alt="DS2 characters-detail/page/desktop/empty" data-caption="DS2 -- characters-detail/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-empty" data-viewport="mobile" data-state="empty">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters-detail__page__mobile__empty__develop" data-route="characters-detail" data-component="page" data-viewport="mobile" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/empty/characters-detail__page.png" alt="develop characters-detail/page/mobile/empty" data-caption="develop -- characters-detail/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-detail__page__mobile__empty__DS3" data-route="characters-detail" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/empty/characters-detail__page.png" alt="DS3 characters-detail/page/mobile/empty" data-caption="DS3 -- characters-detail/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-detail__page__mobile__empty__DS1" data-route="characters-detail" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/empty/characters-detail__page.png" alt="DS1 characters-detail/page/mobile/empty" data-caption="DS1 -- characters-detail/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-detail__page__mobile__empty__DS2" data-route="characters-detail" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/empty/characters-detail__page.png" alt="DS2 characters-detail/page/mobile/empty" data-caption="DS2 -- characters-detail/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters-detail__header__desktop__empty__develop" data-route="characters-detail" data-component="header" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/characters-detail__header.png" alt="develop characters-detail/header/desktop/empty" data-caption="develop -- characters-detail/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters-detail__nav__desktop__empty__develop" data-route="characters-detail" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/characters-detail__nav.png" alt="develop characters-detail/nav/desktop/empty" data-caption="develop -- characters-detail/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-detail__nav__desktop__empty__DS3" data-route="characters-detail" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/characters-detail__nav.png" alt="DS3 characters-detail/nav/desktop/empty" data-caption="DS3 -- characters-detail/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-detail__nav__desktop__empty__DS1" data-route="characters-detail" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/characters-detail__nav.png" alt="DS1 characters-detail/nav/desktop/empty" data-caption="DS1 -- characters-detail/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-detail__nav__desktop__empty__DS2" data-route="characters-detail" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/characters-detail__nav.png" alt="DS2 characters-detail/nav/desktop/empty" data-caption="DS2 -- characters-detail/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters-detail__main__desktop__empty__develop" data-route="characters-detail" data-component="main" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/characters-detail__main.png" alt="develop characters-detail/main/desktop/empty" data-caption="develop -- characters-detail/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-detail__main__desktop__empty__DS3" data-route="characters-detail" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/characters-detail__main.png" alt="DS3 characters-detail/main/desktop/empty" data-caption="DS3 -- characters-detail/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-detail__main__desktop__empty__DS1" data-route="characters-detail" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/characters-detail__main.png" alt="DS1 characters-detail/main/desktop/empty" data-caption="DS1 -- characters-detail/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-detail__main__desktop__empty__DS2" data-route="characters-detail" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/characters-detail__main.png" alt="DS2 characters-detail/main/desktop/empty" data-caption="DS2 -- characters-detail/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters-detail__global-nav__desktop__seeded__develop" data-route="characters-detail" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/characters-detail__nav.png" alt="develop characters-detail/global-nav/desktop/seeded" data-caption="develop -- characters-detail/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-detail__global-nav__desktop__seeded__DS3" data-route="characters-detail" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/characters-detail__nav.png" alt="DS3 characters-detail/global-nav/desktop/seeded" data-caption="DS3 -- characters-detail/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-detail__global-nav__desktop__seeded__DS1" data-route="characters-detail" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/characters-detail__nav.png" alt="DS1 characters-detail/global-nav/desktop/seeded" data-caption="DS1 -- characters-detail/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-detail__global-nav__desktop__seeded__DS2" data-route="characters-detail" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/characters-detail__nav.png" alt="DS2 characters-detail/global-nav/desktop/seeded" data-caption="DS2 -- characters-detail/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters-detail__page__desktop__seeded__develop" data-route="characters-detail" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/characters-detail__page.png" alt="develop characters-detail/page/desktop/seeded" data-caption="develop -- characters-detail/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-detail__page__desktop__seeded__DS3" data-route="characters-detail" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/characters-detail__page.png" alt="DS3 characters-detail/page/desktop/seeded" data-caption="DS3 -- characters-detail/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-detail__page__desktop__seeded__DS1" data-route="characters-detail" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/characters-detail__page.png" alt="DS1 characters-detail/page/desktop/seeded" data-caption="DS1 -- characters-detail/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-detail__page__desktop__seeded__DS2" data-route="characters-detail" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/characters-detail__page.png" alt="DS2 characters-detail/page/desktop/seeded" data-caption="DS2 -- characters-detail/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-seeded" data-viewport="mobile" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters-detail__page__mobile__seeded__develop" data-route="characters-detail" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/seeded/characters-detail__page.png" alt="develop characters-detail/page/mobile/seeded" data-caption="develop -- characters-detail/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-detail__page__mobile__seeded__DS3" data-route="characters-detail" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/seeded/characters-detail__page.png" alt="DS3 characters-detail/page/mobile/seeded" data-caption="DS3 -- characters-detail/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-detail__page__mobile__seeded__DS1" data-route="characters-detail" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/seeded/characters-detail__page.png" alt="DS1 characters-detail/page/mobile/seeded" data-caption="DS1 -- characters-detail/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-detail__page__mobile__seeded__DS2" data-route="characters-detail" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/seeded/characters-detail__page.png" alt="DS2 characters-detail/page/mobile/seeded" data-caption="DS2 -- characters-detail/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters-detail__header__desktop__seeded__develop" data-route="characters-detail" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/characters-detail__header.png" alt="develop characters-detail/header/desktop/seeded" data-caption="develop -- characters-detail/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-detail__header__desktop__seeded__DS3" data-route="characters-detail" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/characters-detail__header.png" alt="DS3 characters-detail/header/desktop/seeded" data-caption="DS3 -- characters-detail/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-detail__header__desktop__seeded__DS1" data-route="characters-detail" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/characters-detail__header.png" alt="DS1 characters-detail/header/desktop/seeded" data-caption="DS1 -- characters-detail/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-detail__header__desktop__seeded__DS2" data-route="characters-detail" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/characters-detail__header.png" alt="DS2 characters-detail/header/desktop/seeded" data-caption="DS2 -- characters-detail/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters-detail__nav__desktop__seeded__develop" data-route="characters-detail" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/characters-detail__nav.png" alt="develop characters-detail/nav/desktop/seeded" data-caption="develop -- characters-detail/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-detail__nav__desktop__seeded__DS3" data-route="characters-detail" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/characters-detail__nav.png" alt="DS3 characters-detail/nav/desktop/seeded" data-caption="DS3 -- characters-detail/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-detail__nav__desktop__seeded__DS1" data-route="characters-detail" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/characters-detail__nav.png" alt="DS1 characters-detail/nav/desktop/seeded" data-caption="DS1 -- characters-detail/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-detail__nav__desktop__seeded__DS2" data-route="characters-detail" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/characters-detail__nav.png" alt="DS2 characters-detail/nav/desktop/seeded" data-caption="DS2 -- characters-detail/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters-detail__main__desktop__seeded__develop" data-route="characters-detail" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/characters-detail__main.png" alt="develop characters-detail/main/desktop/seeded" data-caption="develop -- characters-detail/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-detail__main__desktop__seeded__DS3" data-route="characters-detail" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/characters-detail__main.png" alt="DS3 characters-detail/main/desktop/seeded" data-caption="DS3 -- characters-detail/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-detail__main__desktop__seeded__DS1" data-route="characters-detail" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/characters-detail__main.png" alt="DS1 characters-detail/main/desktop/seeded" data-caption="DS1 -- characters-detail/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-detail__main__desktop__seeded__DS2" data-route="characters-detail" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/characters-detail__main.png" alt="DS2 characters-detail/main/desktop/seeded" data-caption="DS2 -- characters-detail/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+</main>
+
+<div id="lightbox" class="overlay">
+  <img id="lightbox-img" src="" alt="">
+  <div id="lightbox-caption" style="position: fixed; top: 12px; left: 50%; transform: translateX(-50%); color: #fff; font-family: ui-monospace, monospace; font-size: 13px; background: rgba(0,0,0,0.6); padding: 6px 12px; border-radius: 4px;"></div>
+</div>
+
+<div id="md-overlay" class="overlay">
+  <div class="panel">
+    <h3>Audit marks (markdown) -- this route only</h3>
+    <textarea id="md-text" readonly></textarea>
+    <div class="actions">
+      <button id="md-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="md-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-export-overlay" class="overlay">
+  <div class="panel">
+    <h3>Marks (raw JSON) -- all routes</h3>
+    <textarea id="json-export-text" readonly></textarea>
+    <div class="actions">
+      <button id="json-export-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="json-export-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-import-overlay" class="overlay">
+  <div class="panel">
+    <h3>Import marks (paste raw JSON)</h3>
+    <p class="hint">Paste JSON exported from another instance. Legacy IDs without a state segment are migrated to <code>__seeded</code>; v2 values are upgraded to v3 (category=null, why="", updatedAt=now). Existing marks with the same ID are overwritten.</p>
+    <textarea id="json-import-text" placeholder='{"home__page__desktop__seeded__DS3":{"marked":true,"note":"...","category":"bug","why":"...","updatedAt":"..."}}'></textarea>
+    <div class="err" id="json-import-err"></div>
+    <div class="actions">
+      <button id="json-import-apply" type="button">Apply</button>
+      <button class="overlay-close" data-overlay="json-import-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+<script>
+
+  const STORAGE_KEY = 'narraitor-audit-marks-v3';
+  const STORAGE_KEY_V2 = 'narraitor-audit-marks-v2';
+  const STORAGE_KEY_V1 = 'narraitor-audit-marks-v1';
+  // Tracks which routes have had their DS cells auto-prefilled as needs-design.
+  // Once a route is in here, the auto-prefill on page load is skipped.
+  const PREFILLED_KEY = 'narraitor-audit-prefilled-v1';
+  const STATES = ['empty', 'seeded'];
+  const VALID_CATEGORIES = ['needs-design','bug','tooling','intentional','unclear'];
+  const ROUTE_ORDER = ["home", "about", "worlds", "worlds-detail", "worlds-edit", "worlds-create", "worlds-play", "worlds-play-journal", "characters", "characters-detail", "characters-edit", "characters-create", "play", "settings"];
+  const COMPONENT_ORDER = {"page":0,"header":1,"nav":2,"form":3,"main":4};
+  const THEME_ORDER = ["DS3","DS1","DS2","develop"];
+  const BRANCH_META = {"develop": {"theme": "default", "mode": "light", "branchArg": "develop-default"}, "DS3": {"theme": "ds3", "mode": "light", "branchArg": "integration-ds3-light"}, "DS1": {"theme": "ds1", "mode": "light", "branchArg": "integration-ds1-light"}, "DS2": {"theme": "ds2", "mode": "light", "branchArg": "integration-ds2-light"}};
+
+  function componentSortKey(c) {
+    if (c in COMPONENT_ORDER) return [COMPONENT_ORDER[c], 0];
+    if (c.startsWith("main-section-")) {
+      const n = parseInt(c.replace("main-section-",""), 10);
+      return [5, isNaN(n) ? 0 : n];
+    }
+    return [9, c];
+  }
+
+  // Pre-v3 ID migration: v1 (4 segments) -> v2 (5 segments) by inserting __seeded.
+  function migrateLegacyId(id) {
+    const parts = id.split('__');
+    if (parts.length < 4) return id;
+    const last = parts[parts.length - 1];
+    const second = parts[parts.length - 2];
+    const third = parts[parts.length - 3];
+    const isTheme = ['DS1','DS2','DS3','develop'].includes(last);
+    const isViewport = ['desktop','mobile'].includes(second);
+    const alreadyHasState = STATES.includes(third);
+    if (isTheme && isViewport && !alreadyHasState) {
+      const head = parts.slice(0, parts.length - 1).join('__');
+      return head + '__seeded__' + last;
+    }
+    return id;
+  }
+
+  function migrateMarksV1ToV2(input) {
+    const out = {};
+    let migrated = 0;
+    for (const [id, m] of Object.entries(input || {})) {
+      const newId = migrateLegacyId(id);
+      if (newId !== id) migrated++;
+      out[newId] = m;
+    }
+    return { marks: out, migrated };
+  }
+
+  // v2 -> v3: add category, why, updatedAt; preserve marked + note.
+  function upgradeV2ValueToV3(v) {
+    if (!v || typeof v !== 'object') return null;
+    return {
+      marked: !!v.marked,
+      note: typeof v.note === 'string' ? v.note : '',
+      category: v.category && VALID_CATEGORIES.includes(v.category) ? v.category : null,
+      why: typeof v.why === 'string' ? v.why : '',
+      updatedAt: v.updatedAt || new Date().toISOString(),
+    };
+  }
+
+  function migrateV2ObjectToV3(v2obj) {
+    const out = {};
+    for (const [id, m] of Object.entries(v2obj || {})) {
+      out[id] = upgradeV2ValueToV3(m);
+    }
+    return out;
+  }
+
+  function loadMarks() {
+    try {
+      const v3 = localStorage.getItem(STORAGE_KEY);
+      if (v3) return JSON.parse(v3);
+      // No v3 yet — try v2 (lazy migrate; leave v2 untouched for rollback).
+      const v2raw = localStorage.getItem(STORAGE_KEY_V2);
+      if (v2raw) {
+        const v3marks = migrateV2ObjectToV3(JSON.parse(v2raw));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + Object.keys(v3marks).length + ' v2 marks to v3 (v2 untouched).');
+        return v3marks;
+      }
+      // No v3 or v2 — try v1 and migrate v1 -> v2 -> v3 in one pass.
+      const v1raw = localStorage.getItem(STORAGE_KEY_V1);
+      if (v1raw) {
+        const { marks: v2marks, migrated } = migrateMarksV1ToV2(JSON.parse(v1raw));
+        const v3marks = migrateV2ObjectToV3(v2marks);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + migrated + ' v1 IDs through to v3.');
+        return v3marks;
+      }
+    } catch (e) { console.warn(e); }
+    return {};
+  }
+
+  function saveMarks(m) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(m)); } catch (e) {}
+  }
+
+
+  const ROUTE = "characters-detail";
+  let marks = loadMarks();
+
+  function applyMarkState(cell) {
+    const id = cell.dataset.cellId;
+    const m = marks[id];
+    const noteInput = cell.querySelector('textarea[data-action="note"]');
+    const whyInput = cell.querySelector('input[data-action="why"]');
+    const chips = cell.querySelectorAll('.cat-chip');
+    cell.classList.remove('cat-bug','cat-tooling','cat-intentional','cat-unclear');
+    chips.forEach(c => c.classList.remove('active'));
+    if (m && m.marked) {
+      cell.classList.add('marked');
+      if (noteInput) noteInput.value = m.note || '';
+      if (whyInput) whyInput.value = m.why || '';
+      if (m.category) {
+        cell.classList.add('cat-' + m.category);
+        const chip = cell.querySelector('.cat-chip[data-cat="' + m.category + '"]');
+        if (chip) chip.classList.add('active');
+      }
+    } else {
+      cell.classList.remove('marked');
+      if (noteInput) noteInput.value = '';
+      if (whyInput) whyInput.value = '';
+    }
+  }
+
+  function updateRowSectionFlags() {
+    document.querySelectorAll('.component-row').forEach(row => {
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+    document.querySelectorAll('section.route').forEach(sec => {
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+    });
+  }
+
+  function updateCount() {
+    const n = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).length;
+    document.getElementById('mark-count').textContent = n;
+  }
+
+  function writeMark(id, partial) {
+    const existing = marks[id] || { marked: false, note: '', category: null, why: '', updatedAt: null };
+    const next = Object.assign({}, existing, partial, { updatedAt: new Date().toISOString() });
+    if (!next.marked && !next.note && !next.why && !next.category) {
+      delete marks[id];
+    } else {
+      marks[id] = next;
+    }
+    saveMarks(marks);
+    updateCount();
+  }
+
+  function buildRecaptureCommand(cell) {
+    const route = cell.dataset.route;
+    const viewport = cell.dataset.viewport;
+    const state = cell.dataset.state;
+    const themeKey = cell.dataset.theme;
+    const meta = BRANCH_META[themeKey];
+    if (!meta) return null;
+    return 'npx tsx scripts/audit/playwright-crawl.ts'
+      + ' --branch ' + meta.branchArg
+      + ' --viewport ' + viewport
+      + ' --state ' + state
+      + ' --theme ' + meta.theme
+      + ' --mode ' + meta.mode
+      + ' --route ' + route;
+  }
+
+  function loadPrefilledFlags() {
+    try { return JSON.parse(localStorage.getItem(PREFILLED_KEY) || '{}'); }
+    catch (e) { return {}; }
+  }
+  function savePrefilledFlags(f) {
+    try { localStorage.setItem(PREFILLED_KEY, JSON.stringify(f)); } catch (e) {}
+  }
+
+  // Gap-fill: only adds entries for DS cells that have no existing mark.
+  // Returns the count of cells filled. Develop is excluded (it's the baseline).
+  function prefillDsCellsAsNeedsDesign() {
+    const dsCells = Array.from(document.querySelectorAll('.cell[data-cell-id]'))
+      .filter(c => ['DS1','DS2','DS3'].includes(c.dataset.theme));
+    let added = 0;
+    const ts = new Date().toISOString();
+    for (const cell of dsCells) {
+      const id = cell.dataset.cellId;
+      if (!marks[id]) {
+        marks[id] = { marked: true, note: '', category: 'needs-design', why: '', updatedAt: ts };
+        added++;
+      }
+    }
+    if (added > 0) saveMarks(marks);
+    return added;
+  }
+
+  // Auto-prefill on first visit per route.
+  const prefillFlags = loadPrefilledFlags();
+  if (!prefillFlags[ROUTE]) {
+    const added = prefillDsCellsAsNeedsDesign();
+    prefillFlags[ROUTE] = true;
+    savePrefilledFlags(prefillFlags);
+    if (added > 0) console.info('[audit] auto-prefilled ' + added + ' DS cells for ' + ROUTE + ' as needs-design.');
+  }
+
+  document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+  updateRowSectionFlags();
+  updateCount();
+
+  // Lightbox
+  const lb = document.getElementById('lightbox');
+  const lbImg = document.getElementById('lightbox-img');
+  const lbCap = document.getElementById('lightbox-caption');
+  document.querySelectorAll('.cell img').forEach(img => {
+    img.addEventListener('click', () => {
+      lbImg.src = img.src;
+      lbCap.textContent = img.dataset.caption || '';
+      lb.classList.add('open');
+    });
+  });
+  lb.addEventListener('click', () => lb.classList.remove('open'));
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') document.querySelectorAll('.overlay.open').forEach(o => o.classList.remove('open'));
+  });
+
+  // Mark toggle
+  document.querySelectorAll('button[data-action="toggle-mark"]').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      const cell = btn.closest('.cell');
+      const id = cell.dataset.cellId;
+      const isMarked = !cell.classList.contains('marked');
+      writeMark(id, { marked: isMarked });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      const sec = cell.closest('section.route');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+      if (isMarked) {
+        const why = cell.querySelector('input[data-action="why"]');
+        if (why) setTimeout(() => why.focus(), 0);
+      }
+    });
+  });
+
+  // Why / note inputs (debounced save)
+  let saveTimer = null;
+  function bindInput(sel, field) {
+    document.querySelectorAll(sel).forEach(inp => {
+      const handler = () => {
+        const cell = inp.closest('.cell');
+        if (!cell.classList.contains('marked')) return;
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(() => {
+          writeMark(cell.dataset.cellId, { [field]: inp.value });
+        }, 250);
+      };
+      inp.addEventListener('input', handler);
+      inp.addEventListener('blur', () => {
+        const cell = inp.closest('.cell');
+        if (cell.classList.contains('marked')) writeMark(cell.dataset.cellId, { [field]: inp.value });
+      });
+    });
+  }
+  bindInput('input[data-action="why"]', 'why');
+  bindInput('textarea[data-action="note"]', 'note');
+
+  // Category chips
+  document.querySelectorAll('.cat-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const cell = chip.closest('.cell');
+      if (!cell.classList.contains('marked')) {
+        // Mark the cell first so the category sticks
+        writeMark(cell.dataset.cellId, { marked: true });
+      }
+      const cat = chip.dataset.cat;
+      const isActive = chip.classList.contains('active');
+      writeMark(cell.dataset.cellId, { category: isActive ? null : cat });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+  });
+
+  // Re-capture command (copy to clipboard, flash purple)
+  document.querySelectorAll('button[data-action="recapture"]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const cell = btn.closest('.cell');
+      const cmd = buildRecaptureCommand(cell);
+      if (!cmd) return;
+      try {
+        await navigator.clipboard.writeText(cmd);
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Copy re-capture command'; }, 1500);
+      } catch (e) {
+        prompt('Copy this command:', cmd);
+      }
+      cell.classList.remove('pending-recapture');
+      void cell.offsetWidth; // force reflow so the animation restarts
+      cell.classList.add('pending-recapture');
+    });
+  });
+
+  // Toggles
+  document.getElementById('hide-empty').addEventListener('change', e => document.body.classList.toggle('hide-empty', e.target.checked));
+  document.getElementById('compact').addEventListener('change', e => document.body.classList.toggle('compact', e.target.checked));
+  document.getElementById('fit-cell').addEventListener('change', e => document.body.classList.toggle('fit-cell', e.target.checked));
+  document.getElementById('only-marked').addEventListener('change', e => document.body.classList.toggle('only-marked', e.target.checked));
+  document.getElementById('show-suppressed').addEventListener('change', e => document.body.classList.toggle('show-suppressed', e.target.checked));
+  document.getElementById('hide-desktop').addEventListener('change', e => document.body.classList.toggle('hide-desktop', e.target.checked));
+  document.getElementById('hide-mobile').addEventListener('change', e => document.body.classList.toggle('hide-mobile', e.target.checked));
+
+  // True-scale rendering (1x for selector captures, 0.5x for retina full-page).
+  const RETINA_THRESHOLD = 1500;
+  function applyTrueScale(img) {
+    if (!img.naturalWidth) return;
+    const cssWidth = img.naturalWidth > RETINA_THRESHOLD
+      ? Math.round(img.naturalWidth / 2)
+      : img.naturalWidth;
+    img.style.maxWidth = 'min(100%, ' + cssWidth + 'px)';
+  }
+  document.querySelectorAll('.cell img').forEach(img => {
+    if (img.complete && img.naturalWidth > 0) applyTrueScale(img);
+    else img.addEventListener('load', () => applyTrueScale(img), { once: true });
+  });
+
+  // State chips
+  document.querySelectorAll('.state-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const state = chip.dataset.state;
+      chip.classList.toggle('active');
+      document.body.classList.toggle('hide-state-' + state, !chip.classList.contains('active'));
+    });
+  });
+  STATES.forEach(s => {
+    const chip = document.querySelector('.state-chip[data-state="' + s + '"]');
+    if (chip && !chip.classList.contains('active')) document.body.classList.add('hide-state-' + s);
+  });
+
+  // Manual top-up: fill any DS cells that don't have a mark yet
+  document.getElementById('prefill-ds-btn').addEventListener('click', () => {
+    const added = prefillDsCellsAsNeedsDesign();
+    if (added > 0) {
+      document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+      updateRowSectionFlags();
+      updateCount();
+      alert('Filled ' + added + ' missing DS cells as needs-design.');
+    } else {
+      alert('All DS cells in this route already have marks.');
+    }
+  });
+
+  // Clear-route. Also resets the prefilled flag so a reload re-triggers auto-prefill.
+  document.getElementById('clear-route-btn').addEventListener('click', () => {
+    const ids = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).map(([id]) => id);
+    if (!ids.length) { alert('No marks for this route.'); return; }
+    if (!confirm('Clear ' + ids.length + ' marks for route ' + ROUTE + '?\n\nReloading the page will re-prefill all DS cells as needs-design.')) return;
+    ids.forEach(id => delete marks[id]);
+    saveMarks(marks);
+    const flags = loadPrefilledFlags();
+    delete flags[ROUTE];
+    savePrefilledFlags(flags);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+  });
+
+  function buildMarkdown() {
+    const items = [];
+    Object.entries(marks).forEach(([id, m]) => {
+      if (!m || !m.marked) return;
+      if (!id.startsWith(ROUTE + '__')) return;
+      const parts = id.split('__');
+      const themeKey = parts[parts.length - 1];
+      const state = parts[parts.length - 2];
+      const viewport = parts[parts.length - 3];
+      const route = parts[0];
+      const component = parts.slice(1, parts.length - 3).join('__');
+      items.push({ component, viewport, state, theme: themeKey,
+                   note: m.note || '', why: m.why || '', category: m.category || '' });
+    });
+    items.sort((a, b) => {
+      const ak = componentSortKey(a.component);
+      const bk = componentSortKey(b.component);
+      if (ak[0] !== bk[0]) return ak[0] - bk[0];
+      if (ak[1] !== bk[1]) return ak[1] < bk[1] ? -1 : 1;
+      const sd = STATES.indexOf(a.state) - STATES.indexOf(b.state);
+      if (sd !== 0) return sd;
+      const td = THEME_ORDER.indexOf(a.theme) - THEME_ORDER.indexOf(b.theme);
+      if (td !== 0) return td;
+      return a.viewport === b.viewport ? 0 : (a.viewport === 'desktop' ? -1 : 1);
+    });
+    const date = new Date().toISOString().split('T')[0];
+    const lines = ['# Audit marks -- ' + ROUTE + ' -- ' + items.length + ' items -- ' + date, ''];
+    items.forEach(it => {
+      const catTag = it.category ? ' [' + it.category + ']' : '';
+      const whyTxt = it.why ? ': ' + it.why : '';
+      const noteTxt = it.note ? '  -- ' + it.note : '';
+      lines.push('- [ ] **' + it.theme + ' ' + it.component + '** [' + it.viewport + '/' + it.state + ']' + catTag + whyTxt + noteTxt);
+    });
+    return lines.join('\n');
+  }
+
+  function openOverlay(id) { document.getElementById(id).classList.add('open'); }
+  function closeOverlay(id) { document.getElementById(id).classList.remove('open'); }
+  document.querySelectorAll('.overlay-close').forEach(b => b.addEventListener('click', () => closeOverlay(b.dataset.overlay)));
+  document.querySelectorAll('.overlay').forEach(o => {
+    o.addEventListener('click', e => { if (e.target === o) o.classList.remove('open'); });
+  });
+
+  document.getElementById('export-md-btn').addEventListener('click', async () => {
+    const md = buildMarkdown();
+    const ta = document.getElementById('md-text');
+    ta.value = md;
+    openOverlay('md-overlay');
+    try { await navigator.clipboard.writeText(md); document.getElementById('md-copy').textContent = 'Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+  document.getElementById('md-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('md-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('md-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('export-json-btn').addEventListener('click', () => {
+    const ta = document.getElementById('json-export-text');
+    ta.value = JSON.stringify(marks, null, 2);
+    openOverlay('json-export-overlay');
+  });
+  document.getElementById('json-export-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('json-export-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('json-export-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('json-export-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('import-json-btn').addEventListener('click', () => {
+    document.getElementById('json-import-text').value = '';
+    document.getElementById('json-import-err').textContent = '';
+    openOverlay('json-import-overlay');
+  });
+  document.getElementById('json-import-apply').addEventListener('click', () => {
+    const ta = document.getElementById('json-import-text');
+    const err = document.getElementById('json-import-err');
+    err.textContent = '';
+    let parsed;
+    try { parsed = JSON.parse(ta.value); }
+    catch (e) { err.textContent = 'Invalid JSON: ' + e.message; return; }
+    if (!parsed || typeof parsed !== 'object') { err.textContent = 'Expected an object.'; return; }
+    // First migrate v1 IDs (4 segments) -> v2 IDs (5 segments)
+    const { marks: idMigrated, migrated } = migrateMarksV1ToV2(parsed);
+    // Then upgrade each value v2 -> v3 (preserves marked + note, fills new fields)
+    Object.entries(idMigrated).forEach(([id, m]) => {
+      marks[id] = upgradeV2ValueToV3(m);
+    });
+    saveMarks(marks);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+    closeOverlay('json-import-overlay');
+    alert('Imported ' + Object.keys(idMigrated).length + ' marks (' + migrated + ' legacy IDs migrated to __seeded; values upgraded to v3).');
+  });
+</script>
+</body>
+</html>

--- a/scripts/audit/review/characters-edit.html
+++ b/scripts/audit/review/characters-edit.html
@@ -1,0 +1,2065 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Cross-Theme Audit (#1129) — characters-edit</title>
+<style>
+
+  :root { --col-gap: 8px; --row-gap: 16px; }
+  html, body { margin: 0; padding: 0; font-family: -apple-system, system-ui, sans-serif; background: #fafafa; color: #222; }
+  .sticky-shell { position: sticky; top: 0; z-index: 100; border-bottom: 1px solid #444; }
+  header.top {
+    background: #1a1a1a; color: #fff; padding: 12px 16px;
+    display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+  }
+  header.top h1 { font-size: 14px; margin: 0; font-weight: 600; }
+  header.top .legend { display: flex; gap: 12px; font-size: 12px; }
+  header.top .legend .col { padding: 2px 8px; border-radius: 3px; }
+  header.top .legend .develop { background: #6b7280; }
+  header.top .legend .ds3 { background: #4338ca; }
+  header.top .legend .ds1 { background: #92400e; }
+  header.top .legend .ds2 { background: #166534; }
+  header.top a.back { color: #9cf; font-size: 12px; text-decoration: none; padding: 2px 6px; border-radius: 2px; }
+  header.top a.back:hover { background: #444; color: #fff; }
+  header.top .nav-routes { display: flex; gap: 4px; align-items: center; font-size: 12px; }
+  header.top .nav-routes a { color: #9cf; text-decoration: none; padding: 2px 8px; border-radius: 2px; background: #2a2a2a; }
+  header.top .nav-routes a:hover { background: #444; color: #fff; }
+  header.top .nav-routes .current { color: #fff; font-weight: 600; padding: 2px 8px; }
+  main { padding: 16px; max-width: 100%; }
+  section.route {
+    margin-bottom: 32px; background: #fff; border-radius: 6px;
+    padding: 12px 16px 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  section.route h2 {
+    font-size: 18px; margin: 0 0 12px; padding-bottom: 6px;
+    border-bottom: 1px solid #e5e5e5;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+  .component-row {
+    display: grid; grid-template-columns: 180px repeat(4, 1fr);
+    gap: var(--col-gap); margin-bottom: var(--row-gap);
+    align-items: start;
+  }
+  .component-row .label {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px; color: #555; padding-top: 28px; line-height: 1.3;
+    word-break: break-word;
+  }
+  .cell {
+    border: 1px solid #e5e5e5; border-radius: 4px; overflow: hidden;
+    background: #f3f4f6; position: relative; min-height: 100px;
+    display: flex; flex-direction: column;
+  }
+  .cell .header {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.04em; padding: 4px 8px; color: #fff;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .cell.develop .header { background: #6b7280; }
+  .cell.ds3 .header { background: #4338ca; }
+  .cell.ds1 .header { background: #92400e; }
+  .cell.ds2 .header { background: #166534; }
+  .cell img {
+    display: block; width: auto; max-width: 100%; height: auto;
+    cursor: zoom-in; background: #fff; align-self: flex-start;
+  }
+  body.fit-cell .cell img { width: 100%; max-width: 100%; }
+  .cell.empty {
+    display: flex; align-items: center; justify-content: center;
+    color: #999; font-size: 12px; padding: 24px; background: #f9f9f9;
+  }
+  .cell.empty::after { content: "(not captured)"; }
+
+  /* Lightbox */
+  #lightbox {
+    display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.92);
+    z-index: 1000; align-items: center; justify-content: center; cursor: zoom-out;
+  }
+  #lightbox.open { display: flex; }
+  #lightbox img { max-width: 96vw; max-height: 96vh; box-shadow: 0 4px 24px rgba(0,0,0,0.5); }
+
+  .controls { display: flex; gap: 12px; align-items: center; font-size: 12px; flex-wrap: wrap; }
+  .controls label { display: flex; align-items: center; gap: 4px; cursor: pointer; }
+  .controls input[type=checkbox] { margin: 0; }
+
+  .state-chips { display: inline-flex; gap: 4px; align-items: center; }
+  .state-chip {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .state-chip.active { background: #2563eb; border-color: #1d4ed8; }
+  .state-chip:hover { background: #4b5563; }
+  .state-chip.active:hover { background: #1d4ed8; }
+
+  body.hide-empty .component-row.all-empty,
+  body.hide-empty .cell.empty { display: none; }
+  body.compact .cell img { max-height: 360px; object-fit: cover; object-position: top; }
+
+  .cell .mark-btn {
+    margin-left: auto; background: rgba(255,255,255,0.18);
+    color: #fff; border: 1px solid rgba(255,255,255,0.35);
+    border-radius: 3px; font-size: 10px; font-weight: 600;
+    padding: 2px 6px; cursor: pointer;
+    text-transform: none; letter-spacing: 0; line-height: 1.2;
+  }
+  .cell .mark-btn:hover { background: rgba(255,255,255,0.28); }
+  .cell.marked { border: 3px solid #dc2626; }
+  .cell.marked .mark-btn { background: #dc2626; border-color: #b91c1c; color: #fff; }
+  .cell.marked .mark-btn::before { content: "x "; }
+  .cell.pending-recapture { animation: cellPulse 2s ease-out; }
+  @keyframes cellPulse {
+    0%   { box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.9); border-color: #7c3aed; }
+    100% { box-shadow: 0 0 0 8px rgba(124, 58, 237, 0); }
+  }
+  .cell .toolbar {
+    display: none;
+    padding: 6px 8px; background: #fef2f2; border-top: 1px solid #fecaca;
+    font-size: 11px;
+  }
+  .cell.marked .toolbar { display: block; }
+  .cell .toolbar input[type=text],
+  .cell .toolbar textarea {
+    width: 100%; box-sizing: border-box;
+    border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 4px 6px; font-size: 12px; font-family: inherit;
+    background: #fff;
+  }
+  .cell .toolbar input[type=text]:focus,
+  .cell .toolbar textarea:focus { outline: 2px solid #dc2626; outline-offset: -1px; }
+  .cell .toolbar .field { margin-bottom: 6px; }
+  .cell .toolbar .field-label {
+    display: block; font-size: 10px; font-weight: 600;
+    color: #7f1d1d; text-transform: uppercase; letter-spacing: 0.04em;
+    margin-bottom: 2px;
+  }
+  .cell .toolbar .cat-chips { display: flex; gap: 4px; flex-wrap: wrap; }
+  .cell .toolbar .cat-chip {
+    background: #fff; border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 2px 8px; font-size: 11px; cursor: pointer; font-family: inherit;
+    color: #7f1d1d;
+  }
+  .cell .toolbar .cat-chip.active { background: #7f1d1d; color: #fff; border-color: #7f1d1d; }
+  .cell .toolbar .cat-chip[data-cat="needs-design"].active { background: #6d28d9; border-color: #6d28d9; }
+  .cell .toolbar .cat-chip[data-cat="bug"].active        { background: #b91c1c; border-color: #b91c1c; }
+  .cell .toolbar .cat-chip[data-cat="tooling"].active    { background: #b45309; border-color: #b45309; }
+  .cell .toolbar .cat-chip[data-cat="intentional"].active{ background: #15803d; border-color: #15803d; }
+  .cell .toolbar .cat-chip[data-cat="unclear"].active    { background: #6b7280; border-color: #6b7280; }
+  .cell .toolbar .recapture-btn {
+    background: #1d4ed8; color: #fff; border: 0; border-radius: 3px;
+    padding: 4px 10px; font-size: 11px; cursor: pointer;
+    font-family: inherit; font-weight: 600;
+  }
+  .cell .toolbar .recapture-btn:hover { background: #1e40af; }
+  .cell .toolbar textarea { min-height: 32px; resize: vertical; font-size: 11px; }
+  .cell.cat-needs-design { border-color: #6d28d9; }
+  .cell.cat-bug         { border-color: #b91c1c; }
+  .cell.cat-tooling     { border-color: #b45309; }
+  .cell.cat-intentional { border-color: #15803d; }
+  .cell.cat-unclear     { border-color: #6b7280; }
+
+  .marks-cluster {
+    display: flex; align-items: center; gap: 8px;
+    border-left: 1px solid #444; padding-left: 12px; margin-left: 4px;
+    font-size: 12px;
+  }
+  .marks-cluster .count {
+    background: #dc2626; color: #fff; border-radius: 10px;
+    padding: 2px 8px; font-weight: 600; min-width: 18px; text-align: center;
+  }
+  .marks-cluster button {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .marks-cluster button:hover { background: #4b5563; }
+  .marks-cluster button.danger { background: #7f1d1d; border-color: #991b1b; }
+  .marks-cluster button.danger:hover { background: #991b1b; }
+
+  body.only-marked .component-row:not(.has-marked) { display: none; }
+  body.only-marked section.route:not(.has-marked) { display: none; }
+
+  .component-row.suppressed { display: none; }
+  body.show-suppressed .component-row.suppressed { display: grid; }
+  .component-row.suppressed .label::after { content: " (hidden)"; color: #b91c1c; font-style: italic; }
+
+  .component-row .label[data-mapped] { color: #1d4ed8; }
+  .component-row .label[data-mapped]::after { content: " *"; }
+  .mapped-tooltip {
+    display: inline-block; margin-left: 4px;
+    font-size: 10px; color: #6b7280; cursor: help; vertical-align: super;
+  }
+
+  .vp-badge, .state-badge {
+    display: inline-block; font-size: 9px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.05em;
+    padding: 1px 6px; border-radius: 8px; margin-top: 2px;
+  }
+  .vp-badge.desktop { background: #dbeafe; color: #1e3a8a; border: 1px solid #93c5fd; margin-right: 4px; }
+  .vp-badge.mobile  { background: #fef3c7; color: #78350f; border: 1px solid #fcd34d; margin-right: 4px; }
+  .state-badge.empty       { background: #f3f4f6; color: #374151; border: 1px solid #d1d5db; }
+  .state-badge.seeded      { background: #dcfce7; color: #14532d; border: 1px solid #86efac; }
+  .state-badge.mid-session { background: #ede9fe; color: #4c1d95; border: 1px solid #c4b5fd; }
+
+  .component-row.vp-mobile { background: #fffbeb; padding: 4px; border-radius: 4px; }
+  body.hide-desktop .component-row.vp-desktop { display: none; }
+  body.hide-mobile .component-row.vp-mobile { display: none; }
+
+  body.hide-state-empty       .component-row.state-empty       { display: none; }
+  body.hide-state-seeded      .component-row.state-seeded      { display: none; }
+  body.hide-state-mid-session .component-row.state-mid-session { display: none; }
+
+  .overlay {
+    display: none; position: fixed; inset: 0; z-index: 1100;
+    background: rgba(0,0,0,0.6); align-items: center; justify-content: center;
+  }
+  .overlay.open { display: flex; }
+  .overlay .panel {
+    background: #fff; border-radius: 6px; width: min(720px, 92vw);
+    max-height: 80vh; padding: 16px; display: flex; flex-direction: column; gap: 8px;
+  }
+  .overlay h3 { margin: 0; font-size: 14px; }
+  .overlay textarea {
+    flex: 1; min-height: 320px; font-family: ui-monospace, monospace; font-size: 12px;
+    border: 1px solid #ddd; border-radius: 4px; padding: 8px; resize: vertical;
+  }
+  .overlay .actions { display: flex; gap: 8px; justify-content: flex-end; }
+  .overlay button {
+    background: #1a1a1a; color: #fff; border: 0; border-radius: 3px;
+    padding: 6px 12px; font-size: 12px; cursor: pointer;
+  }
+  .overlay .hint { font-size: 11px; color: #555; }
+  .overlay .err  { font-size: 12px; color: #b91c1c; min-height: 16px; }
+
+  /* Index-page table */
+  table.routes-index {
+    width: 100%; border-collapse: collapse; background: #fff;
+    border-radius: 6px; overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  table.routes-index th, table.routes-index td {
+    padding: 8px 12px; text-align: left; font-size: 13px;
+    border-bottom: 1px solid #eee;
+  }
+  table.routes-index th { background: #f3f4f6; font-weight: 600; }
+  table.routes-index td a {
+    color: #1d4ed8; text-decoration: none; font-family: ui-monospace, monospace;
+  }
+  table.routes-index td a:hover { text-decoration: underline; }
+  table.routes-index td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  table.routes-index .marked-count.has-marks { color: #b91c1c; font-weight: 600; }
+  table.routes-index .unresolved-count.has-unresolved { color: #b45309; font-weight: 600; }
+  table.routes-index .breakdown {
+    font-size: 11px; color: #555; margin-left: 6px; font-variant-numeric: tabular-nums;
+  }
+
+
+</style>
+</head>
+<body>
+<div class="sticky-shell">
+<header class="top">
+  <a class="back" href="index.html">&larr; Index</a>
+  <h1>characters-edit</h1>
+  <div class="legend">
+    <span class="col develop">develop</span>
+    <span class="col ds3">DS3</span>
+    <span class="col ds1">DS1</span>
+    <span class="col ds2">DS2</span>
+  </div>
+  <div class="controls">
+    <span class="state-chips" role="group" aria-label="State filter">
+      <span style="font-size: 11px; color: #aaa;">State:</span>
+      <button type="button" class="state-chip" data-state="empty">empty</button>
+      <button type="button" class="state-chip active" data-state="seeded">seeded</button>
+    </span>
+    <label><input type="checkbox" id="hide-empty"> Hide missing</label>
+    <label><input type="checkbox" id="compact"> Compact</label>
+    <label title="Stretch images to cell width"><input type="checkbox" id="fit-cell"> Fit to cell</label>
+    <label><input type="checkbox" id="only-marked"> Only marked</label>
+    <label><input type="checkbox" id="show-suppressed"> Show hidden rows</label>
+    <label><input type="checkbox" id="hide-desktop"> Hide desktop</label>
+    <label><input type="checkbox" id="hide-mobile"> Hide mobile</label>
+  </div>
+  <div class="marks-cluster">
+    <span>Marked (route):</span>
+    <span class="count" id="mark-count">0</span>
+    <button id="prefill-ds-btn" type="button" title="Mark every DS cell that has no mark yet as needs-design (gap-fill, never overwrites your existing marks)">Fill DS gaps</button>
+    <button id="export-md-btn" type="button">Export markdown</button>
+    <button id="export-json-btn" type="button">Export JSON</button>
+    <button id="import-json-btn" type="button">Import JSON</button>
+    <button id="clear-route-btn" type="button" class="danger">Clear (route)</button>
+  </div>
+</header>
+<nav class="toc" style="background:#2a2a2a;color:#ccc;padding:6px 16px;font-size:12px;display:flex;gap:8px;align-items:center;border-top:1px solid #444;">
+  <span class="nav-routes">
+    <a href="characters-detail.html">&larr; characters-detail</a>
+    <span class="current">characters-edit</span>
+    <a href="characters-create.html">characters-create &rarr;</a>
+  </span>
+</nav>
+</div>
+<main>
+<section class="route" id="route-characters-edit">
+  <h2>characters-edit</h2>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters-edit__global-nav__desktop__empty__develop" data-route="characters-edit" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/characters-edit__nav.png" alt="develop characters-edit/global-nav/desktop/empty" data-caption="develop -- characters-edit/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-edit__global-nav__desktop__empty__DS3" data-route="characters-edit" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/characters-edit__nav.png" alt="DS3 characters-edit/global-nav/desktop/empty" data-caption="DS3 -- characters-edit/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-edit__global-nav__desktop__empty__DS1" data-route="characters-edit" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/characters-edit__nav.png" alt="DS1 characters-edit/global-nav/desktop/empty" data-caption="DS1 -- characters-edit/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-edit__global-nav__desktop__empty__DS2" data-route="characters-edit" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/characters-edit__nav.png" alt="DS2 characters-edit/global-nav/desktop/empty" data-caption="DS2 -- characters-edit/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters-edit__page__desktop__empty__develop" data-route="characters-edit" data-component="page" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/characters-edit__page.png" alt="develop characters-edit/page/desktop/empty" data-caption="develop -- characters-edit/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-edit__page__desktop__empty__DS3" data-route="characters-edit" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/characters-edit__page.png" alt="DS3 characters-edit/page/desktop/empty" data-caption="DS3 -- characters-edit/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-edit__page__desktop__empty__DS1" data-route="characters-edit" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/characters-edit__page.png" alt="DS1 characters-edit/page/desktop/empty" data-caption="DS1 -- characters-edit/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-edit__page__desktop__empty__DS2" data-route="characters-edit" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/characters-edit__page.png" alt="DS2 characters-edit/page/desktop/empty" data-caption="DS2 -- characters-edit/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-empty" data-viewport="mobile" data-state="empty">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters-edit__page__mobile__empty__develop" data-route="characters-edit" data-component="page" data-viewport="mobile" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/empty/characters-edit__page.png" alt="develop characters-edit/page/mobile/empty" data-caption="develop -- characters-edit/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-edit__page__mobile__empty__DS3" data-route="characters-edit" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/empty/characters-edit__page.png" alt="DS3 characters-edit/page/mobile/empty" data-caption="DS3 -- characters-edit/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-edit__page__mobile__empty__DS1" data-route="characters-edit" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/empty/characters-edit__page.png" alt="DS1 characters-edit/page/mobile/empty" data-caption="DS1 -- characters-edit/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-edit__page__mobile__empty__DS2" data-route="characters-edit" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/empty/characters-edit__page.png" alt="DS2 characters-edit/page/mobile/empty" data-caption="DS2 -- characters-edit/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters-edit__header__desktop__empty__develop" data-route="characters-edit" data-component="header" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/characters-edit__header.png" alt="develop characters-edit/header/desktop/empty" data-caption="develop -- characters-edit/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters-edit__nav__desktop__empty__develop" data-route="characters-edit" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/characters-edit__nav.png" alt="develop characters-edit/nav/desktop/empty" data-caption="develop -- characters-edit/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-edit__nav__desktop__empty__DS3" data-route="characters-edit" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/characters-edit__nav.png" alt="DS3 characters-edit/nav/desktop/empty" data-caption="DS3 -- characters-edit/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-edit__nav__desktop__empty__DS1" data-route="characters-edit" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/characters-edit__nav.png" alt="DS1 characters-edit/nav/desktop/empty" data-caption="DS1 -- characters-edit/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-edit__nav__desktop__empty__DS2" data-route="characters-edit" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/characters-edit__nav.png" alt="DS2 characters-edit/nav/desktop/empty" data-caption="DS2 -- characters-edit/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters-edit__main__desktop__empty__develop" data-route="characters-edit" data-component="main" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/characters-edit__main.png" alt="develop characters-edit/main/desktop/empty" data-caption="develop -- characters-edit/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-edit__main__desktop__empty__DS3" data-route="characters-edit" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/characters-edit__main.png" alt="DS3 characters-edit/main/desktop/empty" data-caption="DS3 -- characters-edit/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-edit__main__desktop__empty__DS1" data-route="characters-edit" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/characters-edit__main.png" alt="DS1 characters-edit/main/desktop/empty" data-caption="DS1 -- characters-edit/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-edit__main__desktop__empty__DS2" data-route="characters-edit" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/characters-edit__main.png" alt="DS2 characters-edit/main/desktop/empty" data-caption="DS2 -- characters-edit/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters-edit__global-nav__desktop__seeded__develop" data-route="characters-edit" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/characters-edit__nav.png" alt="develop characters-edit/global-nav/desktop/seeded" data-caption="develop -- characters-edit/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-edit__global-nav__desktop__seeded__DS3" data-route="characters-edit" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/characters-edit__nav.png" alt="DS3 characters-edit/global-nav/desktop/seeded" data-caption="DS3 -- characters-edit/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-edit__global-nav__desktop__seeded__DS1" data-route="characters-edit" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/characters-edit__nav.png" alt="DS1 characters-edit/global-nav/desktop/seeded" data-caption="DS1 -- characters-edit/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-edit__global-nav__desktop__seeded__DS2" data-route="characters-edit" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/characters-edit__nav.png" alt="DS2 characters-edit/global-nav/desktop/seeded" data-caption="DS2 -- characters-edit/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters-edit__page__desktop__seeded__develop" data-route="characters-edit" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/characters-edit__page.png" alt="develop characters-edit/page/desktop/seeded" data-caption="develop -- characters-edit/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-edit__page__desktop__seeded__DS3" data-route="characters-edit" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/characters-edit__page.png" alt="DS3 characters-edit/page/desktop/seeded" data-caption="DS3 -- characters-edit/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-edit__page__desktop__seeded__DS1" data-route="characters-edit" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/characters-edit__page.png" alt="DS1 characters-edit/page/desktop/seeded" data-caption="DS1 -- characters-edit/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-edit__page__desktop__seeded__DS2" data-route="characters-edit" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/characters-edit__page.png" alt="DS2 characters-edit/page/desktop/seeded" data-caption="DS2 -- characters-edit/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-seeded" data-viewport="mobile" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters-edit__page__mobile__seeded__develop" data-route="characters-edit" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/seeded/characters-edit__page.png" alt="develop characters-edit/page/mobile/seeded" data-caption="develop -- characters-edit/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-edit__page__mobile__seeded__DS3" data-route="characters-edit" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/seeded/characters-edit__page.png" alt="DS3 characters-edit/page/mobile/seeded" data-caption="DS3 -- characters-edit/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-edit__page__mobile__seeded__DS1" data-route="characters-edit" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/seeded/characters-edit__page.png" alt="DS1 characters-edit/page/mobile/seeded" data-caption="DS1 -- characters-edit/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-edit__page__mobile__seeded__DS2" data-route="characters-edit" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/seeded/characters-edit__page.png" alt="DS2 characters-edit/page/mobile/seeded" data-caption="DS2 -- characters-edit/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters-edit__header__desktop__seeded__develop" data-route="characters-edit" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/characters-edit__header.png" alt="develop characters-edit/header/desktop/seeded" data-caption="develop -- characters-edit/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-edit__header__desktop__seeded__DS3" data-route="characters-edit" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/characters-edit__header.png" alt="DS3 characters-edit/header/desktop/seeded" data-caption="DS3 -- characters-edit/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-edit__header__desktop__seeded__DS1" data-route="characters-edit" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/characters-edit__header.png" alt="DS1 characters-edit/header/desktop/seeded" data-caption="DS1 -- characters-edit/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-edit__header__desktop__seeded__DS2" data-route="characters-edit" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/characters-edit__header.png" alt="DS2 characters-edit/header/desktop/seeded" data-caption="DS2 -- characters-edit/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters-edit__nav__desktop__seeded__develop" data-route="characters-edit" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/characters-edit__nav.png" alt="develop characters-edit/nav/desktop/seeded" data-caption="develop -- characters-edit/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-edit__nav__desktop__seeded__DS3" data-route="characters-edit" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/characters-edit__nav.png" alt="DS3 characters-edit/nav/desktop/seeded" data-caption="DS3 -- characters-edit/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-edit__nav__desktop__seeded__DS1" data-route="characters-edit" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/characters-edit__nav.png" alt="DS1 characters-edit/nav/desktop/seeded" data-caption="DS1 -- characters-edit/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-edit__nav__desktop__seeded__DS2" data-route="characters-edit" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/characters-edit__nav.png" alt="DS2 characters-edit/nav/desktop/seeded" data-caption="DS2 -- characters-edit/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters-edit__main__desktop__seeded__develop" data-route="characters-edit" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/characters-edit__main.png" alt="develop characters-edit/main/desktop/seeded" data-caption="develop -- characters-edit/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters-edit__main__desktop__seeded__DS3" data-route="characters-edit" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/characters-edit__main.png" alt="DS3 characters-edit/main/desktop/seeded" data-caption="DS3 -- characters-edit/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters-edit__main__desktop__seeded__DS1" data-route="characters-edit" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/characters-edit__main.png" alt="DS1 characters-edit/main/desktop/seeded" data-caption="DS1 -- characters-edit/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters-edit__main__desktop__seeded__DS2" data-route="characters-edit" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/characters-edit__main.png" alt="DS2 characters-edit/main/desktop/seeded" data-caption="DS2 -- characters-edit/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+</main>
+
+<div id="lightbox" class="overlay">
+  <img id="lightbox-img" src="" alt="">
+  <div id="lightbox-caption" style="position: fixed; top: 12px; left: 50%; transform: translateX(-50%); color: #fff; font-family: ui-monospace, monospace; font-size: 13px; background: rgba(0,0,0,0.6); padding: 6px 12px; border-radius: 4px;"></div>
+</div>
+
+<div id="md-overlay" class="overlay">
+  <div class="panel">
+    <h3>Audit marks (markdown) -- this route only</h3>
+    <textarea id="md-text" readonly></textarea>
+    <div class="actions">
+      <button id="md-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="md-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-export-overlay" class="overlay">
+  <div class="panel">
+    <h3>Marks (raw JSON) -- all routes</h3>
+    <textarea id="json-export-text" readonly></textarea>
+    <div class="actions">
+      <button id="json-export-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="json-export-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-import-overlay" class="overlay">
+  <div class="panel">
+    <h3>Import marks (paste raw JSON)</h3>
+    <p class="hint">Paste JSON exported from another instance. Legacy IDs without a state segment are migrated to <code>__seeded</code>; v2 values are upgraded to v3 (category=null, why="", updatedAt=now). Existing marks with the same ID are overwritten.</p>
+    <textarea id="json-import-text" placeholder='{"home__page__desktop__seeded__DS3":{"marked":true,"note":"...","category":"bug","why":"...","updatedAt":"..."}}'></textarea>
+    <div class="err" id="json-import-err"></div>
+    <div class="actions">
+      <button id="json-import-apply" type="button">Apply</button>
+      <button class="overlay-close" data-overlay="json-import-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+<script>
+
+  const STORAGE_KEY = 'narraitor-audit-marks-v3';
+  const STORAGE_KEY_V2 = 'narraitor-audit-marks-v2';
+  const STORAGE_KEY_V1 = 'narraitor-audit-marks-v1';
+  // Tracks which routes have had their DS cells auto-prefilled as needs-design.
+  // Once a route is in here, the auto-prefill on page load is skipped.
+  const PREFILLED_KEY = 'narraitor-audit-prefilled-v1';
+  const STATES = ['empty', 'seeded'];
+  const VALID_CATEGORIES = ['needs-design','bug','tooling','intentional','unclear'];
+  const ROUTE_ORDER = ["home", "about", "worlds", "worlds-detail", "worlds-edit", "worlds-create", "worlds-play", "worlds-play-journal", "characters", "characters-detail", "characters-edit", "characters-create", "play", "settings"];
+  const COMPONENT_ORDER = {"page":0,"header":1,"nav":2,"form":3,"main":4};
+  const THEME_ORDER = ["DS3","DS1","DS2","develop"];
+  const BRANCH_META = {"develop": {"theme": "default", "mode": "light", "branchArg": "develop-default"}, "DS3": {"theme": "ds3", "mode": "light", "branchArg": "integration-ds3-light"}, "DS1": {"theme": "ds1", "mode": "light", "branchArg": "integration-ds1-light"}, "DS2": {"theme": "ds2", "mode": "light", "branchArg": "integration-ds2-light"}};
+
+  function componentSortKey(c) {
+    if (c in COMPONENT_ORDER) return [COMPONENT_ORDER[c], 0];
+    if (c.startsWith("main-section-")) {
+      const n = parseInt(c.replace("main-section-",""), 10);
+      return [5, isNaN(n) ? 0 : n];
+    }
+    return [9, c];
+  }
+
+  // Pre-v3 ID migration: v1 (4 segments) -> v2 (5 segments) by inserting __seeded.
+  function migrateLegacyId(id) {
+    const parts = id.split('__');
+    if (parts.length < 4) return id;
+    const last = parts[parts.length - 1];
+    const second = parts[parts.length - 2];
+    const third = parts[parts.length - 3];
+    const isTheme = ['DS1','DS2','DS3','develop'].includes(last);
+    const isViewport = ['desktop','mobile'].includes(second);
+    const alreadyHasState = STATES.includes(third);
+    if (isTheme && isViewport && !alreadyHasState) {
+      const head = parts.slice(0, parts.length - 1).join('__');
+      return head + '__seeded__' + last;
+    }
+    return id;
+  }
+
+  function migrateMarksV1ToV2(input) {
+    const out = {};
+    let migrated = 0;
+    for (const [id, m] of Object.entries(input || {})) {
+      const newId = migrateLegacyId(id);
+      if (newId !== id) migrated++;
+      out[newId] = m;
+    }
+    return { marks: out, migrated };
+  }
+
+  // v2 -> v3: add category, why, updatedAt; preserve marked + note.
+  function upgradeV2ValueToV3(v) {
+    if (!v || typeof v !== 'object') return null;
+    return {
+      marked: !!v.marked,
+      note: typeof v.note === 'string' ? v.note : '',
+      category: v.category && VALID_CATEGORIES.includes(v.category) ? v.category : null,
+      why: typeof v.why === 'string' ? v.why : '',
+      updatedAt: v.updatedAt || new Date().toISOString(),
+    };
+  }
+
+  function migrateV2ObjectToV3(v2obj) {
+    const out = {};
+    for (const [id, m] of Object.entries(v2obj || {})) {
+      out[id] = upgradeV2ValueToV3(m);
+    }
+    return out;
+  }
+
+  function loadMarks() {
+    try {
+      const v3 = localStorage.getItem(STORAGE_KEY);
+      if (v3) return JSON.parse(v3);
+      // No v3 yet — try v2 (lazy migrate; leave v2 untouched for rollback).
+      const v2raw = localStorage.getItem(STORAGE_KEY_V2);
+      if (v2raw) {
+        const v3marks = migrateV2ObjectToV3(JSON.parse(v2raw));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + Object.keys(v3marks).length + ' v2 marks to v3 (v2 untouched).');
+        return v3marks;
+      }
+      // No v3 or v2 — try v1 and migrate v1 -> v2 -> v3 in one pass.
+      const v1raw = localStorage.getItem(STORAGE_KEY_V1);
+      if (v1raw) {
+        const { marks: v2marks, migrated } = migrateMarksV1ToV2(JSON.parse(v1raw));
+        const v3marks = migrateV2ObjectToV3(v2marks);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + migrated + ' v1 IDs through to v3.');
+        return v3marks;
+      }
+    } catch (e) { console.warn(e); }
+    return {};
+  }
+
+  function saveMarks(m) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(m)); } catch (e) {}
+  }
+
+
+  const ROUTE = "characters-edit";
+  let marks = loadMarks();
+
+  function applyMarkState(cell) {
+    const id = cell.dataset.cellId;
+    const m = marks[id];
+    const noteInput = cell.querySelector('textarea[data-action="note"]');
+    const whyInput = cell.querySelector('input[data-action="why"]');
+    const chips = cell.querySelectorAll('.cat-chip');
+    cell.classList.remove('cat-bug','cat-tooling','cat-intentional','cat-unclear');
+    chips.forEach(c => c.classList.remove('active'));
+    if (m && m.marked) {
+      cell.classList.add('marked');
+      if (noteInput) noteInput.value = m.note || '';
+      if (whyInput) whyInput.value = m.why || '';
+      if (m.category) {
+        cell.classList.add('cat-' + m.category);
+        const chip = cell.querySelector('.cat-chip[data-cat="' + m.category + '"]');
+        if (chip) chip.classList.add('active');
+      }
+    } else {
+      cell.classList.remove('marked');
+      if (noteInput) noteInput.value = '';
+      if (whyInput) whyInput.value = '';
+    }
+  }
+
+  function updateRowSectionFlags() {
+    document.querySelectorAll('.component-row').forEach(row => {
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+    document.querySelectorAll('section.route').forEach(sec => {
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+    });
+  }
+
+  function updateCount() {
+    const n = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).length;
+    document.getElementById('mark-count').textContent = n;
+  }
+
+  function writeMark(id, partial) {
+    const existing = marks[id] || { marked: false, note: '', category: null, why: '', updatedAt: null };
+    const next = Object.assign({}, existing, partial, { updatedAt: new Date().toISOString() });
+    if (!next.marked && !next.note && !next.why && !next.category) {
+      delete marks[id];
+    } else {
+      marks[id] = next;
+    }
+    saveMarks(marks);
+    updateCount();
+  }
+
+  function buildRecaptureCommand(cell) {
+    const route = cell.dataset.route;
+    const viewport = cell.dataset.viewport;
+    const state = cell.dataset.state;
+    const themeKey = cell.dataset.theme;
+    const meta = BRANCH_META[themeKey];
+    if (!meta) return null;
+    return 'npx tsx scripts/audit/playwright-crawl.ts'
+      + ' --branch ' + meta.branchArg
+      + ' --viewport ' + viewport
+      + ' --state ' + state
+      + ' --theme ' + meta.theme
+      + ' --mode ' + meta.mode
+      + ' --route ' + route;
+  }
+
+  function loadPrefilledFlags() {
+    try { return JSON.parse(localStorage.getItem(PREFILLED_KEY) || '{}'); }
+    catch (e) { return {}; }
+  }
+  function savePrefilledFlags(f) {
+    try { localStorage.setItem(PREFILLED_KEY, JSON.stringify(f)); } catch (e) {}
+  }
+
+  // Gap-fill: only adds entries for DS cells that have no existing mark.
+  // Returns the count of cells filled. Develop is excluded (it's the baseline).
+  function prefillDsCellsAsNeedsDesign() {
+    const dsCells = Array.from(document.querySelectorAll('.cell[data-cell-id]'))
+      .filter(c => ['DS1','DS2','DS3'].includes(c.dataset.theme));
+    let added = 0;
+    const ts = new Date().toISOString();
+    for (const cell of dsCells) {
+      const id = cell.dataset.cellId;
+      if (!marks[id]) {
+        marks[id] = { marked: true, note: '', category: 'needs-design', why: '', updatedAt: ts };
+        added++;
+      }
+    }
+    if (added > 0) saveMarks(marks);
+    return added;
+  }
+
+  // Auto-prefill on first visit per route.
+  const prefillFlags = loadPrefilledFlags();
+  if (!prefillFlags[ROUTE]) {
+    const added = prefillDsCellsAsNeedsDesign();
+    prefillFlags[ROUTE] = true;
+    savePrefilledFlags(prefillFlags);
+    if (added > 0) console.info('[audit] auto-prefilled ' + added + ' DS cells for ' + ROUTE + ' as needs-design.');
+  }
+
+  document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+  updateRowSectionFlags();
+  updateCount();
+
+  // Lightbox
+  const lb = document.getElementById('lightbox');
+  const lbImg = document.getElementById('lightbox-img');
+  const lbCap = document.getElementById('lightbox-caption');
+  document.querySelectorAll('.cell img').forEach(img => {
+    img.addEventListener('click', () => {
+      lbImg.src = img.src;
+      lbCap.textContent = img.dataset.caption || '';
+      lb.classList.add('open');
+    });
+  });
+  lb.addEventListener('click', () => lb.classList.remove('open'));
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') document.querySelectorAll('.overlay.open').forEach(o => o.classList.remove('open'));
+  });
+
+  // Mark toggle
+  document.querySelectorAll('button[data-action="toggle-mark"]').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      const cell = btn.closest('.cell');
+      const id = cell.dataset.cellId;
+      const isMarked = !cell.classList.contains('marked');
+      writeMark(id, { marked: isMarked });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      const sec = cell.closest('section.route');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+      if (isMarked) {
+        const why = cell.querySelector('input[data-action="why"]');
+        if (why) setTimeout(() => why.focus(), 0);
+      }
+    });
+  });
+
+  // Why / note inputs (debounced save)
+  let saveTimer = null;
+  function bindInput(sel, field) {
+    document.querySelectorAll(sel).forEach(inp => {
+      const handler = () => {
+        const cell = inp.closest('.cell');
+        if (!cell.classList.contains('marked')) return;
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(() => {
+          writeMark(cell.dataset.cellId, { [field]: inp.value });
+        }, 250);
+      };
+      inp.addEventListener('input', handler);
+      inp.addEventListener('blur', () => {
+        const cell = inp.closest('.cell');
+        if (cell.classList.contains('marked')) writeMark(cell.dataset.cellId, { [field]: inp.value });
+      });
+    });
+  }
+  bindInput('input[data-action="why"]', 'why');
+  bindInput('textarea[data-action="note"]', 'note');
+
+  // Category chips
+  document.querySelectorAll('.cat-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const cell = chip.closest('.cell');
+      if (!cell.classList.contains('marked')) {
+        // Mark the cell first so the category sticks
+        writeMark(cell.dataset.cellId, { marked: true });
+      }
+      const cat = chip.dataset.cat;
+      const isActive = chip.classList.contains('active');
+      writeMark(cell.dataset.cellId, { category: isActive ? null : cat });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+  });
+
+  // Re-capture command (copy to clipboard, flash purple)
+  document.querySelectorAll('button[data-action="recapture"]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const cell = btn.closest('.cell');
+      const cmd = buildRecaptureCommand(cell);
+      if (!cmd) return;
+      try {
+        await navigator.clipboard.writeText(cmd);
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Copy re-capture command'; }, 1500);
+      } catch (e) {
+        prompt('Copy this command:', cmd);
+      }
+      cell.classList.remove('pending-recapture');
+      void cell.offsetWidth; // force reflow so the animation restarts
+      cell.classList.add('pending-recapture');
+    });
+  });
+
+  // Toggles
+  document.getElementById('hide-empty').addEventListener('change', e => document.body.classList.toggle('hide-empty', e.target.checked));
+  document.getElementById('compact').addEventListener('change', e => document.body.classList.toggle('compact', e.target.checked));
+  document.getElementById('fit-cell').addEventListener('change', e => document.body.classList.toggle('fit-cell', e.target.checked));
+  document.getElementById('only-marked').addEventListener('change', e => document.body.classList.toggle('only-marked', e.target.checked));
+  document.getElementById('show-suppressed').addEventListener('change', e => document.body.classList.toggle('show-suppressed', e.target.checked));
+  document.getElementById('hide-desktop').addEventListener('change', e => document.body.classList.toggle('hide-desktop', e.target.checked));
+  document.getElementById('hide-mobile').addEventListener('change', e => document.body.classList.toggle('hide-mobile', e.target.checked));
+
+  // True-scale rendering (1x for selector captures, 0.5x for retina full-page).
+  const RETINA_THRESHOLD = 1500;
+  function applyTrueScale(img) {
+    if (!img.naturalWidth) return;
+    const cssWidth = img.naturalWidth > RETINA_THRESHOLD
+      ? Math.round(img.naturalWidth / 2)
+      : img.naturalWidth;
+    img.style.maxWidth = 'min(100%, ' + cssWidth + 'px)';
+  }
+  document.querySelectorAll('.cell img').forEach(img => {
+    if (img.complete && img.naturalWidth > 0) applyTrueScale(img);
+    else img.addEventListener('load', () => applyTrueScale(img), { once: true });
+  });
+
+  // State chips
+  document.querySelectorAll('.state-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const state = chip.dataset.state;
+      chip.classList.toggle('active');
+      document.body.classList.toggle('hide-state-' + state, !chip.classList.contains('active'));
+    });
+  });
+  STATES.forEach(s => {
+    const chip = document.querySelector('.state-chip[data-state="' + s + '"]');
+    if (chip && !chip.classList.contains('active')) document.body.classList.add('hide-state-' + s);
+  });
+
+  // Manual top-up: fill any DS cells that don't have a mark yet
+  document.getElementById('prefill-ds-btn').addEventListener('click', () => {
+    const added = prefillDsCellsAsNeedsDesign();
+    if (added > 0) {
+      document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+      updateRowSectionFlags();
+      updateCount();
+      alert('Filled ' + added + ' missing DS cells as needs-design.');
+    } else {
+      alert('All DS cells in this route already have marks.');
+    }
+  });
+
+  // Clear-route. Also resets the prefilled flag so a reload re-triggers auto-prefill.
+  document.getElementById('clear-route-btn').addEventListener('click', () => {
+    const ids = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).map(([id]) => id);
+    if (!ids.length) { alert('No marks for this route.'); return; }
+    if (!confirm('Clear ' + ids.length + ' marks for route ' + ROUTE + '?\n\nReloading the page will re-prefill all DS cells as needs-design.')) return;
+    ids.forEach(id => delete marks[id]);
+    saveMarks(marks);
+    const flags = loadPrefilledFlags();
+    delete flags[ROUTE];
+    savePrefilledFlags(flags);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+  });
+
+  function buildMarkdown() {
+    const items = [];
+    Object.entries(marks).forEach(([id, m]) => {
+      if (!m || !m.marked) return;
+      if (!id.startsWith(ROUTE + '__')) return;
+      const parts = id.split('__');
+      const themeKey = parts[parts.length - 1];
+      const state = parts[parts.length - 2];
+      const viewport = parts[parts.length - 3];
+      const route = parts[0];
+      const component = parts.slice(1, parts.length - 3).join('__');
+      items.push({ component, viewport, state, theme: themeKey,
+                   note: m.note || '', why: m.why || '', category: m.category || '' });
+    });
+    items.sort((a, b) => {
+      const ak = componentSortKey(a.component);
+      const bk = componentSortKey(b.component);
+      if (ak[0] !== bk[0]) return ak[0] - bk[0];
+      if (ak[1] !== bk[1]) return ak[1] < bk[1] ? -1 : 1;
+      const sd = STATES.indexOf(a.state) - STATES.indexOf(b.state);
+      if (sd !== 0) return sd;
+      const td = THEME_ORDER.indexOf(a.theme) - THEME_ORDER.indexOf(b.theme);
+      if (td !== 0) return td;
+      return a.viewport === b.viewport ? 0 : (a.viewport === 'desktop' ? -1 : 1);
+    });
+    const date = new Date().toISOString().split('T')[0];
+    const lines = ['# Audit marks -- ' + ROUTE + ' -- ' + items.length + ' items -- ' + date, ''];
+    items.forEach(it => {
+      const catTag = it.category ? ' [' + it.category + ']' : '';
+      const whyTxt = it.why ? ': ' + it.why : '';
+      const noteTxt = it.note ? '  -- ' + it.note : '';
+      lines.push('- [ ] **' + it.theme + ' ' + it.component + '** [' + it.viewport + '/' + it.state + ']' + catTag + whyTxt + noteTxt);
+    });
+    return lines.join('\n');
+  }
+
+  function openOverlay(id) { document.getElementById(id).classList.add('open'); }
+  function closeOverlay(id) { document.getElementById(id).classList.remove('open'); }
+  document.querySelectorAll('.overlay-close').forEach(b => b.addEventListener('click', () => closeOverlay(b.dataset.overlay)));
+  document.querySelectorAll('.overlay').forEach(o => {
+    o.addEventListener('click', e => { if (e.target === o) o.classList.remove('open'); });
+  });
+
+  document.getElementById('export-md-btn').addEventListener('click', async () => {
+    const md = buildMarkdown();
+    const ta = document.getElementById('md-text');
+    ta.value = md;
+    openOverlay('md-overlay');
+    try { await navigator.clipboard.writeText(md); document.getElementById('md-copy').textContent = 'Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+  document.getElementById('md-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('md-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('md-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('export-json-btn').addEventListener('click', () => {
+    const ta = document.getElementById('json-export-text');
+    ta.value = JSON.stringify(marks, null, 2);
+    openOverlay('json-export-overlay');
+  });
+  document.getElementById('json-export-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('json-export-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('json-export-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('json-export-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('import-json-btn').addEventListener('click', () => {
+    document.getElementById('json-import-text').value = '';
+    document.getElementById('json-import-err').textContent = '';
+    openOverlay('json-import-overlay');
+  });
+  document.getElementById('json-import-apply').addEventListener('click', () => {
+    const ta = document.getElementById('json-import-text');
+    const err = document.getElementById('json-import-err');
+    err.textContent = '';
+    let parsed;
+    try { parsed = JSON.parse(ta.value); }
+    catch (e) { err.textContent = 'Invalid JSON: ' + e.message; return; }
+    if (!parsed || typeof parsed !== 'object') { err.textContent = 'Expected an object.'; return; }
+    // First migrate v1 IDs (4 segments) -> v2 IDs (5 segments)
+    const { marks: idMigrated, migrated } = migrateMarksV1ToV2(parsed);
+    // Then upgrade each value v2 -> v3 (preserves marked + note, fills new fields)
+    Object.entries(idMigrated).forEach(([id, m]) => {
+      marks[id] = upgradeV2ValueToV3(m);
+    });
+    saveMarks(marks);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+    closeOverlay('json-import-overlay');
+    alert('Imported ' + Object.keys(idMigrated).length + ' marks (' + migrated + ' legacy IDs migrated to __seeded; values upgraded to v3).');
+  });
+</script>
+</body>
+</html>

--- a/scripts/audit/review/characters.html
+++ b/scripts/audit/review/characters.html
@@ -1,0 +1,2065 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Cross-Theme Audit (#1129) — characters</title>
+<style>
+
+  :root { --col-gap: 8px; --row-gap: 16px; }
+  html, body { margin: 0; padding: 0; font-family: -apple-system, system-ui, sans-serif; background: #fafafa; color: #222; }
+  .sticky-shell { position: sticky; top: 0; z-index: 100; border-bottom: 1px solid #444; }
+  header.top {
+    background: #1a1a1a; color: #fff; padding: 12px 16px;
+    display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+  }
+  header.top h1 { font-size: 14px; margin: 0; font-weight: 600; }
+  header.top .legend { display: flex; gap: 12px; font-size: 12px; }
+  header.top .legend .col { padding: 2px 8px; border-radius: 3px; }
+  header.top .legend .develop { background: #6b7280; }
+  header.top .legend .ds3 { background: #4338ca; }
+  header.top .legend .ds1 { background: #92400e; }
+  header.top .legend .ds2 { background: #166534; }
+  header.top a.back { color: #9cf; font-size: 12px; text-decoration: none; padding: 2px 6px; border-radius: 2px; }
+  header.top a.back:hover { background: #444; color: #fff; }
+  header.top .nav-routes { display: flex; gap: 4px; align-items: center; font-size: 12px; }
+  header.top .nav-routes a { color: #9cf; text-decoration: none; padding: 2px 8px; border-radius: 2px; background: #2a2a2a; }
+  header.top .nav-routes a:hover { background: #444; color: #fff; }
+  header.top .nav-routes .current { color: #fff; font-weight: 600; padding: 2px 8px; }
+  main { padding: 16px; max-width: 100%; }
+  section.route {
+    margin-bottom: 32px; background: #fff; border-radius: 6px;
+    padding: 12px 16px 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  section.route h2 {
+    font-size: 18px; margin: 0 0 12px; padding-bottom: 6px;
+    border-bottom: 1px solid #e5e5e5;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+  .component-row {
+    display: grid; grid-template-columns: 180px repeat(4, 1fr);
+    gap: var(--col-gap); margin-bottom: var(--row-gap);
+    align-items: start;
+  }
+  .component-row .label {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px; color: #555; padding-top: 28px; line-height: 1.3;
+    word-break: break-word;
+  }
+  .cell {
+    border: 1px solid #e5e5e5; border-radius: 4px; overflow: hidden;
+    background: #f3f4f6; position: relative; min-height: 100px;
+    display: flex; flex-direction: column;
+  }
+  .cell .header {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.04em; padding: 4px 8px; color: #fff;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .cell.develop .header { background: #6b7280; }
+  .cell.ds3 .header { background: #4338ca; }
+  .cell.ds1 .header { background: #92400e; }
+  .cell.ds2 .header { background: #166534; }
+  .cell img {
+    display: block; width: auto; max-width: 100%; height: auto;
+    cursor: zoom-in; background: #fff; align-self: flex-start;
+  }
+  body.fit-cell .cell img { width: 100%; max-width: 100%; }
+  .cell.empty {
+    display: flex; align-items: center; justify-content: center;
+    color: #999; font-size: 12px; padding: 24px; background: #f9f9f9;
+  }
+  .cell.empty::after { content: "(not captured)"; }
+
+  /* Lightbox */
+  #lightbox {
+    display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.92);
+    z-index: 1000; align-items: center; justify-content: center; cursor: zoom-out;
+  }
+  #lightbox.open { display: flex; }
+  #lightbox img { max-width: 96vw; max-height: 96vh; box-shadow: 0 4px 24px rgba(0,0,0,0.5); }
+
+  .controls { display: flex; gap: 12px; align-items: center; font-size: 12px; flex-wrap: wrap; }
+  .controls label { display: flex; align-items: center; gap: 4px; cursor: pointer; }
+  .controls input[type=checkbox] { margin: 0; }
+
+  .state-chips { display: inline-flex; gap: 4px; align-items: center; }
+  .state-chip {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .state-chip.active { background: #2563eb; border-color: #1d4ed8; }
+  .state-chip:hover { background: #4b5563; }
+  .state-chip.active:hover { background: #1d4ed8; }
+
+  body.hide-empty .component-row.all-empty,
+  body.hide-empty .cell.empty { display: none; }
+  body.compact .cell img { max-height: 360px; object-fit: cover; object-position: top; }
+
+  .cell .mark-btn {
+    margin-left: auto; background: rgba(255,255,255,0.18);
+    color: #fff; border: 1px solid rgba(255,255,255,0.35);
+    border-radius: 3px; font-size: 10px; font-weight: 600;
+    padding: 2px 6px; cursor: pointer;
+    text-transform: none; letter-spacing: 0; line-height: 1.2;
+  }
+  .cell .mark-btn:hover { background: rgba(255,255,255,0.28); }
+  .cell.marked { border: 3px solid #dc2626; }
+  .cell.marked .mark-btn { background: #dc2626; border-color: #b91c1c; color: #fff; }
+  .cell.marked .mark-btn::before { content: "x "; }
+  .cell.pending-recapture { animation: cellPulse 2s ease-out; }
+  @keyframes cellPulse {
+    0%   { box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.9); border-color: #7c3aed; }
+    100% { box-shadow: 0 0 0 8px rgba(124, 58, 237, 0); }
+  }
+  .cell .toolbar {
+    display: none;
+    padding: 6px 8px; background: #fef2f2; border-top: 1px solid #fecaca;
+    font-size: 11px;
+  }
+  .cell.marked .toolbar { display: block; }
+  .cell .toolbar input[type=text],
+  .cell .toolbar textarea {
+    width: 100%; box-sizing: border-box;
+    border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 4px 6px; font-size: 12px; font-family: inherit;
+    background: #fff;
+  }
+  .cell .toolbar input[type=text]:focus,
+  .cell .toolbar textarea:focus { outline: 2px solid #dc2626; outline-offset: -1px; }
+  .cell .toolbar .field { margin-bottom: 6px; }
+  .cell .toolbar .field-label {
+    display: block; font-size: 10px; font-weight: 600;
+    color: #7f1d1d; text-transform: uppercase; letter-spacing: 0.04em;
+    margin-bottom: 2px;
+  }
+  .cell .toolbar .cat-chips { display: flex; gap: 4px; flex-wrap: wrap; }
+  .cell .toolbar .cat-chip {
+    background: #fff; border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 2px 8px; font-size: 11px; cursor: pointer; font-family: inherit;
+    color: #7f1d1d;
+  }
+  .cell .toolbar .cat-chip.active { background: #7f1d1d; color: #fff; border-color: #7f1d1d; }
+  .cell .toolbar .cat-chip[data-cat="needs-design"].active { background: #6d28d9; border-color: #6d28d9; }
+  .cell .toolbar .cat-chip[data-cat="bug"].active        { background: #b91c1c; border-color: #b91c1c; }
+  .cell .toolbar .cat-chip[data-cat="tooling"].active    { background: #b45309; border-color: #b45309; }
+  .cell .toolbar .cat-chip[data-cat="intentional"].active{ background: #15803d; border-color: #15803d; }
+  .cell .toolbar .cat-chip[data-cat="unclear"].active    { background: #6b7280; border-color: #6b7280; }
+  .cell .toolbar .recapture-btn {
+    background: #1d4ed8; color: #fff; border: 0; border-radius: 3px;
+    padding: 4px 10px; font-size: 11px; cursor: pointer;
+    font-family: inherit; font-weight: 600;
+  }
+  .cell .toolbar .recapture-btn:hover { background: #1e40af; }
+  .cell .toolbar textarea { min-height: 32px; resize: vertical; font-size: 11px; }
+  .cell.cat-needs-design { border-color: #6d28d9; }
+  .cell.cat-bug         { border-color: #b91c1c; }
+  .cell.cat-tooling     { border-color: #b45309; }
+  .cell.cat-intentional { border-color: #15803d; }
+  .cell.cat-unclear     { border-color: #6b7280; }
+
+  .marks-cluster {
+    display: flex; align-items: center; gap: 8px;
+    border-left: 1px solid #444; padding-left: 12px; margin-left: 4px;
+    font-size: 12px;
+  }
+  .marks-cluster .count {
+    background: #dc2626; color: #fff; border-radius: 10px;
+    padding: 2px 8px; font-weight: 600; min-width: 18px; text-align: center;
+  }
+  .marks-cluster button {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .marks-cluster button:hover { background: #4b5563; }
+  .marks-cluster button.danger { background: #7f1d1d; border-color: #991b1b; }
+  .marks-cluster button.danger:hover { background: #991b1b; }
+
+  body.only-marked .component-row:not(.has-marked) { display: none; }
+  body.only-marked section.route:not(.has-marked) { display: none; }
+
+  .component-row.suppressed { display: none; }
+  body.show-suppressed .component-row.suppressed { display: grid; }
+  .component-row.suppressed .label::after { content: " (hidden)"; color: #b91c1c; font-style: italic; }
+
+  .component-row .label[data-mapped] { color: #1d4ed8; }
+  .component-row .label[data-mapped]::after { content: " *"; }
+  .mapped-tooltip {
+    display: inline-block; margin-left: 4px;
+    font-size: 10px; color: #6b7280; cursor: help; vertical-align: super;
+  }
+
+  .vp-badge, .state-badge {
+    display: inline-block; font-size: 9px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.05em;
+    padding: 1px 6px; border-radius: 8px; margin-top: 2px;
+  }
+  .vp-badge.desktop { background: #dbeafe; color: #1e3a8a; border: 1px solid #93c5fd; margin-right: 4px; }
+  .vp-badge.mobile  { background: #fef3c7; color: #78350f; border: 1px solid #fcd34d; margin-right: 4px; }
+  .state-badge.empty       { background: #f3f4f6; color: #374151; border: 1px solid #d1d5db; }
+  .state-badge.seeded      { background: #dcfce7; color: #14532d; border: 1px solid #86efac; }
+  .state-badge.mid-session { background: #ede9fe; color: #4c1d95; border: 1px solid #c4b5fd; }
+
+  .component-row.vp-mobile { background: #fffbeb; padding: 4px; border-radius: 4px; }
+  body.hide-desktop .component-row.vp-desktop { display: none; }
+  body.hide-mobile .component-row.vp-mobile { display: none; }
+
+  body.hide-state-empty       .component-row.state-empty       { display: none; }
+  body.hide-state-seeded      .component-row.state-seeded      { display: none; }
+  body.hide-state-mid-session .component-row.state-mid-session { display: none; }
+
+  .overlay {
+    display: none; position: fixed; inset: 0; z-index: 1100;
+    background: rgba(0,0,0,0.6); align-items: center; justify-content: center;
+  }
+  .overlay.open { display: flex; }
+  .overlay .panel {
+    background: #fff; border-radius: 6px; width: min(720px, 92vw);
+    max-height: 80vh; padding: 16px; display: flex; flex-direction: column; gap: 8px;
+  }
+  .overlay h3 { margin: 0; font-size: 14px; }
+  .overlay textarea {
+    flex: 1; min-height: 320px; font-family: ui-monospace, monospace; font-size: 12px;
+    border: 1px solid #ddd; border-radius: 4px; padding: 8px; resize: vertical;
+  }
+  .overlay .actions { display: flex; gap: 8px; justify-content: flex-end; }
+  .overlay button {
+    background: #1a1a1a; color: #fff; border: 0; border-radius: 3px;
+    padding: 6px 12px; font-size: 12px; cursor: pointer;
+  }
+  .overlay .hint { font-size: 11px; color: #555; }
+  .overlay .err  { font-size: 12px; color: #b91c1c; min-height: 16px; }
+
+  /* Index-page table */
+  table.routes-index {
+    width: 100%; border-collapse: collapse; background: #fff;
+    border-radius: 6px; overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  table.routes-index th, table.routes-index td {
+    padding: 8px 12px; text-align: left; font-size: 13px;
+    border-bottom: 1px solid #eee;
+  }
+  table.routes-index th { background: #f3f4f6; font-weight: 600; }
+  table.routes-index td a {
+    color: #1d4ed8; text-decoration: none; font-family: ui-monospace, monospace;
+  }
+  table.routes-index td a:hover { text-decoration: underline; }
+  table.routes-index td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  table.routes-index .marked-count.has-marks { color: #b91c1c; font-weight: 600; }
+  table.routes-index .unresolved-count.has-unresolved { color: #b45309; font-weight: 600; }
+  table.routes-index .breakdown {
+    font-size: 11px; color: #555; margin-left: 6px; font-variant-numeric: tabular-nums;
+  }
+
+
+</style>
+</head>
+<body>
+<div class="sticky-shell">
+<header class="top">
+  <a class="back" href="index.html">&larr; Index</a>
+  <h1>characters</h1>
+  <div class="legend">
+    <span class="col develop">develop</span>
+    <span class="col ds3">DS3</span>
+    <span class="col ds1">DS1</span>
+    <span class="col ds2">DS2</span>
+  </div>
+  <div class="controls">
+    <span class="state-chips" role="group" aria-label="State filter">
+      <span style="font-size: 11px; color: #aaa;">State:</span>
+      <button type="button" class="state-chip" data-state="empty">empty</button>
+      <button type="button" class="state-chip active" data-state="seeded">seeded</button>
+    </span>
+    <label><input type="checkbox" id="hide-empty"> Hide missing</label>
+    <label><input type="checkbox" id="compact"> Compact</label>
+    <label title="Stretch images to cell width"><input type="checkbox" id="fit-cell"> Fit to cell</label>
+    <label><input type="checkbox" id="only-marked"> Only marked</label>
+    <label><input type="checkbox" id="show-suppressed"> Show hidden rows</label>
+    <label><input type="checkbox" id="hide-desktop"> Hide desktop</label>
+    <label><input type="checkbox" id="hide-mobile"> Hide mobile</label>
+  </div>
+  <div class="marks-cluster">
+    <span>Marked (route):</span>
+    <span class="count" id="mark-count">0</span>
+    <button id="prefill-ds-btn" type="button" title="Mark every DS cell that has no mark yet as needs-design (gap-fill, never overwrites your existing marks)">Fill DS gaps</button>
+    <button id="export-md-btn" type="button">Export markdown</button>
+    <button id="export-json-btn" type="button">Export JSON</button>
+    <button id="import-json-btn" type="button">Import JSON</button>
+    <button id="clear-route-btn" type="button" class="danger">Clear (route)</button>
+  </div>
+</header>
+<nav class="toc" style="background:#2a2a2a;color:#ccc;padding:6px 16px;font-size:12px;display:flex;gap:8px;align-items:center;border-top:1px solid #444;">
+  <span class="nav-routes">
+    <a href="worlds-play-journal.html">&larr; worlds-play-journal</a>
+    <span class="current">characters</span>
+    <a href="characters-detail.html">characters-detail &rarr;</a>
+  </span>
+</nav>
+</div>
+<main>
+<section class="route" id="route-characters">
+  <h2>characters</h2>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters__global-nav__desktop__empty__develop" data-route="characters" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/characters__nav.png" alt="develop characters/global-nav/desktop/empty" data-caption="develop -- characters/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters__global-nav__desktop__empty__DS3" data-route="characters" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/characters__nav.png" alt="DS3 characters/global-nav/desktop/empty" data-caption="DS3 -- characters/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters__global-nav__desktop__empty__DS1" data-route="characters" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/characters__nav.png" alt="DS1 characters/global-nav/desktop/empty" data-caption="DS1 -- characters/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters__global-nav__desktop__empty__DS2" data-route="characters" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/characters__nav.png" alt="DS2 characters/global-nav/desktop/empty" data-caption="DS2 -- characters/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters__page__desktop__empty__develop" data-route="characters" data-component="page" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/characters__page.png" alt="develop characters/page/desktop/empty" data-caption="develop -- characters/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters__page__desktop__empty__DS3" data-route="characters" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/characters__page.png" alt="DS3 characters/page/desktop/empty" data-caption="DS3 -- characters/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters__page__desktop__empty__DS1" data-route="characters" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/characters__page.png" alt="DS1 characters/page/desktop/empty" data-caption="DS1 -- characters/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters__page__desktop__empty__DS2" data-route="characters" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/characters__page.png" alt="DS2 characters/page/desktop/empty" data-caption="DS2 -- characters/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-empty" data-viewport="mobile" data-state="empty">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters__page__mobile__empty__develop" data-route="characters" data-component="page" data-viewport="mobile" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/empty/characters__page.png" alt="develop characters/page/mobile/empty" data-caption="develop -- characters/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters__page__mobile__empty__DS3" data-route="characters" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/empty/characters__page.png" alt="DS3 characters/page/mobile/empty" data-caption="DS3 -- characters/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters__page__mobile__empty__DS1" data-route="characters" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/empty/characters__page.png" alt="DS1 characters/page/mobile/empty" data-caption="DS1 -- characters/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters__page__mobile__empty__DS2" data-route="characters" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/empty/characters__page.png" alt="DS2 characters/page/mobile/empty" data-caption="DS2 -- characters/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters__header__desktop__empty__develop" data-route="characters" data-component="header" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/characters__header.png" alt="develop characters/header/desktop/empty" data-caption="develop -- characters/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters__nav__desktop__empty__develop" data-route="characters" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/characters__nav.png" alt="develop characters/nav/desktop/empty" data-caption="develop -- characters/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters__nav__desktop__empty__DS3" data-route="characters" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/characters__nav.png" alt="DS3 characters/nav/desktop/empty" data-caption="DS3 -- characters/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters__nav__desktop__empty__DS1" data-route="characters" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/characters__nav.png" alt="DS1 characters/nav/desktop/empty" data-caption="DS1 -- characters/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters__nav__desktop__empty__DS2" data-route="characters" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/characters__nav.png" alt="DS2 characters/nav/desktop/empty" data-caption="DS2 -- characters/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="characters__main__desktop__empty__develop" data-route="characters" data-component="main" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/characters__main.png" alt="develop characters/main/desktop/empty" data-caption="develop -- characters/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters__main__desktop__empty__DS3" data-route="characters" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/characters__main.png" alt="DS3 characters/main/desktop/empty" data-caption="DS3 -- characters/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters__main__desktop__empty__DS1" data-route="characters" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/characters__main.png" alt="DS1 characters/main/desktop/empty" data-caption="DS1 -- characters/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters__main__desktop__empty__DS2" data-route="characters" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/characters__main.png" alt="DS2 characters/main/desktop/empty" data-caption="DS2 -- characters/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters__global-nav__desktop__seeded__develop" data-route="characters" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/characters__nav.png" alt="develop characters/global-nav/desktop/seeded" data-caption="develop -- characters/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters__global-nav__desktop__seeded__DS3" data-route="characters" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/characters__nav.png" alt="DS3 characters/global-nav/desktop/seeded" data-caption="DS3 -- characters/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters__global-nav__desktop__seeded__DS1" data-route="characters" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/characters__nav.png" alt="DS1 characters/global-nav/desktop/seeded" data-caption="DS1 -- characters/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters__global-nav__desktop__seeded__DS2" data-route="characters" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/characters__nav.png" alt="DS2 characters/global-nav/desktop/seeded" data-caption="DS2 -- characters/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters__page__desktop__seeded__develop" data-route="characters" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/characters__page.png" alt="develop characters/page/desktop/seeded" data-caption="develop -- characters/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters__page__desktop__seeded__DS3" data-route="characters" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/characters__page.png" alt="DS3 characters/page/desktop/seeded" data-caption="DS3 -- characters/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters__page__desktop__seeded__DS1" data-route="characters" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/characters__page.png" alt="DS1 characters/page/desktop/seeded" data-caption="DS1 -- characters/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters__page__desktop__seeded__DS2" data-route="characters" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/characters__page.png" alt="DS2 characters/page/desktop/seeded" data-caption="DS2 -- characters/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-seeded" data-viewport="mobile" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters__page__mobile__seeded__develop" data-route="characters" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/seeded/characters__page.png" alt="develop characters/page/mobile/seeded" data-caption="develop -- characters/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters__page__mobile__seeded__DS3" data-route="characters" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/seeded/characters__page.png" alt="DS3 characters/page/mobile/seeded" data-caption="DS3 -- characters/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters__page__mobile__seeded__DS1" data-route="characters" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/seeded/characters__page.png" alt="DS1 characters/page/mobile/seeded" data-caption="DS1 -- characters/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters__page__mobile__seeded__DS2" data-route="characters" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/seeded/characters__page.png" alt="DS2 characters/page/mobile/seeded" data-caption="DS2 -- characters/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters__header__desktop__seeded__develop" data-route="characters" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/characters__header.png" alt="develop characters/header/desktop/seeded" data-caption="develop -- characters/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters__header__desktop__seeded__DS3" data-route="characters" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/characters__header.png" alt="DS3 characters/header/desktop/seeded" data-caption="DS3 -- characters/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters__header__desktop__seeded__DS1" data-route="characters" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/characters__header.png" alt="DS1 characters/header/desktop/seeded" data-caption="DS1 -- characters/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters__header__desktop__seeded__DS2" data-route="characters" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/characters__header.png" alt="DS2 characters/header/desktop/seeded" data-caption="DS2 -- characters/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters__nav__desktop__seeded__develop" data-route="characters" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/characters__nav.png" alt="develop characters/nav/desktop/seeded" data-caption="develop -- characters/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters__nav__desktop__seeded__DS3" data-route="characters" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/characters__nav.png" alt="DS3 characters/nav/desktop/seeded" data-caption="DS3 -- characters/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters__nav__desktop__seeded__DS1" data-route="characters" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/characters__nav.png" alt="DS1 characters/nav/desktop/seeded" data-caption="DS1 -- characters/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters__nav__desktop__seeded__DS2" data-route="characters" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/characters__nav.png" alt="DS2 characters/nav/desktop/seeded" data-caption="DS2 -- characters/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="characters__main__desktop__seeded__develop" data-route="characters" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/characters__main.png" alt="develop characters/main/desktop/seeded" data-caption="develop -- characters/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="characters__main__desktop__seeded__DS3" data-route="characters" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/characters__main.png" alt="DS3 characters/main/desktop/seeded" data-caption="DS3 -- characters/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="characters__main__desktop__seeded__DS1" data-route="characters" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/characters__main.png" alt="DS1 characters/main/desktop/seeded" data-caption="DS1 -- characters/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="characters__main__desktop__seeded__DS2" data-route="characters" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/characters__main.png" alt="DS2 characters/main/desktop/seeded" data-caption="DS2 -- characters/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+</main>
+
+<div id="lightbox" class="overlay">
+  <img id="lightbox-img" src="" alt="">
+  <div id="lightbox-caption" style="position: fixed; top: 12px; left: 50%; transform: translateX(-50%); color: #fff; font-family: ui-monospace, monospace; font-size: 13px; background: rgba(0,0,0,0.6); padding: 6px 12px; border-radius: 4px;"></div>
+</div>
+
+<div id="md-overlay" class="overlay">
+  <div class="panel">
+    <h3>Audit marks (markdown) -- this route only</h3>
+    <textarea id="md-text" readonly></textarea>
+    <div class="actions">
+      <button id="md-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="md-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-export-overlay" class="overlay">
+  <div class="panel">
+    <h3>Marks (raw JSON) -- all routes</h3>
+    <textarea id="json-export-text" readonly></textarea>
+    <div class="actions">
+      <button id="json-export-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="json-export-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-import-overlay" class="overlay">
+  <div class="panel">
+    <h3>Import marks (paste raw JSON)</h3>
+    <p class="hint">Paste JSON exported from another instance. Legacy IDs without a state segment are migrated to <code>__seeded</code>; v2 values are upgraded to v3 (category=null, why="", updatedAt=now). Existing marks with the same ID are overwritten.</p>
+    <textarea id="json-import-text" placeholder='{"home__page__desktop__seeded__DS3":{"marked":true,"note":"...","category":"bug","why":"...","updatedAt":"..."}}'></textarea>
+    <div class="err" id="json-import-err"></div>
+    <div class="actions">
+      <button id="json-import-apply" type="button">Apply</button>
+      <button class="overlay-close" data-overlay="json-import-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+<script>
+
+  const STORAGE_KEY = 'narraitor-audit-marks-v3';
+  const STORAGE_KEY_V2 = 'narraitor-audit-marks-v2';
+  const STORAGE_KEY_V1 = 'narraitor-audit-marks-v1';
+  // Tracks which routes have had their DS cells auto-prefilled as needs-design.
+  // Once a route is in here, the auto-prefill on page load is skipped.
+  const PREFILLED_KEY = 'narraitor-audit-prefilled-v1';
+  const STATES = ['empty', 'seeded'];
+  const VALID_CATEGORIES = ['needs-design','bug','tooling','intentional','unclear'];
+  const ROUTE_ORDER = ["home", "about", "worlds", "worlds-detail", "worlds-edit", "worlds-create", "worlds-play", "worlds-play-journal", "characters", "characters-detail", "characters-edit", "characters-create", "play", "settings"];
+  const COMPONENT_ORDER = {"page":0,"header":1,"nav":2,"form":3,"main":4};
+  const THEME_ORDER = ["DS3","DS1","DS2","develop"];
+  const BRANCH_META = {"develop": {"theme": "default", "mode": "light", "branchArg": "develop-default"}, "DS3": {"theme": "ds3", "mode": "light", "branchArg": "integration-ds3-light"}, "DS1": {"theme": "ds1", "mode": "light", "branchArg": "integration-ds1-light"}, "DS2": {"theme": "ds2", "mode": "light", "branchArg": "integration-ds2-light"}};
+
+  function componentSortKey(c) {
+    if (c in COMPONENT_ORDER) return [COMPONENT_ORDER[c], 0];
+    if (c.startsWith("main-section-")) {
+      const n = parseInt(c.replace("main-section-",""), 10);
+      return [5, isNaN(n) ? 0 : n];
+    }
+    return [9, c];
+  }
+
+  // Pre-v3 ID migration: v1 (4 segments) -> v2 (5 segments) by inserting __seeded.
+  function migrateLegacyId(id) {
+    const parts = id.split('__');
+    if (parts.length < 4) return id;
+    const last = parts[parts.length - 1];
+    const second = parts[parts.length - 2];
+    const third = parts[parts.length - 3];
+    const isTheme = ['DS1','DS2','DS3','develop'].includes(last);
+    const isViewport = ['desktop','mobile'].includes(second);
+    const alreadyHasState = STATES.includes(third);
+    if (isTheme && isViewport && !alreadyHasState) {
+      const head = parts.slice(0, parts.length - 1).join('__');
+      return head + '__seeded__' + last;
+    }
+    return id;
+  }
+
+  function migrateMarksV1ToV2(input) {
+    const out = {};
+    let migrated = 0;
+    for (const [id, m] of Object.entries(input || {})) {
+      const newId = migrateLegacyId(id);
+      if (newId !== id) migrated++;
+      out[newId] = m;
+    }
+    return { marks: out, migrated };
+  }
+
+  // v2 -> v3: add category, why, updatedAt; preserve marked + note.
+  function upgradeV2ValueToV3(v) {
+    if (!v || typeof v !== 'object') return null;
+    return {
+      marked: !!v.marked,
+      note: typeof v.note === 'string' ? v.note : '',
+      category: v.category && VALID_CATEGORIES.includes(v.category) ? v.category : null,
+      why: typeof v.why === 'string' ? v.why : '',
+      updatedAt: v.updatedAt || new Date().toISOString(),
+    };
+  }
+
+  function migrateV2ObjectToV3(v2obj) {
+    const out = {};
+    for (const [id, m] of Object.entries(v2obj || {})) {
+      out[id] = upgradeV2ValueToV3(m);
+    }
+    return out;
+  }
+
+  function loadMarks() {
+    try {
+      const v3 = localStorage.getItem(STORAGE_KEY);
+      if (v3) return JSON.parse(v3);
+      // No v3 yet — try v2 (lazy migrate; leave v2 untouched for rollback).
+      const v2raw = localStorage.getItem(STORAGE_KEY_V2);
+      if (v2raw) {
+        const v3marks = migrateV2ObjectToV3(JSON.parse(v2raw));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + Object.keys(v3marks).length + ' v2 marks to v3 (v2 untouched).');
+        return v3marks;
+      }
+      // No v3 or v2 — try v1 and migrate v1 -> v2 -> v3 in one pass.
+      const v1raw = localStorage.getItem(STORAGE_KEY_V1);
+      if (v1raw) {
+        const { marks: v2marks, migrated } = migrateMarksV1ToV2(JSON.parse(v1raw));
+        const v3marks = migrateV2ObjectToV3(v2marks);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + migrated + ' v1 IDs through to v3.');
+        return v3marks;
+      }
+    } catch (e) { console.warn(e); }
+    return {};
+  }
+
+  function saveMarks(m) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(m)); } catch (e) {}
+  }
+
+
+  const ROUTE = "characters";
+  let marks = loadMarks();
+
+  function applyMarkState(cell) {
+    const id = cell.dataset.cellId;
+    const m = marks[id];
+    const noteInput = cell.querySelector('textarea[data-action="note"]');
+    const whyInput = cell.querySelector('input[data-action="why"]');
+    const chips = cell.querySelectorAll('.cat-chip');
+    cell.classList.remove('cat-bug','cat-tooling','cat-intentional','cat-unclear');
+    chips.forEach(c => c.classList.remove('active'));
+    if (m && m.marked) {
+      cell.classList.add('marked');
+      if (noteInput) noteInput.value = m.note || '';
+      if (whyInput) whyInput.value = m.why || '';
+      if (m.category) {
+        cell.classList.add('cat-' + m.category);
+        const chip = cell.querySelector('.cat-chip[data-cat="' + m.category + '"]');
+        if (chip) chip.classList.add('active');
+      }
+    } else {
+      cell.classList.remove('marked');
+      if (noteInput) noteInput.value = '';
+      if (whyInput) whyInput.value = '';
+    }
+  }
+
+  function updateRowSectionFlags() {
+    document.querySelectorAll('.component-row').forEach(row => {
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+    document.querySelectorAll('section.route').forEach(sec => {
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+    });
+  }
+
+  function updateCount() {
+    const n = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).length;
+    document.getElementById('mark-count').textContent = n;
+  }
+
+  function writeMark(id, partial) {
+    const existing = marks[id] || { marked: false, note: '', category: null, why: '', updatedAt: null };
+    const next = Object.assign({}, existing, partial, { updatedAt: new Date().toISOString() });
+    if (!next.marked && !next.note && !next.why && !next.category) {
+      delete marks[id];
+    } else {
+      marks[id] = next;
+    }
+    saveMarks(marks);
+    updateCount();
+  }
+
+  function buildRecaptureCommand(cell) {
+    const route = cell.dataset.route;
+    const viewport = cell.dataset.viewport;
+    const state = cell.dataset.state;
+    const themeKey = cell.dataset.theme;
+    const meta = BRANCH_META[themeKey];
+    if (!meta) return null;
+    return 'npx tsx scripts/audit/playwright-crawl.ts'
+      + ' --branch ' + meta.branchArg
+      + ' --viewport ' + viewport
+      + ' --state ' + state
+      + ' --theme ' + meta.theme
+      + ' --mode ' + meta.mode
+      + ' --route ' + route;
+  }
+
+  function loadPrefilledFlags() {
+    try { return JSON.parse(localStorage.getItem(PREFILLED_KEY) || '{}'); }
+    catch (e) { return {}; }
+  }
+  function savePrefilledFlags(f) {
+    try { localStorage.setItem(PREFILLED_KEY, JSON.stringify(f)); } catch (e) {}
+  }
+
+  // Gap-fill: only adds entries for DS cells that have no existing mark.
+  // Returns the count of cells filled. Develop is excluded (it's the baseline).
+  function prefillDsCellsAsNeedsDesign() {
+    const dsCells = Array.from(document.querySelectorAll('.cell[data-cell-id]'))
+      .filter(c => ['DS1','DS2','DS3'].includes(c.dataset.theme));
+    let added = 0;
+    const ts = new Date().toISOString();
+    for (const cell of dsCells) {
+      const id = cell.dataset.cellId;
+      if (!marks[id]) {
+        marks[id] = { marked: true, note: '', category: 'needs-design', why: '', updatedAt: ts };
+        added++;
+      }
+    }
+    if (added > 0) saveMarks(marks);
+    return added;
+  }
+
+  // Auto-prefill on first visit per route.
+  const prefillFlags = loadPrefilledFlags();
+  if (!prefillFlags[ROUTE]) {
+    const added = prefillDsCellsAsNeedsDesign();
+    prefillFlags[ROUTE] = true;
+    savePrefilledFlags(prefillFlags);
+    if (added > 0) console.info('[audit] auto-prefilled ' + added + ' DS cells for ' + ROUTE + ' as needs-design.');
+  }
+
+  document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+  updateRowSectionFlags();
+  updateCount();
+
+  // Lightbox
+  const lb = document.getElementById('lightbox');
+  const lbImg = document.getElementById('lightbox-img');
+  const lbCap = document.getElementById('lightbox-caption');
+  document.querySelectorAll('.cell img').forEach(img => {
+    img.addEventListener('click', () => {
+      lbImg.src = img.src;
+      lbCap.textContent = img.dataset.caption || '';
+      lb.classList.add('open');
+    });
+  });
+  lb.addEventListener('click', () => lb.classList.remove('open'));
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') document.querySelectorAll('.overlay.open').forEach(o => o.classList.remove('open'));
+  });
+
+  // Mark toggle
+  document.querySelectorAll('button[data-action="toggle-mark"]').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      const cell = btn.closest('.cell');
+      const id = cell.dataset.cellId;
+      const isMarked = !cell.classList.contains('marked');
+      writeMark(id, { marked: isMarked });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      const sec = cell.closest('section.route');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+      if (isMarked) {
+        const why = cell.querySelector('input[data-action="why"]');
+        if (why) setTimeout(() => why.focus(), 0);
+      }
+    });
+  });
+
+  // Why / note inputs (debounced save)
+  let saveTimer = null;
+  function bindInput(sel, field) {
+    document.querySelectorAll(sel).forEach(inp => {
+      const handler = () => {
+        const cell = inp.closest('.cell');
+        if (!cell.classList.contains('marked')) return;
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(() => {
+          writeMark(cell.dataset.cellId, { [field]: inp.value });
+        }, 250);
+      };
+      inp.addEventListener('input', handler);
+      inp.addEventListener('blur', () => {
+        const cell = inp.closest('.cell');
+        if (cell.classList.contains('marked')) writeMark(cell.dataset.cellId, { [field]: inp.value });
+      });
+    });
+  }
+  bindInput('input[data-action="why"]', 'why');
+  bindInput('textarea[data-action="note"]', 'note');
+
+  // Category chips
+  document.querySelectorAll('.cat-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const cell = chip.closest('.cell');
+      if (!cell.classList.contains('marked')) {
+        // Mark the cell first so the category sticks
+        writeMark(cell.dataset.cellId, { marked: true });
+      }
+      const cat = chip.dataset.cat;
+      const isActive = chip.classList.contains('active');
+      writeMark(cell.dataset.cellId, { category: isActive ? null : cat });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+  });
+
+  // Re-capture command (copy to clipboard, flash purple)
+  document.querySelectorAll('button[data-action="recapture"]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const cell = btn.closest('.cell');
+      const cmd = buildRecaptureCommand(cell);
+      if (!cmd) return;
+      try {
+        await navigator.clipboard.writeText(cmd);
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Copy re-capture command'; }, 1500);
+      } catch (e) {
+        prompt('Copy this command:', cmd);
+      }
+      cell.classList.remove('pending-recapture');
+      void cell.offsetWidth; // force reflow so the animation restarts
+      cell.classList.add('pending-recapture');
+    });
+  });
+
+  // Toggles
+  document.getElementById('hide-empty').addEventListener('change', e => document.body.classList.toggle('hide-empty', e.target.checked));
+  document.getElementById('compact').addEventListener('change', e => document.body.classList.toggle('compact', e.target.checked));
+  document.getElementById('fit-cell').addEventListener('change', e => document.body.classList.toggle('fit-cell', e.target.checked));
+  document.getElementById('only-marked').addEventListener('change', e => document.body.classList.toggle('only-marked', e.target.checked));
+  document.getElementById('show-suppressed').addEventListener('change', e => document.body.classList.toggle('show-suppressed', e.target.checked));
+  document.getElementById('hide-desktop').addEventListener('change', e => document.body.classList.toggle('hide-desktop', e.target.checked));
+  document.getElementById('hide-mobile').addEventListener('change', e => document.body.classList.toggle('hide-mobile', e.target.checked));
+
+  // True-scale rendering (1x for selector captures, 0.5x for retina full-page).
+  const RETINA_THRESHOLD = 1500;
+  function applyTrueScale(img) {
+    if (!img.naturalWidth) return;
+    const cssWidth = img.naturalWidth > RETINA_THRESHOLD
+      ? Math.round(img.naturalWidth / 2)
+      : img.naturalWidth;
+    img.style.maxWidth = 'min(100%, ' + cssWidth + 'px)';
+  }
+  document.querySelectorAll('.cell img').forEach(img => {
+    if (img.complete && img.naturalWidth > 0) applyTrueScale(img);
+    else img.addEventListener('load', () => applyTrueScale(img), { once: true });
+  });
+
+  // State chips
+  document.querySelectorAll('.state-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const state = chip.dataset.state;
+      chip.classList.toggle('active');
+      document.body.classList.toggle('hide-state-' + state, !chip.classList.contains('active'));
+    });
+  });
+  STATES.forEach(s => {
+    const chip = document.querySelector('.state-chip[data-state="' + s + '"]');
+    if (chip && !chip.classList.contains('active')) document.body.classList.add('hide-state-' + s);
+  });
+
+  // Manual top-up: fill any DS cells that don't have a mark yet
+  document.getElementById('prefill-ds-btn').addEventListener('click', () => {
+    const added = prefillDsCellsAsNeedsDesign();
+    if (added > 0) {
+      document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+      updateRowSectionFlags();
+      updateCount();
+      alert('Filled ' + added + ' missing DS cells as needs-design.');
+    } else {
+      alert('All DS cells in this route already have marks.');
+    }
+  });
+
+  // Clear-route. Also resets the prefilled flag so a reload re-triggers auto-prefill.
+  document.getElementById('clear-route-btn').addEventListener('click', () => {
+    const ids = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).map(([id]) => id);
+    if (!ids.length) { alert('No marks for this route.'); return; }
+    if (!confirm('Clear ' + ids.length + ' marks for route ' + ROUTE + '?\n\nReloading the page will re-prefill all DS cells as needs-design.')) return;
+    ids.forEach(id => delete marks[id]);
+    saveMarks(marks);
+    const flags = loadPrefilledFlags();
+    delete flags[ROUTE];
+    savePrefilledFlags(flags);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+  });
+
+  function buildMarkdown() {
+    const items = [];
+    Object.entries(marks).forEach(([id, m]) => {
+      if (!m || !m.marked) return;
+      if (!id.startsWith(ROUTE + '__')) return;
+      const parts = id.split('__');
+      const themeKey = parts[parts.length - 1];
+      const state = parts[parts.length - 2];
+      const viewport = parts[parts.length - 3];
+      const route = parts[0];
+      const component = parts.slice(1, parts.length - 3).join('__');
+      items.push({ component, viewport, state, theme: themeKey,
+                   note: m.note || '', why: m.why || '', category: m.category || '' });
+    });
+    items.sort((a, b) => {
+      const ak = componentSortKey(a.component);
+      const bk = componentSortKey(b.component);
+      if (ak[0] !== bk[0]) return ak[0] - bk[0];
+      if (ak[1] !== bk[1]) return ak[1] < bk[1] ? -1 : 1;
+      const sd = STATES.indexOf(a.state) - STATES.indexOf(b.state);
+      if (sd !== 0) return sd;
+      const td = THEME_ORDER.indexOf(a.theme) - THEME_ORDER.indexOf(b.theme);
+      if (td !== 0) return td;
+      return a.viewport === b.viewport ? 0 : (a.viewport === 'desktop' ? -1 : 1);
+    });
+    const date = new Date().toISOString().split('T')[0];
+    const lines = ['# Audit marks -- ' + ROUTE + ' -- ' + items.length + ' items -- ' + date, ''];
+    items.forEach(it => {
+      const catTag = it.category ? ' [' + it.category + ']' : '';
+      const whyTxt = it.why ? ': ' + it.why : '';
+      const noteTxt = it.note ? '  -- ' + it.note : '';
+      lines.push('- [ ] **' + it.theme + ' ' + it.component + '** [' + it.viewport + '/' + it.state + ']' + catTag + whyTxt + noteTxt);
+    });
+    return lines.join('\n');
+  }
+
+  function openOverlay(id) { document.getElementById(id).classList.add('open'); }
+  function closeOverlay(id) { document.getElementById(id).classList.remove('open'); }
+  document.querySelectorAll('.overlay-close').forEach(b => b.addEventListener('click', () => closeOverlay(b.dataset.overlay)));
+  document.querySelectorAll('.overlay').forEach(o => {
+    o.addEventListener('click', e => { if (e.target === o) o.classList.remove('open'); });
+  });
+
+  document.getElementById('export-md-btn').addEventListener('click', async () => {
+    const md = buildMarkdown();
+    const ta = document.getElementById('md-text');
+    ta.value = md;
+    openOverlay('md-overlay');
+    try { await navigator.clipboard.writeText(md); document.getElementById('md-copy').textContent = 'Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+  document.getElementById('md-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('md-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('md-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('export-json-btn').addEventListener('click', () => {
+    const ta = document.getElementById('json-export-text');
+    ta.value = JSON.stringify(marks, null, 2);
+    openOverlay('json-export-overlay');
+  });
+  document.getElementById('json-export-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('json-export-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('json-export-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('json-export-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('import-json-btn').addEventListener('click', () => {
+    document.getElementById('json-import-text').value = '';
+    document.getElementById('json-import-err').textContent = '';
+    openOverlay('json-import-overlay');
+  });
+  document.getElementById('json-import-apply').addEventListener('click', () => {
+    const ta = document.getElementById('json-import-text');
+    const err = document.getElementById('json-import-err');
+    err.textContent = '';
+    let parsed;
+    try { parsed = JSON.parse(ta.value); }
+    catch (e) { err.textContent = 'Invalid JSON: ' + e.message; return; }
+    if (!parsed || typeof parsed !== 'object') { err.textContent = 'Expected an object.'; return; }
+    // First migrate v1 IDs (4 segments) -> v2 IDs (5 segments)
+    const { marks: idMigrated, migrated } = migrateMarksV1ToV2(parsed);
+    // Then upgrade each value v2 -> v3 (preserves marked + note, fills new fields)
+    Object.entries(idMigrated).forEach(([id, m]) => {
+      marks[id] = upgradeV2ValueToV3(m);
+    });
+    saveMarks(marks);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+    closeOverlay('json-import-overlay');
+    alert('Imported ' + Object.keys(idMigrated).length + ' marks (' + migrated + ' legacy IDs migrated to __seeded; values upgraded to v3).');
+  });
+</script>
+</body>
+</html>

--- a/scripts/audit/review/home.html
+++ b/scripts/audit/review/home.html
@@ -1,0 +1,2619 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Cross-Theme Audit (#1129) — home</title>
+<style>
+
+  :root { --col-gap: 8px; --row-gap: 16px; }
+  html, body { margin: 0; padding: 0; font-family: -apple-system, system-ui, sans-serif; background: #fafafa; color: #222; }
+  .sticky-shell { position: sticky; top: 0; z-index: 100; border-bottom: 1px solid #444; }
+  header.top {
+    background: #1a1a1a; color: #fff; padding: 12px 16px;
+    display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+  }
+  header.top h1 { font-size: 14px; margin: 0; font-weight: 600; }
+  header.top .legend { display: flex; gap: 12px; font-size: 12px; }
+  header.top .legend .col { padding: 2px 8px; border-radius: 3px; }
+  header.top .legend .develop { background: #6b7280; }
+  header.top .legend .ds3 { background: #4338ca; }
+  header.top .legend .ds1 { background: #92400e; }
+  header.top .legend .ds2 { background: #166534; }
+  header.top a.back { color: #9cf; font-size: 12px; text-decoration: none; padding: 2px 6px; border-radius: 2px; }
+  header.top a.back:hover { background: #444; color: #fff; }
+  header.top .nav-routes { display: flex; gap: 4px; align-items: center; font-size: 12px; }
+  header.top .nav-routes a { color: #9cf; text-decoration: none; padding: 2px 8px; border-radius: 2px; background: #2a2a2a; }
+  header.top .nav-routes a:hover { background: #444; color: #fff; }
+  header.top .nav-routes .current { color: #fff; font-weight: 600; padding: 2px 8px; }
+  main { padding: 16px; max-width: 100%; }
+  section.route {
+    margin-bottom: 32px; background: #fff; border-radius: 6px;
+    padding: 12px 16px 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  section.route h2 {
+    font-size: 18px; margin: 0 0 12px; padding-bottom: 6px;
+    border-bottom: 1px solid #e5e5e5;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+  .component-row {
+    display: grid; grid-template-columns: 180px repeat(4, 1fr);
+    gap: var(--col-gap); margin-bottom: var(--row-gap);
+    align-items: start;
+  }
+  .component-row .label {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px; color: #555; padding-top: 28px; line-height: 1.3;
+    word-break: break-word;
+  }
+  .cell {
+    border: 1px solid #e5e5e5; border-radius: 4px; overflow: hidden;
+    background: #f3f4f6; position: relative; min-height: 100px;
+    display: flex; flex-direction: column;
+  }
+  .cell .header {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.04em; padding: 4px 8px; color: #fff;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .cell.develop .header { background: #6b7280; }
+  .cell.ds3 .header { background: #4338ca; }
+  .cell.ds1 .header { background: #92400e; }
+  .cell.ds2 .header { background: #166534; }
+  .cell img {
+    display: block; width: auto; max-width: 100%; height: auto;
+    cursor: zoom-in; background: #fff; align-self: flex-start;
+  }
+  body.fit-cell .cell img { width: 100%; max-width: 100%; }
+  .cell.empty {
+    display: flex; align-items: center; justify-content: center;
+    color: #999; font-size: 12px; padding: 24px; background: #f9f9f9;
+  }
+  .cell.empty::after { content: "(not captured)"; }
+
+  /* Lightbox */
+  #lightbox {
+    display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.92);
+    z-index: 1000; align-items: center; justify-content: center; cursor: zoom-out;
+  }
+  #lightbox.open { display: flex; }
+  #lightbox img { max-width: 96vw; max-height: 96vh; box-shadow: 0 4px 24px rgba(0,0,0,0.5); }
+
+  .controls { display: flex; gap: 12px; align-items: center; font-size: 12px; flex-wrap: wrap; }
+  .controls label { display: flex; align-items: center; gap: 4px; cursor: pointer; }
+  .controls input[type=checkbox] { margin: 0; }
+
+  .state-chips { display: inline-flex; gap: 4px; align-items: center; }
+  .state-chip {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .state-chip.active { background: #2563eb; border-color: #1d4ed8; }
+  .state-chip:hover { background: #4b5563; }
+  .state-chip.active:hover { background: #1d4ed8; }
+
+  body.hide-empty .component-row.all-empty,
+  body.hide-empty .cell.empty { display: none; }
+  body.compact .cell img { max-height: 360px; object-fit: cover; object-position: top; }
+
+  .cell .mark-btn {
+    margin-left: auto; background: rgba(255,255,255,0.18);
+    color: #fff; border: 1px solid rgba(255,255,255,0.35);
+    border-radius: 3px; font-size: 10px; font-weight: 600;
+    padding: 2px 6px; cursor: pointer;
+    text-transform: none; letter-spacing: 0; line-height: 1.2;
+  }
+  .cell .mark-btn:hover { background: rgba(255,255,255,0.28); }
+  .cell.marked { border: 3px solid #dc2626; }
+  .cell.marked .mark-btn { background: #dc2626; border-color: #b91c1c; color: #fff; }
+  .cell.marked .mark-btn::before { content: "x "; }
+  .cell.pending-recapture { animation: cellPulse 2s ease-out; }
+  @keyframes cellPulse {
+    0%   { box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.9); border-color: #7c3aed; }
+    100% { box-shadow: 0 0 0 8px rgba(124, 58, 237, 0); }
+  }
+  .cell .toolbar {
+    display: none;
+    padding: 6px 8px; background: #fef2f2; border-top: 1px solid #fecaca;
+    font-size: 11px;
+  }
+  .cell.marked .toolbar { display: block; }
+  .cell .toolbar input[type=text],
+  .cell .toolbar textarea {
+    width: 100%; box-sizing: border-box;
+    border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 4px 6px; font-size: 12px; font-family: inherit;
+    background: #fff;
+  }
+  .cell .toolbar input[type=text]:focus,
+  .cell .toolbar textarea:focus { outline: 2px solid #dc2626; outline-offset: -1px; }
+  .cell .toolbar .field { margin-bottom: 6px; }
+  .cell .toolbar .field-label {
+    display: block; font-size: 10px; font-weight: 600;
+    color: #7f1d1d; text-transform: uppercase; letter-spacing: 0.04em;
+    margin-bottom: 2px;
+  }
+  .cell .toolbar .cat-chips { display: flex; gap: 4px; flex-wrap: wrap; }
+  .cell .toolbar .cat-chip {
+    background: #fff; border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 2px 8px; font-size: 11px; cursor: pointer; font-family: inherit;
+    color: #7f1d1d;
+  }
+  .cell .toolbar .cat-chip.active { background: #7f1d1d; color: #fff; border-color: #7f1d1d; }
+  .cell .toolbar .cat-chip[data-cat="needs-design"].active { background: #6d28d9; border-color: #6d28d9; }
+  .cell .toolbar .cat-chip[data-cat="bug"].active        { background: #b91c1c; border-color: #b91c1c; }
+  .cell .toolbar .cat-chip[data-cat="tooling"].active    { background: #b45309; border-color: #b45309; }
+  .cell .toolbar .cat-chip[data-cat="intentional"].active{ background: #15803d; border-color: #15803d; }
+  .cell .toolbar .cat-chip[data-cat="unclear"].active    { background: #6b7280; border-color: #6b7280; }
+  .cell .toolbar .recapture-btn {
+    background: #1d4ed8; color: #fff; border: 0; border-radius: 3px;
+    padding: 4px 10px; font-size: 11px; cursor: pointer;
+    font-family: inherit; font-weight: 600;
+  }
+  .cell .toolbar .recapture-btn:hover { background: #1e40af; }
+  .cell .toolbar textarea { min-height: 32px; resize: vertical; font-size: 11px; }
+  .cell.cat-needs-design { border-color: #6d28d9; }
+  .cell.cat-bug         { border-color: #b91c1c; }
+  .cell.cat-tooling     { border-color: #b45309; }
+  .cell.cat-intentional { border-color: #15803d; }
+  .cell.cat-unclear     { border-color: #6b7280; }
+
+  .marks-cluster {
+    display: flex; align-items: center; gap: 8px;
+    border-left: 1px solid #444; padding-left: 12px; margin-left: 4px;
+    font-size: 12px;
+  }
+  .marks-cluster .count {
+    background: #dc2626; color: #fff; border-radius: 10px;
+    padding: 2px 8px; font-weight: 600; min-width: 18px; text-align: center;
+  }
+  .marks-cluster button {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .marks-cluster button:hover { background: #4b5563; }
+  .marks-cluster button.danger { background: #7f1d1d; border-color: #991b1b; }
+  .marks-cluster button.danger:hover { background: #991b1b; }
+
+  body.only-marked .component-row:not(.has-marked) { display: none; }
+  body.only-marked section.route:not(.has-marked) { display: none; }
+
+  .component-row.suppressed { display: none; }
+  body.show-suppressed .component-row.suppressed { display: grid; }
+  .component-row.suppressed .label::after { content: " (hidden)"; color: #b91c1c; font-style: italic; }
+
+  .component-row .label[data-mapped] { color: #1d4ed8; }
+  .component-row .label[data-mapped]::after { content: " *"; }
+  .mapped-tooltip {
+    display: inline-block; margin-left: 4px;
+    font-size: 10px; color: #6b7280; cursor: help; vertical-align: super;
+  }
+
+  .vp-badge, .state-badge {
+    display: inline-block; font-size: 9px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.05em;
+    padding: 1px 6px; border-radius: 8px; margin-top: 2px;
+  }
+  .vp-badge.desktop { background: #dbeafe; color: #1e3a8a; border: 1px solid #93c5fd; margin-right: 4px; }
+  .vp-badge.mobile  { background: #fef3c7; color: #78350f; border: 1px solid #fcd34d; margin-right: 4px; }
+  .state-badge.empty       { background: #f3f4f6; color: #374151; border: 1px solid #d1d5db; }
+  .state-badge.seeded      { background: #dcfce7; color: #14532d; border: 1px solid #86efac; }
+  .state-badge.mid-session { background: #ede9fe; color: #4c1d95; border: 1px solid #c4b5fd; }
+
+  .component-row.vp-mobile { background: #fffbeb; padding: 4px; border-radius: 4px; }
+  body.hide-desktop .component-row.vp-desktop { display: none; }
+  body.hide-mobile .component-row.vp-mobile { display: none; }
+
+  body.hide-state-empty       .component-row.state-empty       { display: none; }
+  body.hide-state-seeded      .component-row.state-seeded      { display: none; }
+  body.hide-state-mid-session .component-row.state-mid-session { display: none; }
+
+  .overlay {
+    display: none; position: fixed; inset: 0; z-index: 1100;
+    background: rgba(0,0,0,0.6); align-items: center; justify-content: center;
+  }
+  .overlay.open { display: flex; }
+  .overlay .panel {
+    background: #fff; border-radius: 6px; width: min(720px, 92vw);
+    max-height: 80vh; padding: 16px; display: flex; flex-direction: column; gap: 8px;
+  }
+  .overlay h3 { margin: 0; font-size: 14px; }
+  .overlay textarea {
+    flex: 1; min-height: 320px; font-family: ui-monospace, monospace; font-size: 12px;
+    border: 1px solid #ddd; border-radius: 4px; padding: 8px; resize: vertical;
+  }
+  .overlay .actions { display: flex; gap: 8px; justify-content: flex-end; }
+  .overlay button {
+    background: #1a1a1a; color: #fff; border: 0; border-radius: 3px;
+    padding: 6px 12px; font-size: 12px; cursor: pointer;
+  }
+  .overlay .hint { font-size: 11px; color: #555; }
+  .overlay .err  { font-size: 12px; color: #b91c1c; min-height: 16px; }
+
+  /* Index-page table */
+  table.routes-index {
+    width: 100%; border-collapse: collapse; background: #fff;
+    border-radius: 6px; overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  table.routes-index th, table.routes-index td {
+    padding: 8px 12px; text-align: left; font-size: 13px;
+    border-bottom: 1px solid #eee;
+  }
+  table.routes-index th { background: #f3f4f6; font-weight: 600; }
+  table.routes-index td a {
+    color: #1d4ed8; text-decoration: none; font-family: ui-monospace, monospace;
+  }
+  table.routes-index td a:hover { text-decoration: underline; }
+  table.routes-index td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  table.routes-index .marked-count.has-marks { color: #b91c1c; font-weight: 600; }
+  table.routes-index .unresolved-count.has-unresolved { color: #b45309; font-weight: 600; }
+  table.routes-index .breakdown {
+    font-size: 11px; color: #555; margin-left: 6px; font-variant-numeric: tabular-nums;
+  }
+
+
+</style>
+</head>
+<body>
+<div class="sticky-shell">
+<header class="top">
+  <a class="back" href="index.html">&larr; Index</a>
+  <h1>home</h1>
+  <div class="legend">
+    <span class="col develop">develop</span>
+    <span class="col ds3">DS3</span>
+    <span class="col ds1">DS1</span>
+    <span class="col ds2">DS2</span>
+  </div>
+  <div class="controls">
+    <span class="state-chips" role="group" aria-label="State filter">
+      <span style="font-size: 11px; color: #aaa;">State:</span>
+      <button type="button" class="state-chip" data-state="empty">empty</button>
+      <button type="button" class="state-chip active" data-state="seeded">seeded</button>
+    </span>
+    <label><input type="checkbox" id="hide-empty"> Hide missing</label>
+    <label><input type="checkbox" id="compact"> Compact</label>
+    <label title="Stretch images to cell width"><input type="checkbox" id="fit-cell"> Fit to cell</label>
+    <label><input type="checkbox" id="only-marked"> Only marked</label>
+    <label><input type="checkbox" id="show-suppressed"> Show hidden rows</label>
+    <label><input type="checkbox" id="hide-desktop"> Hide desktop</label>
+    <label><input type="checkbox" id="hide-mobile"> Hide mobile</label>
+  </div>
+  <div class="marks-cluster">
+    <span>Marked (route):</span>
+    <span class="count" id="mark-count">0</span>
+    <button id="prefill-ds-btn" type="button" title="Mark every DS cell that has no mark yet as needs-design (gap-fill, never overwrites your existing marks)">Fill DS gaps</button>
+    <button id="export-md-btn" type="button">Export markdown</button>
+    <button id="export-json-btn" type="button">Export JSON</button>
+    <button id="import-json-btn" type="button">Import JSON</button>
+    <button id="clear-route-btn" type="button" class="danger">Clear (route)</button>
+  </div>
+</header>
+<nav class="toc" style="background:#2a2a2a;color:#ccc;padding:6px 16px;font-size:12px;display:flex;gap:8px;align-items:center;border-top:1px solid #444;">
+  <span class="nav-routes">
+    <span class="current">home</span>
+    <a href="about.html">about &rarr;</a>
+  </span>
+</nav>
+</div>
+<main>
+<section class="route" id="route-home">
+  <h2>home</h2>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="home__global-nav__desktop__empty__develop" data-route="home" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/home__nav.png" alt="develop home/global-nav/desktop/empty" data-caption="develop -- home/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="home__global-nav__desktop__empty__DS3" data-route="home" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/home__nav.png" alt="DS3 home/global-nav/desktop/empty" data-caption="DS3 -- home/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="home__global-nav__desktop__empty__DS1" data-route="home" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/home__nav.png" alt="DS1 home/global-nav/desktop/empty" data-caption="DS1 -- home/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="home__global-nav__desktop__empty__DS2" data-route="home" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/home__nav.png" alt="DS2 home/global-nav/desktop/empty" data-caption="DS2 -- home/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="home__page__desktop__empty__develop" data-route="home" data-component="page" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/home__page.png" alt="develop home/page/desktop/empty" data-caption="develop -- home/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="home__page__desktop__empty__DS3" data-route="home" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/home__page.png" alt="DS3 home/page/desktop/empty" data-caption="DS3 -- home/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="home__page__desktop__empty__DS1" data-route="home" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/home__page.png" alt="DS1 home/page/desktop/empty" data-caption="DS1 -- home/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="home__page__desktop__empty__DS2" data-route="home" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/home__page.png" alt="DS2 home/page/desktop/empty" data-caption="DS2 -- home/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-empty" data-viewport="mobile" data-state="empty">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="home__page__mobile__empty__develop" data-route="home" data-component="page" data-viewport="mobile" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/empty/home__page.png" alt="develop home/page/mobile/empty" data-caption="develop -- home/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="home__page__mobile__empty__DS3" data-route="home" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/empty/home__page.png" alt="DS3 home/page/mobile/empty" data-caption="DS3 -- home/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="home__page__mobile__empty__DS1" data-route="home" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/empty/home__page.png" alt="DS1 home/page/mobile/empty" data-caption="DS1 -- home/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="home__page__mobile__empty__DS2" data-route="home" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/empty/home__page.png" alt="DS2 home/page/mobile/empty" data-caption="DS2 -- home/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="home__header__desktop__empty__develop" data-route="home" data-component="header" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/home__header.png" alt="develop home/header/desktop/empty" data-caption="develop -- home/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="home__header__desktop__empty__DS3" data-route="home" data-component="header" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/home__header.png" alt="DS3 home/header/desktop/empty" data-caption="DS3 -- home/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="home__header__desktop__empty__DS1" data-route="home" data-component="header" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/home__header.png" alt="DS1 home/header/desktop/empty" data-caption="DS1 -- home/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="home__header__desktop__empty__DS2" data-route="home" data-component="header" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/home__header.png" alt="DS2 home/header/desktop/empty" data-caption="DS2 -- home/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="home__nav__desktop__empty__develop" data-route="home" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/home__nav.png" alt="develop home/nav/desktop/empty" data-caption="develop -- home/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="home__nav__desktop__empty__DS3" data-route="home" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/home__nav.png" alt="DS3 home/nav/desktop/empty" data-caption="DS3 -- home/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="home__nav__desktop__empty__DS1" data-route="home" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/home__nav.png" alt="DS1 home/nav/desktop/empty" data-caption="DS1 -- home/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="home__nav__desktop__empty__DS2" data-route="home" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/home__nav.png" alt="DS2 home/nav/desktop/empty" data-caption="DS2 -- home/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="home__main__desktop__empty__develop" data-route="home" data-component="main" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/home__main.png" alt="develop home/main/desktop/empty" data-caption="develop -- home/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="home__main__desktop__empty__DS3" data-route="home" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/home__main.png" alt="DS3 home/main/desktop/empty" data-caption="DS3 -- home/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="home__main__desktop__empty__DS1" data-route="home" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/home__main.png" alt="DS1 home/main/desktop/empty" data-caption="DS1 -- home/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="home__main__desktop__empty__DS2" data-route="home" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/home__main.png" alt="DS2 home/main/desktop/empty" data-caption="DS2 -- home/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="home__global-nav__desktop__seeded__develop" data-route="home" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/home__nav.png" alt="develop home/global-nav/desktop/seeded" data-caption="develop -- home/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="home__global-nav__desktop__seeded__DS3" data-route="home" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/home__nav.png" alt="DS3 home/global-nav/desktop/seeded" data-caption="DS3 -- home/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="home__global-nav__desktop__seeded__DS1" data-route="home" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/home__nav.png" alt="DS1 home/global-nav/desktop/seeded" data-caption="DS1 -- home/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="home__global-nav__desktop__seeded__DS2" data-route="home" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/home__nav.png" alt="DS2 home/global-nav/desktop/seeded" data-caption="DS2 -- home/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="home__page__desktop__seeded__develop" data-route="home" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/home__page.png" alt="develop home/page/desktop/seeded" data-caption="develop -- home/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="home__page__desktop__seeded__DS3" data-route="home" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/home__page.png" alt="DS3 home/page/desktop/seeded" data-caption="DS3 -- home/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="home__page__desktop__seeded__DS1" data-route="home" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/home__page.png" alt="DS1 home/page/desktop/seeded" data-caption="DS1 -- home/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="home__page__desktop__seeded__DS2" data-route="home" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/home__page.png" alt="DS2 home/page/desktop/seeded" data-caption="DS2 -- home/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-seeded" data-viewport="mobile" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="home__page__mobile__seeded__develop" data-route="home" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/seeded/home__page.png" alt="develop home/page/mobile/seeded" data-caption="develop -- home/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="home__page__mobile__seeded__DS3" data-route="home" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/seeded/home__page.png" alt="DS3 home/page/mobile/seeded" data-caption="DS3 -- home/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="home__page__mobile__seeded__DS1" data-route="home" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/seeded/home__page.png" alt="DS1 home/page/mobile/seeded" data-caption="DS1 -- home/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="home__page__mobile__seeded__DS2" data-route="home" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/seeded/home__page.png" alt="DS2 home/page/mobile/seeded" data-caption="DS2 -- home/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="home__header__desktop__seeded__develop" data-route="home" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/home__header.png" alt="develop home/header/desktop/seeded" data-caption="develop -- home/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="home__header__desktop__seeded__DS3" data-route="home" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/home__header.png" alt="DS3 home/header/desktop/seeded" data-caption="DS3 -- home/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="home__header__desktop__seeded__DS1" data-route="home" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/home__header.png" alt="DS1 home/header/desktop/seeded" data-caption="DS1 -- home/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="home__header__desktop__seeded__DS2" data-route="home" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/home__header.png" alt="DS2 home/header/desktop/seeded" data-caption="DS2 -- home/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="home__nav__desktop__seeded__develop" data-route="home" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/home__nav.png" alt="develop home/nav/desktop/seeded" data-caption="develop -- home/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="home__nav__desktop__seeded__DS3" data-route="home" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/home__nav.png" alt="DS3 home/nav/desktop/seeded" data-caption="DS3 -- home/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="home__nav__desktop__seeded__DS1" data-route="home" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/home__nav.png" alt="DS1 home/nav/desktop/seeded" data-caption="DS1 -- home/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="home__nav__desktop__seeded__DS2" data-route="home" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/home__nav.png" alt="DS2 home/nav/desktop/seeded" data-caption="DS2 -- home/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="home__main__desktop__seeded__develop" data-route="home" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/home__main.png" alt="develop home/main/desktop/seeded" data-caption="develop -- home/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="home__main__desktop__seeded__DS3" data-route="home" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/home__main.png" alt="DS3 home/main/desktop/seeded" data-caption="DS3 -- home/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="home__main__desktop__seeded__DS1" data-route="home" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/home__main.png" alt="DS1 home/main/desktop/seeded" data-caption="DS1 -- home/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="home__main__desktop__seeded__DS2" data-route="home" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/home__main.png" alt="DS2 home/main/desktop/seeded" data-caption="DS2 -- home/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main-section-2<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="home__main-section-2__desktop__seeded__develop" data-route="home" data-component="main-section-2" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/home__main-section-2.png" alt="develop home/main-section-2/desktop/seeded" data-caption="develop -- home/main-section-2 (desktop/seeded; src: main-section-2)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="home__main-section-2__desktop__seeded__DS3" data-route="home" data-component="main-section-2" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/home__main-section-2.png" alt="DS3 home/main-section-2/desktop/seeded" data-caption="DS3 -- home/main-section-2 (desktop/seeded; src: main-section-2)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="home__main-section-2__desktop__seeded__DS1" data-route="home" data-component="main-section-2" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/home__main-section-2.png" alt="DS1 home/main-section-2/desktop/seeded" data-caption="DS1 -- home/main-section-2 (desktop/seeded; src: main-section-2)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="home__main-section-2__desktop__seeded__DS2" data-route="home" data-component="main-section-2" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/home__main-section-2.png" alt="DS2 home/main-section-2/desktop/seeded" data-caption="DS2 -- home/main-section-2 (desktop/seeded; src: main-section-2)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main-section-3<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="home__main-section-3__desktop__seeded__develop" data-route="home" data-component="main-section-3" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/home__main-section-3.png" alt="develop home/main-section-3/desktop/seeded" data-caption="develop -- home/main-section-3 (desktop/seeded; src: main-section-3)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="home__main-section-3__desktop__seeded__DS3" data-route="home" data-component="main-section-3" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/home__main-section-3.png" alt="DS3 home/main-section-3/desktop/seeded" data-caption="DS3 -- home/main-section-3 (desktop/seeded; src: main-section-3)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="home__main-section-3__desktop__seeded__DS1" data-route="home" data-component="main-section-3" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/home__main-section-3.png" alt="DS1 home/main-section-3/desktop/seeded" data-caption="DS1 -- home/main-section-3 (desktop/seeded; src: main-section-3)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="home__main-section-3__desktop__seeded__DS2" data-route="home" data-component="main-section-3" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/home__main-section-3.png" alt="DS2 home/main-section-3/desktop/seeded" data-caption="DS2 -- home/main-section-3 (desktop/seeded; src: main-section-3)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main-section-4<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="home__main-section-4__desktop__seeded__develop" data-route="home" data-component="main-section-4" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/home__main-section-4.png" alt="develop home/main-section-4/desktop/seeded" data-caption="develop -- home/main-section-4 (desktop/seeded; src: main-section-4)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="home__main-section-4__desktop__seeded__DS3" data-route="home" data-component="main-section-4" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/home__main-section-4.png" alt="DS3 home/main-section-4/desktop/seeded" data-caption="DS3 -- home/main-section-4 (desktop/seeded; src: main-section-4)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="home__main-section-4__desktop__seeded__DS1" data-route="home" data-component="main-section-4" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/home__main-section-4.png" alt="DS1 home/main-section-4/desktop/seeded" data-caption="DS1 -- home/main-section-4 (desktop/seeded; src: main-section-4)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="home__main-section-4__desktop__seeded__DS2" data-route="home" data-component="main-section-4" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/home__main-section-4.png" alt="DS2 home/main-section-4/desktop/seeded" data-caption="DS2 -- home/main-section-4 (desktop/seeded; src: main-section-4)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main-section-5<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="home__main-section-5__desktop__seeded__develop" data-route="home" data-component="main-section-5" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/home__main-section-5.png" alt="develop home/main-section-5/desktop/seeded" data-caption="develop -- home/main-section-5 (desktop/seeded; src: main-section-5)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="home__main-section-5__desktop__seeded__DS3" data-route="home" data-component="main-section-5" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/home__main-section-5.png" alt="DS3 home/main-section-5/desktop/seeded" data-caption="DS3 -- home/main-section-5 (desktop/seeded; src: main-section-5)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="home__main-section-5__desktop__seeded__DS1" data-route="home" data-component="main-section-5" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/home__main-section-5.png" alt="DS1 home/main-section-5/desktop/seeded" data-caption="DS1 -- home/main-section-5 (desktop/seeded; src: main-section-5)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="home__main-section-5__desktop__seeded__DS2" data-route="home" data-component="main-section-5" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/home__main-section-5.png" alt="DS2 home/main-section-5/desktop/seeded" data-caption="DS2 -- home/main-section-5 (desktop/seeded; src: main-section-5)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main-section-6<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="home__main-section-6__desktop__seeded__develop" data-route="home" data-component="main-section-6" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/home__main-section-6.png" alt="develop home/main-section-6/desktop/seeded" data-caption="develop -- home/main-section-6 (desktop/seeded; src: main-section-6)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+</section>
+</main>
+
+<div id="lightbox" class="overlay">
+  <img id="lightbox-img" src="" alt="">
+  <div id="lightbox-caption" style="position: fixed; top: 12px; left: 50%; transform: translateX(-50%); color: #fff; font-family: ui-monospace, monospace; font-size: 13px; background: rgba(0,0,0,0.6); padding: 6px 12px; border-radius: 4px;"></div>
+</div>
+
+<div id="md-overlay" class="overlay">
+  <div class="panel">
+    <h3>Audit marks (markdown) -- this route only</h3>
+    <textarea id="md-text" readonly></textarea>
+    <div class="actions">
+      <button id="md-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="md-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-export-overlay" class="overlay">
+  <div class="panel">
+    <h3>Marks (raw JSON) -- all routes</h3>
+    <textarea id="json-export-text" readonly></textarea>
+    <div class="actions">
+      <button id="json-export-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="json-export-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-import-overlay" class="overlay">
+  <div class="panel">
+    <h3>Import marks (paste raw JSON)</h3>
+    <p class="hint">Paste JSON exported from another instance. Legacy IDs without a state segment are migrated to <code>__seeded</code>; v2 values are upgraded to v3 (category=null, why="", updatedAt=now). Existing marks with the same ID are overwritten.</p>
+    <textarea id="json-import-text" placeholder='{"home__page__desktop__seeded__DS3":{"marked":true,"note":"...","category":"bug","why":"...","updatedAt":"..."}}'></textarea>
+    <div class="err" id="json-import-err"></div>
+    <div class="actions">
+      <button id="json-import-apply" type="button">Apply</button>
+      <button class="overlay-close" data-overlay="json-import-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+<script>
+
+  const STORAGE_KEY = 'narraitor-audit-marks-v3';
+  const STORAGE_KEY_V2 = 'narraitor-audit-marks-v2';
+  const STORAGE_KEY_V1 = 'narraitor-audit-marks-v1';
+  // Tracks which routes have had their DS cells auto-prefilled as needs-design.
+  // Once a route is in here, the auto-prefill on page load is skipped.
+  const PREFILLED_KEY = 'narraitor-audit-prefilled-v1';
+  const STATES = ['empty', 'seeded'];
+  const VALID_CATEGORIES = ['needs-design','bug','tooling','intentional','unclear'];
+  const ROUTE_ORDER = ["home", "about", "worlds", "worlds-detail", "worlds-edit", "worlds-create", "worlds-play", "worlds-play-journal", "characters", "characters-detail", "characters-edit", "characters-create", "play", "settings"];
+  const COMPONENT_ORDER = {"page":0,"header":1,"nav":2,"form":3,"main":4};
+  const THEME_ORDER = ["DS3","DS1","DS2","develop"];
+  const BRANCH_META = {"develop": {"theme": "default", "mode": "light", "branchArg": "develop-default"}, "DS3": {"theme": "ds3", "mode": "light", "branchArg": "integration-ds3-light"}, "DS1": {"theme": "ds1", "mode": "light", "branchArg": "integration-ds1-light"}, "DS2": {"theme": "ds2", "mode": "light", "branchArg": "integration-ds2-light"}};
+
+  function componentSortKey(c) {
+    if (c in COMPONENT_ORDER) return [COMPONENT_ORDER[c], 0];
+    if (c.startsWith("main-section-")) {
+      const n = parseInt(c.replace("main-section-",""), 10);
+      return [5, isNaN(n) ? 0 : n];
+    }
+    return [9, c];
+  }
+
+  // Pre-v3 ID migration: v1 (4 segments) -> v2 (5 segments) by inserting __seeded.
+  function migrateLegacyId(id) {
+    const parts = id.split('__');
+    if (parts.length < 4) return id;
+    const last = parts[parts.length - 1];
+    const second = parts[parts.length - 2];
+    const third = parts[parts.length - 3];
+    const isTheme = ['DS1','DS2','DS3','develop'].includes(last);
+    const isViewport = ['desktop','mobile'].includes(second);
+    const alreadyHasState = STATES.includes(third);
+    if (isTheme && isViewport && !alreadyHasState) {
+      const head = parts.slice(0, parts.length - 1).join('__');
+      return head + '__seeded__' + last;
+    }
+    return id;
+  }
+
+  function migrateMarksV1ToV2(input) {
+    const out = {};
+    let migrated = 0;
+    for (const [id, m] of Object.entries(input || {})) {
+      const newId = migrateLegacyId(id);
+      if (newId !== id) migrated++;
+      out[newId] = m;
+    }
+    return { marks: out, migrated };
+  }
+
+  // v2 -> v3: add category, why, updatedAt; preserve marked + note.
+  function upgradeV2ValueToV3(v) {
+    if (!v || typeof v !== 'object') return null;
+    return {
+      marked: !!v.marked,
+      note: typeof v.note === 'string' ? v.note : '',
+      category: v.category && VALID_CATEGORIES.includes(v.category) ? v.category : null,
+      why: typeof v.why === 'string' ? v.why : '',
+      updatedAt: v.updatedAt || new Date().toISOString(),
+    };
+  }
+
+  function migrateV2ObjectToV3(v2obj) {
+    const out = {};
+    for (const [id, m] of Object.entries(v2obj || {})) {
+      out[id] = upgradeV2ValueToV3(m);
+    }
+    return out;
+  }
+
+  function loadMarks() {
+    try {
+      const v3 = localStorage.getItem(STORAGE_KEY);
+      if (v3) return JSON.parse(v3);
+      // No v3 yet — try v2 (lazy migrate; leave v2 untouched for rollback).
+      const v2raw = localStorage.getItem(STORAGE_KEY_V2);
+      if (v2raw) {
+        const v3marks = migrateV2ObjectToV3(JSON.parse(v2raw));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + Object.keys(v3marks).length + ' v2 marks to v3 (v2 untouched).');
+        return v3marks;
+      }
+      // No v3 or v2 — try v1 and migrate v1 -> v2 -> v3 in one pass.
+      const v1raw = localStorage.getItem(STORAGE_KEY_V1);
+      if (v1raw) {
+        const { marks: v2marks, migrated } = migrateMarksV1ToV2(JSON.parse(v1raw));
+        const v3marks = migrateV2ObjectToV3(v2marks);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + migrated + ' v1 IDs through to v3.');
+        return v3marks;
+      }
+    } catch (e) { console.warn(e); }
+    return {};
+  }
+
+  function saveMarks(m) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(m)); } catch (e) {}
+  }
+
+
+  const ROUTE = "home";
+  let marks = loadMarks();
+
+  function applyMarkState(cell) {
+    const id = cell.dataset.cellId;
+    const m = marks[id];
+    const noteInput = cell.querySelector('textarea[data-action="note"]');
+    const whyInput = cell.querySelector('input[data-action="why"]');
+    const chips = cell.querySelectorAll('.cat-chip');
+    cell.classList.remove('cat-bug','cat-tooling','cat-intentional','cat-unclear');
+    chips.forEach(c => c.classList.remove('active'));
+    if (m && m.marked) {
+      cell.classList.add('marked');
+      if (noteInput) noteInput.value = m.note || '';
+      if (whyInput) whyInput.value = m.why || '';
+      if (m.category) {
+        cell.classList.add('cat-' + m.category);
+        const chip = cell.querySelector('.cat-chip[data-cat="' + m.category + '"]');
+        if (chip) chip.classList.add('active');
+      }
+    } else {
+      cell.classList.remove('marked');
+      if (noteInput) noteInput.value = '';
+      if (whyInput) whyInput.value = '';
+    }
+  }
+
+  function updateRowSectionFlags() {
+    document.querySelectorAll('.component-row').forEach(row => {
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+    document.querySelectorAll('section.route').forEach(sec => {
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+    });
+  }
+
+  function updateCount() {
+    const n = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).length;
+    document.getElementById('mark-count').textContent = n;
+  }
+
+  function writeMark(id, partial) {
+    const existing = marks[id] || { marked: false, note: '', category: null, why: '', updatedAt: null };
+    const next = Object.assign({}, existing, partial, { updatedAt: new Date().toISOString() });
+    if (!next.marked && !next.note && !next.why && !next.category) {
+      delete marks[id];
+    } else {
+      marks[id] = next;
+    }
+    saveMarks(marks);
+    updateCount();
+  }
+
+  function buildRecaptureCommand(cell) {
+    const route = cell.dataset.route;
+    const viewport = cell.dataset.viewport;
+    const state = cell.dataset.state;
+    const themeKey = cell.dataset.theme;
+    const meta = BRANCH_META[themeKey];
+    if (!meta) return null;
+    return 'npx tsx scripts/audit/playwright-crawl.ts'
+      + ' --branch ' + meta.branchArg
+      + ' --viewport ' + viewport
+      + ' --state ' + state
+      + ' --theme ' + meta.theme
+      + ' --mode ' + meta.mode
+      + ' --route ' + route;
+  }
+
+  function loadPrefilledFlags() {
+    try { return JSON.parse(localStorage.getItem(PREFILLED_KEY) || '{}'); }
+    catch (e) { return {}; }
+  }
+  function savePrefilledFlags(f) {
+    try { localStorage.setItem(PREFILLED_KEY, JSON.stringify(f)); } catch (e) {}
+  }
+
+  // Gap-fill: only adds entries for DS cells that have no existing mark.
+  // Returns the count of cells filled. Develop is excluded (it's the baseline).
+  function prefillDsCellsAsNeedsDesign() {
+    const dsCells = Array.from(document.querySelectorAll('.cell[data-cell-id]'))
+      .filter(c => ['DS1','DS2','DS3'].includes(c.dataset.theme));
+    let added = 0;
+    const ts = new Date().toISOString();
+    for (const cell of dsCells) {
+      const id = cell.dataset.cellId;
+      if (!marks[id]) {
+        marks[id] = { marked: true, note: '', category: 'needs-design', why: '', updatedAt: ts };
+        added++;
+      }
+    }
+    if (added > 0) saveMarks(marks);
+    return added;
+  }
+
+  // Auto-prefill on first visit per route.
+  const prefillFlags = loadPrefilledFlags();
+  if (!prefillFlags[ROUTE]) {
+    const added = prefillDsCellsAsNeedsDesign();
+    prefillFlags[ROUTE] = true;
+    savePrefilledFlags(prefillFlags);
+    if (added > 0) console.info('[audit] auto-prefilled ' + added + ' DS cells for ' + ROUTE + ' as needs-design.');
+  }
+
+  document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+  updateRowSectionFlags();
+  updateCount();
+
+  // Lightbox
+  const lb = document.getElementById('lightbox');
+  const lbImg = document.getElementById('lightbox-img');
+  const lbCap = document.getElementById('lightbox-caption');
+  document.querySelectorAll('.cell img').forEach(img => {
+    img.addEventListener('click', () => {
+      lbImg.src = img.src;
+      lbCap.textContent = img.dataset.caption || '';
+      lb.classList.add('open');
+    });
+  });
+  lb.addEventListener('click', () => lb.classList.remove('open'));
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') document.querySelectorAll('.overlay.open').forEach(o => o.classList.remove('open'));
+  });
+
+  // Mark toggle
+  document.querySelectorAll('button[data-action="toggle-mark"]').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      const cell = btn.closest('.cell');
+      const id = cell.dataset.cellId;
+      const isMarked = !cell.classList.contains('marked');
+      writeMark(id, { marked: isMarked });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      const sec = cell.closest('section.route');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+      if (isMarked) {
+        const why = cell.querySelector('input[data-action="why"]');
+        if (why) setTimeout(() => why.focus(), 0);
+      }
+    });
+  });
+
+  // Why / note inputs (debounced save)
+  let saveTimer = null;
+  function bindInput(sel, field) {
+    document.querySelectorAll(sel).forEach(inp => {
+      const handler = () => {
+        const cell = inp.closest('.cell');
+        if (!cell.classList.contains('marked')) return;
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(() => {
+          writeMark(cell.dataset.cellId, { [field]: inp.value });
+        }, 250);
+      };
+      inp.addEventListener('input', handler);
+      inp.addEventListener('blur', () => {
+        const cell = inp.closest('.cell');
+        if (cell.classList.contains('marked')) writeMark(cell.dataset.cellId, { [field]: inp.value });
+      });
+    });
+  }
+  bindInput('input[data-action="why"]', 'why');
+  bindInput('textarea[data-action="note"]', 'note');
+
+  // Category chips
+  document.querySelectorAll('.cat-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const cell = chip.closest('.cell');
+      if (!cell.classList.contains('marked')) {
+        // Mark the cell first so the category sticks
+        writeMark(cell.dataset.cellId, { marked: true });
+      }
+      const cat = chip.dataset.cat;
+      const isActive = chip.classList.contains('active');
+      writeMark(cell.dataset.cellId, { category: isActive ? null : cat });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+  });
+
+  // Re-capture command (copy to clipboard, flash purple)
+  document.querySelectorAll('button[data-action="recapture"]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const cell = btn.closest('.cell');
+      const cmd = buildRecaptureCommand(cell);
+      if (!cmd) return;
+      try {
+        await navigator.clipboard.writeText(cmd);
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Copy re-capture command'; }, 1500);
+      } catch (e) {
+        prompt('Copy this command:', cmd);
+      }
+      cell.classList.remove('pending-recapture');
+      void cell.offsetWidth; // force reflow so the animation restarts
+      cell.classList.add('pending-recapture');
+    });
+  });
+
+  // Toggles
+  document.getElementById('hide-empty').addEventListener('change', e => document.body.classList.toggle('hide-empty', e.target.checked));
+  document.getElementById('compact').addEventListener('change', e => document.body.classList.toggle('compact', e.target.checked));
+  document.getElementById('fit-cell').addEventListener('change', e => document.body.classList.toggle('fit-cell', e.target.checked));
+  document.getElementById('only-marked').addEventListener('change', e => document.body.classList.toggle('only-marked', e.target.checked));
+  document.getElementById('show-suppressed').addEventListener('change', e => document.body.classList.toggle('show-suppressed', e.target.checked));
+  document.getElementById('hide-desktop').addEventListener('change', e => document.body.classList.toggle('hide-desktop', e.target.checked));
+  document.getElementById('hide-mobile').addEventListener('change', e => document.body.classList.toggle('hide-mobile', e.target.checked));
+
+  // True-scale rendering (1x for selector captures, 0.5x for retina full-page).
+  const RETINA_THRESHOLD = 1500;
+  function applyTrueScale(img) {
+    if (!img.naturalWidth) return;
+    const cssWidth = img.naturalWidth > RETINA_THRESHOLD
+      ? Math.round(img.naturalWidth / 2)
+      : img.naturalWidth;
+    img.style.maxWidth = 'min(100%, ' + cssWidth + 'px)';
+  }
+  document.querySelectorAll('.cell img').forEach(img => {
+    if (img.complete && img.naturalWidth > 0) applyTrueScale(img);
+    else img.addEventListener('load', () => applyTrueScale(img), { once: true });
+  });
+
+  // State chips
+  document.querySelectorAll('.state-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const state = chip.dataset.state;
+      chip.classList.toggle('active');
+      document.body.classList.toggle('hide-state-' + state, !chip.classList.contains('active'));
+    });
+  });
+  STATES.forEach(s => {
+    const chip = document.querySelector('.state-chip[data-state="' + s + '"]');
+    if (chip && !chip.classList.contains('active')) document.body.classList.add('hide-state-' + s);
+  });
+
+  // Manual top-up: fill any DS cells that don't have a mark yet
+  document.getElementById('prefill-ds-btn').addEventListener('click', () => {
+    const added = prefillDsCellsAsNeedsDesign();
+    if (added > 0) {
+      document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+      updateRowSectionFlags();
+      updateCount();
+      alert('Filled ' + added + ' missing DS cells as needs-design.');
+    } else {
+      alert('All DS cells in this route already have marks.');
+    }
+  });
+
+  // Clear-route. Also resets the prefilled flag so a reload re-triggers auto-prefill.
+  document.getElementById('clear-route-btn').addEventListener('click', () => {
+    const ids = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).map(([id]) => id);
+    if (!ids.length) { alert('No marks for this route.'); return; }
+    if (!confirm('Clear ' + ids.length + ' marks for route ' + ROUTE + '?\n\nReloading the page will re-prefill all DS cells as needs-design.')) return;
+    ids.forEach(id => delete marks[id]);
+    saveMarks(marks);
+    const flags = loadPrefilledFlags();
+    delete flags[ROUTE];
+    savePrefilledFlags(flags);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+  });
+
+  function buildMarkdown() {
+    const items = [];
+    Object.entries(marks).forEach(([id, m]) => {
+      if (!m || !m.marked) return;
+      if (!id.startsWith(ROUTE + '__')) return;
+      const parts = id.split('__');
+      const themeKey = parts[parts.length - 1];
+      const state = parts[parts.length - 2];
+      const viewport = parts[parts.length - 3];
+      const route = parts[0];
+      const component = parts.slice(1, parts.length - 3).join('__');
+      items.push({ component, viewport, state, theme: themeKey,
+                   note: m.note || '', why: m.why || '', category: m.category || '' });
+    });
+    items.sort((a, b) => {
+      const ak = componentSortKey(a.component);
+      const bk = componentSortKey(b.component);
+      if (ak[0] !== bk[0]) return ak[0] - bk[0];
+      if (ak[1] !== bk[1]) return ak[1] < bk[1] ? -1 : 1;
+      const sd = STATES.indexOf(a.state) - STATES.indexOf(b.state);
+      if (sd !== 0) return sd;
+      const td = THEME_ORDER.indexOf(a.theme) - THEME_ORDER.indexOf(b.theme);
+      if (td !== 0) return td;
+      return a.viewport === b.viewport ? 0 : (a.viewport === 'desktop' ? -1 : 1);
+    });
+    const date = new Date().toISOString().split('T')[0];
+    const lines = ['# Audit marks -- ' + ROUTE + ' -- ' + items.length + ' items -- ' + date, ''];
+    items.forEach(it => {
+      const catTag = it.category ? ' [' + it.category + ']' : '';
+      const whyTxt = it.why ? ': ' + it.why : '';
+      const noteTxt = it.note ? '  -- ' + it.note : '';
+      lines.push('- [ ] **' + it.theme + ' ' + it.component + '** [' + it.viewport + '/' + it.state + ']' + catTag + whyTxt + noteTxt);
+    });
+    return lines.join('\n');
+  }
+
+  function openOverlay(id) { document.getElementById(id).classList.add('open'); }
+  function closeOverlay(id) { document.getElementById(id).classList.remove('open'); }
+  document.querySelectorAll('.overlay-close').forEach(b => b.addEventListener('click', () => closeOverlay(b.dataset.overlay)));
+  document.querySelectorAll('.overlay').forEach(o => {
+    o.addEventListener('click', e => { if (e.target === o) o.classList.remove('open'); });
+  });
+
+  document.getElementById('export-md-btn').addEventListener('click', async () => {
+    const md = buildMarkdown();
+    const ta = document.getElementById('md-text');
+    ta.value = md;
+    openOverlay('md-overlay');
+    try { await navigator.clipboard.writeText(md); document.getElementById('md-copy').textContent = 'Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+  document.getElementById('md-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('md-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('md-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('export-json-btn').addEventListener('click', () => {
+    const ta = document.getElementById('json-export-text');
+    ta.value = JSON.stringify(marks, null, 2);
+    openOverlay('json-export-overlay');
+  });
+  document.getElementById('json-export-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('json-export-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('json-export-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('json-export-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('import-json-btn').addEventListener('click', () => {
+    document.getElementById('json-import-text').value = '';
+    document.getElementById('json-import-err').textContent = '';
+    openOverlay('json-import-overlay');
+  });
+  document.getElementById('json-import-apply').addEventListener('click', () => {
+    const ta = document.getElementById('json-import-text');
+    const err = document.getElementById('json-import-err');
+    err.textContent = '';
+    let parsed;
+    try { parsed = JSON.parse(ta.value); }
+    catch (e) { err.textContent = 'Invalid JSON: ' + e.message; return; }
+    if (!parsed || typeof parsed !== 'object') { err.textContent = 'Expected an object.'; return; }
+    // First migrate v1 IDs (4 segments) -> v2 IDs (5 segments)
+    const { marks: idMigrated, migrated } = migrateMarksV1ToV2(parsed);
+    // Then upgrade each value v2 -> v3 (preserves marked + note, fills new fields)
+    Object.entries(idMigrated).forEach(([id, m]) => {
+      marks[id] = upgradeV2ValueToV3(m);
+    });
+    saveMarks(marks);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+    closeOverlay('json-import-overlay');
+    alert('Imported ' + Object.keys(idMigrated).length + ' marks (' + migrated + ' legacy IDs migrated to __seeded; values upgraded to v3).');
+  });
+</script>
+</body>
+</html>

--- a/scripts/audit/review/play.html
+++ b/scripts/audit/review/play.html
@@ -1,0 +1,1987 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Cross-Theme Audit (#1129) — play</title>
+<style>
+
+  :root { --col-gap: 8px; --row-gap: 16px; }
+  html, body { margin: 0; padding: 0; font-family: -apple-system, system-ui, sans-serif; background: #fafafa; color: #222; }
+  .sticky-shell { position: sticky; top: 0; z-index: 100; border-bottom: 1px solid #444; }
+  header.top {
+    background: #1a1a1a; color: #fff; padding: 12px 16px;
+    display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+  }
+  header.top h1 { font-size: 14px; margin: 0; font-weight: 600; }
+  header.top .legend { display: flex; gap: 12px; font-size: 12px; }
+  header.top .legend .col { padding: 2px 8px; border-radius: 3px; }
+  header.top .legend .develop { background: #6b7280; }
+  header.top .legend .ds3 { background: #4338ca; }
+  header.top .legend .ds1 { background: #92400e; }
+  header.top .legend .ds2 { background: #166534; }
+  header.top a.back { color: #9cf; font-size: 12px; text-decoration: none; padding: 2px 6px; border-radius: 2px; }
+  header.top a.back:hover { background: #444; color: #fff; }
+  header.top .nav-routes { display: flex; gap: 4px; align-items: center; font-size: 12px; }
+  header.top .nav-routes a { color: #9cf; text-decoration: none; padding: 2px 8px; border-radius: 2px; background: #2a2a2a; }
+  header.top .nav-routes a:hover { background: #444; color: #fff; }
+  header.top .nav-routes .current { color: #fff; font-weight: 600; padding: 2px 8px; }
+  main { padding: 16px; max-width: 100%; }
+  section.route {
+    margin-bottom: 32px; background: #fff; border-radius: 6px;
+    padding: 12px 16px 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  section.route h2 {
+    font-size: 18px; margin: 0 0 12px; padding-bottom: 6px;
+    border-bottom: 1px solid #e5e5e5;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+  .component-row {
+    display: grid; grid-template-columns: 180px repeat(4, 1fr);
+    gap: var(--col-gap); margin-bottom: var(--row-gap);
+    align-items: start;
+  }
+  .component-row .label {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px; color: #555; padding-top: 28px; line-height: 1.3;
+    word-break: break-word;
+  }
+  .cell {
+    border: 1px solid #e5e5e5; border-radius: 4px; overflow: hidden;
+    background: #f3f4f6; position: relative; min-height: 100px;
+    display: flex; flex-direction: column;
+  }
+  .cell .header {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.04em; padding: 4px 8px; color: #fff;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .cell.develop .header { background: #6b7280; }
+  .cell.ds3 .header { background: #4338ca; }
+  .cell.ds1 .header { background: #92400e; }
+  .cell.ds2 .header { background: #166534; }
+  .cell img {
+    display: block; width: auto; max-width: 100%; height: auto;
+    cursor: zoom-in; background: #fff; align-self: flex-start;
+  }
+  body.fit-cell .cell img { width: 100%; max-width: 100%; }
+  .cell.empty {
+    display: flex; align-items: center; justify-content: center;
+    color: #999; font-size: 12px; padding: 24px; background: #f9f9f9;
+  }
+  .cell.empty::after { content: "(not captured)"; }
+
+  /* Lightbox */
+  #lightbox {
+    display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.92);
+    z-index: 1000; align-items: center; justify-content: center; cursor: zoom-out;
+  }
+  #lightbox.open { display: flex; }
+  #lightbox img { max-width: 96vw; max-height: 96vh; box-shadow: 0 4px 24px rgba(0,0,0,0.5); }
+
+  .controls { display: flex; gap: 12px; align-items: center; font-size: 12px; flex-wrap: wrap; }
+  .controls label { display: flex; align-items: center; gap: 4px; cursor: pointer; }
+  .controls input[type=checkbox] { margin: 0; }
+
+  .state-chips { display: inline-flex; gap: 4px; align-items: center; }
+  .state-chip {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .state-chip.active { background: #2563eb; border-color: #1d4ed8; }
+  .state-chip:hover { background: #4b5563; }
+  .state-chip.active:hover { background: #1d4ed8; }
+
+  body.hide-empty .component-row.all-empty,
+  body.hide-empty .cell.empty { display: none; }
+  body.compact .cell img { max-height: 360px; object-fit: cover; object-position: top; }
+
+  .cell .mark-btn {
+    margin-left: auto; background: rgba(255,255,255,0.18);
+    color: #fff; border: 1px solid rgba(255,255,255,0.35);
+    border-radius: 3px; font-size: 10px; font-weight: 600;
+    padding: 2px 6px; cursor: pointer;
+    text-transform: none; letter-spacing: 0; line-height: 1.2;
+  }
+  .cell .mark-btn:hover { background: rgba(255,255,255,0.28); }
+  .cell.marked { border: 3px solid #dc2626; }
+  .cell.marked .mark-btn { background: #dc2626; border-color: #b91c1c; color: #fff; }
+  .cell.marked .mark-btn::before { content: "x "; }
+  .cell.pending-recapture { animation: cellPulse 2s ease-out; }
+  @keyframes cellPulse {
+    0%   { box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.9); border-color: #7c3aed; }
+    100% { box-shadow: 0 0 0 8px rgba(124, 58, 237, 0); }
+  }
+  .cell .toolbar {
+    display: none;
+    padding: 6px 8px; background: #fef2f2; border-top: 1px solid #fecaca;
+    font-size: 11px;
+  }
+  .cell.marked .toolbar { display: block; }
+  .cell .toolbar input[type=text],
+  .cell .toolbar textarea {
+    width: 100%; box-sizing: border-box;
+    border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 4px 6px; font-size: 12px; font-family: inherit;
+    background: #fff;
+  }
+  .cell .toolbar input[type=text]:focus,
+  .cell .toolbar textarea:focus { outline: 2px solid #dc2626; outline-offset: -1px; }
+  .cell .toolbar .field { margin-bottom: 6px; }
+  .cell .toolbar .field-label {
+    display: block; font-size: 10px; font-weight: 600;
+    color: #7f1d1d; text-transform: uppercase; letter-spacing: 0.04em;
+    margin-bottom: 2px;
+  }
+  .cell .toolbar .cat-chips { display: flex; gap: 4px; flex-wrap: wrap; }
+  .cell .toolbar .cat-chip {
+    background: #fff; border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 2px 8px; font-size: 11px; cursor: pointer; font-family: inherit;
+    color: #7f1d1d;
+  }
+  .cell .toolbar .cat-chip.active { background: #7f1d1d; color: #fff; border-color: #7f1d1d; }
+  .cell .toolbar .cat-chip[data-cat="needs-design"].active { background: #6d28d9; border-color: #6d28d9; }
+  .cell .toolbar .cat-chip[data-cat="bug"].active        { background: #b91c1c; border-color: #b91c1c; }
+  .cell .toolbar .cat-chip[data-cat="tooling"].active    { background: #b45309; border-color: #b45309; }
+  .cell .toolbar .cat-chip[data-cat="intentional"].active{ background: #15803d; border-color: #15803d; }
+  .cell .toolbar .cat-chip[data-cat="unclear"].active    { background: #6b7280; border-color: #6b7280; }
+  .cell .toolbar .recapture-btn {
+    background: #1d4ed8; color: #fff; border: 0; border-radius: 3px;
+    padding: 4px 10px; font-size: 11px; cursor: pointer;
+    font-family: inherit; font-weight: 600;
+  }
+  .cell .toolbar .recapture-btn:hover { background: #1e40af; }
+  .cell .toolbar textarea { min-height: 32px; resize: vertical; font-size: 11px; }
+  .cell.cat-needs-design { border-color: #6d28d9; }
+  .cell.cat-bug         { border-color: #b91c1c; }
+  .cell.cat-tooling     { border-color: #b45309; }
+  .cell.cat-intentional { border-color: #15803d; }
+  .cell.cat-unclear     { border-color: #6b7280; }
+
+  .marks-cluster {
+    display: flex; align-items: center; gap: 8px;
+    border-left: 1px solid #444; padding-left: 12px; margin-left: 4px;
+    font-size: 12px;
+  }
+  .marks-cluster .count {
+    background: #dc2626; color: #fff; border-radius: 10px;
+    padding: 2px 8px; font-weight: 600; min-width: 18px; text-align: center;
+  }
+  .marks-cluster button {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .marks-cluster button:hover { background: #4b5563; }
+  .marks-cluster button.danger { background: #7f1d1d; border-color: #991b1b; }
+  .marks-cluster button.danger:hover { background: #991b1b; }
+
+  body.only-marked .component-row:not(.has-marked) { display: none; }
+  body.only-marked section.route:not(.has-marked) { display: none; }
+
+  .component-row.suppressed { display: none; }
+  body.show-suppressed .component-row.suppressed { display: grid; }
+  .component-row.suppressed .label::after { content: " (hidden)"; color: #b91c1c; font-style: italic; }
+
+  .component-row .label[data-mapped] { color: #1d4ed8; }
+  .component-row .label[data-mapped]::after { content: " *"; }
+  .mapped-tooltip {
+    display: inline-block; margin-left: 4px;
+    font-size: 10px; color: #6b7280; cursor: help; vertical-align: super;
+  }
+
+  .vp-badge, .state-badge {
+    display: inline-block; font-size: 9px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.05em;
+    padding: 1px 6px; border-radius: 8px; margin-top: 2px;
+  }
+  .vp-badge.desktop { background: #dbeafe; color: #1e3a8a; border: 1px solid #93c5fd; margin-right: 4px; }
+  .vp-badge.mobile  { background: #fef3c7; color: #78350f; border: 1px solid #fcd34d; margin-right: 4px; }
+  .state-badge.empty       { background: #f3f4f6; color: #374151; border: 1px solid #d1d5db; }
+  .state-badge.seeded      { background: #dcfce7; color: #14532d; border: 1px solid #86efac; }
+  .state-badge.mid-session { background: #ede9fe; color: #4c1d95; border: 1px solid #c4b5fd; }
+
+  .component-row.vp-mobile { background: #fffbeb; padding: 4px; border-radius: 4px; }
+  body.hide-desktop .component-row.vp-desktop { display: none; }
+  body.hide-mobile .component-row.vp-mobile { display: none; }
+
+  body.hide-state-empty       .component-row.state-empty       { display: none; }
+  body.hide-state-seeded      .component-row.state-seeded      { display: none; }
+  body.hide-state-mid-session .component-row.state-mid-session { display: none; }
+
+  .overlay {
+    display: none; position: fixed; inset: 0; z-index: 1100;
+    background: rgba(0,0,0,0.6); align-items: center; justify-content: center;
+  }
+  .overlay.open { display: flex; }
+  .overlay .panel {
+    background: #fff; border-radius: 6px; width: min(720px, 92vw);
+    max-height: 80vh; padding: 16px; display: flex; flex-direction: column; gap: 8px;
+  }
+  .overlay h3 { margin: 0; font-size: 14px; }
+  .overlay textarea {
+    flex: 1; min-height: 320px; font-family: ui-monospace, monospace; font-size: 12px;
+    border: 1px solid #ddd; border-radius: 4px; padding: 8px; resize: vertical;
+  }
+  .overlay .actions { display: flex; gap: 8px; justify-content: flex-end; }
+  .overlay button {
+    background: #1a1a1a; color: #fff; border: 0; border-radius: 3px;
+    padding: 6px 12px; font-size: 12px; cursor: pointer;
+  }
+  .overlay .hint { font-size: 11px; color: #555; }
+  .overlay .err  { font-size: 12px; color: #b91c1c; min-height: 16px; }
+
+  /* Index-page table */
+  table.routes-index {
+    width: 100%; border-collapse: collapse; background: #fff;
+    border-radius: 6px; overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  table.routes-index th, table.routes-index td {
+    padding: 8px 12px; text-align: left; font-size: 13px;
+    border-bottom: 1px solid #eee;
+  }
+  table.routes-index th { background: #f3f4f6; font-weight: 600; }
+  table.routes-index td a {
+    color: #1d4ed8; text-decoration: none; font-family: ui-monospace, monospace;
+  }
+  table.routes-index td a:hover { text-decoration: underline; }
+  table.routes-index td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  table.routes-index .marked-count.has-marks { color: #b91c1c; font-weight: 600; }
+  table.routes-index .unresolved-count.has-unresolved { color: #b45309; font-weight: 600; }
+  table.routes-index .breakdown {
+    font-size: 11px; color: #555; margin-left: 6px; font-variant-numeric: tabular-nums;
+  }
+
+
+</style>
+</head>
+<body>
+<div class="sticky-shell">
+<header class="top">
+  <a class="back" href="index.html">&larr; Index</a>
+  <h1>play</h1>
+  <div class="legend">
+    <span class="col develop">develop</span>
+    <span class="col ds3">DS3</span>
+    <span class="col ds1">DS1</span>
+    <span class="col ds2">DS2</span>
+  </div>
+  <div class="controls">
+    <span class="state-chips" role="group" aria-label="State filter">
+      <span style="font-size: 11px; color: #aaa;">State:</span>
+      <button type="button" class="state-chip" data-state="empty">empty</button>
+      <button type="button" class="state-chip active" data-state="seeded">seeded</button>
+    </span>
+    <label><input type="checkbox" id="hide-empty"> Hide missing</label>
+    <label><input type="checkbox" id="compact"> Compact</label>
+    <label title="Stretch images to cell width"><input type="checkbox" id="fit-cell"> Fit to cell</label>
+    <label><input type="checkbox" id="only-marked"> Only marked</label>
+    <label><input type="checkbox" id="show-suppressed"> Show hidden rows</label>
+    <label><input type="checkbox" id="hide-desktop"> Hide desktop</label>
+    <label><input type="checkbox" id="hide-mobile"> Hide mobile</label>
+  </div>
+  <div class="marks-cluster">
+    <span>Marked (route):</span>
+    <span class="count" id="mark-count">0</span>
+    <button id="prefill-ds-btn" type="button" title="Mark every DS cell that has no mark yet as needs-design (gap-fill, never overwrites your existing marks)">Fill DS gaps</button>
+    <button id="export-md-btn" type="button">Export markdown</button>
+    <button id="export-json-btn" type="button">Export JSON</button>
+    <button id="import-json-btn" type="button">Import JSON</button>
+    <button id="clear-route-btn" type="button" class="danger">Clear (route)</button>
+  </div>
+</header>
+<nav class="toc" style="background:#2a2a2a;color:#ccc;padding:6px 16px;font-size:12px;display:flex;gap:8px;align-items:center;border-top:1px solid #444;">
+  <span class="nav-routes">
+    <a href="characters-create.html">&larr; characters-create</a>
+    <span class="current">play</span>
+    <a href="settings.html">settings &rarr;</a>
+  </span>
+</nav>
+</div>
+<main>
+<section class="route" id="route-play">
+  <h2>play</h2>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="play__global-nav__desktop__empty__develop" data-route="play" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/play__nav.png" alt="develop play/global-nav/desktop/empty" data-caption="develop -- play/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="play__global-nav__desktop__empty__DS3" data-route="play" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/play__nav.png" alt="DS3 play/global-nav/desktop/empty" data-caption="DS3 -- play/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="play__global-nav__desktop__empty__DS1" data-route="play" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/play__nav.png" alt="DS1 play/global-nav/desktop/empty" data-caption="DS1 -- play/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="play__global-nav__desktop__empty__DS2" data-route="play" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/play__nav.png" alt="DS2 play/global-nav/desktop/empty" data-caption="DS2 -- play/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="play__page__desktop__empty__develop" data-route="play" data-component="page" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/play__page.png" alt="develop play/page/desktop/empty" data-caption="develop -- play/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="play__page__desktop__empty__DS3" data-route="play" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/play__page.png" alt="DS3 play/page/desktop/empty" data-caption="DS3 -- play/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="play__page__desktop__empty__DS1" data-route="play" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/play__page.png" alt="DS1 play/page/desktop/empty" data-caption="DS1 -- play/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="play__page__desktop__empty__DS2" data-route="play" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/play__page.png" alt="DS2 play/page/desktop/empty" data-caption="DS2 -- play/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-empty" data-viewport="mobile" data-state="empty">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="play__page__mobile__empty__develop" data-route="play" data-component="page" data-viewport="mobile" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/empty/play__page.png" alt="develop play/page/mobile/empty" data-caption="develop -- play/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="play__page__mobile__empty__DS3" data-route="play" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/empty/play__page.png" alt="DS3 play/page/mobile/empty" data-caption="DS3 -- play/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="play__page__mobile__empty__DS1" data-route="play" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/empty/play__page.png" alt="DS1 play/page/mobile/empty" data-caption="DS1 -- play/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="play__page__mobile__empty__DS2" data-route="play" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/empty/play__page.png" alt="DS2 play/page/mobile/empty" data-caption="DS2 -- play/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="play__header__desktop__empty__develop" data-route="play" data-component="header" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/play__header.png" alt="develop play/header/desktop/empty" data-caption="develop -- play/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="play__nav__desktop__empty__develop" data-route="play" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/play__nav.png" alt="develop play/nav/desktop/empty" data-caption="develop -- play/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="play__nav__desktop__empty__DS3" data-route="play" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/play__nav.png" alt="DS3 play/nav/desktop/empty" data-caption="DS3 -- play/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="play__nav__desktop__empty__DS1" data-route="play" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/play__nav.png" alt="DS1 play/nav/desktop/empty" data-caption="DS1 -- play/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="play__nav__desktop__empty__DS2" data-route="play" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/play__nav.png" alt="DS2 play/nav/desktop/empty" data-caption="DS2 -- play/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="play__main__desktop__empty__develop" data-route="play" data-component="main" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/play__main.png" alt="develop play/main/desktop/empty" data-caption="develop -- play/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="play__main__desktop__empty__DS3" data-route="play" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/play__main.png" alt="DS3 play/main/desktop/empty" data-caption="DS3 -- play/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="play__main__desktop__empty__DS1" data-route="play" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/play__main.png" alt="DS1 play/main/desktop/empty" data-caption="DS1 -- play/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="play__main__desktop__empty__DS2" data-route="play" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/play__main.png" alt="DS2 play/main/desktop/empty" data-caption="DS2 -- play/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="play__global-nav__desktop__seeded__develop" data-route="play" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/play__nav.png" alt="develop play/global-nav/desktop/seeded" data-caption="develop -- play/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="play__global-nav__desktop__seeded__DS3" data-route="play" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/play__nav.png" alt="DS3 play/global-nav/desktop/seeded" data-caption="DS3 -- play/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="play__global-nav__desktop__seeded__DS1" data-route="play" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/play__nav.png" alt="DS1 play/global-nav/desktop/seeded" data-caption="DS1 -- play/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="play__global-nav__desktop__seeded__DS2" data-route="play" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/play__nav.png" alt="DS2 play/global-nav/desktop/seeded" data-caption="DS2 -- play/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="play__page__desktop__seeded__develop" data-route="play" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/play__page.png" alt="develop play/page/desktop/seeded" data-caption="develop -- play/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="play__page__desktop__seeded__DS3" data-route="play" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/play__page.png" alt="DS3 play/page/desktop/seeded" data-caption="DS3 -- play/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="play__page__desktop__seeded__DS1" data-route="play" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/play__page.png" alt="DS1 play/page/desktop/seeded" data-caption="DS1 -- play/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="play__page__desktop__seeded__DS2" data-route="play" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/play__page.png" alt="DS2 play/page/desktop/seeded" data-caption="DS2 -- play/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-seeded" data-viewport="mobile" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="play__page__mobile__seeded__develop" data-route="play" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/seeded/play__page.png" alt="develop play/page/mobile/seeded" data-caption="develop -- play/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="play__page__mobile__seeded__DS3" data-route="play" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/seeded/play__page.png" alt="DS3 play/page/mobile/seeded" data-caption="DS3 -- play/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="play__page__mobile__seeded__DS1" data-route="play" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/seeded/play__page.png" alt="DS1 play/page/mobile/seeded" data-caption="DS1 -- play/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="play__page__mobile__seeded__DS2" data-route="play" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/seeded/play__page.png" alt="DS2 play/page/mobile/seeded" data-caption="DS2 -- play/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="play__header__desktop__seeded__develop" data-route="play" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/play__header.png" alt="develop play/header/desktop/seeded" data-caption="develop -- play/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="play__nav__desktop__seeded__develop" data-route="play" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/play__nav.png" alt="develop play/nav/desktop/seeded" data-caption="develop -- play/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="play__nav__desktop__seeded__DS3" data-route="play" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/play__nav.png" alt="DS3 play/nav/desktop/seeded" data-caption="DS3 -- play/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="play__nav__desktop__seeded__DS1" data-route="play" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/play__nav.png" alt="DS1 play/nav/desktop/seeded" data-caption="DS1 -- play/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="play__nav__desktop__seeded__DS2" data-route="play" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/play__nav.png" alt="DS2 play/nav/desktop/seeded" data-caption="DS2 -- play/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="play__main__desktop__seeded__develop" data-route="play" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/play__main.png" alt="develop play/main/desktop/seeded" data-caption="develop -- play/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="play__main__desktop__seeded__DS3" data-route="play" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/play__main.png" alt="DS3 play/main/desktop/seeded" data-caption="DS3 -- play/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="play__main__desktop__seeded__DS1" data-route="play" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/play__main.png" alt="DS1 play/main/desktop/seeded" data-caption="DS1 -- play/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="play__main__desktop__seeded__DS2" data-route="play" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/play__main.png" alt="DS2 play/main/desktop/seeded" data-caption="DS2 -- play/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+</main>
+
+<div id="lightbox" class="overlay">
+  <img id="lightbox-img" src="" alt="">
+  <div id="lightbox-caption" style="position: fixed; top: 12px; left: 50%; transform: translateX(-50%); color: #fff; font-family: ui-monospace, monospace; font-size: 13px; background: rgba(0,0,0,0.6); padding: 6px 12px; border-radius: 4px;"></div>
+</div>
+
+<div id="md-overlay" class="overlay">
+  <div class="panel">
+    <h3>Audit marks (markdown) -- this route only</h3>
+    <textarea id="md-text" readonly></textarea>
+    <div class="actions">
+      <button id="md-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="md-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-export-overlay" class="overlay">
+  <div class="panel">
+    <h3>Marks (raw JSON) -- all routes</h3>
+    <textarea id="json-export-text" readonly></textarea>
+    <div class="actions">
+      <button id="json-export-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="json-export-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-import-overlay" class="overlay">
+  <div class="panel">
+    <h3>Import marks (paste raw JSON)</h3>
+    <p class="hint">Paste JSON exported from another instance. Legacy IDs without a state segment are migrated to <code>__seeded</code>; v2 values are upgraded to v3 (category=null, why="", updatedAt=now). Existing marks with the same ID are overwritten.</p>
+    <textarea id="json-import-text" placeholder='{"home__page__desktop__seeded__DS3":{"marked":true,"note":"...","category":"bug","why":"...","updatedAt":"..."}}'></textarea>
+    <div class="err" id="json-import-err"></div>
+    <div class="actions">
+      <button id="json-import-apply" type="button">Apply</button>
+      <button class="overlay-close" data-overlay="json-import-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+<script>
+
+  const STORAGE_KEY = 'narraitor-audit-marks-v3';
+  const STORAGE_KEY_V2 = 'narraitor-audit-marks-v2';
+  const STORAGE_KEY_V1 = 'narraitor-audit-marks-v1';
+  // Tracks which routes have had their DS cells auto-prefilled as needs-design.
+  // Once a route is in here, the auto-prefill on page load is skipped.
+  const PREFILLED_KEY = 'narraitor-audit-prefilled-v1';
+  const STATES = ['empty', 'seeded'];
+  const VALID_CATEGORIES = ['needs-design','bug','tooling','intentional','unclear'];
+  const ROUTE_ORDER = ["home", "about", "worlds", "worlds-detail", "worlds-edit", "worlds-create", "worlds-play", "worlds-play-journal", "characters", "characters-detail", "characters-edit", "characters-create", "play", "settings"];
+  const COMPONENT_ORDER = {"page":0,"header":1,"nav":2,"form":3,"main":4};
+  const THEME_ORDER = ["DS3","DS1","DS2","develop"];
+  const BRANCH_META = {"develop": {"theme": "default", "mode": "light", "branchArg": "develop-default"}, "DS3": {"theme": "ds3", "mode": "light", "branchArg": "integration-ds3-light"}, "DS1": {"theme": "ds1", "mode": "light", "branchArg": "integration-ds1-light"}, "DS2": {"theme": "ds2", "mode": "light", "branchArg": "integration-ds2-light"}};
+
+  function componentSortKey(c) {
+    if (c in COMPONENT_ORDER) return [COMPONENT_ORDER[c], 0];
+    if (c.startsWith("main-section-")) {
+      const n = parseInt(c.replace("main-section-",""), 10);
+      return [5, isNaN(n) ? 0 : n];
+    }
+    return [9, c];
+  }
+
+  // Pre-v3 ID migration: v1 (4 segments) -> v2 (5 segments) by inserting __seeded.
+  function migrateLegacyId(id) {
+    const parts = id.split('__');
+    if (parts.length < 4) return id;
+    const last = parts[parts.length - 1];
+    const second = parts[parts.length - 2];
+    const third = parts[parts.length - 3];
+    const isTheme = ['DS1','DS2','DS3','develop'].includes(last);
+    const isViewport = ['desktop','mobile'].includes(second);
+    const alreadyHasState = STATES.includes(third);
+    if (isTheme && isViewport && !alreadyHasState) {
+      const head = parts.slice(0, parts.length - 1).join('__');
+      return head + '__seeded__' + last;
+    }
+    return id;
+  }
+
+  function migrateMarksV1ToV2(input) {
+    const out = {};
+    let migrated = 0;
+    for (const [id, m] of Object.entries(input || {})) {
+      const newId = migrateLegacyId(id);
+      if (newId !== id) migrated++;
+      out[newId] = m;
+    }
+    return { marks: out, migrated };
+  }
+
+  // v2 -> v3: add category, why, updatedAt; preserve marked + note.
+  function upgradeV2ValueToV3(v) {
+    if (!v || typeof v !== 'object') return null;
+    return {
+      marked: !!v.marked,
+      note: typeof v.note === 'string' ? v.note : '',
+      category: v.category && VALID_CATEGORIES.includes(v.category) ? v.category : null,
+      why: typeof v.why === 'string' ? v.why : '',
+      updatedAt: v.updatedAt || new Date().toISOString(),
+    };
+  }
+
+  function migrateV2ObjectToV3(v2obj) {
+    const out = {};
+    for (const [id, m] of Object.entries(v2obj || {})) {
+      out[id] = upgradeV2ValueToV3(m);
+    }
+    return out;
+  }
+
+  function loadMarks() {
+    try {
+      const v3 = localStorage.getItem(STORAGE_KEY);
+      if (v3) return JSON.parse(v3);
+      // No v3 yet — try v2 (lazy migrate; leave v2 untouched for rollback).
+      const v2raw = localStorage.getItem(STORAGE_KEY_V2);
+      if (v2raw) {
+        const v3marks = migrateV2ObjectToV3(JSON.parse(v2raw));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + Object.keys(v3marks).length + ' v2 marks to v3 (v2 untouched).');
+        return v3marks;
+      }
+      // No v3 or v2 — try v1 and migrate v1 -> v2 -> v3 in one pass.
+      const v1raw = localStorage.getItem(STORAGE_KEY_V1);
+      if (v1raw) {
+        const { marks: v2marks, migrated } = migrateMarksV1ToV2(JSON.parse(v1raw));
+        const v3marks = migrateV2ObjectToV3(v2marks);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + migrated + ' v1 IDs through to v3.');
+        return v3marks;
+      }
+    } catch (e) { console.warn(e); }
+    return {};
+  }
+
+  function saveMarks(m) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(m)); } catch (e) {}
+  }
+
+
+  const ROUTE = "play";
+  let marks = loadMarks();
+
+  function applyMarkState(cell) {
+    const id = cell.dataset.cellId;
+    const m = marks[id];
+    const noteInput = cell.querySelector('textarea[data-action="note"]');
+    const whyInput = cell.querySelector('input[data-action="why"]');
+    const chips = cell.querySelectorAll('.cat-chip');
+    cell.classList.remove('cat-bug','cat-tooling','cat-intentional','cat-unclear');
+    chips.forEach(c => c.classList.remove('active'));
+    if (m && m.marked) {
+      cell.classList.add('marked');
+      if (noteInput) noteInput.value = m.note || '';
+      if (whyInput) whyInput.value = m.why || '';
+      if (m.category) {
+        cell.classList.add('cat-' + m.category);
+        const chip = cell.querySelector('.cat-chip[data-cat="' + m.category + '"]');
+        if (chip) chip.classList.add('active');
+      }
+    } else {
+      cell.classList.remove('marked');
+      if (noteInput) noteInput.value = '';
+      if (whyInput) whyInput.value = '';
+    }
+  }
+
+  function updateRowSectionFlags() {
+    document.querySelectorAll('.component-row').forEach(row => {
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+    document.querySelectorAll('section.route').forEach(sec => {
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+    });
+  }
+
+  function updateCount() {
+    const n = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).length;
+    document.getElementById('mark-count').textContent = n;
+  }
+
+  function writeMark(id, partial) {
+    const existing = marks[id] || { marked: false, note: '', category: null, why: '', updatedAt: null };
+    const next = Object.assign({}, existing, partial, { updatedAt: new Date().toISOString() });
+    if (!next.marked && !next.note && !next.why && !next.category) {
+      delete marks[id];
+    } else {
+      marks[id] = next;
+    }
+    saveMarks(marks);
+    updateCount();
+  }
+
+  function buildRecaptureCommand(cell) {
+    const route = cell.dataset.route;
+    const viewport = cell.dataset.viewport;
+    const state = cell.dataset.state;
+    const themeKey = cell.dataset.theme;
+    const meta = BRANCH_META[themeKey];
+    if (!meta) return null;
+    return 'npx tsx scripts/audit/playwright-crawl.ts'
+      + ' --branch ' + meta.branchArg
+      + ' --viewport ' + viewport
+      + ' --state ' + state
+      + ' --theme ' + meta.theme
+      + ' --mode ' + meta.mode
+      + ' --route ' + route;
+  }
+
+  function loadPrefilledFlags() {
+    try { return JSON.parse(localStorage.getItem(PREFILLED_KEY) || '{}'); }
+    catch (e) { return {}; }
+  }
+  function savePrefilledFlags(f) {
+    try { localStorage.setItem(PREFILLED_KEY, JSON.stringify(f)); } catch (e) {}
+  }
+
+  // Gap-fill: only adds entries for DS cells that have no existing mark.
+  // Returns the count of cells filled. Develop is excluded (it's the baseline).
+  function prefillDsCellsAsNeedsDesign() {
+    const dsCells = Array.from(document.querySelectorAll('.cell[data-cell-id]'))
+      .filter(c => ['DS1','DS2','DS3'].includes(c.dataset.theme));
+    let added = 0;
+    const ts = new Date().toISOString();
+    for (const cell of dsCells) {
+      const id = cell.dataset.cellId;
+      if (!marks[id]) {
+        marks[id] = { marked: true, note: '', category: 'needs-design', why: '', updatedAt: ts };
+        added++;
+      }
+    }
+    if (added > 0) saveMarks(marks);
+    return added;
+  }
+
+  // Auto-prefill on first visit per route.
+  const prefillFlags = loadPrefilledFlags();
+  if (!prefillFlags[ROUTE]) {
+    const added = prefillDsCellsAsNeedsDesign();
+    prefillFlags[ROUTE] = true;
+    savePrefilledFlags(prefillFlags);
+    if (added > 0) console.info('[audit] auto-prefilled ' + added + ' DS cells for ' + ROUTE + ' as needs-design.');
+  }
+
+  document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+  updateRowSectionFlags();
+  updateCount();
+
+  // Lightbox
+  const lb = document.getElementById('lightbox');
+  const lbImg = document.getElementById('lightbox-img');
+  const lbCap = document.getElementById('lightbox-caption');
+  document.querySelectorAll('.cell img').forEach(img => {
+    img.addEventListener('click', () => {
+      lbImg.src = img.src;
+      lbCap.textContent = img.dataset.caption || '';
+      lb.classList.add('open');
+    });
+  });
+  lb.addEventListener('click', () => lb.classList.remove('open'));
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') document.querySelectorAll('.overlay.open').forEach(o => o.classList.remove('open'));
+  });
+
+  // Mark toggle
+  document.querySelectorAll('button[data-action="toggle-mark"]').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      const cell = btn.closest('.cell');
+      const id = cell.dataset.cellId;
+      const isMarked = !cell.classList.contains('marked');
+      writeMark(id, { marked: isMarked });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      const sec = cell.closest('section.route');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+      if (isMarked) {
+        const why = cell.querySelector('input[data-action="why"]');
+        if (why) setTimeout(() => why.focus(), 0);
+      }
+    });
+  });
+
+  // Why / note inputs (debounced save)
+  let saveTimer = null;
+  function bindInput(sel, field) {
+    document.querySelectorAll(sel).forEach(inp => {
+      const handler = () => {
+        const cell = inp.closest('.cell');
+        if (!cell.classList.contains('marked')) return;
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(() => {
+          writeMark(cell.dataset.cellId, { [field]: inp.value });
+        }, 250);
+      };
+      inp.addEventListener('input', handler);
+      inp.addEventListener('blur', () => {
+        const cell = inp.closest('.cell');
+        if (cell.classList.contains('marked')) writeMark(cell.dataset.cellId, { [field]: inp.value });
+      });
+    });
+  }
+  bindInput('input[data-action="why"]', 'why');
+  bindInput('textarea[data-action="note"]', 'note');
+
+  // Category chips
+  document.querySelectorAll('.cat-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const cell = chip.closest('.cell');
+      if (!cell.classList.contains('marked')) {
+        // Mark the cell first so the category sticks
+        writeMark(cell.dataset.cellId, { marked: true });
+      }
+      const cat = chip.dataset.cat;
+      const isActive = chip.classList.contains('active');
+      writeMark(cell.dataset.cellId, { category: isActive ? null : cat });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+  });
+
+  // Re-capture command (copy to clipboard, flash purple)
+  document.querySelectorAll('button[data-action="recapture"]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const cell = btn.closest('.cell');
+      const cmd = buildRecaptureCommand(cell);
+      if (!cmd) return;
+      try {
+        await navigator.clipboard.writeText(cmd);
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Copy re-capture command'; }, 1500);
+      } catch (e) {
+        prompt('Copy this command:', cmd);
+      }
+      cell.classList.remove('pending-recapture');
+      void cell.offsetWidth; // force reflow so the animation restarts
+      cell.classList.add('pending-recapture');
+    });
+  });
+
+  // Toggles
+  document.getElementById('hide-empty').addEventListener('change', e => document.body.classList.toggle('hide-empty', e.target.checked));
+  document.getElementById('compact').addEventListener('change', e => document.body.classList.toggle('compact', e.target.checked));
+  document.getElementById('fit-cell').addEventListener('change', e => document.body.classList.toggle('fit-cell', e.target.checked));
+  document.getElementById('only-marked').addEventListener('change', e => document.body.classList.toggle('only-marked', e.target.checked));
+  document.getElementById('show-suppressed').addEventListener('change', e => document.body.classList.toggle('show-suppressed', e.target.checked));
+  document.getElementById('hide-desktop').addEventListener('change', e => document.body.classList.toggle('hide-desktop', e.target.checked));
+  document.getElementById('hide-mobile').addEventListener('change', e => document.body.classList.toggle('hide-mobile', e.target.checked));
+
+  // True-scale rendering (1x for selector captures, 0.5x for retina full-page).
+  const RETINA_THRESHOLD = 1500;
+  function applyTrueScale(img) {
+    if (!img.naturalWidth) return;
+    const cssWidth = img.naturalWidth > RETINA_THRESHOLD
+      ? Math.round(img.naturalWidth / 2)
+      : img.naturalWidth;
+    img.style.maxWidth = 'min(100%, ' + cssWidth + 'px)';
+  }
+  document.querySelectorAll('.cell img').forEach(img => {
+    if (img.complete && img.naturalWidth > 0) applyTrueScale(img);
+    else img.addEventListener('load', () => applyTrueScale(img), { once: true });
+  });
+
+  // State chips
+  document.querySelectorAll('.state-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const state = chip.dataset.state;
+      chip.classList.toggle('active');
+      document.body.classList.toggle('hide-state-' + state, !chip.classList.contains('active'));
+    });
+  });
+  STATES.forEach(s => {
+    const chip = document.querySelector('.state-chip[data-state="' + s + '"]');
+    if (chip && !chip.classList.contains('active')) document.body.classList.add('hide-state-' + s);
+  });
+
+  // Manual top-up: fill any DS cells that don't have a mark yet
+  document.getElementById('prefill-ds-btn').addEventListener('click', () => {
+    const added = prefillDsCellsAsNeedsDesign();
+    if (added > 0) {
+      document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+      updateRowSectionFlags();
+      updateCount();
+      alert('Filled ' + added + ' missing DS cells as needs-design.');
+    } else {
+      alert('All DS cells in this route already have marks.');
+    }
+  });
+
+  // Clear-route. Also resets the prefilled flag so a reload re-triggers auto-prefill.
+  document.getElementById('clear-route-btn').addEventListener('click', () => {
+    const ids = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).map(([id]) => id);
+    if (!ids.length) { alert('No marks for this route.'); return; }
+    if (!confirm('Clear ' + ids.length + ' marks for route ' + ROUTE + '?\n\nReloading the page will re-prefill all DS cells as needs-design.')) return;
+    ids.forEach(id => delete marks[id]);
+    saveMarks(marks);
+    const flags = loadPrefilledFlags();
+    delete flags[ROUTE];
+    savePrefilledFlags(flags);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+  });
+
+  function buildMarkdown() {
+    const items = [];
+    Object.entries(marks).forEach(([id, m]) => {
+      if (!m || !m.marked) return;
+      if (!id.startsWith(ROUTE + '__')) return;
+      const parts = id.split('__');
+      const themeKey = parts[parts.length - 1];
+      const state = parts[parts.length - 2];
+      const viewport = parts[parts.length - 3];
+      const route = parts[0];
+      const component = parts.slice(1, parts.length - 3).join('__');
+      items.push({ component, viewport, state, theme: themeKey,
+                   note: m.note || '', why: m.why || '', category: m.category || '' });
+    });
+    items.sort((a, b) => {
+      const ak = componentSortKey(a.component);
+      const bk = componentSortKey(b.component);
+      if (ak[0] !== bk[0]) return ak[0] - bk[0];
+      if (ak[1] !== bk[1]) return ak[1] < bk[1] ? -1 : 1;
+      const sd = STATES.indexOf(a.state) - STATES.indexOf(b.state);
+      if (sd !== 0) return sd;
+      const td = THEME_ORDER.indexOf(a.theme) - THEME_ORDER.indexOf(b.theme);
+      if (td !== 0) return td;
+      return a.viewport === b.viewport ? 0 : (a.viewport === 'desktop' ? -1 : 1);
+    });
+    const date = new Date().toISOString().split('T')[0];
+    const lines = ['# Audit marks -- ' + ROUTE + ' -- ' + items.length + ' items -- ' + date, ''];
+    items.forEach(it => {
+      const catTag = it.category ? ' [' + it.category + ']' : '';
+      const whyTxt = it.why ? ': ' + it.why : '';
+      const noteTxt = it.note ? '  -- ' + it.note : '';
+      lines.push('- [ ] **' + it.theme + ' ' + it.component + '** [' + it.viewport + '/' + it.state + ']' + catTag + whyTxt + noteTxt);
+    });
+    return lines.join('\n');
+  }
+
+  function openOverlay(id) { document.getElementById(id).classList.add('open'); }
+  function closeOverlay(id) { document.getElementById(id).classList.remove('open'); }
+  document.querySelectorAll('.overlay-close').forEach(b => b.addEventListener('click', () => closeOverlay(b.dataset.overlay)));
+  document.querySelectorAll('.overlay').forEach(o => {
+    o.addEventListener('click', e => { if (e.target === o) o.classList.remove('open'); });
+  });
+
+  document.getElementById('export-md-btn').addEventListener('click', async () => {
+    const md = buildMarkdown();
+    const ta = document.getElementById('md-text');
+    ta.value = md;
+    openOverlay('md-overlay');
+    try { await navigator.clipboard.writeText(md); document.getElementById('md-copy').textContent = 'Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+  document.getElementById('md-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('md-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('md-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('export-json-btn').addEventListener('click', () => {
+    const ta = document.getElementById('json-export-text');
+    ta.value = JSON.stringify(marks, null, 2);
+    openOverlay('json-export-overlay');
+  });
+  document.getElementById('json-export-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('json-export-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('json-export-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('json-export-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('import-json-btn').addEventListener('click', () => {
+    document.getElementById('json-import-text').value = '';
+    document.getElementById('json-import-err').textContent = '';
+    openOverlay('json-import-overlay');
+  });
+  document.getElementById('json-import-apply').addEventListener('click', () => {
+    const ta = document.getElementById('json-import-text');
+    const err = document.getElementById('json-import-err');
+    err.textContent = '';
+    let parsed;
+    try { parsed = JSON.parse(ta.value); }
+    catch (e) { err.textContent = 'Invalid JSON: ' + e.message; return; }
+    if (!parsed || typeof parsed !== 'object') { err.textContent = 'Expected an object.'; return; }
+    // First migrate v1 IDs (4 segments) -> v2 IDs (5 segments)
+    const { marks: idMigrated, migrated } = migrateMarksV1ToV2(parsed);
+    // Then upgrade each value v2 -> v3 (preserves marked + note, fills new fields)
+    Object.entries(idMigrated).forEach(([id, m]) => {
+      marks[id] = upgradeV2ValueToV3(m);
+    });
+    saveMarks(marks);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+    closeOverlay('json-import-overlay');
+    alert('Imported ' + Object.keys(idMigrated).length + ' marks (' + migrated + ' legacy IDs migrated to __seeded; values upgraded to v3).');
+  });
+</script>
+</body>
+</html>

--- a/scripts/audit/review/settings.html
+++ b/scripts/audit/review/settings.html
@@ -1,0 +1,2064 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Cross-Theme Audit (#1129) — settings</title>
+<style>
+
+  :root { --col-gap: 8px; --row-gap: 16px; }
+  html, body { margin: 0; padding: 0; font-family: -apple-system, system-ui, sans-serif; background: #fafafa; color: #222; }
+  .sticky-shell { position: sticky; top: 0; z-index: 100; border-bottom: 1px solid #444; }
+  header.top {
+    background: #1a1a1a; color: #fff; padding: 12px 16px;
+    display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+  }
+  header.top h1 { font-size: 14px; margin: 0; font-weight: 600; }
+  header.top .legend { display: flex; gap: 12px; font-size: 12px; }
+  header.top .legend .col { padding: 2px 8px; border-radius: 3px; }
+  header.top .legend .develop { background: #6b7280; }
+  header.top .legend .ds3 { background: #4338ca; }
+  header.top .legend .ds1 { background: #92400e; }
+  header.top .legend .ds2 { background: #166534; }
+  header.top a.back { color: #9cf; font-size: 12px; text-decoration: none; padding: 2px 6px; border-radius: 2px; }
+  header.top a.back:hover { background: #444; color: #fff; }
+  header.top .nav-routes { display: flex; gap: 4px; align-items: center; font-size: 12px; }
+  header.top .nav-routes a { color: #9cf; text-decoration: none; padding: 2px 8px; border-radius: 2px; background: #2a2a2a; }
+  header.top .nav-routes a:hover { background: #444; color: #fff; }
+  header.top .nav-routes .current { color: #fff; font-weight: 600; padding: 2px 8px; }
+  main { padding: 16px; max-width: 100%; }
+  section.route {
+    margin-bottom: 32px; background: #fff; border-radius: 6px;
+    padding: 12px 16px 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  section.route h2 {
+    font-size: 18px; margin: 0 0 12px; padding-bottom: 6px;
+    border-bottom: 1px solid #e5e5e5;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+  .component-row {
+    display: grid; grid-template-columns: 180px repeat(4, 1fr);
+    gap: var(--col-gap); margin-bottom: var(--row-gap);
+    align-items: start;
+  }
+  .component-row .label {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px; color: #555; padding-top: 28px; line-height: 1.3;
+    word-break: break-word;
+  }
+  .cell {
+    border: 1px solid #e5e5e5; border-radius: 4px; overflow: hidden;
+    background: #f3f4f6; position: relative; min-height: 100px;
+    display: flex; flex-direction: column;
+  }
+  .cell .header {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.04em; padding: 4px 8px; color: #fff;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .cell.develop .header { background: #6b7280; }
+  .cell.ds3 .header { background: #4338ca; }
+  .cell.ds1 .header { background: #92400e; }
+  .cell.ds2 .header { background: #166534; }
+  .cell img {
+    display: block; width: auto; max-width: 100%; height: auto;
+    cursor: zoom-in; background: #fff; align-self: flex-start;
+  }
+  body.fit-cell .cell img { width: 100%; max-width: 100%; }
+  .cell.empty {
+    display: flex; align-items: center; justify-content: center;
+    color: #999; font-size: 12px; padding: 24px; background: #f9f9f9;
+  }
+  .cell.empty::after { content: "(not captured)"; }
+
+  /* Lightbox */
+  #lightbox {
+    display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.92);
+    z-index: 1000; align-items: center; justify-content: center; cursor: zoom-out;
+  }
+  #lightbox.open { display: flex; }
+  #lightbox img { max-width: 96vw; max-height: 96vh; box-shadow: 0 4px 24px rgba(0,0,0,0.5); }
+
+  .controls { display: flex; gap: 12px; align-items: center; font-size: 12px; flex-wrap: wrap; }
+  .controls label { display: flex; align-items: center; gap: 4px; cursor: pointer; }
+  .controls input[type=checkbox] { margin: 0; }
+
+  .state-chips { display: inline-flex; gap: 4px; align-items: center; }
+  .state-chip {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .state-chip.active { background: #2563eb; border-color: #1d4ed8; }
+  .state-chip:hover { background: #4b5563; }
+  .state-chip.active:hover { background: #1d4ed8; }
+
+  body.hide-empty .component-row.all-empty,
+  body.hide-empty .cell.empty { display: none; }
+  body.compact .cell img { max-height: 360px; object-fit: cover; object-position: top; }
+
+  .cell .mark-btn {
+    margin-left: auto; background: rgba(255,255,255,0.18);
+    color: #fff; border: 1px solid rgba(255,255,255,0.35);
+    border-radius: 3px; font-size: 10px; font-weight: 600;
+    padding: 2px 6px; cursor: pointer;
+    text-transform: none; letter-spacing: 0; line-height: 1.2;
+  }
+  .cell .mark-btn:hover { background: rgba(255,255,255,0.28); }
+  .cell.marked { border: 3px solid #dc2626; }
+  .cell.marked .mark-btn { background: #dc2626; border-color: #b91c1c; color: #fff; }
+  .cell.marked .mark-btn::before { content: "x "; }
+  .cell.pending-recapture { animation: cellPulse 2s ease-out; }
+  @keyframes cellPulse {
+    0%   { box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.9); border-color: #7c3aed; }
+    100% { box-shadow: 0 0 0 8px rgba(124, 58, 237, 0); }
+  }
+  .cell .toolbar {
+    display: none;
+    padding: 6px 8px; background: #fef2f2; border-top: 1px solid #fecaca;
+    font-size: 11px;
+  }
+  .cell.marked .toolbar { display: block; }
+  .cell .toolbar input[type=text],
+  .cell .toolbar textarea {
+    width: 100%; box-sizing: border-box;
+    border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 4px 6px; font-size: 12px; font-family: inherit;
+    background: #fff;
+  }
+  .cell .toolbar input[type=text]:focus,
+  .cell .toolbar textarea:focus { outline: 2px solid #dc2626; outline-offset: -1px; }
+  .cell .toolbar .field { margin-bottom: 6px; }
+  .cell .toolbar .field-label {
+    display: block; font-size: 10px; font-weight: 600;
+    color: #7f1d1d; text-transform: uppercase; letter-spacing: 0.04em;
+    margin-bottom: 2px;
+  }
+  .cell .toolbar .cat-chips { display: flex; gap: 4px; flex-wrap: wrap; }
+  .cell .toolbar .cat-chip {
+    background: #fff; border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 2px 8px; font-size: 11px; cursor: pointer; font-family: inherit;
+    color: #7f1d1d;
+  }
+  .cell .toolbar .cat-chip.active { background: #7f1d1d; color: #fff; border-color: #7f1d1d; }
+  .cell .toolbar .cat-chip[data-cat="needs-design"].active { background: #6d28d9; border-color: #6d28d9; }
+  .cell .toolbar .cat-chip[data-cat="bug"].active        { background: #b91c1c; border-color: #b91c1c; }
+  .cell .toolbar .cat-chip[data-cat="tooling"].active    { background: #b45309; border-color: #b45309; }
+  .cell .toolbar .cat-chip[data-cat="intentional"].active{ background: #15803d; border-color: #15803d; }
+  .cell .toolbar .cat-chip[data-cat="unclear"].active    { background: #6b7280; border-color: #6b7280; }
+  .cell .toolbar .recapture-btn {
+    background: #1d4ed8; color: #fff; border: 0; border-radius: 3px;
+    padding: 4px 10px; font-size: 11px; cursor: pointer;
+    font-family: inherit; font-weight: 600;
+  }
+  .cell .toolbar .recapture-btn:hover { background: #1e40af; }
+  .cell .toolbar textarea { min-height: 32px; resize: vertical; font-size: 11px; }
+  .cell.cat-needs-design { border-color: #6d28d9; }
+  .cell.cat-bug         { border-color: #b91c1c; }
+  .cell.cat-tooling     { border-color: #b45309; }
+  .cell.cat-intentional { border-color: #15803d; }
+  .cell.cat-unclear     { border-color: #6b7280; }
+
+  .marks-cluster {
+    display: flex; align-items: center; gap: 8px;
+    border-left: 1px solid #444; padding-left: 12px; margin-left: 4px;
+    font-size: 12px;
+  }
+  .marks-cluster .count {
+    background: #dc2626; color: #fff; border-radius: 10px;
+    padding: 2px 8px; font-weight: 600; min-width: 18px; text-align: center;
+  }
+  .marks-cluster button {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .marks-cluster button:hover { background: #4b5563; }
+  .marks-cluster button.danger { background: #7f1d1d; border-color: #991b1b; }
+  .marks-cluster button.danger:hover { background: #991b1b; }
+
+  body.only-marked .component-row:not(.has-marked) { display: none; }
+  body.only-marked section.route:not(.has-marked) { display: none; }
+
+  .component-row.suppressed { display: none; }
+  body.show-suppressed .component-row.suppressed { display: grid; }
+  .component-row.suppressed .label::after { content: " (hidden)"; color: #b91c1c; font-style: italic; }
+
+  .component-row .label[data-mapped] { color: #1d4ed8; }
+  .component-row .label[data-mapped]::after { content: " *"; }
+  .mapped-tooltip {
+    display: inline-block; margin-left: 4px;
+    font-size: 10px; color: #6b7280; cursor: help; vertical-align: super;
+  }
+
+  .vp-badge, .state-badge {
+    display: inline-block; font-size: 9px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.05em;
+    padding: 1px 6px; border-radius: 8px; margin-top: 2px;
+  }
+  .vp-badge.desktop { background: #dbeafe; color: #1e3a8a; border: 1px solid #93c5fd; margin-right: 4px; }
+  .vp-badge.mobile  { background: #fef3c7; color: #78350f; border: 1px solid #fcd34d; margin-right: 4px; }
+  .state-badge.empty       { background: #f3f4f6; color: #374151; border: 1px solid #d1d5db; }
+  .state-badge.seeded      { background: #dcfce7; color: #14532d; border: 1px solid #86efac; }
+  .state-badge.mid-session { background: #ede9fe; color: #4c1d95; border: 1px solid #c4b5fd; }
+
+  .component-row.vp-mobile { background: #fffbeb; padding: 4px; border-radius: 4px; }
+  body.hide-desktop .component-row.vp-desktop { display: none; }
+  body.hide-mobile .component-row.vp-mobile { display: none; }
+
+  body.hide-state-empty       .component-row.state-empty       { display: none; }
+  body.hide-state-seeded      .component-row.state-seeded      { display: none; }
+  body.hide-state-mid-session .component-row.state-mid-session { display: none; }
+
+  .overlay {
+    display: none; position: fixed; inset: 0; z-index: 1100;
+    background: rgba(0,0,0,0.6); align-items: center; justify-content: center;
+  }
+  .overlay.open { display: flex; }
+  .overlay .panel {
+    background: #fff; border-radius: 6px; width: min(720px, 92vw);
+    max-height: 80vh; padding: 16px; display: flex; flex-direction: column; gap: 8px;
+  }
+  .overlay h3 { margin: 0; font-size: 14px; }
+  .overlay textarea {
+    flex: 1; min-height: 320px; font-family: ui-monospace, monospace; font-size: 12px;
+    border: 1px solid #ddd; border-radius: 4px; padding: 8px; resize: vertical;
+  }
+  .overlay .actions { display: flex; gap: 8px; justify-content: flex-end; }
+  .overlay button {
+    background: #1a1a1a; color: #fff; border: 0; border-radius: 3px;
+    padding: 6px 12px; font-size: 12px; cursor: pointer;
+  }
+  .overlay .hint { font-size: 11px; color: #555; }
+  .overlay .err  { font-size: 12px; color: #b91c1c; min-height: 16px; }
+
+  /* Index-page table */
+  table.routes-index {
+    width: 100%; border-collapse: collapse; background: #fff;
+    border-radius: 6px; overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  table.routes-index th, table.routes-index td {
+    padding: 8px 12px; text-align: left; font-size: 13px;
+    border-bottom: 1px solid #eee;
+  }
+  table.routes-index th { background: #f3f4f6; font-weight: 600; }
+  table.routes-index td a {
+    color: #1d4ed8; text-decoration: none; font-family: ui-monospace, monospace;
+  }
+  table.routes-index td a:hover { text-decoration: underline; }
+  table.routes-index td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  table.routes-index .marked-count.has-marks { color: #b91c1c; font-weight: 600; }
+  table.routes-index .unresolved-count.has-unresolved { color: #b45309; font-weight: 600; }
+  table.routes-index .breakdown {
+    font-size: 11px; color: #555; margin-left: 6px; font-variant-numeric: tabular-nums;
+  }
+
+
+</style>
+</head>
+<body>
+<div class="sticky-shell">
+<header class="top">
+  <a class="back" href="index.html">&larr; Index</a>
+  <h1>settings</h1>
+  <div class="legend">
+    <span class="col develop">develop</span>
+    <span class="col ds3">DS3</span>
+    <span class="col ds1">DS1</span>
+    <span class="col ds2">DS2</span>
+  </div>
+  <div class="controls">
+    <span class="state-chips" role="group" aria-label="State filter">
+      <span style="font-size: 11px; color: #aaa;">State:</span>
+      <button type="button" class="state-chip" data-state="empty">empty</button>
+      <button type="button" class="state-chip active" data-state="seeded">seeded</button>
+    </span>
+    <label><input type="checkbox" id="hide-empty"> Hide missing</label>
+    <label><input type="checkbox" id="compact"> Compact</label>
+    <label title="Stretch images to cell width"><input type="checkbox" id="fit-cell"> Fit to cell</label>
+    <label><input type="checkbox" id="only-marked"> Only marked</label>
+    <label><input type="checkbox" id="show-suppressed"> Show hidden rows</label>
+    <label><input type="checkbox" id="hide-desktop"> Hide desktop</label>
+    <label><input type="checkbox" id="hide-mobile"> Hide mobile</label>
+  </div>
+  <div class="marks-cluster">
+    <span>Marked (route):</span>
+    <span class="count" id="mark-count">0</span>
+    <button id="prefill-ds-btn" type="button" title="Mark every DS cell that has no mark yet as needs-design (gap-fill, never overwrites your existing marks)">Fill DS gaps</button>
+    <button id="export-md-btn" type="button">Export markdown</button>
+    <button id="export-json-btn" type="button">Export JSON</button>
+    <button id="import-json-btn" type="button">Import JSON</button>
+    <button id="clear-route-btn" type="button" class="danger">Clear (route)</button>
+  </div>
+</header>
+<nav class="toc" style="background:#2a2a2a;color:#ccc;padding:6px 16px;font-size:12px;display:flex;gap:8px;align-items:center;border-top:1px solid #444;">
+  <span class="nav-routes">
+    <a href="play.html">&larr; play</a>
+    <span class="current">settings</span>
+  </span>
+</nav>
+</div>
+<main>
+<section class="route" id="route-settings">
+  <h2>settings</h2>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="settings__global-nav__desktop__empty__develop" data-route="settings" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/settings__nav.png" alt="develop settings/global-nav/desktop/empty" data-caption="develop -- settings/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="settings__global-nav__desktop__empty__DS3" data-route="settings" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/settings__nav.png" alt="DS3 settings/global-nav/desktop/empty" data-caption="DS3 -- settings/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="settings__global-nav__desktop__empty__DS1" data-route="settings" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/settings__nav.png" alt="DS1 settings/global-nav/desktop/empty" data-caption="DS1 -- settings/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="settings__global-nav__desktop__empty__DS2" data-route="settings" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/settings__nav.png" alt="DS2 settings/global-nav/desktop/empty" data-caption="DS2 -- settings/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="settings__page__desktop__empty__develop" data-route="settings" data-component="page" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/settings__page.png" alt="develop settings/page/desktop/empty" data-caption="develop -- settings/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="settings__page__desktop__empty__DS3" data-route="settings" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/settings__page.png" alt="DS3 settings/page/desktop/empty" data-caption="DS3 -- settings/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="settings__page__desktop__empty__DS1" data-route="settings" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/settings__page.png" alt="DS1 settings/page/desktop/empty" data-caption="DS1 -- settings/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="settings__page__desktop__empty__DS2" data-route="settings" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/settings__page.png" alt="DS2 settings/page/desktop/empty" data-caption="DS2 -- settings/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-empty" data-viewport="mobile" data-state="empty">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="settings__page__mobile__empty__develop" data-route="settings" data-component="page" data-viewport="mobile" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/empty/settings__page.png" alt="develop settings/page/mobile/empty" data-caption="develop -- settings/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="settings__page__mobile__empty__DS3" data-route="settings" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/empty/settings__page.png" alt="DS3 settings/page/mobile/empty" data-caption="DS3 -- settings/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="settings__page__mobile__empty__DS1" data-route="settings" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/empty/settings__page.png" alt="DS1 settings/page/mobile/empty" data-caption="DS1 -- settings/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="settings__page__mobile__empty__DS2" data-route="settings" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/empty/settings__page.png" alt="DS2 settings/page/mobile/empty" data-caption="DS2 -- settings/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="settings__header__desktop__empty__develop" data-route="settings" data-component="header" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/settings__header.png" alt="develop settings/header/desktop/empty" data-caption="develop -- settings/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="settings__nav__desktop__empty__develop" data-route="settings" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/settings__nav.png" alt="develop settings/nav/desktop/empty" data-caption="develop -- settings/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="settings__nav__desktop__empty__DS3" data-route="settings" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/settings__nav.png" alt="DS3 settings/nav/desktop/empty" data-caption="DS3 -- settings/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="settings__nav__desktop__empty__DS1" data-route="settings" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/settings__nav.png" alt="DS1 settings/nav/desktop/empty" data-caption="DS1 -- settings/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="settings__nav__desktop__empty__DS2" data-route="settings" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/settings__nav.png" alt="DS2 settings/nav/desktop/empty" data-caption="DS2 -- settings/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="settings__main__desktop__empty__develop" data-route="settings" data-component="main" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/settings__main.png" alt="develop settings/main/desktop/empty" data-caption="develop -- settings/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="settings__main__desktop__empty__DS3" data-route="settings" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/settings__main.png" alt="DS3 settings/main/desktop/empty" data-caption="DS3 -- settings/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="settings__main__desktop__empty__DS1" data-route="settings" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/settings__main.png" alt="DS1 settings/main/desktop/empty" data-caption="DS1 -- settings/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="settings__main__desktop__empty__DS2" data-route="settings" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/settings__main.png" alt="DS2 settings/main/desktop/empty" data-caption="DS2 -- settings/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="settings__global-nav__desktop__seeded__develop" data-route="settings" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/settings__nav.png" alt="develop settings/global-nav/desktop/seeded" data-caption="develop -- settings/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="settings__global-nav__desktop__seeded__DS3" data-route="settings" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/settings__nav.png" alt="DS3 settings/global-nav/desktop/seeded" data-caption="DS3 -- settings/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="settings__global-nav__desktop__seeded__DS1" data-route="settings" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/settings__nav.png" alt="DS1 settings/global-nav/desktop/seeded" data-caption="DS1 -- settings/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="settings__global-nav__desktop__seeded__DS2" data-route="settings" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/settings__nav.png" alt="DS2 settings/global-nav/desktop/seeded" data-caption="DS2 -- settings/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="settings__page__desktop__seeded__develop" data-route="settings" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/settings__page.png" alt="develop settings/page/desktop/seeded" data-caption="develop -- settings/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="settings__page__desktop__seeded__DS3" data-route="settings" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/settings__page.png" alt="DS3 settings/page/desktop/seeded" data-caption="DS3 -- settings/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="settings__page__desktop__seeded__DS1" data-route="settings" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/settings__page.png" alt="DS1 settings/page/desktop/seeded" data-caption="DS1 -- settings/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="settings__page__desktop__seeded__DS2" data-route="settings" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/settings__page.png" alt="DS2 settings/page/desktop/seeded" data-caption="DS2 -- settings/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-seeded" data-viewport="mobile" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="settings__page__mobile__seeded__develop" data-route="settings" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/seeded/settings__page.png" alt="develop settings/page/mobile/seeded" data-caption="develop -- settings/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="settings__page__mobile__seeded__DS3" data-route="settings" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/seeded/settings__page.png" alt="DS3 settings/page/mobile/seeded" data-caption="DS3 -- settings/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="settings__page__mobile__seeded__DS1" data-route="settings" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/seeded/settings__page.png" alt="DS1 settings/page/mobile/seeded" data-caption="DS1 -- settings/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="settings__page__mobile__seeded__DS2" data-route="settings" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/seeded/settings__page.png" alt="DS2 settings/page/mobile/seeded" data-caption="DS2 -- settings/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="settings__header__desktop__seeded__develop" data-route="settings" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/settings__header.png" alt="develop settings/header/desktop/seeded" data-caption="develop -- settings/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="settings__header__desktop__seeded__DS3" data-route="settings" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/settings__header.png" alt="DS3 settings/header/desktop/seeded" data-caption="DS3 -- settings/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="settings__header__desktop__seeded__DS1" data-route="settings" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/settings__header.png" alt="DS1 settings/header/desktop/seeded" data-caption="DS1 -- settings/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="settings__header__desktop__seeded__DS2" data-route="settings" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/settings__header.png" alt="DS2 settings/header/desktop/seeded" data-caption="DS2 -- settings/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="settings__nav__desktop__seeded__develop" data-route="settings" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/settings__nav.png" alt="develop settings/nav/desktop/seeded" data-caption="develop -- settings/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="settings__nav__desktop__seeded__DS3" data-route="settings" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/settings__nav.png" alt="DS3 settings/nav/desktop/seeded" data-caption="DS3 -- settings/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="settings__nav__desktop__seeded__DS1" data-route="settings" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/settings__nav.png" alt="DS1 settings/nav/desktop/seeded" data-caption="DS1 -- settings/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="settings__nav__desktop__seeded__DS2" data-route="settings" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/settings__nav.png" alt="DS2 settings/nav/desktop/seeded" data-caption="DS2 -- settings/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="settings__main__desktop__seeded__develop" data-route="settings" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/settings__main.png" alt="develop settings/main/desktop/seeded" data-caption="develop -- settings/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="settings__main__desktop__seeded__DS3" data-route="settings" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/settings__main.png" alt="DS3 settings/main/desktop/seeded" data-caption="DS3 -- settings/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="settings__main__desktop__seeded__DS1" data-route="settings" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/settings__main.png" alt="DS1 settings/main/desktop/seeded" data-caption="DS1 -- settings/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="settings__main__desktop__seeded__DS2" data-route="settings" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/settings__main.png" alt="DS2 settings/main/desktop/seeded" data-caption="DS2 -- settings/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+</main>
+
+<div id="lightbox" class="overlay">
+  <img id="lightbox-img" src="" alt="">
+  <div id="lightbox-caption" style="position: fixed; top: 12px; left: 50%; transform: translateX(-50%); color: #fff; font-family: ui-monospace, monospace; font-size: 13px; background: rgba(0,0,0,0.6); padding: 6px 12px; border-radius: 4px;"></div>
+</div>
+
+<div id="md-overlay" class="overlay">
+  <div class="panel">
+    <h3>Audit marks (markdown) -- this route only</h3>
+    <textarea id="md-text" readonly></textarea>
+    <div class="actions">
+      <button id="md-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="md-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-export-overlay" class="overlay">
+  <div class="panel">
+    <h3>Marks (raw JSON) -- all routes</h3>
+    <textarea id="json-export-text" readonly></textarea>
+    <div class="actions">
+      <button id="json-export-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="json-export-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-import-overlay" class="overlay">
+  <div class="panel">
+    <h3>Import marks (paste raw JSON)</h3>
+    <p class="hint">Paste JSON exported from another instance. Legacy IDs without a state segment are migrated to <code>__seeded</code>; v2 values are upgraded to v3 (category=null, why="", updatedAt=now). Existing marks with the same ID are overwritten.</p>
+    <textarea id="json-import-text" placeholder='{"home__page__desktop__seeded__DS3":{"marked":true,"note":"...","category":"bug","why":"...","updatedAt":"..."}}'></textarea>
+    <div class="err" id="json-import-err"></div>
+    <div class="actions">
+      <button id="json-import-apply" type="button">Apply</button>
+      <button class="overlay-close" data-overlay="json-import-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+<script>
+
+  const STORAGE_KEY = 'narraitor-audit-marks-v3';
+  const STORAGE_KEY_V2 = 'narraitor-audit-marks-v2';
+  const STORAGE_KEY_V1 = 'narraitor-audit-marks-v1';
+  // Tracks which routes have had their DS cells auto-prefilled as needs-design.
+  // Once a route is in here, the auto-prefill on page load is skipped.
+  const PREFILLED_KEY = 'narraitor-audit-prefilled-v1';
+  const STATES = ['empty', 'seeded'];
+  const VALID_CATEGORIES = ['needs-design','bug','tooling','intentional','unclear'];
+  const ROUTE_ORDER = ["home", "about", "worlds", "worlds-detail", "worlds-edit", "worlds-create", "worlds-play", "worlds-play-journal", "characters", "characters-detail", "characters-edit", "characters-create", "play", "settings"];
+  const COMPONENT_ORDER = {"page":0,"header":1,"nav":2,"form":3,"main":4};
+  const THEME_ORDER = ["DS3","DS1","DS2","develop"];
+  const BRANCH_META = {"develop": {"theme": "default", "mode": "light", "branchArg": "develop-default"}, "DS3": {"theme": "ds3", "mode": "light", "branchArg": "integration-ds3-light"}, "DS1": {"theme": "ds1", "mode": "light", "branchArg": "integration-ds1-light"}, "DS2": {"theme": "ds2", "mode": "light", "branchArg": "integration-ds2-light"}};
+
+  function componentSortKey(c) {
+    if (c in COMPONENT_ORDER) return [COMPONENT_ORDER[c], 0];
+    if (c.startsWith("main-section-")) {
+      const n = parseInt(c.replace("main-section-",""), 10);
+      return [5, isNaN(n) ? 0 : n];
+    }
+    return [9, c];
+  }
+
+  // Pre-v3 ID migration: v1 (4 segments) -> v2 (5 segments) by inserting __seeded.
+  function migrateLegacyId(id) {
+    const parts = id.split('__');
+    if (parts.length < 4) return id;
+    const last = parts[parts.length - 1];
+    const second = parts[parts.length - 2];
+    const third = parts[parts.length - 3];
+    const isTheme = ['DS1','DS2','DS3','develop'].includes(last);
+    const isViewport = ['desktop','mobile'].includes(second);
+    const alreadyHasState = STATES.includes(third);
+    if (isTheme && isViewport && !alreadyHasState) {
+      const head = parts.slice(0, parts.length - 1).join('__');
+      return head + '__seeded__' + last;
+    }
+    return id;
+  }
+
+  function migrateMarksV1ToV2(input) {
+    const out = {};
+    let migrated = 0;
+    for (const [id, m] of Object.entries(input || {})) {
+      const newId = migrateLegacyId(id);
+      if (newId !== id) migrated++;
+      out[newId] = m;
+    }
+    return { marks: out, migrated };
+  }
+
+  // v2 -> v3: add category, why, updatedAt; preserve marked + note.
+  function upgradeV2ValueToV3(v) {
+    if (!v || typeof v !== 'object') return null;
+    return {
+      marked: !!v.marked,
+      note: typeof v.note === 'string' ? v.note : '',
+      category: v.category && VALID_CATEGORIES.includes(v.category) ? v.category : null,
+      why: typeof v.why === 'string' ? v.why : '',
+      updatedAt: v.updatedAt || new Date().toISOString(),
+    };
+  }
+
+  function migrateV2ObjectToV3(v2obj) {
+    const out = {};
+    for (const [id, m] of Object.entries(v2obj || {})) {
+      out[id] = upgradeV2ValueToV3(m);
+    }
+    return out;
+  }
+
+  function loadMarks() {
+    try {
+      const v3 = localStorage.getItem(STORAGE_KEY);
+      if (v3) return JSON.parse(v3);
+      // No v3 yet — try v2 (lazy migrate; leave v2 untouched for rollback).
+      const v2raw = localStorage.getItem(STORAGE_KEY_V2);
+      if (v2raw) {
+        const v3marks = migrateV2ObjectToV3(JSON.parse(v2raw));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + Object.keys(v3marks).length + ' v2 marks to v3 (v2 untouched).');
+        return v3marks;
+      }
+      // No v3 or v2 — try v1 and migrate v1 -> v2 -> v3 in one pass.
+      const v1raw = localStorage.getItem(STORAGE_KEY_V1);
+      if (v1raw) {
+        const { marks: v2marks, migrated } = migrateMarksV1ToV2(JSON.parse(v1raw));
+        const v3marks = migrateV2ObjectToV3(v2marks);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + migrated + ' v1 IDs through to v3.');
+        return v3marks;
+      }
+    } catch (e) { console.warn(e); }
+    return {};
+  }
+
+  function saveMarks(m) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(m)); } catch (e) {}
+  }
+
+
+  const ROUTE = "settings";
+  let marks = loadMarks();
+
+  function applyMarkState(cell) {
+    const id = cell.dataset.cellId;
+    const m = marks[id];
+    const noteInput = cell.querySelector('textarea[data-action="note"]');
+    const whyInput = cell.querySelector('input[data-action="why"]');
+    const chips = cell.querySelectorAll('.cat-chip');
+    cell.classList.remove('cat-bug','cat-tooling','cat-intentional','cat-unclear');
+    chips.forEach(c => c.classList.remove('active'));
+    if (m && m.marked) {
+      cell.classList.add('marked');
+      if (noteInput) noteInput.value = m.note || '';
+      if (whyInput) whyInput.value = m.why || '';
+      if (m.category) {
+        cell.classList.add('cat-' + m.category);
+        const chip = cell.querySelector('.cat-chip[data-cat="' + m.category + '"]');
+        if (chip) chip.classList.add('active');
+      }
+    } else {
+      cell.classList.remove('marked');
+      if (noteInput) noteInput.value = '';
+      if (whyInput) whyInput.value = '';
+    }
+  }
+
+  function updateRowSectionFlags() {
+    document.querySelectorAll('.component-row').forEach(row => {
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+    document.querySelectorAll('section.route').forEach(sec => {
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+    });
+  }
+
+  function updateCount() {
+    const n = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).length;
+    document.getElementById('mark-count').textContent = n;
+  }
+
+  function writeMark(id, partial) {
+    const existing = marks[id] || { marked: false, note: '', category: null, why: '', updatedAt: null };
+    const next = Object.assign({}, existing, partial, { updatedAt: new Date().toISOString() });
+    if (!next.marked && !next.note && !next.why && !next.category) {
+      delete marks[id];
+    } else {
+      marks[id] = next;
+    }
+    saveMarks(marks);
+    updateCount();
+  }
+
+  function buildRecaptureCommand(cell) {
+    const route = cell.dataset.route;
+    const viewport = cell.dataset.viewport;
+    const state = cell.dataset.state;
+    const themeKey = cell.dataset.theme;
+    const meta = BRANCH_META[themeKey];
+    if (!meta) return null;
+    return 'npx tsx scripts/audit/playwright-crawl.ts'
+      + ' --branch ' + meta.branchArg
+      + ' --viewport ' + viewport
+      + ' --state ' + state
+      + ' --theme ' + meta.theme
+      + ' --mode ' + meta.mode
+      + ' --route ' + route;
+  }
+
+  function loadPrefilledFlags() {
+    try { return JSON.parse(localStorage.getItem(PREFILLED_KEY) || '{}'); }
+    catch (e) { return {}; }
+  }
+  function savePrefilledFlags(f) {
+    try { localStorage.setItem(PREFILLED_KEY, JSON.stringify(f)); } catch (e) {}
+  }
+
+  // Gap-fill: only adds entries for DS cells that have no existing mark.
+  // Returns the count of cells filled. Develop is excluded (it's the baseline).
+  function prefillDsCellsAsNeedsDesign() {
+    const dsCells = Array.from(document.querySelectorAll('.cell[data-cell-id]'))
+      .filter(c => ['DS1','DS2','DS3'].includes(c.dataset.theme));
+    let added = 0;
+    const ts = new Date().toISOString();
+    for (const cell of dsCells) {
+      const id = cell.dataset.cellId;
+      if (!marks[id]) {
+        marks[id] = { marked: true, note: '', category: 'needs-design', why: '', updatedAt: ts };
+        added++;
+      }
+    }
+    if (added > 0) saveMarks(marks);
+    return added;
+  }
+
+  // Auto-prefill on first visit per route.
+  const prefillFlags = loadPrefilledFlags();
+  if (!prefillFlags[ROUTE]) {
+    const added = prefillDsCellsAsNeedsDesign();
+    prefillFlags[ROUTE] = true;
+    savePrefilledFlags(prefillFlags);
+    if (added > 0) console.info('[audit] auto-prefilled ' + added + ' DS cells for ' + ROUTE + ' as needs-design.');
+  }
+
+  document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+  updateRowSectionFlags();
+  updateCount();
+
+  // Lightbox
+  const lb = document.getElementById('lightbox');
+  const lbImg = document.getElementById('lightbox-img');
+  const lbCap = document.getElementById('lightbox-caption');
+  document.querySelectorAll('.cell img').forEach(img => {
+    img.addEventListener('click', () => {
+      lbImg.src = img.src;
+      lbCap.textContent = img.dataset.caption || '';
+      lb.classList.add('open');
+    });
+  });
+  lb.addEventListener('click', () => lb.classList.remove('open'));
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') document.querySelectorAll('.overlay.open').forEach(o => o.classList.remove('open'));
+  });
+
+  // Mark toggle
+  document.querySelectorAll('button[data-action="toggle-mark"]').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      const cell = btn.closest('.cell');
+      const id = cell.dataset.cellId;
+      const isMarked = !cell.classList.contains('marked');
+      writeMark(id, { marked: isMarked });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      const sec = cell.closest('section.route');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+      if (isMarked) {
+        const why = cell.querySelector('input[data-action="why"]');
+        if (why) setTimeout(() => why.focus(), 0);
+      }
+    });
+  });
+
+  // Why / note inputs (debounced save)
+  let saveTimer = null;
+  function bindInput(sel, field) {
+    document.querySelectorAll(sel).forEach(inp => {
+      const handler = () => {
+        const cell = inp.closest('.cell');
+        if (!cell.classList.contains('marked')) return;
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(() => {
+          writeMark(cell.dataset.cellId, { [field]: inp.value });
+        }, 250);
+      };
+      inp.addEventListener('input', handler);
+      inp.addEventListener('blur', () => {
+        const cell = inp.closest('.cell');
+        if (cell.classList.contains('marked')) writeMark(cell.dataset.cellId, { [field]: inp.value });
+      });
+    });
+  }
+  bindInput('input[data-action="why"]', 'why');
+  bindInput('textarea[data-action="note"]', 'note');
+
+  // Category chips
+  document.querySelectorAll('.cat-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const cell = chip.closest('.cell');
+      if (!cell.classList.contains('marked')) {
+        // Mark the cell first so the category sticks
+        writeMark(cell.dataset.cellId, { marked: true });
+      }
+      const cat = chip.dataset.cat;
+      const isActive = chip.classList.contains('active');
+      writeMark(cell.dataset.cellId, { category: isActive ? null : cat });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+  });
+
+  // Re-capture command (copy to clipboard, flash purple)
+  document.querySelectorAll('button[data-action="recapture"]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const cell = btn.closest('.cell');
+      const cmd = buildRecaptureCommand(cell);
+      if (!cmd) return;
+      try {
+        await navigator.clipboard.writeText(cmd);
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Copy re-capture command'; }, 1500);
+      } catch (e) {
+        prompt('Copy this command:', cmd);
+      }
+      cell.classList.remove('pending-recapture');
+      void cell.offsetWidth; // force reflow so the animation restarts
+      cell.classList.add('pending-recapture');
+    });
+  });
+
+  // Toggles
+  document.getElementById('hide-empty').addEventListener('change', e => document.body.classList.toggle('hide-empty', e.target.checked));
+  document.getElementById('compact').addEventListener('change', e => document.body.classList.toggle('compact', e.target.checked));
+  document.getElementById('fit-cell').addEventListener('change', e => document.body.classList.toggle('fit-cell', e.target.checked));
+  document.getElementById('only-marked').addEventListener('change', e => document.body.classList.toggle('only-marked', e.target.checked));
+  document.getElementById('show-suppressed').addEventListener('change', e => document.body.classList.toggle('show-suppressed', e.target.checked));
+  document.getElementById('hide-desktop').addEventListener('change', e => document.body.classList.toggle('hide-desktop', e.target.checked));
+  document.getElementById('hide-mobile').addEventListener('change', e => document.body.classList.toggle('hide-mobile', e.target.checked));
+
+  // True-scale rendering (1x for selector captures, 0.5x for retina full-page).
+  const RETINA_THRESHOLD = 1500;
+  function applyTrueScale(img) {
+    if (!img.naturalWidth) return;
+    const cssWidth = img.naturalWidth > RETINA_THRESHOLD
+      ? Math.round(img.naturalWidth / 2)
+      : img.naturalWidth;
+    img.style.maxWidth = 'min(100%, ' + cssWidth + 'px)';
+  }
+  document.querySelectorAll('.cell img').forEach(img => {
+    if (img.complete && img.naturalWidth > 0) applyTrueScale(img);
+    else img.addEventListener('load', () => applyTrueScale(img), { once: true });
+  });
+
+  // State chips
+  document.querySelectorAll('.state-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const state = chip.dataset.state;
+      chip.classList.toggle('active');
+      document.body.classList.toggle('hide-state-' + state, !chip.classList.contains('active'));
+    });
+  });
+  STATES.forEach(s => {
+    const chip = document.querySelector('.state-chip[data-state="' + s + '"]');
+    if (chip && !chip.classList.contains('active')) document.body.classList.add('hide-state-' + s);
+  });
+
+  // Manual top-up: fill any DS cells that don't have a mark yet
+  document.getElementById('prefill-ds-btn').addEventListener('click', () => {
+    const added = prefillDsCellsAsNeedsDesign();
+    if (added > 0) {
+      document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+      updateRowSectionFlags();
+      updateCount();
+      alert('Filled ' + added + ' missing DS cells as needs-design.');
+    } else {
+      alert('All DS cells in this route already have marks.');
+    }
+  });
+
+  // Clear-route. Also resets the prefilled flag so a reload re-triggers auto-prefill.
+  document.getElementById('clear-route-btn').addEventListener('click', () => {
+    const ids = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).map(([id]) => id);
+    if (!ids.length) { alert('No marks for this route.'); return; }
+    if (!confirm('Clear ' + ids.length + ' marks for route ' + ROUTE + '?\n\nReloading the page will re-prefill all DS cells as needs-design.')) return;
+    ids.forEach(id => delete marks[id]);
+    saveMarks(marks);
+    const flags = loadPrefilledFlags();
+    delete flags[ROUTE];
+    savePrefilledFlags(flags);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+  });
+
+  function buildMarkdown() {
+    const items = [];
+    Object.entries(marks).forEach(([id, m]) => {
+      if (!m || !m.marked) return;
+      if (!id.startsWith(ROUTE + '__')) return;
+      const parts = id.split('__');
+      const themeKey = parts[parts.length - 1];
+      const state = parts[parts.length - 2];
+      const viewport = parts[parts.length - 3];
+      const route = parts[0];
+      const component = parts.slice(1, parts.length - 3).join('__');
+      items.push({ component, viewport, state, theme: themeKey,
+                   note: m.note || '', why: m.why || '', category: m.category || '' });
+    });
+    items.sort((a, b) => {
+      const ak = componentSortKey(a.component);
+      const bk = componentSortKey(b.component);
+      if (ak[0] !== bk[0]) return ak[0] - bk[0];
+      if (ak[1] !== bk[1]) return ak[1] < bk[1] ? -1 : 1;
+      const sd = STATES.indexOf(a.state) - STATES.indexOf(b.state);
+      if (sd !== 0) return sd;
+      const td = THEME_ORDER.indexOf(a.theme) - THEME_ORDER.indexOf(b.theme);
+      if (td !== 0) return td;
+      return a.viewport === b.viewport ? 0 : (a.viewport === 'desktop' ? -1 : 1);
+    });
+    const date = new Date().toISOString().split('T')[0];
+    const lines = ['# Audit marks -- ' + ROUTE + ' -- ' + items.length + ' items -- ' + date, ''];
+    items.forEach(it => {
+      const catTag = it.category ? ' [' + it.category + ']' : '';
+      const whyTxt = it.why ? ': ' + it.why : '';
+      const noteTxt = it.note ? '  -- ' + it.note : '';
+      lines.push('- [ ] **' + it.theme + ' ' + it.component + '** [' + it.viewport + '/' + it.state + ']' + catTag + whyTxt + noteTxt);
+    });
+    return lines.join('\n');
+  }
+
+  function openOverlay(id) { document.getElementById(id).classList.add('open'); }
+  function closeOverlay(id) { document.getElementById(id).classList.remove('open'); }
+  document.querySelectorAll('.overlay-close').forEach(b => b.addEventListener('click', () => closeOverlay(b.dataset.overlay)));
+  document.querySelectorAll('.overlay').forEach(o => {
+    o.addEventListener('click', e => { if (e.target === o) o.classList.remove('open'); });
+  });
+
+  document.getElementById('export-md-btn').addEventListener('click', async () => {
+    const md = buildMarkdown();
+    const ta = document.getElementById('md-text');
+    ta.value = md;
+    openOverlay('md-overlay');
+    try { await navigator.clipboard.writeText(md); document.getElementById('md-copy').textContent = 'Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+  document.getElementById('md-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('md-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('md-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('export-json-btn').addEventListener('click', () => {
+    const ta = document.getElementById('json-export-text');
+    ta.value = JSON.stringify(marks, null, 2);
+    openOverlay('json-export-overlay');
+  });
+  document.getElementById('json-export-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('json-export-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('json-export-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('json-export-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('import-json-btn').addEventListener('click', () => {
+    document.getElementById('json-import-text').value = '';
+    document.getElementById('json-import-err').textContent = '';
+    openOverlay('json-import-overlay');
+  });
+  document.getElementById('json-import-apply').addEventListener('click', () => {
+    const ta = document.getElementById('json-import-text');
+    const err = document.getElementById('json-import-err');
+    err.textContent = '';
+    let parsed;
+    try { parsed = JSON.parse(ta.value); }
+    catch (e) { err.textContent = 'Invalid JSON: ' + e.message; return; }
+    if (!parsed || typeof parsed !== 'object') { err.textContent = 'Expected an object.'; return; }
+    // First migrate v1 IDs (4 segments) -> v2 IDs (5 segments)
+    const { marks: idMigrated, migrated } = migrateMarksV1ToV2(parsed);
+    // Then upgrade each value v2 -> v3 (preserves marked + note, fills new fields)
+    Object.entries(idMigrated).forEach(([id, m]) => {
+      marks[id] = upgradeV2ValueToV3(m);
+    });
+    saveMarks(marks);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+    closeOverlay('json-import-overlay');
+    alert('Imported ' + Object.keys(idMigrated).length + ' marks (' + migrated + ' legacy IDs migrated to __seeded; values upgraded to v3).');
+  });
+</script>
+</body>
+</html>

--- a/scripts/audit/review/worlds-create.html
+++ b/scripts/audit/review/worlds-create.html
@@ -1,0 +1,2131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Cross-Theme Audit (#1129) — worlds-create</title>
+<style>
+
+  :root { --col-gap: 8px; --row-gap: 16px; }
+  html, body { margin: 0; padding: 0; font-family: -apple-system, system-ui, sans-serif; background: #fafafa; color: #222; }
+  .sticky-shell { position: sticky; top: 0; z-index: 100; border-bottom: 1px solid #444; }
+  header.top {
+    background: #1a1a1a; color: #fff; padding: 12px 16px;
+    display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+  }
+  header.top h1 { font-size: 14px; margin: 0; font-weight: 600; }
+  header.top .legend { display: flex; gap: 12px; font-size: 12px; }
+  header.top .legend .col { padding: 2px 8px; border-radius: 3px; }
+  header.top .legend .develop { background: #6b7280; }
+  header.top .legend .ds3 { background: #4338ca; }
+  header.top .legend .ds1 { background: #92400e; }
+  header.top .legend .ds2 { background: #166534; }
+  header.top a.back { color: #9cf; font-size: 12px; text-decoration: none; padding: 2px 6px; border-radius: 2px; }
+  header.top a.back:hover { background: #444; color: #fff; }
+  header.top .nav-routes { display: flex; gap: 4px; align-items: center; font-size: 12px; }
+  header.top .nav-routes a { color: #9cf; text-decoration: none; padding: 2px 8px; border-radius: 2px; background: #2a2a2a; }
+  header.top .nav-routes a:hover { background: #444; color: #fff; }
+  header.top .nav-routes .current { color: #fff; font-weight: 600; padding: 2px 8px; }
+  main { padding: 16px; max-width: 100%; }
+  section.route {
+    margin-bottom: 32px; background: #fff; border-radius: 6px;
+    padding: 12px 16px 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  section.route h2 {
+    font-size: 18px; margin: 0 0 12px; padding-bottom: 6px;
+    border-bottom: 1px solid #e5e5e5;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+  .component-row {
+    display: grid; grid-template-columns: 180px repeat(4, 1fr);
+    gap: var(--col-gap); margin-bottom: var(--row-gap);
+    align-items: start;
+  }
+  .component-row .label {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px; color: #555; padding-top: 28px; line-height: 1.3;
+    word-break: break-word;
+  }
+  .cell {
+    border: 1px solid #e5e5e5; border-radius: 4px; overflow: hidden;
+    background: #f3f4f6; position: relative; min-height: 100px;
+    display: flex; flex-direction: column;
+  }
+  .cell .header {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.04em; padding: 4px 8px; color: #fff;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .cell.develop .header { background: #6b7280; }
+  .cell.ds3 .header { background: #4338ca; }
+  .cell.ds1 .header { background: #92400e; }
+  .cell.ds2 .header { background: #166534; }
+  .cell img {
+    display: block; width: auto; max-width: 100%; height: auto;
+    cursor: zoom-in; background: #fff; align-self: flex-start;
+  }
+  body.fit-cell .cell img { width: 100%; max-width: 100%; }
+  .cell.empty {
+    display: flex; align-items: center; justify-content: center;
+    color: #999; font-size: 12px; padding: 24px; background: #f9f9f9;
+  }
+  .cell.empty::after { content: "(not captured)"; }
+
+  /* Lightbox */
+  #lightbox {
+    display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.92);
+    z-index: 1000; align-items: center; justify-content: center; cursor: zoom-out;
+  }
+  #lightbox.open { display: flex; }
+  #lightbox img { max-width: 96vw; max-height: 96vh; box-shadow: 0 4px 24px rgba(0,0,0,0.5); }
+
+  .controls { display: flex; gap: 12px; align-items: center; font-size: 12px; flex-wrap: wrap; }
+  .controls label { display: flex; align-items: center; gap: 4px; cursor: pointer; }
+  .controls input[type=checkbox] { margin: 0; }
+
+  .state-chips { display: inline-flex; gap: 4px; align-items: center; }
+  .state-chip {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .state-chip.active { background: #2563eb; border-color: #1d4ed8; }
+  .state-chip:hover { background: #4b5563; }
+  .state-chip.active:hover { background: #1d4ed8; }
+
+  body.hide-empty .component-row.all-empty,
+  body.hide-empty .cell.empty { display: none; }
+  body.compact .cell img { max-height: 360px; object-fit: cover; object-position: top; }
+
+  .cell .mark-btn {
+    margin-left: auto; background: rgba(255,255,255,0.18);
+    color: #fff; border: 1px solid rgba(255,255,255,0.35);
+    border-radius: 3px; font-size: 10px; font-weight: 600;
+    padding: 2px 6px; cursor: pointer;
+    text-transform: none; letter-spacing: 0; line-height: 1.2;
+  }
+  .cell .mark-btn:hover { background: rgba(255,255,255,0.28); }
+  .cell.marked { border: 3px solid #dc2626; }
+  .cell.marked .mark-btn { background: #dc2626; border-color: #b91c1c; color: #fff; }
+  .cell.marked .mark-btn::before { content: "x "; }
+  .cell.pending-recapture { animation: cellPulse 2s ease-out; }
+  @keyframes cellPulse {
+    0%   { box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.9); border-color: #7c3aed; }
+    100% { box-shadow: 0 0 0 8px rgba(124, 58, 237, 0); }
+  }
+  .cell .toolbar {
+    display: none;
+    padding: 6px 8px; background: #fef2f2; border-top: 1px solid #fecaca;
+    font-size: 11px;
+  }
+  .cell.marked .toolbar { display: block; }
+  .cell .toolbar input[type=text],
+  .cell .toolbar textarea {
+    width: 100%; box-sizing: border-box;
+    border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 4px 6px; font-size: 12px; font-family: inherit;
+    background: #fff;
+  }
+  .cell .toolbar input[type=text]:focus,
+  .cell .toolbar textarea:focus { outline: 2px solid #dc2626; outline-offset: -1px; }
+  .cell .toolbar .field { margin-bottom: 6px; }
+  .cell .toolbar .field-label {
+    display: block; font-size: 10px; font-weight: 600;
+    color: #7f1d1d; text-transform: uppercase; letter-spacing: 0.04em;
+    margin-bottom: 2px;
+  }
+  .cell .toolbar .cat-chips { display: flex; gap: 4px; flex-wrap: wrap; }
+  .cell .toolbar .cat-chip {
+    background: #fff; border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 2px 8px; font-size: 11px; cursor: pointer; font-family: inherit;
+    color: #7f1d1d;
+  }
+  .cell .toolbar .cat-chip.active { background: #7f1d1d; color: #fff; border-color: #7f1d1d; }
+  .cell .toolbar .cat-chip[data-cat="needs-design"].active { background: #6d28d9; border-color: #6d28d9; }
+  .cell .toolbar .cat-chip[data-cat="bug"].active        { background: #b91c1c; border-color: #b91c1c; }
+  .cell .toolbar .cat-chip[data-cat="tooling"].active    { background: #b45309; border-color: #b45309; }
+  .cell .toolbar .cat-chip[data-cat="intentional"].active{ background: #15803d; border-color: #15803d; }
+  .cell .toolbar .cat-chip[data-cat="unclear"].active    { background: #6b7280; border-color: #6b7280; }
+  .cell .toolbar .recapture-btn {
+    background: #1d4ed8; color: #fff; border: 0; border-radius: 3px;
+    padding: 4px 10px; font-size: 11px; cursor: pointer;
+    font-family: inherit; font-weight: 600;
+  }
+  .cell .toolbar .recapture-btn:hover { background: #1e40af; }
+  .cell .toolbar textarea { min-height: 32px; resize: vertical; font-size: 11px; }
+  .cell.cat-needs-design { border-color: #6d28d9; }
+  .cell.cat-bug         { border-color: #b91c1c; }
+  .cell.cat-tooling     { border-color: #b45309; }
+  .cell.cat-intentional { border-color: #15803d; }
+  .cell.cat-unclear     { border-color: #6b7280; }
+
+  .marks-cluster {
+    display: flex; align-items: center; gap: 8px;
+    border-left: 1px solid #444; padding-left: 12px; margin-left: 4px;
+    font-size: 12px;
+  }
+  .marks-cluster .count {
+    background: #dc2626; color: #fff; border-radius: 10px;
+    padding: 2px 8px; font-weight: 600; min-width: 18px; text-align: center;
+  }
+  .marks-cluster button {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .marks-cluster button:hover { background: #4b5563; }
+  .marks-cluster button.danger { background: #7f1d1d; border-color: #991b1b; }
+  .marks-cluster button.danger:hover { background: #991b1b; }
+
+  body.only-marked .component-row:not(.has-marked) { display: none; }
+  body.only-marked section.route:not(.has-marked) { display: none; }
+
+  .component-row.suppressed { display: none; }
+  body.show-suppressed .component-row.suppressed { display: grid; }
+  .component-row.suppressed .label::after { content: " (hidden)"; color: #b91c1c; font-style: italic; }
+
+  .component-row .label[data-mapped] { color: #1d4ed8; }
+  .component-row .label[data-mapped]::after { content: " *"; }
+  .mapped-tooltip {
+    display: inline-block; margin-left: 4px;
+    font-size: 10px; color: #6b7280; cursor: help; vertical-align: super;
+  }
+
+  .vp-badge, .state-badge {
+    display: inline-block; font-size: 9px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.05em;
+    padding: 1px 6px; border-radius: 8px; margin-top: 2px;
+  }
+  .vp-badge.desktop { background: #dbeafe; color: #1e3a8a; border: 1px solid #93c5fd; margin-right: 4px; }
+  .vp-badge.mobile  { background: #fef3c7; color: #78350f; border: 1px solid #fcd34d; margin-right: 4px; }
+  .state-badge.empty       { background: #f3f4f6; color: #374151; border: 1px solid #d1d5db; }
+  .state-badge.seeded      { background: #dcfce7; color: #14532d; border: 1px solid #86efac; }
+  .state-badge.mid-session { background: #ede9fe; color: #4c1d95; border: 1px solid #c4b5fd; }
+
+  .component-row.vp-mobile { background: #fffbeb; padding: 4px; border-radius: 4px; }
+  body.hide-desktop .component-row.vp-desktop { display: none; }
+  body.hide-mobile .component-row.vp-mobile { display: none; }
+
+  body.hide-state-empty       .component-row.state-empty       { display: none; }
+  body.hide-state-seeded      .component-row.state-seeded      { display: none; }
+  body.hide-state-mid-session .component-row.state-mid-session { display: none; }
+
+  .overlay {
+    display: none; position: fixed; inset: 0; z-index: 1100;
+    background: rgba(0,0,0,0.6); align-items: center; justify-content: center;
+  }
+  .overlay.open { display: flex; }
+  .overlay .panel {
+    background: #fff; border-radius: 6px; width: min(720px, 92vw);
+    max-height: 80vh; padding: 16px; display: flex; flex-direction: column; gap: 8px;
+  }
+  .overlay h3 { margin: 0; font-size: 14px; }
+  .overlay textarea {
+    flex: 1; min-height: 320px; font-family: ui-monospace, monospace; font-size: 12px;
+    border: 1px solid #ddd; border-radius: 4px; padding: 8px; resize: vertical;
+  }
+  .overlay .actions { display: flex; gap: 8px; justify-content: flex-end; }
+  .overlay button {
+    background: #1a1a1a; color: #fff; border: 0; border-radius: 3px;
+    padding: 6px 12px; font-size: 12px; cursor: pointer;
+  }
+  .overlay .hint { font-size: 11px; color: #555; }
+  .overlay .err  { font-size: 12px; color: #b91c1c; min-height: 16px; }
+
+  /* Index-page table */
+  table.routes-index {
+    width: 100%; border-collapse: collapse; background: #fff;
+    border-radius: 6px; overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  table.routes-index th, table.routes-index td {
+    padding: 8px 12px; text-align: left; font-size: 13px;
+    border-bottom: 1px solid #eee;
+  }
+  table.routes-index th { background: #f3f4f6; font-weight: 600; }
+  table.routes-index td a {
+    color: #1d4ed8; text-decoration: none; font-family: ui-monospace, monospace;
+  }
+  table.routes-index td a:hover { text-decoration: underline; }
+  table.routes-index td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  table.routes-index .marked-count.has-marks { color: #b91c1c; font-weight: 600; }
+  table.routes-index .unresolved-count.has-unresolved { color: #b45309; font-weight: 600; }
+  table.routes-index .breakdown {
+    font-size: 11px; color: #555; margin-left: 6px; font-variant-numeric: tabular-nums;
+  }
+
+
+</style>
+</head>
+<body>
+<div class="sticky-shell">
+<header class="top">
+  <a class="back" href="index.html">&larr; Index</a>
+  <h1>worlds-create</h1>
+  <div class="legend">
+    <span class="col develop">develop</span>
+    <span class="col ds3">DS3</span>
+    <span class="col ds1">DS1</span>
+    <span class="col ds2">DS2</span>
+  </div>
+  <div class="controls">
+    <span class="state-chips" role="group" aria-label="State filter">
+      <span style="font-size: 11px; color: #aaa;">State:</span>
+      <button type="button" class="state-chip" data-state="empty">empty</button>
+      <button type="button" class="state-chip active" data-state="seeded">seeded</button>
+    </span>
+    <label><input type="checkbox" id="hide-empty"> Hide missing</label>
+    <label><input type="checkbox" id="compact"> Compact</label>
+    <label title="Stretch images to cell width"><input type="checkbox" id="fit-cell"> Fit to cell</label>
+    <label><input type="checkbox" id="only-marked"> Only marked</label>
+    <label><input type="checkbox" id="show-suppressed"> Show hidden rows</label>
+    <label><input type="checkbox" id="hide-desktop"> Hide desktop</label>
+    <label><input type="checkbox" id="hide-mobile"> Hide mobile</label>
+  </div>
+  <div class="marks-cluster">
+    <span>Marked (route):</span>
+    <span class="count" id="mark-count">0</span>
+    <button id="prefill-ds-btn" type="button" title="Mark every DS cell that has no mark yet as needs-design (gap-fill, never overwrites your existing marks)">Fill DS gaps</button>
+    <button id="export-md-btn" type="button">Export markdown</button>
+    <button id="export-json-btn" type="button">Export JSON</button>
+    <button id="import-json-btn" type="button">Import JSON</button>
+    <button id="clear-route-btn" type="button" class="danger">Clear (route)</button>
+  </div>
+</header>
+<nav class="toc" style="background:#2a2a2a;color:#ccc;padding:6px 16px;font-size:12px;display:flex;gap:8px;align-items:center;border-top:1px solid #444;">
+  <span class="nav-routes">
+    <a href="worlds-edit.html">&larr; worlds-edit</a>
+    <span class="current">worlds-create</span>
+    <a href="worlds-play.html">worlds-play &rarr;</a>
+  </span>
+</nav>
+</div>
+<main>
+<section class="route" id="route-worlds-create">
+  <h2>worlds-create</h2>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-create__global-nav__desktop__empty__develop" data-route="worlds-create" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-create__nav.png" alt="develop worlds-create/global-nav/desktop/empty" data-caption="develop -- worlds-create/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-create__global-nav__desktop__empty__DS3" data-route="worlds-create" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/worlds-create__nav.png" alt="DS3 worlds-create/global-nav/desktop/empty" data-caption="DS3 -- worlds-create/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-create__global-nav__desktop__empty__DS1" data-route="worlds-create" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/worlds-create__nav.png" alt="DS1 worlds-create/global-nav/desktop/empty" data-caption="DS1 -- worlds-create/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-create__global-nav__desktop__empty__DS2" data-route="worlds-create" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/worlds-create__nav.png" alt="DS2 worlds-create/global-nav/desktop/empty" data-caption="DS2 -- worlds-create/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-create__page__desktop__empty__develop" data-route="worlds-create" data-component="page" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-create__page.png" alt="develop worlds-create/page/desktop/empty" data-caption="develop -- worlds-create/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-create__page__desktop__empty__DS3" data-route="worlds-create" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/worlds-create__page.png" alt="DS3 worlds-create/page/desktop/empty" data-caption="DS3 -- worlds-create/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-create__page__desktop__empty__DS1" data-route="worlds-create" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/worlds-create__page.png" alt="DS1 worlds-create/page/desktop/empty" data-caption="DS1 -- worlds-create/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-create__page__desktop__empty__DS2" data-route="worlds-create" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/worlds-create__page.png" alt="DS2 worlds-create/page/desktop/empty" data-caption="DS2 -- worlds-create/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-empty" data-viewport="mobile" data-state="empty">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-create__page__mobile__empty__develop" data-route="worlds-create" data-component="page" data-viewport="mobile" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/empty/worlds-create__page.png" alt="develop worlds-create/page/mobile/empty" data-caption="develop -- worlds-create/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-create__page__mobile__empty__DS3" data-route="worlds-create" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/empty/worlds-create__page.png" alt="DS3 worlds-create/page/mobile/empty" data-caption="DS3 -- worlds-create/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-create__page__mobile__empty__DS1" data-route="worlds-create" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/empty/worlds-create__page.png" alt="DS1 worlds-create/page/mobile/empty" data-caption="DS1 -- worlds-create/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-create__page__mobile__empty__DS2" data-route="worlds-create" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/empty/worlds-create__page.png" alt="DS2 worlds-create/page/mobile/empty" data-caption="DS2 -- worlds-create/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-create__header__desktop__empty__develop" data-route="worlds-create" data-component="header" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-create__header.png" alt="develop worlds-create/header/desktop/empty" data-caption="develop -- worlds-create/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-create__nav__desktop__empty__develop" data-route="worlds-create" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-create__nav.png" alt="develop worlds-create/nav/desktop/empty" data-caption="develop -- worlds-create/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-create__nav__desktop__empty__DS3" data-route="worlds-create" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/worlds-create__nav.png" alt="DS3 worlds-create/nav/desktop/empty" data-caption="DS3 -- worlds-create/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-create__nav__desktop__empty__DS1" data-route="worlds-create" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/worlds-create__nav.png" alt="DS1 worlds-create/nav/desktop/empty" data-caption="DS1 -- worlds-create/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-create__nav__desktop__empty__DS2" data-route="worlds-create" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/worlds-create__nav.png" alt="DS2 worlds-create/nav/desktop/empty" data-caption="DS2 -- worlds-create/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-create__main__desktop__empty__develop" data-route="worlds-create" data-component="main" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-create__main.png" alt="develop worlds-create/main/desktop/empty" data-caption="develop -- worlds-create/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-create__main__desktop__empty__DS3" data-route="worlds-create" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/worlds-create__main.png" alt="DS3 worlds-create/main/desktop/empty" data-caption="DS3 -- worlds-create/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-create__main__desktop__empty__DS1" data-route="worlds-create" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/worlds-create__main.png" alt="DS1 worlds-create/main/desktop/empty" data-caption="DS1 -- worlds-create/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-create__main__desktop__empty__DS2" data-route="worlds-create" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/worlds-create__main.png" alt="DS2 worlds-create/main/desktop/empty" data-caption="DS2 -- worlds-create/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">main-section-2<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-create__main-section-2__desktop__empty__develop" data-route="worlds-create" data-component="main-section-2" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-create__main-section-2.png" alt="develop worlds-create/main-section-2/desktop/empty" data-caption="develop -- worlds-create/main-section-2 (desktop/empty; src: main-section-2)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-create__global-nav__desktop__seeded__develop" data-route="worlds-create" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-create__nav.png" alt="develop worlds-create/global-nav/desktop/seeded" data-caption="develop -- worlds-create/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-create__global-nav__desktop__seeded__DS3" data-route="worlds-create" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds-create__nav.png" alt="DS3 worlds-create/global-nav/desktop/seeded" data-caption="DS3 -- worlds-create/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-create__global-nav__desktop__seeded__DS1" data-route="worlds-create" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds-create__nav.png" alt="DS1 worlds-create/global-nav/desktop/seeded" data-caption="DS1 -- worlds-create/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-create__global-nav__desktop__seeded__DS2" data-route="worlds-create" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds-create__nav.png" alt="DS2 worlds-create/global-nav/desktop/seeded" data-caption="DS2 -- worlds-create/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-create__page__desktop__seeded__develop" data-route="worlds-create" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-create__page.png" alt="develop worlds-create/page/desktop/seeded" data-caption="develop -- worlds-create/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-create__page__desktop__seeded__DS3" data-route="worlds-create" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds-create__page.png" alt="DS3 worlds-create/page/desktop/seeded" data-caption="DS3 -- worlds-create/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-create__page__desktop__seeded__DS1" data-route="worlds-create" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds-create__page.png" alt="DS1 worlds-create/page/desktop/seeded" data-caption="DS1 -- worlds-create/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-create__page__desktop__seeded__DS2" data-route="worlds-create" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds-create__page.png" alt="DS2 worlds-create/page/desktop/seeded" data-caption="DS2 -- worlds-create/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-seeded" data-viewport="mobile" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-create__page__mobile__seeded__develop" data-route="worlds-create" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/seeded/worlds-create__page.png" alt="develop worlds-create/page/mobile/seeded" data-caption="develop -- worlds-create/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-create__page__mobile__seeded__DS3" data-route="worlds-create" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/seeded/worlds-create__page.png" alt="DS3 worlds-create/page/mobile/seeded" data-caption="DS3 -- worlds-create/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-create__page__mobile__seeded__DS1" data-route="worlds-create" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/seeded/worlds-create__page.png" alt="DS1 worlds-create/page/mobile/seeded" data-caption="DS1 -- worlds-create/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-create__page__mobile__seeded__DS2" data-route="worlds-create" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/seeded/worlds-create__page.png" alt="DS2 worlds-create/page/mobile/seeded" data-caption="DS2 -- worlds-create/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-create__header__desktop__seeded__develop" data-route="worlds-create" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-create__header.png" alt="develop worlds-create/header/desktop/seeded" data-caption="develop -- worlds-create/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-create__header__desktop__seeded__DS3" data-route="worlds-create" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds-create__header.png" alt="DS3 worlds-create/header/desktop/seeded" data-caption="DS3 -- worlds-create/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-create__header__desktop__seeded__DS1" data-route="worlds-create" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds-create__header.png" alt="DS1 worlds-create/header/desktop/seeded" data-caption="DS1 -- worlds-create/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-create__header__desktop__seeded__DS2" data-route="worlds-create" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds-create__header.png" alt="DS2 worlds-create/header/desktop/seeded" data-caption="DS2 -- worlds-create/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-create__nav__desktop__seeded__develop" data-route="worlds-create" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-create__nav.png" alt="develop worlds-create/nav/desktop/seeded" data-caption="develop -- worlds-create/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-create__nav__desktop__seeded__DS3" data-route="worlds-create" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds-create__nav.png" alt="DS3 worlds-create/nav/desktop/seeded" data-caption="DS3 -- worlds-create/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-create__nav__desktop__seeded__DS1" data-route="worlds-create" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds-create__nav.png" alt="DS1 worlds-create/nav/desktop/seeded" data-caption="DS1 -- worlds-create/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-create__nav__desktop__seeded__DS2" data-route="worlds-create" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds-create__nav.png" alt="DS2 worlds-create/nav/desktop/seeded" data-caption="DS2 -- worlds-create/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-create__main__desktop__seeded__develop" data-route="worlds-create" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-create__main.png" alt="develop worlds-create/main/desktop/seeded" data-caption="develop -- worlds-create/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-create__main__desktop__seeded__DS3" data-route="worlds-create" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds-create__main.png" alt="DS3 worlds-create/main/desktop/seeded" data-caption="DS3 -- worlds-create/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-create__main__desktop__seeded__DS1" data-route="worlds-create" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds-create__main.png" alt="DS1 worlds-create/main/desktop/seeded" data-caption="DS1 -- worlds-create/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-create__main__desktop__seeded__DS2" data-route="worlds-create" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds-create__main.png" alt="DS2 worlds-create/main/desktop/seeded" data-caption="DS2 -- worlds-create/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main-section-2<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-create__main-section-2__desktop__seeded__develop" data-route="worlds-create" data-component="main-section-2" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-create__main-section-2.png" alt="develop worlds-create/main-section-2/desktop/seeded" data-caption="develop -- worlds-create/main-section-2 (desktop/seeded; src: main-section-2)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+</section>
+</main>
+
+<div id="lightbox" class="overlay">
+  <img id="lightbox-img" src="" alt="">
+  <div id="lightbox-caption" style="position: fixed; top: 12px; left: 50%; transform: translateX(-50%); color: #fff; font-family: ui-monospace, monospace; font-size: 13px; background: rgba(0,0,0,0.6); padding: 6px 12px; border-radius: 4px;"></div>
+</div>
+
+<div id="md-overlay" class="overlay">
+  <div class="panel">
+    <h3>Audit marks (markdown) -- this route only</h3>
+    <textarea id="md-text" readonly></textarea>
+    <div class="actions">
+      <button id="md-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="md-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-export-overlay" class="overlay">
+  <div class="panel">
+    <h3>Marks (raw JSON) -- all routes</h3>
+    <textarea id="json-export-text" readonly></textarea>
+    <div class="actions">
+      <button id="json-export-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="json-export-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-import-overlay" class="overlay">
+  <div class="panel">
+    <h3>Import marks (paste raw JSON)</h3>
+    <p class="hint">Paste JSON exported from another instance. Legacy IDs without a state segment are migrated to <code>__seeded</code>; v2 values are upgraded to v3 (category=null, why="", updatedAt=now). Existing marks with the same ID are overwritten.</p>
+    <textarea id="json-import-text" placeholder='{"home__page__desktop__seeded__DS3":{"marked":true,"note":"...","category":"bug","why":"...","updatedAt":"..."}}'></textarea>
+    <div class="err" id="json-import-err"></div>
+    <div class="actions">
+      <button id="json-import-apply" type="button">Apply</button>
+      <button class="overlay-close" data-overlay="json-import-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+<script>
+
+  const STORAGE_KEY = 'narraitor-audit-marks-v3';
+  const STORAGE_KEY_V2 = 'narraitor-audit-marks-v2';
+  const STORAGE_KEY_V1 = 'narraitor-audit-marks-v1';
+  // Tracks which routes have had their DS cells auto-prefilled as needs-design.
+  // Once a route is in here, the auto-prefill on page load is skipped.
+  const PREFILLED_KEY = 'narraitor-audit-prefilled-v1';
+  const STATES = ['empty', 'seeded'];
+  const VALID_CATEGORIES = ['needs-design','bug','tooling','intentional','unclear'];
+  const ROUTE_ORDER = ["home", "about", "worlds", "worlds-detail", "worlds-edit", "worlds-create", "worlds-play", "worlds-play-journal", "characters", "characters-detail", "characters-edit", "characters-create", "play", "settings"];
+  const COMPONENT_ORDER = {"page":0,"header":1,"nav":2,"form":3,"main":4};
+  const THEME_ORDER = ["DS3","DS1","DS2","develop"];
+  const BRANCH_META = {"develop": {"theme": "default", "mode": "light", "branchArg": "develop-default"}, "DS3": {"theme": "ds3", "mode": "light", "branchArg": "integration-ds3-light"}, "DS1": {"theme": "ds1", "mode": "light", "branchArg": "integration-ds1-light"}, "DS2": {"theme": "ds2", "mode": "light", "branchArg": "integration-ds2-light"}};
+
+  function componentSortKey(c) {
+    if (c in COMPONENT_ORDER) return [COMPONENT_ORDER[c], 0];
+    if (c.startsWith("main-section-")) {
+      const n = parseInt(c.replace("main-section-",""), 10);
+      return [5, isNaN(n) ? 0 : n];
+    }
+    return [9, c];
+  }
+
+  // Pre-v3 ID migration: v1 (4 segments) -> v2 (5 segments) by inserting __seeded.
+  function migrateLegacyId(id) {
+    const parts = id.split('__');
+    if (parts.length < 4) return id;
+    const last = parts[parts.length - 1];
+    const second = parts[parts.length - 2];
+    const third = parts[parts.length - 3];
+    const isTheme = ['DS1','DS2','DS3','develop'].includes(last);
+    const isViewport = ['desktop','mobile'].includes(second);
+    const alreadyHasState = STATES.includes(third);
+    if (isTheme && isViewport && !alreadyHasState) {
+      const head = parts.slice(0, parts.length - 1).join('__');
+      return head + '__seeded__' + last;
+    }
+    return id;
+  }
+
+  function migrateMarksV1ToV2(input) {
+    const out = {};
+    let migrated = 0;
+    for (const [id, m] of Object.entries(input || {})) {
+      const newId = migrateLegacyId(id);
+      if (newId !== id) migrated++;
+      out[newId] = m;
+    }
+    return { marks: out, migrated };
+  }
+
+  // v2 -> v3: add category, why, updatedAt; preserve marked + note.
+  function upgradeV2ValueToV3(v) {
+    if (!v || typeof v !== 'object') return null;
+    return {
+      marked: !!v.marked,
+      note: typeof v.note === 'string' ? v.note : '',
+      category: v.category && VALID_CATEGORIES.includes(v.category) ? v.category : null,
+      why: typeof v.why === 'string' ? v.why : '',
+      updatedAt: v.updatedAt || new Date().toISOString(),
+    };
+  }
+
+  function migrateV2ObjectToV3(v2obj) {
+    const out = {};
+    for (const [id, m] of Object.entries(v2obj || {})) {
+      out[id] = upgradeV2ValueToV3(m);
+    }
+    return out;
+  }
+
+  function loadMarks() {
+    try {
+      const v3 = localStorage.getItem(STORAGE_KEY);
+      if (v3) return JSON.parse(v3);
+      // No v3 yet — try v2 (lazy migrate; leave v2 untouched for rollback).
+      const v2raw = localStorage.getItem(STORAGE_KEY_V2);
+      if (v2raw) {
+        const v3marks = migrateV2ObjectToV3(JSON.parse(v2raw));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + Object.keys(v3marks).length + ' v2 marks to v3 (v2 untouched).');
+        return v3marks;
+      }
+      // No v3 or v2 — try v1 and migrate v1 -> v2 -> v3 in one pass.
+      const v1raw = localStorage.getItem(STORAGE_KEY_V1);
+      if (v1raw) {
+        const { marks: v2marks, migrated } = migrateMarksV1ToV2(JSON.parse(v1raw));
+        const v3marks = migrateV2ObjectToV3(v2marks);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + migrated + ' v1 IDs through to v3.');
+        return v3marks;
+      }
+    } catch (e) { console.warn(e); }
+    return {};
+  }
+
+  function saveMarks(m) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(m)); } catch (e) {}
+  }
+
+
+  const ROUTE = "worlds-create";
+  let marks = loadMarks();
+
+  function applyMarkState(cell) {
+    const id = cell.dataset.cellId;
+    const m = marks[id];
+    const noteInput = cell.querySelector('textarea[data-action="note"]');
+    const whyInput = cell.querySelector('input[data-action="why"]');
+    const chips = cell.querySelectorAll('.cat-chip');
+    cell.classList.remove('cat-bug','cat-tooling','cat-intentional','cat-unclear');
+    chips.forEach(c => c.classList.remove('active'));
+    if (m && m.marked) {
+      cell.classList.add('marked');
+      if (noteInput) noteInput.value = m.note || '';
+      if (whyInput) whyInput.value = m.why || '';
+      if (m.category) {
+        cell.classList.add('cat-' + m.category);
+        const chip = cell.querySelector('.cat-chip[data-cat="' + m.category + '"]');
+        if (chip) chip.classList.add('active');
+      }
+    } else {
+      cell.classList.remove('marked');
+      if (noteInput) noteInput.value = '';
+      if (whyInput) whyInput.value = '';
+    }
+  }
+
+  function updateRowSectionFlags() {
+    document.querySelectorAll('.component-row').forEach(row => {
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+    document.querySelectorAll('section.route').forEach(sec => {
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+    });
+  }
+
+  function updateCount() {
+    const n = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).length;
+    document.getElementById('mark-count').textContent = n;
+  }
+
+  function writeMark(id, partial) {
+    const existing = marks[id] || { marked: false, note: '', category: null, why: '', updatedAt: null };
+    const next = Object.assign({}, existing, partial, { updatedAt: new Date().toISOString() });
+    if (!next.marked && !next.note && !next.why && !next.category) {
+      delete marks[id];
+    } else {
+      marks[id] = next;
+    }
+    saveMarks(marks);
+    updateCount();
+  }
+
+  function buildRecaptureCommand(cell) {
+    const route = cell.dataset.route;
+    const viewport = cell.dataset.viewport;
+    const state = cell.dataset.state;
+    const themeKey = cell.dataset.theme;
+    const meta = BRANCH_META[themeKey];
+    if (!meta) return null;
+    return 'npx tsx scripts/audit/playwright-crawl.ts'
+      + ' --branch ' + meta.branchArg
+      + ' --viewport ' + viewport
+      + ' --state ' + state
+      + ' --theme ' + meta.theme
+      + ' --mode ' + meta.mode
+      + ' --route ' + route;
+  }
+
+  function loadPrefilledFlags() {
+    try { return JSON.parse(localStorage.getItem(PREFILLED_KEY) || '{}'); }
+    catch (e) { return {}; }
+  }
+  function savePrefilledFlags(f) {
+    try { localStorage.setItem(PREFILLED_KEY, JSON.stringify(f)); } catch (e) {}
+  }
+
+  // Gap-fill: only adds entries for DS cells that have no existing mark.
+  // Returns the count of cells filled. Develop is excluded (it's the baseline).
+  function prefillDsCellsAsNeedsDesign() {
+    const dsCells = Array.from(document.querySelectorAll('.cell[data-cell-id]'))
+      .filter(c => ['DS1','DS2','DS3'].includes(c.dataset.theme));
+    let added = 0;
+    const ts = new Date().toISOString();
+    for (const cell of dsCells) {
+      const id = cell.dataset.cellId;
+      if (!marks[id]) {
+        marks[id] = { marked: true, note: '', category: 'needs-design', why: '', updatedAt: ts };
+        added++;
+      }
+    }
+    if (added > 0) saveMarks(marks);
+    return added;
+  }
+
+  // Auto-prefill on first visit per route.
+  const prefillFlags = loadPrefilledFlags();
+  if (!prefillFlags[ROUTE]) {
+    const added = prefillDsCellsAsNeedsDesign();
+    prefillFlags[ROUTE] = true;
+    savePrefilledFlags(prefillFlags);
+    if (added > 0) console.info('[audit] auto-prefilled ' + added + ' DS cells for ' + ROUTE + ' as needs-design.');
+  }
+
+  document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+  updateRowSectionFlags();
+  updateCount();
+
+  // Lightbox
+  const lb = document.getElementById('lightbox');
+  const lbImg = document.getElementById('lightbox-img');
+  const lbCap = document.getElementById('lightbox-caption');
+  document.querySelectorAll('.cell img').forEach(img => {
+    img.addEventListener('click', () => {
+      lbImg.src = img.src;
+      lbCap.textContent = img.dataset.caption || '';
+      lb.classList.add('open');
+    });
+  });
+  lb.addEventListener('click', () => lb.classList.remove('open'));
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') document.querySelectorAll('.overlay.open').forEach(o => o.classList.remove('open'));
+  });
+
+  // Mark toggle
+  document.querySelectorAll('button[data-action="toggle-mark"]').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      const cell = btn.closest('.cell');
+      const id = cell.dataset.cellId;
+      const isMarked = !cell.classList.contains('marked');
+      writeMark(id, { marked: isMarked });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      const sec = cell.closest('section.route');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+      if (isMarked) {
+        const why = cell.querySelector('input[data-action="why"]');
+        if (why) setTimeout(() => why.focus(), 0);
+      }
+    });
+  });
+
+  // Why / note inputs (debounced save)
+  let saveTimer = null;
+  function bindInput(sel, field) {
+    document.querySelectorAll(sel).forEach(inp => {
+      const handler = () => {
+        const cell = inp.closest('.cell');
+        if (!cell.classList.contains('marked')) return;
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(() => {
+          writeMark(cell.dataset.cellId, { [field]: inp.value });
+        }, 250);
+      };
+      inp.addEventListener('input', handler);
+      inp.addEventListener('blur', () => {
+        const cell = inp.closest('.cell');
+        if (cell.classList.contains('marked')) writeMark(cell.dataset.cellId, { [field]: inp.value });
+      });
+    });
+  }
+  bindInput('input[data-action="why"]', 'why');
+  bindInput('textarea[data-action="note"]', 'note');
+
+  // Category chips
+  document.querySelectorAll('.cat-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const cell = chip.closest('.cell');
+      if (!cell.classList.contains('marked')) {
+        // Mark the cell first so the category sticks
+        writeMark(cell.dataset.cellId, { marked: true });
+      }
+      const cat = chip.dataset.cat;
+      const isActive = chip.classList.contains('active');
+      writeMark(cell.dataset.cellId, { category: isActive ? null : cat });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+  });
+
+  // Re-capture command (copy to clipboard, flash purple)
+  document.querySelectorAll('button[data-action="recapture"]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const cell = btn.closest('.cell');
+      const cmd = buildRecaptureCommand(cell);
+      if (!cmd) return;
+      try {
+        await navigator.clipboard.writeText(cmd);
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Copy re-capture command'; }, 1500);
+      } catch (e) {
+        prompt('Copy this command:', cmd);
+      }
+      cell.classList.remove('pending-recapture');
+      void cell.offsetWidth; // force reflow so the animation restarts
+      cell.classList.add('pending-recapture');
+    });
+  });
+
+  // Toggles
+  document.getElementById('hide-empty').addEventListener('change', e => document.body.classList.toggle('hide-empty', e.target.checked));
+  document.getElementById('compact').addEventListener('change', e => document.body.classList.toggle('compact', e.target.checked));
+  document.getElementById('fit-cell').addEventListener('change', e => document.body.classList.toggle('fit-cell', e.target.checked));
+  document.getElementById('only-marked').addEventListener('change', e => document.body.classList.toggle('only-marked', e.target.checked));
+  document.getElementById('show-suppressed').addEventListener('change', e => document.body.classList.toggle('show-suppressed', e.target.checked));
+  document.getElementById('hide-desktop').addEventListener('change', e => document.body.classList.toggle('hide-desktop', e.target.checked));
+  document.getElementById('hide-mobile').addEventListener('change', e => document.body.classList.toggle('hide-mobile', e.target.checked));
+
+  // True-scale rendering (1x for selector captures, 0.5x for retina full-page).
+  const RETINA_THRESHOLD = 1500;
+  function applyTrueScale(img) {
+    if (!img.naturalWidth) return;
+    const cssWidth = img.naturalWidth > RETINA_THRESHOLD
+      ? Math.round(img.naturalWidth / 2)
+      : img.naturalWidth;
+    img.style.maxWidth = 'min(100%, ' + cssWidth + 'px)';
+  }
+  document.querySelectorAll('.cell img').forEach(img => {
+    if (img.complete && img.naturalWidth > 0) applyTrueScale(img);
+    else img.addEventListener('load', () => applyTrueScale(img), { once: true });
+  });
+
+  // State chips
+  document.querySelectorAll('.state-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const state = chip.dataset.state;
+      chip.classList.toggle('active');
+      document.body.classList.toggle('hide-state-' + state, !chip.classList.contains('active'));
+    });
+  });
+  STATES.forEach(s => {
+    const chip = document.querySelector('.state-chip[data-state="' + s + '"]');
+    if (chip && !chip.classList.contains('active')) document.body.classList.add('hide-state-' + s);
+  });
+
+  // Manual top-up: fill any DS cells that don't have a mark yet
+  document.getElementById('prefill-ds-btn').addEventListener('click', () => {
+    const added = prefillDsCellsAsNeedsDesign();
+    if (added > 0) {
+      document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+      updateRowSectionFlags();
+      updateCount();
+      alert('Filled ' + added + ' missing DS cells as needs-design.');
+    } else {
+      alert('All DS cells in this route already have marks.');
+    }
+  });
+
+  // Clear-route. Also resets the prefilled flag so a reload re-triggers auto-prefill.
+  document.getElementById('clear-route-btn').addEventListener('click', () => {
+    const ids = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).map(([id]) => id);
+    if (!ids.length) { alert('No marks for this route.'); return; }
+    if (!confirm('Clear ' + ids.length + ' marks for route ' + ROUTE + '?\n\nReloading the page will re-prefill all DS cells as needs-design.')) return;
+    ids.forEach(id => delete marks[id]);
+    saveMarks(marks);
+    const flags = loadPrefilledFlags();
+    delete flags[ROUTE];
+    savePrefilledFlags(flags);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+  });
+
+  function buildMarkdown() {
+    const items = [];
+    Object.entries(marks).forEach(([id, m]) => {
+      if (!m || !m.marked) return;
+      if (!id.startsWith(ROUTE + '__')) return;
+      const parts = id.split('__');
+      const themeKey = parts[parts.length - 1];
+      const state = parts[parts.length - 2];
+      const viewport = parts[parts.length - 3];
+      const route = parts[0];
+      const component = parts.slice(1, parts.length - 3).join('__');
+      items.push({ component, viewport, state, theme: themeKey,
+                   note: m.note || '', why: m.why || '', category: m.category || '' });
+    });
+    items.sort((a, b) => {
+      const ak = componentSortKey(a.component);
+      const bk = componentSortKey(b.component);
+      if (ak[0] !== bk[0]) return ak[0] - bk[0];
+      if (ak[1] !== bk[1]) return ak[1] < bk[1] ? -1 : 1;
+      const sd = STATES.indexOf(a.state) - STATES.indexOf(b.state);
+      if (sd !== 0) return sd;
+      const td = THEME_ORDER.indexOf(a.theme) - THEME_ORDER.indexOf(b.theme);
+      if (td !== 0) return td;
+      return a.viewport === b.viewport ? 0 : (a.viewport === 'desktop' ? -1 : 1);
+    });
+    const date = new Date().toISOString().split('T')[0];
+    const lines = ['# Audit marks -- ' + ROUTE + ' -- ' + items.length + ' items -- ' + date, ''];
+    items.forEach(it => {
+      const catTag = it.category ? ' [' + it.category + ']' : '';
+      const whyTxt = it.why ? ': ' + it.why : '';
+      const noteTxt = it.note ? '  -- ' + it.note : '';
+      lines.push('- [ ] **' + it.theme + ' ' + it.component + '** [' + it.viewport + '/' + it.state + ']' + catTag + whyTxt + noteTxt);
+    });
+    return lines.join('\n');
+  }
+
+  function openOverlay(id) { document.getElementById(id).classList.add('open'); }
+  function closeOverlay(id) { document.getElementById(id).classList.remove('open'); }
+  document.querySelectorAll('.overlay-close').forEach(b => b.addEventListener('click', () => closeOverlay(b.dataset.overlay)));
+  document.querySelectorAll('.overlay').forEach(o => {
+    o.addEventListener('click', e => { if (e.target === o) o.classList.remove('open'); });
+  });
+
+  document.getElementById('export-md-btn').addEventListener('click', async () => {
+    const md = buildMarkdown();
+    const ta = document.getElementById('md-text');
+    ta.value = md;
+    openOverlay('md-overlay');
+    try { await navigator.clipboard.writeText(md); document.getElementById('md-copy').textContent = 'Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+  document.getElementById('md-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('md-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('md-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('export-json-btn').addEventListener('click', () => {
+    const ta = document.getElementById('json-export-text');
+    ta.value = JSON.stringify(marks, null, 2);
+    openOverlay('json-export-overlay');
+  });
+  document.getElementById('json-export-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('json-export-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('json-export-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('json-export-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('import-json-btn').addEventListener('click', () => {
+    document.getElementById('json-import-text').value = '';
+    document.getElementById('json-import-err').textContent = '';
+    openOverlay('json-import-overlay');
+  });
+  document.getElementById('json-import-apply').addEventListener('click', () => {
+    const ta = document.getElementById('json-import-text');
+    const err = document.getElementById('json-import-err');
+    err.textContent = '';
+    let parsed;
+    try { parsed = JSON.parse(ta.value); }
+    catch (e) { err.textContent = 'Invalid JSON: ' + e.message; return; }
+    if (!parsed || typeof parsed !== 'object') { err.textContent = 'Expected an object.'; return; }
+    // First migrate v1 IDs (4 segments) -> v2 IDs (5 segments)
+    const { marks: idMigrated, migrated } = migrateMarksV1ToV2(parsed);
+    // Then upgrade each value v2 -> v3 (preserves marked + note, fills new fields)
+    Object.entries(idMigrated).forEach(([id, m]) => {
+      marks[id] = upgradeV2ValueToV3(m);
+    });
+    saveMarks(marks);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+    closeOverlay('json-import-overlay');
+    alert('Imported ' + Object.keys(idMigrated).length + ' marks (' + migrated + ' legacy IDs migrated to __seeded; values upgraded to v3).');
+  });
+</script>
+</body>
+</html>

--- a/scripts/audit/review/worlds-detail.html
+++ b/scripts/audit/review/worlds-detail.html
@@ -1,0 +1,2263 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Cross-Theme Audit (#1129) — worlds-detail</title>
+<style>
+
+  :root { --col-gap: 8px; --row-gap: 16px; }
+  html, body { margin: 0; padding: 0; font-family: -apple-system, system-ui, sans-serif; background: #fafafa; color: #222; }
+  .sticky-shell { position: sticky; top: 0; z-index: 100; border-bottom: 1px solid #444; }
+  header.top {
+    background: #1a1a1a; color: #fff; padding: 12px 16px;
+    display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+  }
+  header.top h1 { font-size: 14px; margin: 0; font-weight: 600; }
+  header.top .legend { display: flex; gap: 12px; font-size: 12px; }
+  header.top .legend .col { padding: 2px 8px; border-radius: 3px; }
+  header.top .legend .develop { background: #6b7280; }
+  header.top .legend .ds3 { background: #4338ca; }
+  header.top .legend .ds1 { background: #92400e; }
+  header.top .legend .ds2 { background: #166534; }
+  header.top a.back { color: #9cf; font-size: 12px; text-decoration: none; padding: 2px 6px; border-radius: 2px; }
+  header.top a.back:hover { background: #444; color: #fff; }
+  header.top .nav-routes { display: flex; gap: 4px; align-items: center; font-size: 12px; }
+  header.top .nav-routes a { color: #9cf; text-decoration: none; padding: 2px 8px; border-radius: 2px; background: #2a2a2a; }
+  header.top .nav-routes a:hover { background: #444; color: #fff; }
+  header.top .nav-routes .current { color: #fff; font-weight: 600; padding: 2px 8px; }
+  main { padding: 16px; max-width: 100%; }
+  section.route {
+    margin-bottom: 32px; background: #fff; border-radius: 6px;
+    padding: 12px 16px 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  section.route h2 {
+    font-size: 18px; margin: 0 0 12px; padding-bottom: 6px;
+    border-bottom: 1px solid #e5e5e5;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+  .component-row {
+    display: grid; grid-template-columns: 180px repeat(4, 1fr);
+    gap: var(--col-gap); margin-bottom: var(--row-gap);
+    align-items: start;
+  }
+  .component-row .label {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px; color: #555; padding-top: 28px; line-height: 1.3;
+    word-break: break-word;
+  }
+  .cell {
+    border: 1px solid #e5e5e5; border-radius: 4px; overflow: hidden;
+    background: #f3f4f6; position: relative; min-height: 100px;
+    display: flex; flex-direction: column;
+  }
+  .cell .header {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.04em; padding: 4px 8px; color: #fff;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .cell.develop .header { background: #6b7280; }
+  .cell.ds3 .header { background: #4338ca; }
+  .cell.ds1 .header { background: #92400e; }
+  .cell.ds2 .header { background: #166534; }
+  .cell img {
+    display: block; width: auto; max-width: 100%; height: auto;
+    cursor: zoom-in; background: #fff; align-self: flex-start;
+  }
+  body.fit-cell .cell img { width: 100%; max-width: 100%; }
+  .cell.empty {
+    display: flex; align-items: center; justify-content: center;
+    color: #999; font-size: 12px; padding: 24px; background: #f9f9f9;
+  }
+  .cell.empty::after { content: "(not captured)"; }
+
+  /* Lightbox */
+  #lightbox {
+    display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.92);
+    z-index: 1000; align-items: center; justify-content: center; cursor: zoom-out;
+  }
+  #lightbox.open { display: flex; }
+  #lightbox img { max-width: 96vw; max-height: 96vh; box-shadow: 0 4px 24px rgba(0,0,0,0.5); }
+
+  .controls { display: flex; gap: 12px; align-items: center; font-size: 12px; flex-wrap: wrap; }
+  .controls label { display: flex; align-items: center; gap: 4px; cursor: pointer; }
+  .controls input[type=checkbox] { margin: 0; }
+
+  .state-chips { display: inline-flex; gap: 4px; align-items: center; }
+  .state-chip {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .state-chip.active { background: #2563eb; border-color: #1d4ed8; }
+  .state-chip:hover { background: #4b5563; }
+  .state-chip.active:hover { background: #1d4ed8; }
+
+  body.hide-empty .component-row.all-empty,
+  body.hide-empty .cell.empty { display: none; }
+  body.compact .cell img { max-height: 360px; object-fit: cover; object-position: top; }
+
+  .cell .mark-btn {
+    margin-left: auto; background: rgba(255,255,255,0.18);
+    color: #fff; border: 1px solid rgba(255,255,255,0.35);
+    border-radius: 3px; font-size: 10px; font-weight: 600;
+    padding: 2px 6px; cursor: pointer;
+    text-transform: none; letter-spacing: 0; line-height: 1.2;
+  }
+  .cell .mark-btn:hover { background: rgba(255,255,255,0.28); }
+  .cell.marked { border: 3px solid #dc2626; }
+  .cell.marked .mark-btn { background: #dc2626; border-color: #b91c1c; color: #fff; }
+  .cell.marked .mark-btn::before { content: "x "; }
+  .cell.pending-recapture { animation: cellPulse 2s ease-out; }
+  @keyframes cellPulse {
+    0%   { box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.9); border-color: #7c3aed; }
+    100% { box-shadow: 0 0 0 8px rgba(124, 58, 237, 0); }
+  }
+  .cell .toolbar {
+    display: none;
+    padding: 6px 8px; background: #fef2f2; border-top: 1px solid #fecaca;
+    font-size: 11px;
+  }
+  .cell.marked .toolbar { display: block; }
+  .cell .toolbar input[type=text],
+  .cell .toolbar textarea {
+    width: 100%; box-sizing: border-box;
+    border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 4px 6px; font-size: 12px; font-family: inherit;
+    background: #fff;
+  }
+  .cell .toolbar input[type=text]:focus,
+  .cell .toolbar textarea:focus { outline: 2px solid #dc2626; outline-offset: -1px; }
+  .cell .toolbar .field { margin-bottom: 6px; }
+  .cell .toolbar .field-label {
+    display: block; font-size: 10px; font-weight: 600;
+    color: #7f1d1d; text-transform: uppercase; letter-spacing: 0.04em;
+    margin-bottom: 2px;
+  }
+  .cell .toolbar .cat-chips { display: flex; gap: 4px; flex-wrap: wrap; }
+  .cell .toolbar .cat-chip {
+    background: #fff; border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 2px 8px; font-size: 11px; cursor: pointer; font-family: inherit;
+    color: #7f1d1d;
+  }
+  .cell .toolbar .cat-chip.active { background: #7f1d1d; color: #fff; border-color: #7f1d1d; }
+  .cell .toolbar .cat-chip[data-cat="needs-design"].active { background: #6d28d9; border-color: #6d28d9; }
+  .cell .toolbar .cat-chip[data-cat="bug"].active        { background: #b91c1c; border-color: #b91c1c; }
+  .cell .toolbar .cat-chip[data-cat="tooling"].active    { background: #b45309; border-color: #b45309; }
+  .cell .toolbar .cat-chip[data-cat="intentional"].active{ background: #15803d; border-color: #15803d; }
+  .cell .toolbar .cat-chip[data-cat="unclear"].active    { background: #6b7280; border-color: #6b7280; }
+  .cell .toolbar .recapture-btn {
+    background: #1d4ed8; color: #fff; border: 0; border-radius: 3px;
+    padding: 4px 10px; font-size: 11px; cursor: pointer;
+    font-family: inherit; font-weight: 600;
+  }
+  .cell .toolbar .recapture-btn:hover { background: #1e40af; }
+  .cell .toolbar textarea { min-height: 32px; resize: vertical; font-size: 11px; }
+  .cell.cat-needs-design { border-color: #6d28d9; }
+  .cell.cat-bug         { border-color: #b91c1c; }
+  .cell.cat-tooling     { border-color: #b45309; }
+  .cell.cat-intentional { border-color: #15803d; }
+  .cell.cat-unclear     { border-color: #6b7280; }
+
+  .marks-cluster {
+    display: flex; align-items: center; gap: 8px;
+    border-left: 1px solid #444; padding-left: 12px; margin-left: 4px;
+    font-size: 12px;
+  }
+  .marks-cluster .count {
+    background: #dc2626; color: #fff; border-radius: 10px;
+    padding: 2px 8px; font-weight: 600; min-width: 18px; text-align: center;
+  }
+  .marks-cluster button {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .marks-cluster button:hover { background: #4b5563; }
+  .marks-cluster button.danger { background: #7f1d1d; border-color: #991b1b; }
+  .marks-cluster button.danger:hover { background: #991b1b; }
+
+  body.only-marked .component-row:not(.has-marked) { display: none; }
+  body.only-marked section.route:not(.has-marked) { display: none; }
+
+  .component-row.suppressed { display: none; }
+  body.show-suppressed .component-row.suppressed { display: grid; }
+  .component-row.suppressed .label::after { content: " (hidden)"; color: #b91c1c; font-style: italic; }
+
+  .component-row .label[data-mapped] { color: #1d4ed8; }
+  .component-row .label[data-mapped]::after { content: " *"; }
+  .mapped-tooltip {
+    display: inline-block; margin-left: 4px;
+    font-size: 10px; color: #6b7280; cursor: help; vertical-align: super;
+  }
+
+  .vp-badge, .state-badge {
+    display: inline-block; font-size: 9px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.05em;
+    padding: 1px 6px; border-radius: 8px; margin-top: 2px;
+  }
+  .vp-badge.desktop { background: #dbeafe; color: #1e3a8a; border: 1px solid #93c5fd; margin-right: 4px; }
+  .vp-badge.mobile  { background: #fef3c7; color: #78350f; border: 1px solid #fcd34d; margin-right: 4px; }
+  .state-badge.empty       { background: #f3f4f6; color: #374151; border: 1px solid #d1d5db; }
+  .state-badge.seeded      { background: #dcfce7; color: #14532d; border: 1px solid #86efac; }
+  .state-badge.mid-session { background: #ede9fe; color: #4c1d95; border: 1px solid #c4b5fd; }
+
+  .component-row.vp-mobile { background: #fffbeb; padding: 4px; border-radius: 4px; }
+  body.hide-desktop .component-row.vp-desktop { display: none; }
+  body.hide-mobile .component-row.vp-mobile { display: none; }
+
+  body.hide-state-empty       .component-row.state-empty       { display: none; }
+  body.hide-state-seeded      .component-row.state-seeded      { display: none; }
+  body.hide-state-mid-session .component-row.state-mid-session { display: none; }
+
+  .overlay {
+    display: none; position: fixed; inset: 0; z-index: 1100;
+    background: rgba(0,0,0,0.6); align-items: center; justify-content: center;
+  }
+  .overlay.open { display: flex; }
+  .overlay .panel {
+    background: #fff; border-radius: 6px; width: min(720px, 92vw);
+    max-height: 80vh; padding: 16px; display: flex; flex-direction: column; gap: 8px;
+  }
+  .overlay h3 { margin: 0; font-size: 14px; }
+  .overlay textarea {
+    flex: 1; min-height: 320px; font-family: ui-monospace, monospace; font-size: 12px;
+    border: 1px solid #ddd; border-radius: 4px; padding: 8px; resize: vertical;
+  }
+  .overlay .actions { display: flex; gap: 8px; justify-content: flex-end; }
+  .overlay button {
+    background: #1a1a1a; color: #fff; border: 0; border-radius: 3px;
+    padding: 6px 12px; font-size: 12px; cursor: pointer;
+  }
+  .overlay .hint { font-size: 11px; color: #555; }
+  .overlay .err  { font-size: 12px; color: #b91c1c; min-height: 16px; }
+
+  /* Index-page table */
+  table.routes-index {
+    width: 100%; border-collapse: collapse; background: #fff;
+    border-radius: 6px; overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  table.routes-index th, table.routes-index td {
+    padding: 8px 12px; text-align: left; font-size: 13px;
+    border-bottom: 1px solid #eee;
+  }
+  table.routes-index th { background: #f3f4f6; font-weight: 600; }
+  table.routes-index td a {
+    color: #1d4ed8; text-decoration: none; font-family: ui-monospace, monospace;
+  }
+  table.routes-index td a:hover { text-decoration: underline; }
+  table.routes-index td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  table.routes-index .marked-count.has-marks { color: #b91c1c; font-weight: 600; }
+  table.routes-index .unresolved-count.has-unresolved { color: #b45309; font-weight: 600; }
+  table.routes-index .breakdown {
+    font-size: 11px; color: #555; margin-left: 6px; font-variant-numeric: tabular-nums;
+  }
+
+
+</style>
+</head>
+<body>
+<div class="sticky-shell">
+<header class="top">
+  <a class="back" href="index.html">&larr; Index</a>
+  <h1>worlds-detail</h1>
+  <div class="legend">
+    <span class="col develop">develop</span>
+    <span class="col ds3">DS3</span>
+    <span class="col ds1">DS1</span>
+    <span class="col ds2">DS2</span>
+  </div>
+  <div class="controls">
+    <span class="state-chips" role="group" aria-label="State filter">
+      <span style="font-size: 11px; color: #aaa;">State:</span>
+      <button type="button" class="state-chip" data-state="empty">empty</button>
+      <button type="button" class="state-chip active" data-state="seeded">seeded</button>
+    </span>
+    <label><input type="checkbox" id="hide-empty"> Hide missing</label>
+    <label><input type="checkbox" id="compact"> Compact</label>
+    <label title="Stretch images to cell width"><input type="checkbox" id="fit-cell"> Fit to cell</label>
+    <label><input type="checkbox" id="only-marked"> Only marked</label>
+    <label><input type="checkbox" id="show-suppressed"> Show hidden rows</label>
+    <label><input type="checkbox" id="hide-desktop"> Hide desktop</label>
+    <label><input type="checkbox" id="hide-mobile"> Hide mobile</label>
+  </div>
+  <div class="marks-cluster">
+    <span>Marked (route):</span>
+    <span class="count" id="mark-count">0</span>
+    <button id="prefill-ds-btn" type="button" title="Mark every DS cell that has no mark yet as needs-design (gap-fill, never overwrites your existing marks)">Fill DS gaps</button>
+    <button id="export-md-btn" type="button">Export markdown</button>
+    <button id="export-json-btn" type="button">Export JSON</button>
+    <button id="import-json-btn" type="button">Import JSON</button>
+    <button id="clear-route-btn" type="button" class="danger">Clear (route)</button>
+  </div>
+</header>
+<nav class="toc" style="background:#2a2a2a;color:#ccc;padding:6px 16px;font-size:12px;display:flex;gap:8px;align-items:center;border-top:1px solid #444;">
+  <span class="nav-routes">
+    <a href="worlds.html">&larr; worlds</a>
+    <span class="current">worlds-detail</span>
+    <a href="worlds-edit.html">worlds-edit &rarr;</a>
+  </span>
+</nav>
+</div>
+<main>
+<section class="route" id="route-worlds-detail">
+  <h2>worlds-detail</h2>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-detail__global-nav__desktop__empty__develop" data-route="worlds-detail" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-detail__nav.png" alt="develop worlds-detail/global-nav/desktop/empty" data-caption="develop -- worlds-detail/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-detail__global-nav__desktop__empty__DS3" data-route="worlds-detail" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/worlds-detail__nav.png" alt="DS3 worlds-detail/global-nav/desktop/empty" data-caption="DS3 -- worlds-detail/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-detail__global-nav__desktop__empty__DS1" data-route="worlds-detail" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/worlds-detail__nav.png" alt="DS1 worlds-detail/global-nav/desktop/empty" data-caption="DS1 -- worlds-detail/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-detail__global-nav__desktop__empty__DS2" data-route="worlds-detail" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/worlds-detail__nav.png" alt="DS2 worlds-detail/global-nav/desktop/empty" data-caption="DS2 -- worlds-detail/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-detail__page__desktop__empty__develop" data-route="worlds-detail" data-component="page" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-detail__page.png" alt="develop worlds-detail/page/desktop/empty" data-caption="develop -- worlds-detail/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-detail__page__desktop__empty__DS3" data-route="worlds-detail" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/worlds-detail__page.png" alt="DS3 worlds-detail/page/desktop/empty" data-caption="DS3 -- worlds-detail/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-detail__page__desktop__empty__DS1" data-route="worlds-detail" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/worlds-detail__page.png" alt="DS1 worlds-detail/page/desktop/empty" data-caption="DS1 -- worlds-detail/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-detail__page__desktop__empty__DS2" data-route="worlds-detail" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/worlds-detail__page.png" alt="DS2 worlds-detail/page/desktop/empty" data-caption="DS2 -- worlds-detail/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-empty" data-viewport="mobile" data-state="empty">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-detail__page__mobile__empty__develop" data-route="worlds-detail" data-component="page" data-viewport="mobile" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/empty/worlds-detail__page.png" alt="develop worlds-detail/page/mobile/empty" data-caption="develop -- worlds-detail/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-detail__page__mobile__empty__DS3" data-route="worlds-detail" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/empty/worlds-detail__page.png" alt="DS3 worlds-detail/page/mobile/empty" data-caption="DS3 -- worlds-detail/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-detail__page__mobile__empty__DS1" data-route="worlds-detail" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/empty/worlds-detail__page.png" alt="DS1 worlds-detail/page/mobile/empty" data-caption="DS1 -- worlds-detail/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-detail__page__mobile__empty__DS2" data-route="worlds-detail" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/empty/worlds-detail__page.png" alt="DS2 worlds-detail/page/mobile/empty" data-caption="DS2 -- worlds-detail/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-detail__header__desktop__empty__develop" data-route="worlds-detail" data-component="header" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-detail__header.png" alt="develop worlds-detail/header/desktop/empty" data-caption="develop -- worlds-detail/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-detail__nav__desktop__empty__develop" data-route="worlds-detail" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-detail__nav.png" alt="develop worlds-detail/nav/desktop/empty" data-caption="develop -- worlds-detail/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-detail__nav__desktop__empty__DS3" data-route="worlds-detail" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/worlds-detail__nav.png" alt="DS3 worlds-detail/nav/desktop/empty" data-caption="DS3 -- worlds-detail/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-detail__nav__desktop__empty__DS1" data-route="worlds-detail" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/worlds-detail__nav.png" alt="DS1 worlds-detail/nav/desktop/empty" data-caption="DS1 -- worlds-detail/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-detail__nav__desktop__empty__DS2" data-route="worlds-detail" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/worlds-detail__nav.png" alt="DS2 worlds-detail/nav/desktop/empty" data-caption="DS2 -- worlds-detail/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-detail__main__desktop__empty__develop" data-route="worlds-detail" data-component="main" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-detail__main.png" alt="develop worlds-detail/main/desktop/empty" data-caption="develop -- worlds-detail/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-detail__main__desktop__empty__DS3" data-route="worlds-detail" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/worlds-detail__main.png" alt="DS3 worlds-detail/main/desktop/empty" data-caption="DS3 -- worlds-detail/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-detail__main__desktop__empty__DS1" data-route="worlds-detail" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/worlds-detail__main.png" alt="DS1 worlds-detail/main/desktop/empty" data-caption="DS1 -- worlds-detail/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-detail__main__desktop__empty__DS2" data-route="worlds-detail" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/worlds-detail__main.png" alt="DS2 worlds-detail/main/desktop/empty" data-caption="DS2 -- worlds-detail/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-detail__global-nav__desktop__seeded__develop" data-route="worlds-detail" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-detail__nav.png" alt="develop worlds-detail/global-nav/desktop/seeded" data-caption="develop -- worlds-detail/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-detail__global-nav__desktop__seeded__DS3" data-route="worlds-detail" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds-detail__nav.png" alt="DS3 worlds-detail/global-nav/desktop/seeded" data-caption="DS3 -- worlds-detail/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-detail__global-nav__desktop__seeded__DS1" data-route="worlds-detail" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds-detail__nav.png" alt="DS1 worlds-detail/global-nav/desktop/seeded" data-caption="DS1 -- worlds-detail/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-detail__global-nav__desktop__seeded__DS2" data-route="worlds-detail" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds-detail__nav.png" alt="DS2 worlds-detail/global-nav/desktop/seeded" data-caption="DS2 -- worlds-detail/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-detail__page__desktop__seeded__develop" data-route="worlds-detail" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-detail__page.png" alt="develop worlds-detail/page/desktop/seeded" data-caption="develop -- worlds-detail/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-detail__page__desktop__seeded__DS3" data-route="worlds-detail" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds-detail__page.png" alt="DS3 worlds-detail/page/desktop/seeded" data-caption="DS3 -- worlds-detail/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-detail__page__desktop__seeded__DS1" data-route="worlds-detail" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds-detail__page.png" alt="DS1 worlds-detail/page/desktop/seeded" data-caption="DS1 -- worlds-detail/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-detail__page__desktop__seeded__DS2" data-route="worlds-detail" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds-detail__page.png" alt="DS2 worlds-detail/page/desktop/seeded" data-caption="DS2 -- worlds-detail/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-seeded" data-viewport="mobile" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-detail__page__mobile__seeded__develop" data-route="worlds-detail" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/seeded/worlds-detail__page.png" alt="develop worlds-detail/page/mobile/seeded" data-caption="develop -- worlds-detail/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-detail__page__mobile__seeded__DS3" data-route="worlds-detail" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/seeded/worlds-detail__page.png" alt="DS3 worlds-detail/page/mobile/seeded" data-caption="DS3 -- worlds-detail/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-detail__page__mobile__seeded__DS1" data-route="worlds-detail" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/seeded/worlds-detail__page.png" alt="DS1 worlds-detail/page/mobile/seeded" data-caption="DS1 -- worlds-detail/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-detail__page__mobile__seeded__DS2" data-route="worlds-detail" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/seeded/worlds-detail__page.png" alt="DS2 worlds-detail/page/mobile/seeded" data-caption="DS2 -- worlds-detail/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-detail__header__desktop__seeded__develop" data-route="worlds-detail" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-detail__header.png" alt="develop worlds-detail/header/desktop/seeded" data-caption="develop -- worlds-detail/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-detail__header__desktop__seeded__DS3" data-route="worlds-detail" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds-detail__header.png" alt="DS3 worlds-detail/header/desktop/seeded" data-caption="DS3 -- worlds-detail/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-detail__header__desktop__seeded__DS1" data-route="worlds-detail" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds-detail__header.png" alt="DS1 worlds-detail/header/desktop/seeded" data-caption="DS1 -- worlds-detail/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-detail__header__desktop__seeded__DS2" data-route="worlds-detail" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds-detail__header.png" alt="DS2 worlds-detail/header/desktop/seeded" data-caption="DS2 -- worlds-detail/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-detail__nav__desktop__seeded__develop" data-route="worlds-detail" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-detail__nav.png" alt="develop worlds-detail/nav/desktop/seeded" data-caption="develop -- worlds-detail/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-detail__nav__desktop__seeded__DS3" data-route="worlds-detail" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds-detail__nav.png" alt="DS3 worlds-detail/nav/desktop/seeded" data-caption="DS3 -- worlds-detail/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-detail__nav__desktop__seeded__DS1" data-route="worlds-detail" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds-detail__nav.png" alt="DS1 worlds-detail/nav/desktop/seeded" data-caption="DS1 -- worlds-detail/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-detail__nav__desktop__seeded__DS2" data-route="worlds-detail" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds-detail__nav.png" alt="DS2 worlds-detail/nav/desktop/seeded" data-caption="DS2 -- worlds-detail/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-detail__main__desktop__seeded__develop" data-route="worlds-detail" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-detail__main.png" alt="develop worlds-detail/main/desktop/seeded" data-caption="develop -- worlds-detail/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-detail__main__desktop__seeded__DS3" data-route="worlds-detail" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds-detail__main.png" alt="DS3 worlds-detail/main/desktop/seeded" data-caption="DS3 -- worlds-detail/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-detail__main__desktop__seeded__DS1" data-route="worlds-detail" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds-detail__main.png" alt="DS1 worlds-detail/main/desktop/seeded" data-caption="DS1 -- worlds-detail/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-detail__main__desktop__seeded__DS2" data-route="worlds-detail" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds-detail__main.png" alt="DS2 worlds-detail/main/desktop/seeded" data-caption="DS2 -- worlds-detail/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main-section-2<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-detail__main-section-2__desktop__seeded__develop" data-route="worlds-detail" data-component="main-section-2" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-detail__main-section-2.png" alt="develop worlds-detail/main-section-2/desktop/seeded" data-caption="develop -- worlds-detail/main-section-2 (desktop/seeded; src: main-section-2)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main-section-3<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-detail__main-section-3__desktop__seeded__develop" data-route="worlds-detail" data-component="main-section-3" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-detail__main-section-3.png" alt="develop worlds-detail/main-section-3/desktop/seeded" data-caption="develop -- worlds-detail/main-section-3 (desktop/seeded; src: main-section-3)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main-section-4<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-detail__main-section-4__desktop__seeded__develop" data-route="worlds-detail" data-component="main-section-4" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-detail__main-section-4.png" alt="develop worlds-detail/main-section-4/desktop/seeded" data-caption="develop -- worlds-detail/main-section-4 (desktop/seeded; src: main-section-4)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main-section-5<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-detail__main-section-5__desktop__seeded__develop" data-route="worlds-detail" data-component="main-section-5" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-detail__main-section-5.png" alt="develop worlds-detail/main-section-5/desktop/seeded" data-caption="develop -- worlds-detail/main-section-5 (desktop/seeded; src: main-section-5)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main-section-6<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-detail__main-section-6__desktop__seeded__develop" data-route="worlds-detail" data-component="main-section-6" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-detail__main-section-6.png" alt="develop worlds-detail/main-section-6/desktop/seeded" data-caption="develop -- worlds-detail/main-section-6 (desktop/seeded; src: main-section-6)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main-section-7<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-detail__main-section-7__desktop__seeded__develop" data-route="worlds-detail" data-component="main-section-7" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-detail__main-section-7.png" alt="develop worlds-detail/main-section-7/desktop/seeded" data-caption="develop -- worlds-detail/main-section-7 (desktop/seeded; src: main-section-7)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+</section>
+</main>
+
+<div id="lightbox" class="overlay">
+  <img id="lightbox-img" src="" alt="">
+  <div id="lightbox-caption" style="position: fixed; top: 12px; left: 50%; transform: translateX(-50%); color: #fff; font-family: ui-monospace, monospace; font-size: 13px; background: rgba(0,0,0,0.6); padding: 6px 12px; border-radius: 4px;"></div>
+</div>
+
+<div id="md-overlay" class="overlay">
+  <div class="panel">
+    <h3>Audit marks (markdown) -- this route only</h3>
+    <textarea id="md-text" readonly></textarea>
+    <div class="actions">
+      <button id="md-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="md-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-export-overlay" class="overlay">
+  <div class="panel">
+    <h3>Marks (raw JSON) -- all routes</h3>
+    <textarea id="json-export-text" readonly></textarea>
+    <div class="actions">
+      <button id="json-export-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="json-export-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-import-overlay" class="overlay">
+  <div class="panel">
+    <h3>Import marks (paste raw JSON)</h3>
+    <p class="hint">Paste JSON exported from another instance. Legacy IDs without a state segment are migrated to <code>__seeded</code>; v2 values are upgraded to v3 (category=null, why="", updatedAt=now). Existing marks with the same ID are overwritten.</p>
+    <textarea id="json-import-text" placeholder='{"home__page__desktop__seeded__DS3":{"marked":true,"note":"...","category":"bug","why":"...","updatedAt":"..."}}'></textarea>
+    <div class="err" id="json-import-err"></div>
+    <div class="actions">
+      <button id="json-import-apply" type="button">Apply</button>
+      <button class="overlay-close" data-overlay="json-import-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+<script>
+
+  const STORAGE_KEY = 'narraitor-audit-marks-v3';
+  const STORAGE_KEY_V2 = 'narraitor-audit-marks-v2';
+  const STORAGE_KEY_V1 = 'narraitor-audit-marks-v1';
+  // Tracks which routes have had their DS cells auto-prefilled as needs-design.
+  // Once a route is in here, the auto-prefill on page load is skipped.
+  const PREFILLED_KEY = 'narraitor-audit-prefilled-v1';
+  const STATES = ['empty', 'seeded'];
+  const VALID_CATEGORIES = ['needs-design','bug','tooling','intentional','unclear'];
+  const ROUTE_ORDER = ["home", "about", "worlds", "worlds-detail", "worlds-edit", "worlds-create", "worlds-play", "worlds-play-journal", "characters", "characters-detail", "characters-edit", "characters-create", "play", "settings"];
+  const COMPONENT_ORDER = {"page":0,"header":1,"nav":2,"form":3,"main":4};
+  const THEME_ORDER = ["DS3","DS1","DS2","develop"];
+  const BRANCH_META = {"develop": {"theme": "default", "mode": "light", "branchArg": "develop-default"}, "DS3": {"theme": "ds3", "mode": "light", "branchArg": "integration-ds3-light"}, "DS1": {"theme": "ds1", "mode": "light", "branchArg": "integration-ds1-light"}, "DS2": {"theme": "ds2", "mode": "light", "branchArg": "integration-ds2-light"}};
+
+  function componentSortKey(c) {
+    if (c in COMPONENT_ORDER) return [COMPONENT_ORDER[c], 0];
+    if (c.startsWith("main-section-")) {
+      const n = parseInt(c.replace("main-section-",""), 10);
+      return [5, isNaN(n) ? 0 : n];
+    }
+    return [9, c];
+  }
+
+  // Pre-v3 ID migration: v1 (4 segments) -> v2 (5 segments) by inserting __seeded.
+  function migrateLegacyId(id) {
+    const parts = id.split('__');
+    if (parts.length < 4) return id;
+    const last = parts[parts.length - 1];
+    const second = parts[parts.length - 2];
+    const third = parts[parts.length - 3];
+    const isTheme = ['DS1','DS2','DS3','develop'].includes(last);
+    const isViewport = ['desktop','mobile'].includes(second);
+    const alreadyHasState = STATES.includes(third);
+    if (isTheme && isViewport && !alreadyHasState) {
+      const head = parts.slice(0, parts.length - 1).join('__');
+      return head + '__seeded__' + last;
+    }
+    return id;
+  }
+
+  function migrateMarksV1ToV2(input) {
+    const out = {};
+    let migrated = 0;
+    for (const [id, m] of Object.entries(input || {})) {
+      const newId = migrateLegacyId(id);
+      if (newId !== id) migrated++;
+      out[newId] = m;
+    }
+    return { marks: out, migrated };
+  }
+
+  // v2 -> v3: add category, why, updatedAt; preserve marked + note.
+  function upgradeV2ValueToV3(v) {
+    if (!v || typeof v !== 'object') return null;
+    return {
+      marked: !!v.marked,
+      note: typeof v.note === 'string' ? v.note : '',
+      category: v.category && VALID_CATEGORIES.includes(v.category) ? v.category : null,
+      why: typeof v.why === 'string' ? v.why : '',
+      updatedAt: v.updatedAt || new Date().toISOString(),
+    };
+  }
+
+  function migrateV2ObjectToV3(v2obj) {
+    const out = {};
+    for (const [id, m] of Object.entries(v2obj || {})) {
+      out[id] = upgradeV2ValueToV3(m);
+    }
+    return out;
+  }
+
+  function loadMarks() {
+    try {
+      const v3 = localStorage.getItem(STORAGE_KEY);
+      if (v3) return JSON.parse(v3);
+      // No v3 yet — try v2 (lazy migrate; leave v2 untouched for rollback).
+      const v2raw = localStorage.getItem(STORAGE_KEY_V2);
+      if (v2raw) {
+        const v3marks = migrateV2ObjectToV3(JSON.parse(v2raw));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + Object.keys(v3marks).length + ' v2 marks to v3 (v2 untouched).');
+        return v3marks;
+      }
+      // No v3 or v2 — try v1 and migrate v1 -> v2 -> v3 in one pass.
+      const v1raw = localStorage.getItem(STORAGE_KEY_V1);
+      if (v1raw) {
+        const { marks: v2marks, migrated } = migrateMarksV1ToV2(JSON.parse(v1raw));
+        const v3marks = migrateV2ObjectToV3(v2marks);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + migrated + ' v1 IDs through to v3.');
+        return v3marks;
+      }
+    } catch (e) { console.warn(e); }
+    return {};
+  }
+
+  function saveMarks(m) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(m)); } catch (e) {}
+  }
+
+
+  const ROUTE = "worlds-detail";
+  let marks = loadMarks();
+
+  function applyMarkState(cell) {
+    const id = cell.dataset.cellId;
+    const m = marks[id];
+    const noteInput = cell.querySelector('textarea[data-action="note"]');
+    const whyInput = cell.querySelector('input[data-action="why"]');
+    const chips = cell.querySelectorAll('.cat-chip');
+    cell.classList.remove('cat-bug','cat-tooling','cat-intentional','cat-unclear');
+    chips.forEach(c => c.classList.remove('active'));
+    if (m && m.marked) {
+      cell.classList.add('marked');
+      if (noteInput) noteInput.value = m.note || '';
+      if (whyInput) whyInput.value = m.why || '';
+      if (m.category) {
+        cell.classList.add('cat-' + m.category);
+        const chip = cell.querySelector('.cat-chip[data-cat="' + m.category + '"]');
+        if (chip) chip.classList.add('active');
+      }
+    } else {
+      cell.classList.remove('marked');
+      if (noteInput) noteInput.value = '';
+      if (whyInput) whyInput.value = '';
+    }
+  }
+
+  function updateRowSectionFlags() {
+    document.querySelectorAll('.component-row').forEach(row => {
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+    document.querySelectorAll('section.route').forEach(sec => {
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+    });
+  }
+
+  function updateCount() {
+    const n = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).length;
+    document.getElementById('mark-count').textContent = n;
+  }
+
+  function writeMark(id, partial) {
+    const existing = marks[id] || { marked: false, note: '', category: null, why: '', updatedAt: null };
+    const next = Object.assign({}, existing, partial, { updatedAt: new Date().toISOString() });
+    if (!next.marked && !next.note && !next.why && !next.category) {
+      delete marks[id];
+    } else {
+      marks[id] = next;
+    }
+    saveMarks(marks);
+    updateCount();
+  }
+
+  function buildRecaptureCommand(cell) {
+    const route = cell.dataset.route;
+    const viewport = cell.dataset.viewport;
+    const state = cell.dataset.state;
+    const themeKey = cell.dataset.theme;
+    const meta = BRANCH_META[themeKey];
+    if (!meta) return null;
+    return 'npx tsx scripts/audit/playwright-crawl.ts'
+      + ' --branch ' + meta.branchArg
+      + ' --viewport ' + viewport
+      + ' --state ' + state
+      + ' --theme ' + meta.theme
+      + ' --mode ' + meta.mode
+      + ' --route ' + route;
+  }
+
+  function loadPrefilledFlags() {
+    try { return JSON.parse(localStorage.getItem(PREFILLED_KEY) || '{}'); }
+    catch (e) { return {}; }
+  }
+  function savePrefilledFlags(f) {
+    try { localStorage.setItem(PREFILLED_KEY, JSON.stringify(f)); } catch (e) {}
+  }
+
+  // Gap-fill: only adds entries for DS cells that have no existing mark.
+  // Returns the count of cells filled. Develop is excluded (it's the baseline).
+  function prefillDsCellsAsNeedsDesign() {
+    const dsCells = Array.from(document.querySelectorAll('.cell[data-cell-id]'))
+      .filter(c => ['DS1','DS2','DS3'].includes(c.dataset.theme));
+    let added = 0;
+    const ts = new Date().toISOString();
+    for (const cell of dsCells) {
+      const id = cell.dataset.cellId;
+      if (!marks[id]) {
+        marks[id] = { marked: true, note: '', category: 'needs-design', why: '', updatedAt: ts };
+        added++;
+      }
+    }
+    if (added > 0) saveMarks(marks);
+    return added;
+  }
+
+  // Auto-prefill on first visit per route.
+  const prefillFlags = loadPrefilledFlags();
+  if (!prefillFlags[ROUTE]) {
+    const added = prefillDsCellsAsNeedsDesign();
+    prefillFlags[ROUTE] = true;
+    savePrefilledFlags(prefillFlags);
+    if (added > 0) console.info('[audit] auto-prefilled ' + added + ' DS cells for ' + ROUTE + ' as needs-design.');
+  }
+
+  document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+  updateRowSectionFlags();
+  updateCount();
+
+  // Lightbox
+  const lb = document.getElementById('lightbox');
+  const lbImg = document.getElementById('lightbox-img');
+  const lbCap = document.getElementById('lightbox-caption');
+  document.querySelectorAll('.cell img').forEach(img => {
+    img.addEventListener('click', () => {
+      lbImg.src = img.src;
+      lbCap.textContent = img.dataset.caption || '';
+      lb.classList.add('open');
+    });
+  });
+  lb.addEventListener('click', () => lb.classList.remove('open'));
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') document.querySelectorAll('.overlay.open').forEach(o => o.classList.remove('open'));
+  });
+
+  // Mark toggle
+  document.querySelectorAll('button[data-action="toggle-mark"]').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      const cell = btn.closest('.cell');
+      const id = cell.dataset.cellId;
+      const isMarked = !cell.classList.contains('marked');
+      writeMark(id, { marked: isMarked });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      const sec = cell.closest('section.route');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+      if (isMarked) {
+        const why = cell.querySelector('input[data-action="why"]');
+        if (why) setTimeout(() => why.focus(), 0);
+      }
+    });
+  });
+
+  // Why / note inputs (debounced save)
+  let saveTimer = null;
+  function bindInput(sel, field) {
+    document.querySelectorAll(sel).forEach(inp => {
+      const handler = () => {
+        const cell = inp.closest('.cell');
+        if (!cell.classList.contains('marked')) return;
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(() => {
+          writeMark(cell.dataset.cellId, { [field]: inp.value });
+        }, 250);
+      };
+      inp.addEventListener('input', handler);
+      inp.addEventListener('blur', () => {
+        const cell = inp.closest('.cell');
+        if (cell.classList.contains('marked')) writeMark(cell.dataset.cellId, { [field]: inp.value });
+      });
+    });
+  }
+  bindInput('input[data-action="why"]', 'why');
+  bindInput('textarea[data-action="note"]', 'note');
+
+  // Category chips
+  document.querySelectorAll('.cat-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const cell = chip.closest('.cell');
+      if (!cell.classList.contains('marked')) {
+        // Mark the cell first so the category sticks
+        writeMark(cell.dataset.cellId, { marked: true });
+      }
+      const cat = chip.dataset.cat;
+      const isActive = chip.classList.contains('active');
+      writeMark(cell.dataset.cellId, { category: isActive ? null : cat });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+  });
+
+  // Re-capture command (copy to clipboard, flash purple)
+  document.querySelectorAll('button[data-action="recapture"]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const cell = btn.closest('.cell');
+      const cmd = buildRecaptureCommand(cell);
+      if (!cmd) return;
+      try {
+        await navigator.clipboard.writeText(cmd);
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Copy re-capture command'; }, 1500);
+      } catch (e) {
+        prompt('Copy this command:', cmd);
+      }
+      cell.classList.remove('pending-recapture');
+      void cell.offsetWidth; // force reflow so the animation restarts
+      cell.classList.add('pending-recapture');
+    });
+  });
+
+  // Toggles
+  document.getElementById('hide-empty').addEventListener('change', e => document.body.classList.toggle('hide-empty', e.target.checked));
+  document.getElementById('compact').addEventListener('change', e => document.body.classList.toggle('compact', e.target.checked));
+  document.getElementById('fit-cell').addEventListener('change', e => document.body.classList.toggle('fit-cell', e.target.checked));
+  document.getElementById('only-marked').addEventListener('change', e => document.body.classList.toggle('only-marked', e.target.checked));
+  document.getElementById('show-suppressed').addEventListener('change', e => document.body.classList.toggle('show-suppressed', e.target.checked));
+  document.getElementById('hide-desktop').addEventListener('change', e => document.body.classList.toggle('hide-desktop', e.target.checked));
+  document.getElementById('hide-mobile').addEventListener('change', e => document.body.classList.toggle('hide-mobile', e.target.checked));
+
+  // True-scale rendering (1x for selector captures, 0.5x for retina full-page).
+  const RETINA_THRESHOLD = 1500;
+  function applyTrueScale(img) {
+    if (!img.naturalWidth) return;
+    const cssWidth = img.naturalWidth > RETINA_THRESHOLD
+      ? Math.round(img.naturalWidth / 2)
+      : img.naturalWidth;
+    img.style.maxWidth = 'min(100%, ' + cssWidth + 'px)';
+  }
+  document.querySelectorAll('.cell img').forEach(img => {
+    if (img.complete && img.naturalWidth > 0) applyTrueScale(img);
+    else img.addEventListener('load', () => applyTrueScale(img), { once: true });
+  });
+
+  // State chips
+  document.querySelectorAll('.state-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const state = chip.dataset.state;
+      chip.classList.toggle('active');
+      document.body.classList.toggle('hide-state-' + state, !chip.classList.contains('active'));
+    });
+  });
+  STATES.forEach(s => {
+    const chip = document.querySelector('.state-chip[data-state="' + s + '"]');
+    if (chip && !chip.classList.contains('active')) document.body.classList.add('hide-state-' + s);
+  });
+
+  // Manual top-up: fill any DS cells that don't have a mark yet
+  document.getElementById('prefill-ds-btn').addEventListener('click', () => {
+    const added = prefillDsCellsAsNeedsDesign();
+    if (added > 0) {
+      document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+      updateRowSectionFlags();
+      updateCount();
+      alert('Filled ' + added + ' missing DS cells as needs-design.');
+    } else {
+      alert('All DS cells in this route already have marks.');
+    }
+  });
+
+  // Clear-route. Also resets the prefilled flag so a reload re-triggers auto-prefill.
+  document.getElementById('clear-route-btn').addEventListener('click', () => {
+    const ids = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).map(([id]) => id);
+    if (!ids.length) { alert('No marks for this route.'); return; }
+    if (!confirm('Clear ' + ids.length + ' marks for route ' + ROUTE + '?\n\nReloading the page will re-prefill all DS cells as needs-design.')) return;
+    ids.forEach(id => delete marks[id]);
+    saveMarks(marks);
+    const flags = loadPrefilledFlags();
+    delete flags[ROUTE];
+    savePrefilledFlags(flags);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+  });
+
+  function buildMarkdown() {
+    const items = [];
+    Object.entries(marks).forEach(([id, m]) => {
+      if (!m || !m.marked) return;
+      if (!id.startsWith(ROUTE + '__')) return;
+      const parts = id.split('__');
+      const themeKey = parts[parts.length - 1];
+      const state = parts[parts.length - 2];
+      const viewport = parts[parts.length - 3];
+      const route = parts[0];
+      const component = parts.slice(1, parts.length - 3).join('__');
+      items.push({ component, viewport, state, theme: themeKey,
+                   note: m.note || '', why: m.why || '', category: m.category || '' });
+    });
+    items.sort((a, b) => {
+      const ak = componentSortKey(a.component);
+      const bk = componentSortKey(b.component);
+      if (ak[0] !== bk[0]) return ak[0] - bk[0];
+      if (ak[1] !== bk[1]) return ak[1] < bk[1] ? -1 : 1;
+      const sd = STATES.indexOf(a.state) - STATES.indexOf(b.state);
+      if (sd !== 0) return sd;
+      const td = THEME_ORDER.indexOf(a.theme) - THEME_ORDER.indexOf(b.theme);
+      if (td !== 0) return td;
+      return a.viewport === b.viewport ? 0 : (a.viewport === 'desktop' ? -1 : 1);
+    });
+    const date = new Date().toISOString().split('T')[0];
+    const lines = ['# Audit marks -- ' + ROUTE + ' -- ' + items.length + ' items -- ' + date, ''];
+    items.forEach(it => {
+      const catTag = it.category ? ' [' + it.category + ']' : '';
+      const whyTxt = it.why ? ': ' + it.why : '';
+      const noteTxt = it.note ? '  -- ' + it.note : '';
+      lines.push('- [ ] **' + it.theme + ' ' + it.component + '** [' + it.viewport + '/' + it.state + ']' + catTag + whyTxt + noteTxt);
+    });
+    return lines.join('\n');
+  }
+
+  function openOverlay(id) { document.getElementById(id).classList.add('open'); }
+  function closeOverlay(id) { document.getElementById(id).classList.remove('open'); }
+  document.querySelectorAll('.overlay-close').forEach(b => b.addEventListener('click', () => closeOverlay(b.dataset.overlay)));
+  document.querySelectorAll('.overlay').forEach(o => {
+    o.addEventListener('click', e => { if (e.target === o) o.classList.remove('open'); });
+  });
+
+  document.getElementById('export-md-btn').addEventListener('click', async () => {
+    const md = buildMarkdown();
+    const ta = document.getElementById('md-text');
+    ta.value = md;
+    openOverlay('md-overlay');
+    try { await navigator.clipboard.writeText(md); document.getElementById('md-copy').textContent = 'Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+  document.getElementById('md-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('md-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('md-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('export-json-btn').addEventListener('click', () => {
+    const ta = document.getElementById('json-export-text');
+    ta.value = JSON.stringify(marks, null, 2);
+    openOverlay('json-export-overlay');
+  });
+  document.getElementById('json-export-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('json-export-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('json-export-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('json-export-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('import-json-btn').addEventListener('click', () => {
+    document.getElementById('json-import-text').value = '';
+    document.getElementById('json-import-err').textContent = '';
+    openOverlay('json-import-overlay');
+  });
+  document.getElementById('json-import-apply').addEventListener('click', () => {
+    const ta = document.getElementById('json-import-text');
+    const err = document.getElementById('json-import-err');
+    err.textContent = '';
+    let parsed;
+    try { parsed = JSON.parse(ta.value); }
+    catch (e) { err.textContent = 'Invalid JSON: ' + e.message; return; }
+    if (!parsed || typeof parsed !== 'object') { err.textContent = 'Expected an object.'; return; }
+    // First migrate v1 IDs (4 segments) -> v2 IDs (5 segments)
+    const { marks: idMigrated, migrated } = migrateMarksV1ToV2(parsed);
+    // Then upgrade each value v2 -> v3 (preserves marked + note, fills new fields)
+    Object.entries(idMigrated).forEach(([id, m]) => {
+      marks[id] = upgradeV2ValueToV3(m);
+    });
+    saveMarks(marks);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+    closeOverlay('json-import-overlay');
+    alert('Imported ' + Object.keys(idMigrated).length + ' marks (' + migrated + ' legacy IDs migrated to __seeded; values upgraded to v3).');
+  });
+</script>
+</body>
+</html>

--- a/scripts/audit/review/worlds-edit.html
+++ b/scripts/audit/review/worlds-edit.html
@@ -1,0 +1,2176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Cross-Theme Audit (#1129) — worlds-edit</title>
+<style>
+
+  :root { --col-gap: 8px; --row-gap: 16px; }
+  html, body { margin: 0; padding: 0; font-family: -apple-system, system-ui, sans-serif; background: #fafafa; color: #222; }
+  .sticky-shell { position: sticky; top: 0; z-index: 100; border-bottom: 1px solid #444; }
+  header.top {
+    background: #1a1a1a; color: #fff; padding: 12px 16px;
+    display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+  }
+  header.top h1 { font-size: 14px; margin: 0; font-weight: 600; }
+  header.top .legend { display: flex; gap: 12px; font-size: 12px; }
+  header.top .legend .col { padding: 2px 8px; border-radius: 3px; }
+  header.top .legend .develop { background: #6b7280; }
+  header.top .legend .ds3 { background: #4338ca; }
+  header.top .legend .ds1 { background: #92400e; }
+  header.top .legend .ds2 { background: #166534; }
+  header.top a.back { color: #9cf; font-size: 12px; text-decoration: none; padding: 2px 6px; border-radius: 2px; }
+  header.top a.back:hover { background: #444; color: #fff; }
+  header.top .nav-routes { display: flex; gap: 4px; align-items: center; font-size: 12px; }
+  header.top .nav-routes a { color: #9cf; text-decoration: none; padding: 2px 8px; border-radius: 2px; background: #2a2a2a; }
+  header.top .nav-routes a:hover { background: #444; color: #fff; }
+  header.top .nav-routes .current { color: #fff; font-weight: 600; padding: 2px 8px; }
+  main { padding: 16px; max-width: 100%; }
+  section.route {
+    margin-bottom: 32px; background: #fff; border-radius: 6px;
+    padding: 12px 16px 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  section.route h2 {
+    font-size: 18px; margin: 0 0 12px; padding-bottom: 6px;
+    border-bottom: 1px solid #e5e5e5;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+  .component-row {
+    display: grid; grid-template-columns: 180px repeat(4, 1fr);
+    gap: var(--col-gap); margin-bottom: var(--row-gap);
+    align-items: start;
+  }
+  .component-row .label {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px; color: #555; padding-top: 28px; line-height: 1.3;
+    word-break: break-word;
+  }
+  .cell {
+    border: 1px solid #e5e5e5; border-radius: 4px; overflow: hidden;
+    background: #f3f4f6; position: relative; min-height: 100px;
+    display: flex; flex-direction: column;
+  }
+  .cell .header {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.04em; padding: 4px 8px; color: #fff;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .cell.develop .header { background: #6b7280; }
+  .cell.ds3 .header { background: #4338ca; }
+  .cell.ds1 .header { background: #92400e; }
+  .cell.ds2 .header { background: #166534; }
+  .cell img {
+    display: block; width: auto; max-width: 100%; height: auto;
+    cursor: zoom-in; background: #fff; align-self: flex-start;
+  }
+  body.fit-cell .cell img { width: 100%; max-width: 100%; }
+  .cell.empty {
+    display: flex; align-items: center; justify-content: center;
+    color: #999; font-size: 12px; padding: 24px; background: #f9f9f9;
+  }
+  .cell.empty::after { content: "(not captured)"; }
+
+  /* Lightbox */
+  #lightbox {
+    display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.92);
+    z-index: 1000; align-items: center; justify-content: center; cursor: zoom-out;
+  }
+  #lightbox.open { display: flex; }
+  #lightbox img { max-width: 96vw; max-height: 96vh; box-shadow: 0 4px 24px rgba(0,0,0,0.5); }
+
+  .controls { display: flex; gap: 12px; align-items: center; font-size: 12px; flex-wrap: wrap; }
+  .controls label { display: flex; align-items: center; gap: 4px; cursor: pointer; }
+  .controls input[type=checkbox] { margin: 0; }
+
+  .state-chips { display: inline-flex; gap: 4px; align-items: center; }
+  .state-chip {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .state-chip.active { background: #2563eb; border-color: #1d4ed8; }
+  .state-chip:hover { background: #4b5563; }
+  .state-chip.active:hover { background: #1d4ed8; }
+
+  body.hide-empty .component-row.all-empty,
+  body.hide-empty .cell.empty { display: none; }
+  body.compact .cell img { max-height: 360px; object-fit: cover; object-position: top; }
+
+  .cell .mark-btn {
+    margin-left: auto; background: rgba(255,255,255,0.18);
+    color: #fff; border: 1px solid rgba(255,255,255,0.35);
+    border-radius: 3px; font-size: 10px; font-weight: 600;
+    padding: 2px 6px; cursor: pointer;
+    text-transform: none; letter-spacing: 0; line-height: 1.2;
+  }
+  .cell .mark-btn:hover { background: rgba(255,255,255,0.28); }
+  .cell.marked { border: 3px solid #dc2626; }
+  .cell.marked .mark-btn { background: #dc2626; border-color: #b91c1c; color: #fff; }
+  .cell.marked .mark-btn::before { content: "x "; }
+  .cell.pending-recapture { animation: cellPulse 2s ease-out; }
+  @keyframes cellPulse {
+    0%   { box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.9); border-color: #7c3aed; }
+    100% { box-shadow: 0 0 0 8px rgba(124, 58, 237, 0); }
+  }
+  .cell .toolbar {
+    display: none;
+    padding: 6px 8px; background: #fef2f2; border-top: 1px solid #fecaca;
+    font-size: 11px;
+  }
+  .cell.marked .toolbar { display: block; }
+  .cell .toolbar input[type=text],
+  .cell .toolbar textarea {
+    width: 100%; box-sizing: border-box;
+    border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 4px 6px; font-size: 12px; font-family: inherit;
+    background: #fff;
+  }
+  .cell .toolbar input[type=text]:focus,
+  .cell .toolbar textarea:focus { outline: 2px solid #dc2626; outline-offset: -1px; }
+  .cell .toolbar .field { margin-bottom: 6px; }
+  .cell .toolbar .field-label {
+    display: block; font-size: 10px; font-weight: 600;
+    color: #7f1d1d; text-transform: uppercase; letter-spacing: 0.04em;
+    margin-bottom: 2px;
+  }
+  .cell .toolbar .cat-chips { display: flex; gap: 4px; flex-wrap: wrap; }
+  .cell .toolbar .cat-chip {
+    background: #fff; border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 2px 8px; font-size: 11px; cursor: pointer; font-family: inherit;
+    color: #7f1d1d;
+  }
+  .cell .toolbar .cat-chip.active { background: #7f1d1d; color: #fff; border-color: #7f1d1d; }
+  .cell .toolbar .cat-chip[data-cat="needs-design"].active { background: #6d28d9; border-color: #6d28d9; }
+  .cell .toolbar .cat-chip[data-cat="bug"].active        { background: #b91c1c; border-color: #b91c1c; }
+  .cell .toolbar .cat-chip[data-cat="tooling"].active    { background: #b45309; border-color: #b45309; }
+  .cell .toolbar .cat-chip[data-cat="intentional"].active{ background: #15803d; border-color: #15803d; }
+  .cell .toolbar .cat-chip[data-cat="unclear"].active    { background: #6b7280; border-color: #6b7280; }
+  .cell .toolbar .recapture-btn {
+    background: #1d4ed8; color: #fff; border: 0; border-radius: 3px;
+    padding: 4px 10px; font-size: 11px; cursor: pointer;
+    font-family: inherit; font-weight: 600;
+  }
+  .cell .toolbar .recapture-btn:hover { background: #1e40af; }
+  .cell .toolbar textarea { min-height: 32px; resize: vertical; font-size: 11px; }
+  .cell.cat-needs-design { border-color: #6d28d9; }
+  .cell.cat-bug         { border-color: #b91c1c; }
+  .cell.cat-tooling     { border-color: #b45309; }
+  .cell.cat-intentional { border-color: #15803d; }
+  .cell.cat-unclear     { border-color: #6b7280; }
+
+  .marks-cluster {
+    display: flex; align-items: center; gap: 8px;
+    border-left: 1px solid #444; padding-left: 12px; margin-left: 4px;
+    font-size: 12px;
+  }
+  .marks-cluster .count {
+    background: #dc2626; color: #fff; border-radius: 10px;
+    padding: 2px 8px; font-weight: 600; min-width: 18px; text-align: center;
+  }
+  .marks-cluster button {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .marks-cluster button:hover { background: #4b5563; }
+  .marks-cluster button.danger { background: #7f1d1d; border-color: #991b1b; }
+  .marks-cluster button.danger:hover { background: #991b1b; }
+
+  body.only-marked .component-row:not(.has-marked) { display: none; }
+  body.only-marked section.route:not(.has-marked) { display: none; }
+
+  .component-row.suppressed { display: none; }
+  body.show-suppressed .component-row.suppressed { display: grid; }
+  .component-row.suppressed .label::after { content: " (hidden)"; color: #b91c1c; font-style: italic; }
+
+  .component-row .label[data-mapped] { color: #1d4ed8; }
+  .component-row .label[data-mapped]::after { content: " *"; }
+  .mapped-tooltip {
+    display: inline-block; margin-left: 4px;
+    font-size: 10px; color: #6b7280; cursor: help; vertical-align: super;
+  }
+
+  .vp-badge, .state-badge {
+    display: inline-block; font-size: 9px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.05em;
+    padding: 1px 6px; border-radius: 8px; margin-top: 2px;
+  }
+  .vp-badge.desktop { background: #dbeafe; color: #1e3a8a; border: 1px solid #93c5fd; margin-right: 4px; }
+  .vp-badge.mobile  { background: #fef3c7; color: #78350f; border: 1px solid #fcd34d; margin-right: 4px; }
+  .state-badge.empty       { background: #f3f4f6; color: #374151; border: 1px solid #d1d5db; }
+  .state-badge.seeded      { background: #dcfce7; color: #14532d; border: 1px solid #86efac; }
+  .state-badge.mid-session { background: #ede9fe; color: #4c1d95; border: 1px solid #c4b5fd; }
+
+  .component-row.vp-mobile { background: #fffbeb; padding: 4px; border-radius: 4px; }
+  body.hide-desktop .component-row.vp-desktop { display: none; }
+  body.hide-mobile .component-row.vp-mobile { display: none; }
+
+  body.hide-state-empty       .component-row.state-empty       { display: none; }
+  body.hide-state-seeded      .component-row.state-seeded      { display: none; }
+  body.hide-state-mid-session .component-row.state-mid-session { display: none; }
+
+  .overlay {
+    display: none; position: fixed; inset: 0; z-index: 1100;
+    background: rgba(0,0,0,0.6); align-items: center; justify-content: center;
+  }
+  .overlay.open { display: flex; }
+  .overlay .panel {
+    background: #fff; border-radius: 6px; width: min(720px, 92vw);
+    max-height: 80vh; padding: 16px; display: flex; flex-direction: column; gap: 8px;
+  }
+  .overlay h3 { margin: 0; font-size: 14px; }
+  .overlay textarea {
+    flex: 1; min-height: 320px; font-family: ui-monospace, monospace; font-size: 12px;
+    border: 1px solid #ddd; border-radius: 4px; padding: 8px; resize: vertical;
+  }
+  .overlay .actions { display: flex; gap: 8px; justify-content: flex-end; }
+  .overlay button {
+    background: #1a1a1a; color: #fff; border: 0; border-radius: 3px;
+    padding: 6px 12px; font-size: 12px; cursor: pointer;
+  }
+  .overlay .hint { font-size: 11px; color: #555; }
+  .overlay .err  { font-size: 12px; color: #b91c1c; min-height: 16px; }
+
+  /* Index-page table */
+  table.routes-index {
+    width: 100%; border-collapse: collapse; background: #fff;
+    border-radius: 6px; overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  table.routes-index th, table.routes-index td {
+    padding: 8px 12px; text-align: left; font-size: 13px;
+    border-bottom: 1px solid #eee;
+  }
+  table.routes-index th { background: #f3f4f6; font-weight: 600; }
+  table.routes-index td a {
+    color: #1d4ed8; text-decoration: none; font-family: ui-monospace, monospace;
+  }
+  table.routes-index td a:hover { text-decoration: underline; }
+  table.routes-index td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  table.routes-index .marked-count.has-marks { color: #b91c1c; font-weight: 600; }
+  table.routes-index .unresolved-count.has-unresolved { color: #b45309; font-weight: 600; }
+  table.routes-index .breakdown {
+    font-size: 11px; color: #555; margin-left: 6px; font-variant-numeric: tabular-nums;
+  }
+
+
+</style>
+</head>
+<body>
+<div class="sticky-shell">
+<header class="top">
+  <a class="back" href="index.html">&larr; Index</a>
+  <h1>worlds-edit</h1>
+  <div class="legend">
+    <span class="col develop">develop</span>
+    <span class="col ds3">DS3</span>
+    <span class="col ds1">DS1</span>
+    <span class="col ds2">DS2</span>
+  </div>
+  <div class="controls">
+    <span class="state-chips" role="group" aria-label="State filter">
+      <span style="font-size: 11px; color: #aaa;">State:</span>
+      <button type="button" class="state-chip" data-state="empty">empty</button>
+      <button type="button" class="state-chip active" data-state="seeded">seeded</button>
+    </span>
+    <label><input type="checkbox" id="hide-empty"> Hide missing</label>
+    <label><input type="checkbox" id="compact"> Compact</label>
+    <label title="Stretch images to cell width"><input type="checkbox" id="fit-cell"> Fit to cell</label>
+    <label><input type="checkbox" id="only-marked"> Only marked</label>
+    <label><input type="checkbox" id="show-suppressed"> Show hidden rows</label>
+    <label><input type="checkbox" id="hide-desktop"> Hide desktop</label>
+    <label><input type="checkbox" id="hide-mobile"> Hide mobile</label>
+  </div>
+  <div class="marks-cluster">
+    <span>Marked (route):</span>
+    <span class="count" id="mark-count">0</span>
+    <button id="prefill-ds-btn" type="button" title="Mark every DS cell that has no mark yet as needs-design (gap-fill, never overwrites your existing marks)">Fill DS gaps</button>
+    <button id="export-md-btn" type="button">Export markdown</button>
+    <button id="export-json-btn" type="button">Export JSON</button>
+    <button id="import-json-btn" type="button">Import JSON</button>
+    <button id="clear-route-btn" type="button" class="danger">Clear (route)</button>
+  </div>
+</header>
+<nav class="toc" style="background:#2a2a2a;color:#ccc;padding:6px 16px;font-size:12px;display:flex;gap:8px;align-items:center;border-top:1px solid #444;">
+  <span class="nav-routes">
+    <a href="worlds-detail.html">&larr; worlds-detail</a>
+    <span class="current">worlds-edit</span>
+    <a href="worlds-create.html">worlds-create &rarr;</a>
+  </span>
+</nav>
+</div>
+<main>
+<section class="route" id="route-worlds-edit">
+  <h2>worlds-edit</h2>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-edit__global-nav__desktop__empty__develop" data-route="worlds-edit" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-edit__nav.png" alt="develop worlds-edit/global-nav/desktop/empty" data-caption="develop -- worlds-edit/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-edit__global-nav__desktop__empty__DS3" data-route="worlds-edit" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/worlds-edit__nav.png" alt="DS3 worlds-edit/global-nav/desktop/empty" data-caption="DS3 -- worlds-edit/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-edit__global-nav__desktop__empty__DS1" data-route="worlds-edit" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/worlds-edit__nav.png" alt="DS1 worlds-edit/global-nav/desktop/empty" data-caption="DS1 -- worlds-edit/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-edit__global-nav__desktop__empty__DS2" data-route="worlds-edit" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/worlds-edit__nav.png" alt="DS2 worlds-edit/global-nav/desktop/empty" data-caption="DS2 -- worlds-edit/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-edit__page__desktop__empty__develop" data-route="worlds-edit" data-component="page" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-edit__page.png" alt="develop worlds-edit/page/desktop/empty" data-caption="develop -- worlds-edit/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-edit__page__desktop__empty__DS3" data-route="worlds-edit" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/worlds-edit__page.png" alt="DS3 worlds-edit/page/desktop/empty" data-caption="DS3 -- worlds-edit/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-edit__page__desktop__empty__DS1" data-route="worlds-edit" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/worlds-edit__page.png" alt="DS1 worlds-edit/page/desktop/empty" data-caption="DS1 -- worlds-edit/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-edit__page__desktop__empty__DS2" data-route="worlds-edit" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/worlds-edit__page.png" alt="DS2 worlds-edit/page/desktop/empty" data-caption="DS2 -- worlds-edit/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-empty" data-viewport="mobile" data-state="empty">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-edit__page__mobile__empty__develop" data-route="worlds-edit" data-component="page" data-viewport="mobile" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/empty/worlds-edit__page.png" alt="develop worlds-edit/page/mobile/empty" data-caption="develop -- worlds-edit/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-edit__page__mobile__empty__DS3" data-route="worlds-edit" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/empty/worlds-edit__page.png" alt="DS3 worlds-edit/page/mobile/empty" data-caption="DS3 -- worlds-edit/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-edit__page__mobile__empty__DS1" data-route="worlds-edit" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/empty/worlds-edit__page.png" alt="DS1 worlds-edit/page/mobile/empty" data-caption="DS1 -- worlds-edit/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-edit__page__mobile__empty__DS2" data-route="worlds-edit" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/empty/worlds-edit__page.png" alt="DS2 worlds-edit/page/mobile/empty" data-caption="DS2 -- worlds-edit/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-edit__header__desktop__empty__develop" data-route="worlds-edit" data-component="header" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-edit__header.png" alt="develop worlds-edit/header/desktop/empty" data-caption="develop -- worlds-edit/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-edit__nav__desktop__empty__develop" data-route="worlds-edit" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-edit__nav.png" alt="develop worlds-edit/nav/desktop/empty" data-caption="develop -- worlds-edit/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-edit__nav__desktop__empty__DS3" data-route="worlds-edit" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/worlds-edit__nav.png" alt="DS3 worlds-edit/nav/desktop/empty" data-caption="DS3 -- worlds-edit/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-edit__nav__desktop__empty__DS1" data-route="worlds-edit" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/worlds-edit__nav.png" alt="DS1 worlds-edit/nav/desktop/empty" data-caption="DS1 -- worlds-edit/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-edit__nav__desktop__empty__DS2" data-route="worlds-edit" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/worlds-edit__nav.png" alt="DS2 worlds-edit/nav/desktop/empty" data-caption="DS2 -- worlds-edit/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-edit__main__desktop__empty__develop" data-route="worlds-edit" data-component="main" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-edit__main.png" alt="develop worlds-edit/main/desktop/empty" data-caption="develop -- worlds-edit/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-edit__main__desktop__empty__DS3" data-route="worlds-edit" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/worlds-edit__main.png" alt="DS3 worlds-edit/main/desktop/empty" data-caption="DS3 -- worlds-edit/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-edit__main__desktop__empty__DS1" data-route="worlds-edit" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/worlds-edit__main.png" alt="DS1 worlds-edit/main/desktop/empty" data-caption="DS1 -- worlds-edit/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-edit__main__desktop__empty__DS2" data-route="worlds-edit" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/worlds-edit__main.png" alt="DS2 worlds-edit/main/desktop/empty" data-caption="DS2 -- worlds-edit/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-edit__global-nav__desktop__seeded__develop" data-route="worlds-edit" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-edit__nav.png" alt="develop worlds-edit/global-nav/desktop/seeded" data-caption="develop -- worlds-edit/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-edit__global-nav__desktop__seeded__DS3" data-route="worlds-edit" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds-edit__nav.png" alt="DS3 worlds-edit/global-nav/desktop/seeded" data-caption="DS3 -- worlds-edit/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-edit__global-nav__desktop__seeded__DS1" data-route="worlds-edit" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds-edit__nav.png" alt="DS1 worlds-edit/global-nav/desktop/seeded" data-caption="DS1 -- worlds-edit/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-edit__global-nav__desktop__seeded__DS2" data-route="worlds-edit" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds-edit__nav.png" alt="DS2 worlds-edit/global-nav/desktop/seeded" data-caption="DS2 -- worlds-edit/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-edit__page__desktop__seeded__develop" data-route="worlds-edit" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-edit__page.png" alt="develop worlds-edit/page/desktop/seeded" data-caption="develop -- worlds-edit/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-edit__page__desktop__seeded__DS3" data-route="worlds-edit" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds-edit__page.png" alt="DS3 worlds-edit/page/desktop/seeded" data-caption="DS3 -- worlds-edit/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-edit__page__desktop__seeded__DS1" data-route="worlds-edit" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds-edit__page.png" alt="DS1 worlds-edit/page/desktop/seeded" data-caption="DS1 -- worlds-edit/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-edit__page__desktop__seeded__DS2" data-route="worlds-edit" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds-edit__page.png" alt="DS2 worlds-edit/page/desktop/seeded" data-caption="DS2 -- worlds-edit/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-seeded" data-viewport="mobile" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-edit__page__mobile__seeded__develop" data-route="worlds-edit" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/seeded/worlds-edit__page.png" alt="develop worlds-edit/page/mobile/seeded" data-caption="develop -- worlds-edit/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-edit__page__mobile__seeded__DS3" data-route="worlds-edit" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/seeded/worlds-edit__page.png" alt="DS3 worlds-edit/page/mobile/seeded" data-caption="DS3 -- worlds-edit/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-edit__page__mobile__seeded__DS1" data-route="worlds-edit" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/seeded/worlds-edit__page.png" alt="DS1 worlds-edit/page/mobile/seeded" data-caption="DS1 -- worlds-edit/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-edit__page__mobile__seeded__DS2" data-route="worlds-edit" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/seeded/worlds-edit__page.png" alt="DS2 worlds-edit/page/mobile/seeded" data-caption="DS2 -- worlds-edit/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-edit__header__desktop__seeded__develop" data-route="worlds-edit" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-edit__header.png" alt="develop worlds-edit/header/desktop/seeded" data-caption="develop -- worlds-edit/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-edit__header__desktop__seeded__DS3" data-route="worlds-edit" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds-edit__header.png" alt="DS3 worlds-edit/header/desktop/seeded" data-caption="DS3 -- worlds-edit/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-edit__header__desktop__seeded__DS1" data-route="worlds-edit" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds-edit__header.png" alt="DS1 worlds-edit/header/desktop/seeded" data-caption="DS1 -- worlds-edit/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-edit__header__desktop__seeded__DS2" data-route="worlds-edit" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds-edit__header.png" alt="DS2 worlds-edit/header/desktop/seeded" data-caption="DS2 -- worlds-edit/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-edit__nav__desktop__seeded__develop" data-route="worlds-edit" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-edit__nav.png" alt="develop worlds-edit/nav/desktop/seeded" data-caption="develop -- worlds-edit/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-edit__nav__desktop__seeded__DS3" data-route="worlds-edit" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds-edit__nav.png" alt="DS3 worlds-edit/nav/desktop/seeded" data-caption="DS3 -- worlds-edit/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-edit__nav__desktop__seeded__DS1" data-route="worlds-edit" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds-edit__nav.png" alt="DS1 worlds-edit/nav/desktop/seeded" data-caption="DS1 -- worlds-edit/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-edit__nav__desktop__seeded__DS2" data-route="worlds-edit" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds-edit__nav.png" alt="DS2 worlds-edit/nav/desktop/seeded" data-caption="DS2 -- worlds-edit/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">form<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-edit__form__desktop__seeded__develop" data-route="worlds-edit" data-component="form" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-edit__form.png" alt="develop worlds-edit/form/desktop/seeded" data-caption="develop -- worlds-edit/form (desktop/seeded; src: form)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-edit__form__desktop__seeded__DS3" data-route="worlds-edit" data-component="form" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds-edit__form.png" alt="DS3 worlds-edit/form/desktop/seeded" data-caption="DS3 -- worlds-edit/form (desktop/seeded; src: form)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-edit__form__desktop__seeded__DS1" data-route="worlds-edit" data-component="form" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds-edit__form.png" alt="DS1 worlds-edit/form/desktop/seeded" data-caption="DS1 -- worlds-edit/form (desktop/seeded; src: form)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-edit__form__desktop__seeded__DS2" data-route="worlds-edit" data-component="form" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds-edit__form.png" alt="DS2 worlds-edit/form/desktop/seeded" data-caption="DS2 -- worlds-edit/form (desktop/seeded; src: form)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-edit__main__desktop__seeded__develop" data-route="worlds-edit" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-edit__main.png" alt="develop worlds-edit/main/desktop/seeded" data-caption="develop -- worlds-edit/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-edit__main__desktop__seeded__DS3" data-route="worlds-edit" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds-edit__main.png" alt="DS3 worlds-edit/main/desktop/seeded" data-caption="DS3 -- worlds-edit/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-edit__main__desktop__seeded__DS1" data-route="worlds-edit" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds-edit__main.png" alt="DS1 worlds-edit/main/desktop/seeded" data-caption="DS1 -- worlds-edit/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-edit__main__desktop__seeded__DS2" data-route="worlds-edit" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds-edit__main.png" alt="DS2 worlds-edit/main/desktop/seeded" data-caption="DS2 -- worlds-edit/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+</main>
+
+<div id="lightbox" class="overlay">
+  <img id="lightbox-img" src="" alt="">
+  <div id="lightbox-caption" style="position: fixed; top: 12px; left: 50%; transform: translateX(-50%); color: #fff; font-family: ui-monospace, monospace; font-size: 13px; background: rgba(0,0,0,0.6); padding: 6px 12px; border-radius: 4px;"></div>
+</div>
+
+<div id="md-overlay" class="overlay">
+  <div class="panel">
+    <h3>Audit marks (markdown) -- this route only</h3>
+    <textarea id="md-text" readonly></textarea>
+    <div class="actions">
+      <button id="md-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="md-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-export-overlay" class="overlay">
+  <div class="panel">
+    <h3>Marks (raw JSON) -- all routes</h3>
+    <textarea id="json-export-text" readonly></textarea>
+    <div class="actions">
+      <button id="json-export-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="json-export-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-import-overlay" class="overlay">
+  <div class="panel">
+    <h3>Import marks (paste raw JSON)</h3>
+    <p class="hint">Paste JSON exported from another instance. Legacy IDs without a state segment are migrated to <code>__seeded</code>; v2 values are upgraded to v3 (category=null, why="", updatedAt=now). Existing marks with the same ID are overwritten.</p>
+    <textarea id="json-import-text" placeholder='{"home__page__desktop__seeded__DS3":{"marked":true,"note":"...","category":"bug","why":"...","updatedAt":"..."}}'></textarea>
+    <div class="err" id="json-import-err"></div>
+    <div class="actions">
+      <button id="json-import-apply" type="button">Apply</button>
+      <button class="overlay-close" data-overlay="json-import-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+<script>
+
+  const STORAGE_KEY = 'narraitor-audit-marks-v3';
+  const STORAGE_KEY_V2 = 'narraitor-audit-marks-v2';
+  const STORAGE_KEY_V1 = 'narraitor-audit-marks-v1';
+  // Tracks which routes have had their DS cells auto-prefilled as needs-design.
+  // Once a route is in here, the auto-prefill on page load is skipped.
+  const PREFILLED_KEY = 'narraitor-audit-prefilled-v1';
+  const STATES = ['empty', 'seeded'];
+  const VALID_CATEGORIES = ['needs-design','bug','tooling','intentional','unclear'];
+  const ROUTE_ORDER = ["home", "about", "worlds", "worlds-detail", "worlds-edit", "worlds-create", "worlds-play", "worlds-play-journal", "characters", "characters-detail", "characters-edit", "characters-create", "play", "settings"];
+  const COMPONENT_ORDER = {"page":0,"header":1,"nav":2,"form":3,"main":4};
+  const THEME_ORDER = ["DS3","DS1","DS2","develop"];
+  const BRANCH_META = {"develop": {"theme": "default", "mode": "light", "branchArg": "develop-default"}, "DS3": {"theme": "ds3", "mode": "light", "branchArg": "integration-ds3-light"}, "DS1": {"theme": "ds1", "mode": "light", "branchArg": "integration-ds1-light"}, "DS2": {"theme": "ds2", "mode": "light", "branchArg": "integration-ds2-light"}};
+
+  function componentSortKey(c) {
+    if (c in COMPONENT_ORDER) return [COMPONENT_ORDER[c], 0];
+    if (c.startsWith("main-section-")) {
+      const n = parseInt(c.replace("main-section-",""), 10);
+      return [5, isNaN(n) ? 0 : n];
+    }
+    return [9, c];
+  }
+
+  // Pre-v3 ID migration: v1 (4 segments) -> v2 (5 segments) by inserting __seeded.
+  function migrateLegacyId(id) {
+    const parts = id.split('__');
+    if (parts.length < 4) return id;
+    const last = parts[parts.length - 1];
+    const second = parts[parts.length - 2];
+    const third = parts[parts.length - 3];
+    const isTheme = ['DS1','DS2','DS3','develop'].includes(last);
+    const isViewport = ['desktop','mobile'].includes(second);
+    const alreadyHasState = STATES.includes(third);
+    if (isTheme && isViewport && !alreadyHasState) {
+      const head = parts.slice(0, parts.length - 1).join('__');
+      return head + '__seeded__' + last;
+    }
+    return id;
+  }
+
+  function migrateMarksV1ToV2(input) {
+    const out = {};
+    let migrated = 0;
+    for (const [id, m] of Object.entries(input || {})) {
+      const newId = migrateLegacyId(id);
+      if (newId !== id) migrated++;
+      out[newId] = m;
+    }
+    return { marks: out, migrated };
+  }
+
+  // v2 -> v3: add category, why, updatedAt; preserve marked + note.
+  function upgradeV2ValueToV3(v) {
+    if (!v || typeof v !== 'object') return null;
+    return {
+      marked: !!v.marked,
+      note: typeof v.note === 'string' ? v.note : '',
+      category: v.category && VALID_CATEGORIES.includes(v.category) ? v.category : null,
+      why: typeof v.why === 'string' ? v.why : '',
+      updatedAt: v.updatedAt || new Date().toISOString(),
+    };
+  }
+
+  function migrateV2ObjectToV3(v2obj) {
+    const out = {};
+    for (const [id, m] of Object.entries(v2obj || {})) {
+      out[id] = upgradeV2ValueToV3(m);
+    }
+    return out;
+  }
+
+  function loadMarks() {
+    try {
+      const v3 = localStorage.getItem(STORAGE_KEY);
+      if (v3) return JSON.parse(v3);
+      // No v3 yet — try v2 (lazy migrate; leave v2 untouched for rollback).
+      const v2raw = localStorage.getItem(STORAGE_KEY_V2);
+      if (v2raw) {
+        const v3marks = migrateV2ObjectToV3(JSON.parse(v2raw));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + Object.keys(v3marks).length + ' v2 marks to v3 (v2 untouched).');
+        return v3marks;
+      }
+      // No v3 or v2 — try v1 and migrate v1 -> v2 -> v3 in one pass.
+      const v1raw = localStorage.getItem(STORAGE_KEY_V1);
+      if (v1raw) {
+        const { marks: v2marks, migrated } = migrateMarksV1ToV2(JSON.parse(v1raw));
+        const v3marks = migrateV2ObjectToV3(v2marks);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + migrated + ' v1 IDs through to v3.');
+        return v3marks;
+      }
+    } catch (e) { console.warn(e); }
+    return {};
+  }
+
+  function saveMarks(m) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(m)); } catch (e) {}
+  }
+
+
+  const ROUTE = "worlds-edit";
+  let marks = loadMarks();
+
+  function applyMarkState(cell) {
+    const id = cell.dataset.cellId;
+    const m = marks[id];
+    const noteInput = cell.querySelector('textarea[data-action="note"]');
+    const whyInput = cell.querySelector('input[data-action="why"]');
+    const chips = cell.querySelectorAll('.cat-chip');
+    cell.classList.remove('cat-bug','cat-tooling','cat-intentional','cat-unclear');
+    chips.forEach(c => c.classList.remove('active'));
+    if (m && m.marked) {
+      cell.classList.add('marked');
+      if (noteInput) noteInput.value = m.note || '';
+      if (whyInput) whyInput.value = m.why || '';
+      if (m.category) {
+        cell.classList.add('cat-' + m.category);
+        const chip = cell.querySelector('.cat-chip[data-cat="' + m.category + '"]');
+        if (chip) chip.classList.add('active');
+      }
+    } else {
+      cell.classList.remove('marked');
+      if (noteInput) noteInput.value = '';
+      if (whyInput) whyInput.value = '';
+    }
+  }
+
+  function updateRowSectionFlags() {
+    document.querySelectorAll('.component-row').forEach(row => {
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+    document.querySelectorAll('section.route').forEach(sec => {
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+    });
+  }
+
+  function updateCount() {
+    const n = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).length;
+    document.getElementById('mark-count').textContent = n;
+  }
+
+  function writeMark(id, partial) {
+    const existing = marks[id] || { marked: false, note: '', category: null, why: '', updatedAt: null };
+    const next = Object.assign({}, existing, partial, { updatedAt: new Date().toISOString() });
+    if (!next.marked && !next.note && !next.why && !next.category) {
+      delete marks[id];
+    } else {
+      marks[id] = next;
+    }
+    saveMarks(marks);
+    updateCount();
+  }
+
+  function buildRecaptureCommand(cell) {
+    const route = cell.dataset.route;
+    const viewport = cell.dataset.viewport;
+    const state = cell.dataset.state;
+    const themeKey = cell.dataset.theme;
+    const meta = BRANCH_META[themeKey];
+    if (!meta) return null;
+    return 'npx tsx scripts/audit/playwright-crawl.ts'
+      + ' --branch ' + meta.branchArg
+      + ' --viewport ' + viewport
+      + ' --state ' + state
+      + ' --theme ' + meta.theme
+      + ' --mode ' + meta.mode
+      + ' --route ' + route;
+  }
+
+  function loadPrefilledFlags() {
+    try { return JSON.parse(localStorage.getItem(PREFILLED_KEY) || '{}'); }
+    catch (e) { return {}; }
+  }
+  function savePrefilledFlags(f) {
+    try { localStorage.setItem(PREFILLED_KEY, JSON.stringify(f)); } catch (e) {}
+  }
+
+  // Gap-fill: only adds entries for DS cells that have no existing mark.
+  // Returns the count of cells filled. Develop is excluded (it's the baseline).
+  function prefillDsCellsAsNeedsDesign() {
+    const dsCells = Array.from(document.querySelectorAll('.cell[data-cell-id]'))
+      .filter(c => ['DS1','DS2','DS3'].includes(c.dataset.theme));
+    let added = 0;
+    const ts = new Date().toISOString();
+    for (const cell of dsCells) {
+      const id = cell.dataset.cellId;
+      if (!marks[id]) {
+        marks[id] = { marked: true, note: '', category: 'needs-design', why: '', updatedAt: ts };
+        added++;
+      }
+    }
+    if (added > 0) saveMarks(marks);
+    return added;
+  }
+
+  // Auto-prefill on first visit per route.
+  const prefillFlags = loadPrefilledFlags();
+  if (!prefillFlags[ROUTE]) {
+    const added = prefillDsCellsAsNeedsDesign();
+    prefillFlags[ROUTE] = true;
+    savePrefilledFlags(prefillFlags);
+    if (added > 0) console.info('[audit] auto-prefilled ' + added + ' DS cells for ' + ROUTE + ' as needs-design.');
+  }
+
+  document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+  updateRowSectionFlags();
+  updateCount();
+
+  // Lightbox
+  const lb = document.getElementById('lightbox');
+  const lbImg = document.getElementById('lightbox-img');
+  const lbCap = document.getElementById('lightbox-caption');
+  document.querySelectorAll('.cell img').forEach(img => {
+    img.addEventListener('click', () => {
+      lbImg.src = img.src;
+      lbCap.textContent = img.dataset.caption || '';
+      lb.classList.add('open');
+    });
+  });
+  lb.addEventListener('click', () => lb.classList.remove('open'));
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') document.querySelectorAll('.overlay.open').forEach(o => o.classList.remove('open'));
+  });
+
+  // Mark toggle
+  document.querySelectorAll('button[data-action="toggle-mark"]').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      const cell = btn.closest('.cell');
+      const id = cell.dataset.cellId;
+      const isMarked = !cell.classList.contains('marked');
+      writeMark(id, { marked: isMarked });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      const sec = cell.closest('section.route');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+      if (isMarked) {
+        const why = cell.querySelector('input[data-action="why"]');
+        if (why) setTimeout(() => why.focus(), 0);
+      }
+    });
+  });
+
+  // Why / note inputs (debounced save)
+  let saveTimer = null;
+  function bindInput(sel, field) {
+    document.querySelectorAll(sel).forEach(inp => {
+      const handler = () => {
+        const cell = inp.closest('.cell');
+        if (!cell.classList.contains('marked')) return;
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(() => {
+          writeMark(cell.dataset.cellId, { [field]: inp.value });
+        }, 250);
+      };
+      inp.addEventListener('input', handler);
+      inp.addEventListener('blur', () => {
+        const cell = inp.closest('.cell');
+        if (cell.classList.contains('marked')) writeMark(cell.dataset.cellId, { [field]: inp.value });
+      });
+    });
+  }
+  bindInput('input[data-action="why"]', 'why');
+  bindInput('textarea[data-action="note"]', 'note');
+
+  // Category chips
+  document.querySelectorAll('.cat-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const cell = chip.closest('.cell');
+      if (!cell.classList.contains('marked')) {
+        // Mark the cell first so the category sticks
+        writeMark(cell.dataset.cellId, { marked: true });
+      }
+      const cat = chip.dataset.cat;
+      const isActive = chip.classList.contains('active');
+      writeMark(cell.dataset.cellId, { category: isActive ? null : cat });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+  });
+
+  // Re-capture command (copy to clipboard, flash purple)
+  document.querySelectorAll('button[data-action="recapture"]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const cell = btn.closest('.cell');
+      const cmd = buildRecaptureCommand(cell);
+      if (!cmd) return;
+      try {
+        await navigator.clipboard.writeText(cmd);
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Copy re-capture command'; }, 1500);
+      } catch (e) {
+        prompt('Copy this command:', cmd);
+      }
+      cell.classList.remove('pending-recapture');
+      void cell.offsetWidth; // force reflow so the animation restarts
+      cell.classList.add('pending-recapture');
+    });
+  });
+
+  // Toggles
+  document.getElementById('hide-empty').addEventListener('change', e => document.body.classList.toggle('hide-empty', e.target.checked));
+  document.getElementById('compact').addEventListener('change', e => document.body.classList.toggle('compact', e.target.checked));
+  document.getElementById('fit-cell').addEventListener('change', e => document.body.classList.toggle('fit-cell', e.target.checked));
+  document.getElementById('only-marked').addEventListener('change', e => document.body.classList.toggle('only-marked', e.target.checked));
+  document.getElementById('show-suppressed').addEventListener('change', e => document.body.classList.toggle('show-suppressed', e.target.checked));
+  document.getElementById('hide-desktop').addEventListener('change', e => document.body.classList.toggle('hide-desktop', e.target.checked));
+  document.getElementById('hide-mobile').addEventListener('change', e => document.body.classList.toggle('hide-mobile', e.target.checked));
+
+  // True-scale rendering (1x for selector captures, 0.5x for retina full-page).
+  const RETINA_THRESHOLD = 1500;
+  function applyTrueScale(img) {
+    if (!img.naturalWidth) return;
+    const cssWidth = img.naturalWidth > RETINA_THRESHOLD
+      ? Math.round(img.naturalWidth / 2)
+      : img.naturalWidth;
+    img.style.maxWidth = 'min(100%, ' + cssWidth + 'px)';
+  }
+  document.querySelectorAll('.cell img').forEach(img => {
+    if (img.complete && img.naturalWidth > 0) applyTrueScale(img);
+    else img.addEventListener('load', () => applyTrueScale(img), { once: true });
+  });
+
+  // State chips
+  document.querySelectorAll('.state-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const state = chip.dataset.state;
+      chip.classList.toggle('active');
+      document.body.classList.toggle('hide-state-' + state, !chip.classList.contains('active'));
+    });
+  });
+  STATES.forEach(s => {
+    const chip = document.querySelector('.state-chip[data-state="' + s + '"]');
+    if (chip && !chip.classList.contains('active')) document.body.classList.add('hide-state-' + s);
+  });
+
+  // Manual top-up: fill any DS cells that don't have a mark yet
+  document.getElementById('prefill-ds-btn').addEventListener('click', () => {
+    const added = prefillDsCellsAsNeedsDesign();
+    if (added > 0) {
+      document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+      updateRowSectionFlags();
+      updateCount();
+      alert('Filled ' + added + ' missing DS cells as needs-design.');
+    } else {
+      alert('All DS cells in this route already have marks.');
+    }
+  });
+
+  // Clear-route. Also resets the prefilled flag so a reload re-triggers auto-prefill.
+  document.getElementById('clear-route-btn').addEventListener('click', () => {
+    const ids = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).map(([id]) => id);
+    if (!ids.length) { alert('No marks for this route.'); return; }
+    if (!confirm('Clear ' + ids.length + ' marks for route ' + ROUTE + '?\n\nReloading the page will re-prefill all DS cells as needs-design.')) return;
+    ids.forEach(id => delete marks[id]);
+    saveMarks(marks);
+    const flags = loadPrefilledFlags();
+    delete flags[ROUTE];
+    savePrefilledFlags(flags);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+  });
+
+  function buildMarkdown() {
+    const items = [];
+    Object.entries(marks).forEach(([id, m]) => {
+      if (!m || !m.marked) return;
+      if (!id.startsWith(ROUTE + '__')) return;
+      const parts = id.split('__');
+      const themeKey = parts[parts.length - 1];
+      const state = parts[parts.length - 2];
+      const viewport = parts[parts.length - 3];
+      const route = parts[0];
+      const component = parts.slice(1, parts.length - 3).join('__');
+      items.push({ component, viewport, state, theme: themeKey,
+                   note: m.note || '', why: m.why || '', category: m.category || '' });
+    });
+    items.sort((a, b) => {
+      const ak = componentSortKey(a.component);
+      const bk = componentSortKey(b.component);
+      if (ak[0] !== bk[0]) return ak[0] - bk[0];
+      if (ak[1] !== bk[1]) return ak[1] < bk[1] ? -1 : 1;
+      const sd = STATES.indexOf(a.state) - STATES.indexOf(b.state);
+      if (sd !== 0) return sd;
+      const td = THEME_ORDER.indexOf(a.theme) - THEME_ORDER.indexOf(b.theme);
+      if (td !== 0) return td;
+      return a.viewport === b.viewport ? 0 : (a.viewport === 'desktop' ? -1 : 1);
+    });
+    const date = new Date().toISOString().split('T')[0];
+    const lines = ['# Audit marks -- ' + ROUTE + ' -- ' + items.length + ' items -- ' + date, ''];
+    items.forEach(it => {
+      const catTag = it.category ? ' [' + it.category + ']' : '';
+      const whyTxt = it.why ? ': ' + it.why : '';
+      const noteTxt = it.note ? '  -- ' + it.note : '';
+      lines.push('- [ ] **' + it.theme + ' ' + it.component + '** [' + it.viewport + '/' + it.state + ']' + catTag + whyTxt + noteTxt);
+    });
+    return lines.join('\n');
+  }
+
+  function openOverlay(id) { document.getElementById(id).classList.add('open'); }
+  function closeOverlay(id) { document.getElementById(id).classList.remove('open'); }
+  document.querySelectorAll('.overlay-close').forEach(b => b.addEventListener('click', () => closeOverlay(b.dataset.overlay)));
+  document.querySelectorAll('.overlay').forEach(o => {
+    o.addEventListener('click', e => { if (e.target === o) o.classList.remove('open'); });
+  });
+
+  document.getElementById('export-md-btn').addEventListener('click', async () => {
+    const md = buildMarkdown();
+    const ta = document.getElementById('md-text');
+    ta.value = md;
+    openOverlay('md-overlay');
+    try { await navigator.clipboard.writeText(md); document.getElementById('md-copy').textContent = 'Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+  document.getElementById('md-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('md-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('md-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('export-json-btn').addEventListener('click', () => {
+    const ta = document.getElementById('json-export-text');
+    ta.value = JSON.stringify(marks, null, 2);
+    openOverlay('json-export-overlay');
+  });
+  document.getElementById('json-export-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('json-export-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('json-export-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('json-export-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('import-json-btn').addEventListener('click', () => {
+    document.getElementById('json-import-text').value = '';
+    document.getElementById('json-import-err').textContent = '';
+    openOverlay('json-import-overlay');
+  });
+  document.getElementById('json-import-apply').addEventListener('click', () => {
+    const ta = document.getElementById('json-import-text');
+    const err = document.getElementById('json-import-err');
+    err.textContent = '';
+    let parsed;
+    try { parsed = JSON.parse(ta.value); }
+    catch (e) { err.textContent = 'Invalid JSON: ' + e.message; return; }
+    if (!parsed || typeof parsed !== 'object') { err.textContent = 'Expected an object.'; return; }
+    // First migrate v1 IDs (4 segments) -> v2 IDs (5 segments)
+    const { marks: idMigrated, migrated } = migrateMarksV1ToV2(parsed);
+    // Then upgrade each value v2 -> v3 (preserves marked + note, fills new fields)
+    Object.entries(idMigrated).forEach(([id, m]) => {
+      marks[id] = upgradeV2ValueToV3(m);
+    });
+    saveMarks(marks);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+    closeOverlay('json-import-overlay');
+    alert('Imported ' + Object.keys(idMigrated).length + ' marks (' + migrated + ' legacy IDs migrated to __seeded; values upgraded to v3).');
+  });
+</script>
+</body>
+</html>

--- a/scripts/audit/review/worlds-play-journal.html
+++ b/scripts/audit/review/worlds-play-journal.html
@@ -1,0 +1,1753 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Cross-Theme Audit (#1129) — worlds-play-journal</title>
+<style>
+
+  :root { --col-gap: 8px; --row-gap: 16px; }
+  html, body { margin: 0; padding: 0; font-family: -apple-system, system-ui, sans-serif; background: #fafafa; color: #222; }
+  .sticky-shell { position: sticky; top: 0; z-index: 100; border-bottom: 1px solid #444; }
+  header.top {
+    background: #1a1a1a; color: #fff; padding: 12px 16px;
+    display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+  }
+  header.top h1 { font-size: 14px; margin: 0; font-weight: 600; }
+  header.top .legend { display: flex; gap: 12px; font-size: 12px; }
+  header.top .legend .col { padding: 2px 8px; border-radius: 3px; }
+  header.top .legend .develop { background: #6b7280; }
+  header.top .legend .ds3 { background: #4338ca; }
+  header.top .legend .ds1 { background: #92400e; }
+  header.top .legend .ds2 { background: #166534; }
+  header.top a.back { color: #9cf; font-size: 12px; text-decoration: none; padding: 2px 6px; border-radius: 2px; }
+  header.top a.back:hover { background: #444; color: #fff; }
+  header.top .nav-routes { display: flex; gap: 4px; align-items: center; font-size: 12px; }
+  header.top .nav-routes a { color: #9cf; text-decoration: none; padding: 2px 8px; border-radius: 2px; background: #2a2a2a; }
+  header.top .nav-routes a:hover { background: #444; color: #fff; }
+  header.top .nav-routes .current { color: #fff; font-weight: 600; padding: 2px 8px; }
+  main { padding: 16px; max-width: 100%; }
+  section.route {
+    margin-bottom: 32px; background: #fff; border-radius: 6px;
+    padding: 12px 16px 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  section.route h2 {
+    font-size: 18px; margin: 0 0 12px; padding-bottom: 6px;
+    border-bottom: 1px solid #e5e5e5;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+  .component-row {
+    display: grid; grid-template-columns: 180px repeat(4, 1fr);
+    gap: var(--col-gap); margin-bottom: var(--row-gap);
+    align-items: start;
+  }
+  .component-row .label {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px; color: #555; padding-top: 28px; line-height: 1.3;
+    word-break: break-word;
+  }
+  .cell {
+    border: 1px solid #e5e5e5; border-radius: 4px; overflow: hidden;
+    background: #f3f4f6; position: relative; min-height: 100px;
+    display: flex; flex-direction: column;
+  }
+  .cell .header {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.04em; padding: 4px 8px; color: #fff;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .cell.develop .header { background: #6b7280; }
+  .cell.ds3 .header { background: #4338ca; }
+  .cell.ds1 .header { background: #92400e; }
+  .cell.ds2 .header { background: #166534; }
+  .cell img {
+    display: block; width: auto; max-width: 100%; height: auto;
+    cursor: zoom-in; background: #fff; align-self: flex-start;
+  }
+  body.fit-cell .cell img { width: 100%; max-width: 100%; }
+  .cell.empty {
+    display: flex; align-items: center; justify-content: center;
+    color: #999; font-size: 12px; padding: 24px; background: #f9f9f9;
+  }
+  .cell.empty::after { content: "(not captured)"; }
+
+  /* Lightbox */
+  #lightbox {
+    display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.92);
+    z-index: 1000; align-items: center; justify-content: center; cursor: zoom-out;
+  }
+  #lightbox.open { display: flex; }
+  #lightbox img { max-width: 96vw; max-height: 96vh; box-shadow: 0 4px 24px rgba(0,0,0,0.5); }
+
+  .controls { display: flex; gap: 12px; align-items: center; font-size: 12px; flex-wrap: wrap; }
+  .controls label { display: flex; align-items: center; gap: 4px; cursor: pointer; }
+  .controls input[type=checkbox] { margin: 0; }
+
+  .state-chips { display: inline-flex; gap: 4px; align-items: center; }
+  .state-chip {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .state-chip.active { background: #2563eb; border-color: #1d4ed8; }
+  .state-chip:hover { background: #4b5563; }
+  .state-chip.active:hover { background: #1d4ed8; }
+
+  body.hide-empty .component-row.all-empty,
+  body.hide-empty .cell.empty { display: none; }
+  body.compact .cell img { max-height: 360px; object-fit: cover; object-position: top; }
+
+  .cell .mark-btn {
+    margin-left: auto; background: rgba(255,255,255,0.18);
+    color: #fff; border: 1px solid rgba(255,255,255,0.35);
+    border-radius: 3px; font-size: 10px; font-weight: 600;
+    padding: 2px 6px; cursor: pointer;
+    text-transform: none; letter-spacing: 0; line-height: 1.2;
+  }
+  .cell .mark-btn:hover { background: rgba(255,255,255,0.28); }
+  .cell.marked { border: 3px solid #dc2626; }
+  .cell.marked .mark-btn { background: #dc2626; border-color: #b91c1c; color: #fff; }
+  .cell.marked .mark-btn::before { content: "x "; }
+  .cell.pending-recapture { animation: cellPulse 2s ease-out; }
+  @keyframes cellPulse {
+    0%   { box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.9); border-color: #7c3aed; }
+    100% { box-shadow: 0 0 0 8px rgba(124, 58, 237, 0); }
+  }
+  .cell .toolbar {
+    display: none;
+    padding: 6px 8px; background: #fef2f2; border-top: 1px solid #fecaca;
+    font-size: 11px;
+  }
+  .cell.marked .toolbar { display: block; }
+  .cell .toolbar input[type=text],
+  .cell .toolbar textarea {
+    width: 100%; box-sizing: border-box;
+    border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 4px 6px; font-size: 12px; font-family: inherit;
+    background: #fff;
+  }
+  .cell .toolbar input[type=text]:focus,
+  .cell .toolbar textarea:focus { outline: 2px solid #dc2626; outline-offset: -1px; }
+  .cell .toolbar .field { margin-bottom: 6px; }
+  .cell .toolbar .field-label {
+    display: block; font-size: 10px; font-weight: 600;
+    color: #7f1d1d; text-transform: uppercase; letter-spacing: 0.04em;
+    margin-bottom: 2px;
+  }
+  .cell .toolbar .cat-chips { display: flex; gap: 4px; flex-wrap: wrap; }
+  .cell .toolbar .cat-chip {
+    background: #fff; border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 2px 8px; font-size: 11px; cursor: pointer; font-family: inherit;
+    color: #7f1d1d;
+  }
+  .cell .toolbar .cat-chip.active { background: #7f1d1d; color: #fff; border-color: #7f1d1d; }
+  .cell .toolbar .cat-chip[data-cat="needs-design"].active { background: #6d28d9; border-color: #6d28d9; }
+  .cell .toolbar .cat-chip[data-cat="bug"].active        { background: #b91c1c; border-color: #b91c1c; }
+  .cell .toolbar .cat-chip[data-cat="tooling"].active    { background: #b45309; border-color: #b45309; }
+  .cell .toolbar .cat-chip[data-cat="intentional"].active{ background: #15803d; border-color: #15803d; }
+  .cell .toolbar .cat-chip[data-cat="unclear"].active    { background: #6b7280; border-color: #6b7280; }
+  .cell .toolbar .recapture-btn {
+    background: #1d4ed8; color: #fff; border: 0; border-radius: 3px;
+    padding: 4px 10px; font-size: 11px; cursor: pointer;
+    font-family: inherit; font-weight: 600;
+  }
+  .cell .toolbar .recapture-btn:hover { background: #1e40af; }
+  .cell .toolbar textarea { min-height: 32px; resize: vertical; font-size: 11px; }
+  .cell.cat-needs-design { border-color: #6d28d9; }
+  .cell.cat-bug         { border-color: #b91c1c; }
+  .cell.cat-tooling     { border-color: #b45309; }
+  .cell.cat-intentional { border-color: #15803d; }
+  .cell.cat-unclear     { border-color: #6b7280; }
+
+  .marks-cluster {
+    display: flex; align-items: center; gap: 8px;
+    border-left: 1px solid #444; padding-left: 12px; margin-left: 4px;
+    font-size: 12px;
+  }
+  .marks-cluster .count {
+    background: #dc2626; color: #fff; border-radius: 10px;
+    padding: 2px 8px; font-weight: 600; min-width: 18px; text-align: center;
+  }
+  .marks-cluster button {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .marks-cluster button:hover { background: #4b5563; }
+  .marks-cluster button.danger { background: #7f1d1d; border-color: #991b1b; }
+  .marks-cluster button.danger:hover { background: #991b1b; }
+
+  body.only-marked .component-row:not(.has-marked) { display: none; }
+  body.only-marked section.route:not(.has-marked) { display: none; }
+
+  .component-row.suppressed { display: none; }
+  body.show-suppressed .component-row.suppressed { display: grid; }
+  .component-row.suppressed .label::after { content: " (hidden)"; color: #b91c1c; font-style: italic; }
+
+  .component-row .label[data-mapped] { color: #1d4ed8; }
+  .component-row .label[data-mapped]::after { content: " *"; }
+  .mapped-tooltip {
+    display: inline-block; margin-left: 4px;
+    font-size: 10px; color: #6b7280; cursor: help; vertical-align: super;
+  }
+
+  .vp-badge, .state-badge {
+    display: inline-block; font-size: 9px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.05em;
+    padding: 1px 6px; border-radius: 8px; margin-top: 2px;
+  }
+  .vp-badge.desktop { background: #dbeafe; color: #1e3a8a; border: 1px solid #93c5fd; margin-right: 4px; }
+  .vp-badge.mobile  { background: #fef3c7; color: #78350f; border: 1px solid #fcd34d; margin-right: 4px; }
+  .state-badge.empty       { background: #f3f4f6; color: #374151; border: 1px solid #d1d5db; }
+  .state-badge.seeded      { background: #dcfce7; color: #14532d; border: 1px solid #86efac; }
+  .state-badge.mid-session { background: #ede9fe; color: #4c1d95; border: 1px solid #c4b5fd; }
+
+  .component-row.vp-mobile { background: #fffbeb; padding: 4px; border-radius: 4px; }
+  body.hide-desktop .component-row.vp-desktop { display: none; }
+  body.hide-mobile .component-row.vp-mobile { display: none; }
+
+  body.hide-state-empty       .component-row.state-empty       { display: none; }
+  body.hide-state-seeded      .component-row.state-seeded      { display: none; }
+  body.hide-state-mid-session .component-row.state-mid-session { display: none; }
+
+  .overlay {
+    display: none; position: fixed; inset: 0; z-index: 1100;
+    background: rgba(0,0,0,0.6); align-items: center; justify-content: center;
+  }
+  .overlay.open { display: flex; }
+  .overlay .panel {
+    background: #fff; border-radius: 6px; width: min(720px, 92vw);
+    max-height: 80vh; padding: 16px; display: flex; flex-direction: column; gap: 8px;
+  }
+  .overlay h3 { margin: 0; font-size: 14px; }
+  .overlay textarea {
+    flex: 1; min-height: 320px; font-family: ui-monospace, monospace; font-size: 12px;
+    border: 1px solid #ddd; border-radius: 4px; padding: 8px; resize: vertical;
+  }
+  .overlay .actions { display: flex; gap: 8px; justify-content: flex-end; }
+  .overlay button {
+    background: #1a1a1a; color: #fff; border: 0; border-radius: 3px;
+    padding: 6px 12px; font-size: 12px; cursor: pointer;
+  }
+  .overlay .hint { font-size: 11px; color: #555; }
+  .overlay .err  { font-size: 12px; color: #b91c1c; min-height: 16px; }
+
+  /* Index-page table */
+  table.routes-index {
+    width: 100%; border-collapse: collapse; background: #fff;
+    border-radius: 6px; overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  table.routes-index th, table.routes-index td {
+    padding: 8px 12px; text-align: left; font-size: 13px;
+    border-bottom: 1px solid #eee;
+  }
+  table.routes-index th { background: #f3f4f6; font-weight: 600; }
+  table.routes-index td a {
+    color: #1d4ed8; text-decoration: none; font-family: ui-monospace, monospace;
+  }
+  table.routes-index td a:hover { text-decoration: underline; }
+  table.routes-index td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  table.routes-index .marked-count.has-marks { color: #b91c1c; font-weight: 600; }
+  table.routes-index .unresolved-count.has-unresolved { color: #b45309; font-weight: 600; }
+  table.routes-index .breakdown {
+    font-size: 11px; color: #555; margin-left: 6px; font-variant-numeric: tabular-nums;
+  }
+
+
+</style>
+</head>
+<body>
+<div class="sticky-shell">
+<header class="top">
+  <a class="back" href="index.html">&larr; Index</a>
+  <h1>worlds-play-journal</h1>
+  <div class="legend">
+    <span class="col develop">develop</span>
+    <span class="col ds3">DS3</span>
+    <span class="col ds1">DS1</span>
+    <span class="col ds2">DS2</span>
+  </div>
+  <div class="controls">
+    <span class="state-chips" role="group" aria-label="State filter">
+      <span style="font-size: 11px; color: #aaa;">State:</span>
+      <button type="button" class="state-chip" data-state="empty">empty</button>
+      <button type="button" class="state-chip active" data-state="seeded">seeded</button>
+    </span>
+    <label><input type="checkbox" id="hide-empty"> Hide missing</label>
+    <label><input type="checkbox" id="compact"> Compact</label>
+    <label title="Stretch images to cell width"><input type="checkbox" id="fit-cell"> Fit to cell</label>
+    <label><input type="checkbox" id="only-marked"> Only marked</label>
+    <label><input type="checkbox" id="show-suppressed"> Show hidden rows</label>
+    <label><input type="checkbox" id="hide-desktop"> Hide desktop</label>
+    <label><input type="checkbox" id="hide-mobile"> Hide mobile</label>
+  </div>
+  <div class="marks-cluster">
+    <span>Marked (route):</span>
+    <span class="count" id="mark-count">0</span>
+    <button id="prefill-ds-btn" type="button" title="Mark every DS cell that has no mark yet as needs-design (gap-fill, never overwrites your existing marks)">Fill DS gaps</button>
+    <button id="export-md-btn" type="button">Export markdown</button>
+    <button id="export-json-btn" type="button">Export JSON</button>
+    <button id="import-json-btn" type="button">Import JSON</button>
+    <button id="clear-route-btn" type="button" class="danger">Clear (route)</button>
+  </div>
+</header>
+<nav class="toc" style="background:#2a2a2a;color:#ccc;padding:6px 16px;font-size:12px;display:flex;gap:8px;align-items:center;border-top:1px solid #444;">
+  <span class="nav-routes">
+    <a href="worlds-play.html">&larr; worlds-play</a>
+    <span class="current">worlds-play-journal</span>
+    <a href="characters.html">characters &rarr;</a>
+  </span>
+</nav>
+</div>
+<main>
+<section class="route" id="route-worlds-play-journal">
+  <h2>worlds-play-journal</h2>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-play-journal__global-nav__desktop__empty__develop" data-route="worlds-play-journal" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-play-journal__nav.png" alt="develop worlds-play-journal/global-nav/desktop/empty" data-caption="develop -- worlds-play-journal/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-play-journal__page__desktop__empty__develop" data-route="worlds-play-journal" data-component="page" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-play-journal__page.png" alt="develop worlds-play-journal/page/desktop/empty" data-caption="develop -- worlds-play-journal/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-play-journal__page__desktop__empty__DS3" data-route="worlds-play-journal" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/worlds-play-journal__page.png" alt="DS3 worlds-play-journal/page/desktop/empty" data-caption="DS3 -- worlds-play-journal/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-play-journal__page__desktop__empty__DS1" data-route="worlds-play-journal" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/worlds-play-journal__page.png" alt="DS1 worlds-play-journal/page/desktop/empty" data-caption="DS1 -- worlds-play-journal/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-play-journal__page__desktop__empty__DS2" data-route="worlds-play-journal" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/worlds-play-journal__page.png" alt="DS2 worlds-play-journal/page/desktop/empty" data-caption="DS2 -- worlds-play-journal/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-empty" data-viewport="mobile" data-state="empty">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-play-journal__page__mobile__empty__develop" data-route="worlds-play-journal" data-component="page" data-viewport="mobile" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/empty/worlds-play-journal__page.png" alt="develop worlds-play-journal/page/mobile/empty" data-caption="develop -- worlds-play-journal/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-play-journal__page__mobile__empty__DS3" data-route="worlds-play-journal" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/empty/worlds-play-journal__page.png" alt="DS3 worlds-play-journal/page/mobile/empty" data-caption="DS3 -- worlds-play-journal/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-play-journal__page__mobile__empty__DS1" data-route="worlds-play-journal" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/empty/worlds-play-journal__page.png" alt="DS1 worlds-play-journal/page/mobile/empty" data-caption="DS1 -- worlds-play-journal/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-play-journal__page__mobile__empty__DS2" data-route="worlds-play-journal" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/empty/worlds-play-journal__page.png" alt="DS2 worlds-play-journal/page/mobile/empty" data-caption="DS2 -- worlds-play-journal/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-play-journal__header__desktop__empty__develop" data-route="worlds-play-journal" data-component="header" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-play-journal__header.png" alt="develop worlds-play-journal/header/desktop/empty" data-caption="develop -- worlds-play-journal/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-play-journal__header__desktop__empty__DS3" data-route="worlds-play-journal" data-component="header" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/worlds-play-journal__header.png" alt="DS3 worlds-play-journal/header/desktop/empty" data-caption="DS3 -- worlds-play-journal/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-play-journal__header__desktop__empty__DS1" data-route="worlds-play-journal" data-component="header" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/worlds-play-journal__header.png" alt="DS1 worlds-play-journal/header/desktop/empty" data-caption="DS1 -- worlds-play-journal/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-play-journal__header__desktop__empty__DS2" data-route="worlds-play-journal" data-component="header" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/worlds-play-journal__header.png" alt="DS2 worlds-play-journal/header/desktop/empty" data-caption="DS2 -- worlds-play-journal/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-play-journal__nav__desktop__empty__develop" data-route="worlds-play-journal" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-play-journal__nav.png" alt="develop worlds-play-journal/nav/desktop/empty" data-caption="develop -- worlds-play-journal/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-play-journal__main__desktop__empty__develop" data-route="worlds-play-journal" data-component="main" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-play-journal__main.png" alt="develop worlds-play-journal/main/desktop/empty" data-caption="develop -- worlds-play-journal/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-play-journal__main__desktop__empty__DS3" data-route="worlds-play-journal" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/worlds-play-journal__main.png" alt="DS3 worlds-play-journal/main/desktop/empty" data-caption="DS3 -- worlds-play-journal/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-play-journal__main__desktop__empty__DS1" data-route="worlds-play-journal" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/worlds-play-journal__main.png" alt="DS1 worlds-play-journal/main/desktop/empty" data-caption="DS1 -- worlds-play-journal/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-play-journal__main__desktop__empty__DS2" data-route="worlds-play-journal" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/worlds-play-journal__main.png" alt="DS2 worlds-play-journal/main/desktop/empty" data-caption="DS2 -- worlds-play-journal/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-play-journal__global-nav__desktop__seeded__develop" data-route="worlds-play-journal" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-play-journal__nav.png" alt="develop worlds-play-journal/global-nav/desktop/seeded" data-caption="develop -- worlds-play-journal/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-play-journal__page__desktop__seeded__develop" data-route="worlds-play-journal" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-play-journal__page.png" alt="develop worlds-play-journal/page/desktop/seeded" data-caption="develop -- worlds-play-journal/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-play-journal__page__desktop__seeded__DS3" data-route="worlds-play-journal" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds-play-journal__page.png" alt="DS3 worlds-play-journal/page/desktop/seeded" data-caption="DS3 -- worlds-play-journal/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-play-journal__page__desktop__seeded__DS1" data-route="worlds-play-journal" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds-play-journal__page.png" alt="DS1 worlds-play-journal/page/desktop/seeded" data-caption="DS1 -- worlds-play-journal/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-play-journal__page__desktop__seeded__DS2" data-route="worlds-play-journal" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds-play-journal__page.png" alt="DS2 worlds-play-journal/page/desktop/seeded" data-caption="DS2 -- worlds-play-journal/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-seeded" data-viewport="mobile" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-play-journal__page__mobile__seeded__develop" data-route="worlds-play-journal" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/seeded/worlds-play-journal__page.png" alt="develop worlds-play-journal/page/mobile/seeded" data-caption="develop -- worlds-play-journal/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-play-journal__page__mobile__seeded__DS3" data-route="worlds-play-journal" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/seeded/worlds-play-journal__page.png" alt="DS3 worlds-play-journal/page/mobile/seeded" data-caption="DS3 -- worlds-play-journal/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-play-journal__page__mobile__seeded__DS1" data-route="worlds-play-journal" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/seeded/worlds-play-journal__page.png" alt="DS1 worlds-play-journal/page/mobile/seeded" data-caption="DS1 -- worlds-play-journal/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-play-journal__page__mobile__seeded__DS2" data-route="worlds-play-journal" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/seeded/worlds-play-journal__page.png" alt="DS2 worlds-play-journal/page/mobile/seeded" data-caption="DS2 -- worlds-play-journal/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-play-journal__header__desktop__seeded__develop" data-route="worlds-play-journal" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-play-journal__header.png" alt="develop worlds-play-journal/header/desktop/seeded" data-caption="develop -- worlds-play-journal/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-play-journal__nav__desktop__seeded__develop" data-route="worlds-play-journal" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-play-journal__nav.png" alt="develop worlds-play-journal/nav/desktop/seeded" data-caption="develop -- worlds-play-journal/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-play-journal__main__desktop__seeded__develop" data-route="worlds-play-journal" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-play-journal__main.png" alt="develop worlds-play-journal/main/desktop/seeded" data-caption="develop -- worlds-play-journal/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-play-journal__main__desktop__seeded__DS3" data-route="worlds-play-journal" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds-play-journal__main.png" alt="DS3 worlds-play-journal/main/desktop/seeded" data-caption="DS3 -- worlds-play-journal/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-play-journal__main__desktop__seeded__DS1" data-route="worlds-play-journal" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds-play-journal__main.png" alt="DS1 worlds-play-journal/main/desktop/seeded" data-caption="DS1 -- worlds-play-journal/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-play-journal__main__desktop__seeded__DS2" data-route="worlds-play-journal" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds-play-journal__main.png" alt="DS2 worlds-play-journal/main/desktop/seeded" data-caption="DS2 -- worlds-play-journal/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+</main>
+
+<div id="lightbox" class="overlay">
+  <img id="lightbox-img" src="" alt="">
+  <div id="lightbox-caption" style="position: fixed; top: 12px; left: 50%; transform: translateX(-50%); color: #fff; font-family: ui-monospace, monospace; font-size: 13px; background: rgba(0,0,0,0.6); padding: 6px 12px; border-radius: 4px;"></div>
+</div>
+
+<div id="md-overlay" class="overlay">
+  <div class="panel">
+    <h3>Audit marks (markdown) -- this route only</h3>
+    <textarea id="md-text" readonly></textarea>
+    <div class="actions">
+      <button id="md-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="md-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-export-overlay" class="overlay">
+  <div class="panel">
+    <h3>Marks (raw JSON) -- all routes</h3>
+    <textarea id="json-export-text" readonly></textarea>
+    <div class="actions">
+      <button id="json-export-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="json-export-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-import-overlay" class="overlay">
+  <div class="panel">
+    <h3>Import marks (paste raw JSON)</h3>
+    <p class="hint">Paste JSON exported from another instance. Legacy IDs without a state segment are migrated to <code>__seeded</code>; v2 values are upgraded to v3 (category=null, why="", updatedAt=now). Existing marks with the same ID are overwritten.</p>
+    <textarea id="json-import-text" placeholder='{"home__page__desktop__seeded__DS3":{"marked":true,"note":"...","category":"bug","why":"...","updatedAt":"..."}}'></textarea>
+    <div class="err" id="json-import-err"></div>
+    <div class="actions">
+      <button id="json-import-apply" type="button">Apply</button>
+      <button class="overlay-close" data-overlay="json-import-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+<script>
+
+  const STORAGE_KEY = 'narraitor-audit-marks-v3';
+  const STORAGE_KEY_V2 = 'narraitor-audit-marks-v2';
+  const STORAGE_KEY_V1 = 'narraitor-audit-marks-v1';
+  // Tracks which routes have had their DS cells auto-prefilled as needs-design.
+  // Once a route is in here, the auto-prefill on page load is skipped.
+  const PREFILLED_KEY = 'narraitor-audit-prefilled-v1';
+  const STATES = ['empty', 'seeded'];
+  const VALID_CATEGORIES = ['needs-design','bug','tooling','intentional','unclear'];
+  const ROUTE_ORDER = ["home", "about", "worlds", "worlds-detail", "worlds-edit", "worlds-create", "worlds-play", "worlds-play-journal", "characters", "characters-detail", "characters-edit", "characters-create", "play", "settings"];
+  const COMPONENT_ORDER = {"page":0,"header":1,"nav":2,"form":3,"main":4};
+  const THEME_ORDER = ["DS3","DS1","DS2","develop"];
+  const BRANCH_META = {"develop": {"theme": "default", "mode": "light", "branchArg": "develop-default"}, "DS3": {"theme": "ds3", "mode": "light", "branchArg": "integration-ds3-light"}, "DS1": {"theme": "ds1", "mode": "light", "branchArg": "integration-ds1-light"}, "DS2": {"theme": "ds2", "mode": "light", "branchArg": "integration-ds2-light"}};
+
+  function componentSortKey(c) {
+    if (c in COMPONENT_ORDER) return [COMPONENT_ORDER[c], 0];
+    if (c.startsWith("main-section-")) {
+      const n = parseInt(c.replace("main-section-",""), 10);
+      return [5, isNaN(n) ? 0 : n];
+    }
+    return [9, c];
+  }
+
+  // Pre-v3 ID migration: v1 (4 segments) -> v2 (5 segments) by inserting __seeded.
+  function migrateLegacyId(id) {
+    const parts = id.split('__');
+    if (parts.length < 4) return id;
+    const last = parts[parts.length - 1];
+    const second = parts[parts.length - 2];
+    const third = parts[parts.length - 3];
+    const isTheme = ['DS1','DS2','DS3','develop'].includes(last);
+    const isViewport = ['desktop','mobile'].includes(second);
+    const alreadyHasState = STATES.includes(third);
+    if (isTheme && isViewport && !alreadyHasState) {
+      const head = parts.slice(0, parts.length - 1).join('__');
+      return head + '__seeded__' + last;
+    }
+    return id;
+  }
+
+  function migrateMarksV1ToV2(input) {
+    const out = {};
+    let migrated = 0;
+    for (const [id, m] of Object.entries(input || {})) {
+      const newId = migrateLegacyId(id);
+      if (newId !== id) migrated++;
+      out[newId] = m;
+    }
+    return { marks: out, migrated };
+  }
+
+  // v2 -> v3: add category, why, updatedAt; preserve marked + note.
+  function upgradeV2ValueToV3(v) {
+    if (!v || typeof v !== 'object') return null;
+    return {
+      marked: !!v.marked,
+      note: typeof v.note === 'string' ? v.note : '',
+      category: v.category && VALID_CATEGORIES.includes(v.category) ? v.category : null,
+      why: typeof v.why === 'string' ? v.why : '',
+      updatedAt: v.updatedAt || new Date().toISOString(),
+    };
+  }
+
+  function migrateV2ObjectToV3(v2obj) {
+    const out = {};
+    for (const [id, m] of Object.entries(v2obj || {})) {
+      out[id] = upgradeV2ValueToV3(m);
+    }
+    return out;
+  }
+
+  function loadMarks() {
+    try {
+      const v3 = localStorage.getItem(STORAGE_KEY);
+      if (v3) return JSON.parse(v3);
+      // No v3 yet — try v2 (lazy migrate; leave v2 untouched for rollback).
+      const v2raw = localStorage.getItem(STORAGE_KEY_V2);
+      if (v2raw) {
+        const v3marks = migrateV2ObjectToV3(JSON.parse(v2raw));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + Object.keys(v3marks).length + ' v2 marks to v3 (v2 untouched).');
+        return v3marks;
+      }
+      // No v3 or v2 — try v1 and migrate v1 -> v2 -> v3 in one pass.
+      const v1raw = localStorage.getItem(STORAGE_KEY_V1);
+      if (v1raw) {
+        const { marks: v2marks, migrated } = migrateMarksV1ToV2(JSON.parse(v1raw));
+        const v3marks = migrateV2ObjectToV3(v2marks);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + migrated + ' v1 IDs through to v3.');
+        return v3marks;
+      }
+    } catch (e) { console.warn(e); }
+    return {};
+  }
+
+  function saveMarks(m) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(m)); } catch (e) {}
+  }
+
+
+  const ROUTE = "worlds-play-journal";
+  let marks = loadMarks();
+
+  function applyMarkState(cell) {
+    const id = cell.dataset.cellId;
+    const m = marks[id];
+    const noteInput = cell.querySelector('textarea[data-action="note"]');
+    const whyInput = cell.querySelector('input[data-action="why"]');
+    const chips = cell.querySelectorAll('.cat-chip');
+    cell.classList.remove('cat-bug','cat-tooling','cat-intentional','cat-unclear');
+    chips.forEach(c => c.classList.remove('active'));
+    if (m && m.marked) {
+      cell.classList.add('marked');
+      if (noteInput) noteInput.value = m.note || '';
+      if (whyInput) whyInput.value = m.why || '';
+      if (m.category) {
+        cell.classList.add('cat-' + m.category);
+        const chip = cell.querySelector('.cat-chip[data-cat="' + m.category + '"]');
+        if (chip) chip.classList.add('active');
+      }
+    } else {
+      cell.classList.remove('marked');
+      if (noteInput) noteInput.value = '';
+      if (whyInput) whyInput.value = '';
+    }
+  }
+
+  function updateRowSectionFlags() {
+    document.querySelectorAll('.component-row').forEach(row => {
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+    document.querySelectorAll('section.route').forEach(sec => {
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+    });
+  }
+
+  function updateCount() {
+    const n = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).length;
+    document.getElementById('mark-count').textContent = n;
+  }
+
+  function writeMark(id, partial) {
+    const existing = marks[id] || { marked: false, note: '', category: null, why: '', updatedAt: null };
+    const next = Object.assign({}, existing, partial, { updatedAt: new Date().toISOString() });
+    if (!next.marked && !next.note && !next.why && !next.category) {
+      delete marks[id];
+    } else {
+      marks[id] = next;
+    }
+    saveMarks(marks);
+    updateCount();
+  }
+
+  function buildRecaptureCommand(cell) {
+    const route = cell.dataset.route;
+    const viewport = cell.dataset.viewport;
+    const state = cell.dataset.state;
+    const themeKey = cell.dataset.theme;
+    const meta = BRANCH_META[themeKey];
+    if (!meta) return null;
+    return 'npx tsx scripts/audit/playwright-crawl.ts'
+      + ' --branch ' + meta.branchArg
+      + ' --viewport ' + viewport
+      + ' --state ' + state
+      + ' --theme ' + meta.theme
+      + ' --mode ' + meta.mode
+      + ' --route ' + route;
+  }
+
+  function loadPrefilledFlags() {
+    try { return JSON.parse(localStorage.getItem(PREFILLED_KEY) || '{}'); }
+    catch (e) { return {}; }
+  }
+  function savePrefilledFlags(f) {
+    try { localStorage.setItem(PREFILLED_KEY, JSON.stringify(f)); } catch (e) {}
+  }
+
+  // Gap-fill: only adds entries for DS cells that have no existing mark.
+  // Returns the count of cells filled. Develop is excluded (it's the baseline).
+  function prefillDsCellsAsNeedsDesign() {
+    const dsCells = Array.from(document.querySelectorAll('.cell[data-cell-id]'))
+      .filter(c => ['DS1','DS2','DS3'].includes(c.dataset.theme));
+    let added = 0;
+    const ts = new Date().toISOString();
+    for (const cell of dsCells) {
+      const id = cell.dataset.cellId;
+      if (!marks[id]) {
+        marks[id] = { marked: true, note: '', category: 'needs-design', why: '', updatedAt: ts };
+        added++;
+      }
+    }
+    if (added > 0) saveMarks(marks);
+    return added;
+  }
+
+  // Auto-prefill on first visit per route.
+  const prefillFlags = loadPrefilledFlags();
+  if (!prefillFlags[ROUTE]) {
+    const added = prefillDsCellsAsNeedsDesign();
+    prefillFlags[ROUTE] = true;
+    savePrefilledFlags(prefillFlags);
+    if (added > 0) console.info('[audit] auto-prefilled ' + added + ' DS cells for ' + ROUTE + ' as needs-design.');
+  }
+
+  document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+  updateRowSectionFlags();
+  updateCount();
+
+  // Lightbox
+  const lb = document.getElementById('lightbox');
+  const lbImg = document.getElementById('lightbox-img');
+  const lbCap = document.getElementById('lightbox-caption');
+  document.querySelectorAll('.cell img').forEach(img => {
+    img.addEventListener('click', () => {
+      lbImg.src = img.src;
+      lbCap.textContent = img.dataset.caption || '';
+      lb.classList.add('open');
+    });
+  });
+  lb.addEventListener('click', () => lb.classList.remove('open'));
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') document.querySelectorAll('.overlay.open').forEach(o => o.classList.remove('open'));
+  });
+
+  // Mark toggle
+  document.querySelectorAll('button[data-action="toggle-mark"]').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      const cell = btn.closest('.cell');
+      const id = cell.dataset.cellId;
+      const isMarked = !cell.classList.contains('marked');
+      writeMark(id, { marked: isMarked });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      const sec = cell.closest('section.route');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+      if (isMarked) {
+        const why = cell.querySelector('input[data-action="why"]');
+        if (why) setTimeout(() => why.focus(), 0);
+      }
+    });
+  });
+
+  // Why / note inputs (debounced save)
+  let saveTimer = null;
+  function bindInput(sel, field) {
+    document.querySelectorAll(sel).forEach(inp => {
+      const handler = () => {
+        const cell = inp.closest('.cell');
+        if (!cell.classList.contains('marked')) return;
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(() => {
+          writeMark(cell.dataset.cellId, { [field]: inp.value });
+        }, 250);
+      };
+      inp.addEventListener('input', handler);
+      inp.addEventListener('blur', () => {
+        const cell = inp.closest('.cell');
+        if (cell.classList.contains('marked')) writeMark(cell.dataset.cellId, { [field]: inp.value });
+      });
+    });
+  }
+  bindInput('input[data-action="why"]', 'why');
+  bindInput('textarea[data-action="note"]', 'note');
+
+  // Category chips
+  document.querySelectorAll('.cat-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const cell = chip.closest('.cell');
+      if (!cell.classList.contains('marked')) {
+        // Mark the cell first so the category sticks
+        writeMark(cell.dataset.cellId, { marked: true });
+      }
+      const cat = chip.dataset.cat;
+      const isActive = chip.classList.contains('active');
+      writeMark(cell.dataset.cellId, { category: isActive ? null : cat });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+  });
+
+  // Re-capture command (copy to clipboard, flash purple)
+  document.querySelectorAll('button[data-action="recapture"]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const cell = btn.closest('.cell');
+      const cmd = buildRecaptureCommand(cell);
+      if (!cmd) return;
+      try {
+        await navigator.clipboard.writeText(cmd);
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Copy re-capture command'; }, 1500);
+      } catch (e) {
+        prompt('Copy this command:', cmd);
+      }
+      cell.classList.remove('pending-recapture');
+      void cell.offsetWidth; // force reflow so the animation restarts
+      cell.classList.add('pending-recapture');
+    });
+  });
+
+  // Toggles
+  document.getElementById('hide-empty').addEventListener('change', e => document.body.classList.toggle('hide-empty', e.target.checked));
+  document.getElementById('compact').addEventListener('change', e => document.body.classList.toggle('compact', e.target.checked));
+  document.getElementById('fit-cell').addEventListener('change', e => document.body.classList.toggle('fit-cell', e.target.checked));
+  document.getElementById('only-marked').addEventListener('change', e => document.body.classList.toggle('only-marked', e.target.checked));
+  document.getElementById('show-suppressed').addEventListener('change', e => document.body.classList.toggle('show-suppressed', e.target.checked));
+  document.getElementById('hide-desktop').addEventListener('change', e => document.body.classList.toggle('hide-desktop', e.target.checked));
+  document.getElementById('hide-mobile').addEventListener('change', e => document.body.classList.toggle('hide-mobile', e.target.checked));
+
+  // True-scale rendering (1x for selector captures, 0.5x for retina full-page).
+  const RETINA_THRESHOLD = 1500;
+  function applyTrueScale(img) {
+    if (!img.naturalWidth) return;
+    const cssWidth = img.naturalWidth > RETINA_THRESHOLD
+      ? Math.round(img.naturalWidth / 2)
+      : img.naturalWidth;
+    img.style.maxWidth = 'min(100%, ' + cssWidth + 'px)';
+  }
+  document.querySelectorAll('.cell img').forEach(img => {
+    if (img.complete && img.naturalWidth > 0) applyTrueScale(img);
+    else img.addEventListener('load', () => applyTrueScale(img), { once: true });
+  });
+
+  // State chips
+  document.querySelectorAll('.state-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const state = chip.dataset.state;
+      chip.classList.toggle('active');
+      document.body.classList.toggle('hide-state-' + state, !chip.classList.contains('active'));
+    });
+  });
+  STATES.forEach(s => {
+    const chip = document.querySelector('.state-chip[data-state="' + s + '"]');
+    if (chip && !chip.classList.contains('active')) document.body.classList.add('hide-state-' + s);
+  });
+
+  // Manual top-up: fill any DS cells that don't have a mark yet
+  document.getElementById('prefill-ds-btn').addEventListener('click', () => {
+    const added = prefillDsCellsAsNeedsDesign();
+    if (added > 0) {
+      document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+      updateRowSectionFlags();
+      updateCount();
+      alert('Filled ' + added + ' missing DS cells as needs-design.');
+    } else {
+      alert('All DS cells in this route already have marks.');
+    }
+  });
+
+  // Clear-route. Also resets the prefilled flag so a reload re-triggers auto-prefill.
+  document.getElementById('clear-route-btn').addEventListener('click', () => {
+    const ids = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).map(([id]) => id);
+    if (!ids.length) { alert('No marks for this route.'); return; }
+    if (!confirm('Clear ' + ids.length + ' marks for route ' + ROUTE + '?\n\nReloading the page will re-prefill all DS cells as needs-design.')) return;
+    ids.forEach(id => delete marks[id]);
+    saveMarks(marks);
+    const flags = loadPrefilledFlags();
+    delete flags[ROUTE];
+    savePrefilledFlags(flags);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+  });
+
+  function buildMarkdown() {
+    const items = [];
+    Object.entries(marks).forEach(([id, m]) => {
+      if (!m || !m.marked) return;
+      if (!id.startsWith(ROUTE + '__')) return;
+      const parts = id.split('__');
+      const themeKey = parts[parts.length - 1];
+      const state = parts[parts.length - 2];
+      const viewport = parts[parts.length - 3];
+      const route = parts[0];
+      const component = parts.slice(1, parts.length - 3).join('__');
+      items.push({ component, viewport, state, theme: themeKey,
+                   note: m.note || '', why: m.why || '', category: m.category || '' });
+    });
+    items.sort((a, b) => {
+      const ak = componentSortKey(a.component);
+      const bk = componentSortKey(b.component);
+      if (ak[0] !== bk[0]) return ak[0] - bk[0];
+      if (ak[1] !== bk[1]) return ak[1] < bk[1] ? -1 : 1;
+      const sd = STATES.indexOf(a.state) - STATES.indexOf(b.state);
+      if (sd !== 0) return sd;
+      const td = THEME_ORDER.indexOf(a.theme) - THEME_ORDER.indexOf(b.theme);
+      if (td !== 0) return td;
+      return a.viewport === b.viewport ? 0 : (a.viewport === 'desktop' ? -1 : 1);
+    });
+    const date = new Date().toISOString().split('T')[0];
+    const lines = ['# Audit marks -- ' + ROUTE + ' -- ' + items.length + ' items -- ' + date, ''];
+    items.forEach(it => {
+      const catTag = it.category ? ' [' + it.category + ']' : '';
+      const whyTxt = it.why ? ': ' + it.why : '';
+      const noteTxt = it.note ? '  -- ' + it.note : '';
+      lines.push('- [ ] **' + it.theme + ' ' + it.component + '** [' + it.viewport + '/' + it.state + ']' + catTag + whyTxt + noteTxt);
+    });
+    return lines.join('\n');
+  }
+
+  function openOverlay(id) { document.getElementById(id).classList.add('open'); }
+  function closeOverlay(id) { document.getElementById(id).classList.remove('open'); }
+  document.querySelectorAll('.overlay-close').forEach(b => b.addEventListener('click', () => closeOverlay(b.dataset.overlay)));
+  document.querySelectorAll('.overlay').forEach(o => {
+    o.addEventListener('click', e => { if (e.target === o) o.classList.remove('open'); });
+  });
+
+  document.getElementById('export-md-btn').addEventListener('click', async () => {
+    const md = buildMarkdown();
+    const ta = document.getElementById('md-text');
+    ta.value = md;
+    openOverlay('md-overlay');
+    try { await navigator.clipboard.writeText(md); document.getElementById('md-copy').textContent = 'Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+  document.getElementById('md-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('md-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('md-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('export-json-btn').addEventListener('click', () => {
+    const ta = document.getElementById('json-export-text');
+    ta.value = JSON.stringify(marks, null, 2);
+    openOverlay('json-export-overlay');
+  });
+  document.getElementById('json-export-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('json-export-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('json-export-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('json-export-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('import-json-btn').addEventListener('click', () => {
+    document.getElementById('json-import-text').value = '';
+    document.getElementById('json-import-err').textContent = '';
+    openOverlay('json-import-overlay');
+  });
+  document.getElementById('json-import-apply').addEventListener('click', () => {
+    const ta = document.getElementById('json-import-text');
+    const err = document.getElementById('json-import-err');
+    err.textContent = '';
+    let parsed;
+    try { parsed = JSON.parse(ta.value); }
+    catch (e) { err.textContent = 'Invalid JSON: ' + e.message; return; }
+    if (!parsed || typeof parsed !== 'object') { err.textContent = 'Expected an object.'; return; }
+    // First migrate v1 IDs (4 segments) -> v2 IDs (5 segments)
+    const { marks: idMigrated, migrated } = migrateMarksV1ToV2(parsed);
+    // Then upgrade each value v2 -> v3 (preserves marked + note, fills new fields)
+    Object.entries(idMigrated).forEach(([id, m]) => {
+      marks[id] = upgradeV2ValueToV3(m);
+    });
+    saveMarks(marks);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+    closeOverlay('json-import-overlay');
+    alert('Imported ' + Object.keys(idMigrated).length + ' marks (' + migrated + ' legacy IDs migrated to __seeded; values upgraded to v3).');
+  });
+</script>
+</body>
+</html>

--- a/scripts/audit/review/worlds-play.html
+++ b/scripts/audit/review/worlds-play.html
@@ -1,0 +1,1701 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Cross-Theme Audit (#1129) — worlds-play</title>
+<style>
+
+  :root { --col-gap: 8px; --row-gap: 16px; }
+  html, body { margin: 0; padding: 0; font-family: -apple-system, system-ui, sans-serif; background: #fafafa; color: #222; }
+  .sticky-shell { position: sticky; top: 0; z-index: 100; border-bottom: 1px solid #444; }
+  header.top {
+    background: #1a1a1a; color: #fff; padding: 12px 16px;
+    display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+  }
+  header.top h1 { font-size: 14px; margin: 0; font-weight: 600; }
+  header.top .legend { display: flex; gap: 12px; font-size: 12px; }
+  header.top .legend .col { padding: 2px 8px; border-radius: 3px; }
+  header.top .legend .develop { background: #6b7280; }
+  header.top .legend .ds3 { background: #4338ca; }
+  header.top .legend .ds1 { background: #92400e; }
+  header.top .legend .ds2 { background: #166534; }
+  header.top a.back { color: #9cf; font-size: 12px; text-decoration: none; padding: 2px 6px; border-radius: 2px; }
+  header.top a.back:hover { background: #444; color: #fff; }
+  header.top .nav-routes { display: flex; gap: 4px; align-items: center; font-size: 12px; }
+  header.top .nav-routes a { color: #9cf; text-decoration: none; padding: 2px 8px; border-radius: 2px; background: #2a2a2a; }
+  header.top .nav-routes a:hover { background: #444; color: #fff; }
+  header.top .nav-routes .current { color: #fff; font-weight: 600; padding: 2px 8px; }
+  main { padding: 16px; max-width: 100%; }
+  section.route {
+    margin-bottom: 32px; background: #fff; border-radius: 6px;
+    padding: 12px 16px 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  section.route h2 {
+    font-size: 18px; margin: 0 0 12px; padding-bottom: 6px;
+    border-bottom: 1px solid #e5e5e5;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+  .component-row {
+    display: grid; grid-template-columns: 180px repeat(4, 1fr);
+    gap: var(--col-gap); margin-bottom: var(--row-gap);
+    align-items: start;
+  }
+  .component-row .label {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px; color: #555; padding-top: 28px; line-height: 1.3;
+    word-break: break-word;
+  }
+  .cell {
+    border: 1px solid #e5e5e5; border-radius: 4px; overflow: hidden;
+    background: #f3f4f6; position: relative; min-height: 100px;
+    display: flex; flex-direction: column;
+  }
+  .cell .header {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.04em; padding: 4px 8px; color: #fff;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .cell.develop .header { background: #6b7280; }
+  .cell.ds3 .header { background: #4338ca; }
+  .cell.ds1 .header { background: #92400e; }
+  .cell.ds2 .header { background: #166534; }
+  .cell img {
+    display: block; width: auto; max-width: 100%; height: auto;
+    cursor: zoom-in; background: #fff; align-self: flex-start;
+  }
+  body.fit-cell .cell img { width: 100%; max-width: 100%; }
+  .cell.empty {
+    display: flex; align-items: center; justify-content: center;
+    color: #999; font-size: 12px; padding: 24px; background: #f9f9f9;
+  }
+  .cell.empty::after { content: "(not captured)"; }
+
+  /* Lightbox */
+  #lightbox {
+    display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.92);
+    z-index: 1000; align-items: center; justify-content: center; cursor: zoom-out;
+  }
+  #lightbox.open { display: flex; }
+  #lightbox img { max-width: 96vw; max-height: 96vh; box-shadow: 0 4px 24px rgba(0,0,0,0.5); }
+
+  .controls { display: flex; gap: 12px; align-items: center; font-size: 12px; flex-wrap: wrap; }
+  .controls label { display: flex; align-items: center; gap: 4px; cursor: pointer; }
+  .controls input[type=checkbox] { margin: 0; }
+
+  .state-chips { display: inline-flex; gap: 4px; align-items: center; }
+  .state-chip {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .state-chip.active { background: #2563eb; border-color: #1d4ed8; }
+  .state-chip:hover { background: #4b5563; }
+  .state-chip.active:hover { background: #1d4ed8; }
+
+  body.hide-empty .component-row.all-empty,
+  body.hide-empty .cell.empty { display: none; }
+  body.compact .cell img { max-height: 360px; object-fit: cover; object-position: top; }
+
+  .cell .mark-btn {
+    margin-left: auto; background: rgba(255,255,255,0.18);
+    color: #fff; border: 1px solid rgba(255,255,255,0.35);
+    border-radius: 3px; font-size: 10px; font-weight: 600;
+    padding: 2px 6px; cursor: pointer;
+    text-transform: none; letter-spacing: 0; line-height: 1.2;
+  }
+  .cell .mark-btn:hover { background: rgba(255,255,255,0.28); }
+  .cell.marked { border: 3px solid #dc2626; }
+  .cell.marked .mark-btn { background: #dc2626; border-color: #b91c1c; color: #fff; }
+  .cell.marked .mark-btn::before { content: "x "; }
+  .cell.pending-recapture { animation: cellPulse 2s ease-out; }
+  @keyframes cellPulse {
+    0%   { box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.9); border-color: #7c3aed; }
+    100% { box-shadow: 0 0 0 8px rgba(124, 58, 237, 0); }
+  }
+  .cell .toolbar {
+    display: none;
+    padding: 6px 8px; background: #fef2f2; border-top: 1px solid #fecaca;
+    font-size: 11px;
+  }
+  .cell.marked .toolbar { display: block; }
+  .cell .toolbar input[type=text],
+  .cell .toolbar textarea {
+    width: 100%; box-sizing: border-box;
+    border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 4px 6px; font-size: 12px; font-family: inherit;
+    background: #fff;
+  }
+  .cell .toolbar input[type=text]:focus,
+  .cell .toolbar textarea:focus { outline: 2px solid #dc2626; outline-offset: -1px; }
+  .cell .toolbar .field { margin-bottom: 6px; }
+  .cell .toolbar .field-label {
+    display: block; font-size: 10px; font-weight: 600;
+    color: #7f1d1d; text-transform: uppercase; letter-spacing: 0.04em;
+    margin-bottom: 2px;
+  }
+  .cell .toolbar .cat-chips { display: flex; gap: 4px; flex-wrap: wrap; }
+  .cell .toolbar .cat-chip {
+    background: #fff; border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 2px 8px; font-size: 11px; cursor: pointer; font-family: inherit;
+    color: #7f1d1d;
+  }
+  .cell .toolbar .cat-chip.active { background: #7f1d1d; color: #fff; border-color: #7f1d1d; }
+  .cell .toolbar .cat-chip[data-cat="needs-design"].active { background: #6d28d9; border-color: #6d28d9; }
+  .cell .toolbar .cat-chip[data-cat="bug"].active        { background: #b91c1c; border-color: #b91c1c; }
+  .cell .toolbar .cat-chip[data-cat="tooling"].active    { background: #b45309; border-color: #b45309; }
+  .cell .toolbar .cat-chip[data-cat="intentional"].active{ background: #15803d; border-color: #15803d; }
+  .cell .toolbar .cat-chip[data-cat="unclear"].active    { background: #6b7280; border-color: #6b7280; }
+  .cell .toolbar .recapture-btn {
+    background: #1d4ed8; color: #fff; border: 0; border-radius: 3px;
+    padding: 4px 10px; font-size: 11px; cursor: pointer;
+    font-family: inherit; font-weight: 600;
+  }
+  .cell .toolbar .recapture-btn:hover { background: #1e40af; }
+  .cell .toolbar textarea { min-height: 32px; resize: vertical; font-size: 11px; }
+  .cell.cat-needs-design { border-color: #6d28d9; }
+  .cell.cat-bug         { border-color: #b91c1c; }
+  .cell.cat-tooling     { border-color: #b45309; }
+  .cell.cat-intentional { border-color: #15803d; }
+  .cell.cat-unclear     { border-color: #6b7280; }
+
+  .marks-cluster {
+    display: flex; align-items: center; gap: 8px;
+    border-left: 1px solid #444; padding-left: 12px; margin-left: 4px;
+    font-size: 12px;
+  }
+  .marks-cluster .count {
+    background: #dc2626; color: #fff; border-radius: 10px;
+    padding: 2px 8px; font-weight: 600; min-width: 18px; text-align: center;
+  }
+  .marks-cluster button {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .marks-cluster button:hover { background: #4b5563; }
+  .marks-cluster button.danger { background: #7f1d1d; border-color: #991b1b; }
+  .marks-cluster button.danger:hover { background: #991b1b; }
+
+  body.only-marked .component-row:not(.has-marked) { display: none; }
+  body.only-marked section.route:not(.has-marked) { display: none; }
+
+  .component-row.suppressed { display: none; }
+  body.show-suppressed .component-row.suppressed { display: grid; }
+  .component-row.suppressed .label::after { content: " (hidden)"; color: #b91c1c; font-style: italic; }
+
+  .component-row .label[data-mapped] { color: #1d4ed8; }
+  .component-row .label[data-mapped]::after { content: " *"; }
+  .mapped-tooltip {
+    display: inline-block; margin-left: 4px;
+    font-size: 10px; color: #6b7280; cursor: help; vertical-align: super;
+  }
+
+  .vp-badge, .state-badge {
+    display: inline-block; font-size: 9px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.05em;
+    padding: 1px 6px; border-radius: 8px; margin-top: 2px;
+  }
+  .vp-badge.desktop { background: #dbeafe; color: #1e3a8a; border: 1px solid #93c5fd; margin-right: 4px; }
+  .vp-badge.mobile  { background: #fef3c7; color: #78350f; border: 1px solid #fcd34d; margin-right: 4px; }
+  .state-badge.empty       { background: #f3f4f6; color: #374151; border: 1px solid #d1d5db; }
+  .state-badge.seeded      { background: #dcfce7; color: #14532d; border: 1px solid #86efac; }
+  .state-badge.mid-session { background: #ede9fe; color: #4c1d95; border: 1px solid #c4b5fd; }
+
+  .component-row.vp-mobile { background: #fffbeb; padding: 4px; border-radius: 4px; }
+  body.hide-desktop .component-row.vp-desktop { display: none; }
+  body.hide-mobile .component-row.vp-mobile { display: none; }
+
+  body.hide-state-empty       .component-row.state-empty       { display: none; }
+  body.hide-state-seeded      .component-row.state-seeded      { display: none; }
+  body.hide-state-mid-session .component-row.state-mid-session { display: none; }
+
+  .overlay {
+    display: none; position: fixed; inset: 0; z-index: 1100;
+    background: rgba(0,0,0,0.6); align-items: center; justify-content: center;
+  }
+  .overlay.open { display: flex; }
+  .overlay .panel {
+    background: #fff; border-radius: 6px; width: min(720px, 92vw);
+    max-height: 80vh; padding: 16px; display: flex; flex-direction: column; gap: 8px;
+  }
+  .overlay h3 { margin: 0; font-size: 14px; }
+  .overlay textarea {
+    flex: 1; min-height: 320px; font-family: ui-monospace, monospace; font-size: 12px;
+    border: 1px solid #ddd; border-radius: 4px; padding: 8px; resize: vertical;
+  }
+  .overlay .actions { display: flex; gap: 8px; justify-content: flex-end; }
+  .overlay button {
+    background: #1a1a1a; color: #fff; border: 0; border-radius: 3px;
+    padding: 6px 12px; font-size: 12px; cursor: pointer;
+  }
+  .overlay .hint { font-size: 11px; color: #555; }
+  .overlay .err  { font-size: 12px; color: #b91c1c; min-height: 16px; }
+
+  /* Index-page table */
+  table.routes-index {
+    width: 100%; border-collapse: collapse; background: #fff;
+    border-radius: 6px; overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  table.routes-index th, table.routes-index td {
+    padding: 8px 12px; text-align: left; font-size: 13px;
+    border-bottom: 1px solid #eee;
+  }
+  table.routes-index th { background: #f3f4f6; font-weight: 600; }
+  table.routes-index td a {
+    color: #1d4ed8; text-decoration: none; font-family: ui-monospace, monospace;
+  }
+  table.routes-index td a:hover { text-decoration: underline; }
+  table.routes-index td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  table.routes-index .marked-count.has-marks { color: #b91c1c; font-weight: 600; }
+  table.routes-index .unresolved-count.has-unresolved { color: #b45309; font-weight: 600; }
+  table.routes-index .breakdown {
+    font-size: 11px; color: #555; margin-left: 6px; font-variant-numeric: tabular-nums;
+  }
+
+
+</style>
+</head>
+<body>
+<div class="sticky-shell">
+<header class="top">
+  <a class="back" href="index.html">&larr; Index</a>
+  <h1>worlds-play</h1>
+  <div class="legend">
+    <span class="col develop">develop</span>
+    <span class="col ds3">DS3</span>
+    <span class="col ds1">DS1</span>
+    <span class="col ds2">DS2</span>
+  </div>
+  <div class="controls">
+    <span class="state-chips" role="group" aria-label="State filter">
+      <span style="font-size: 11px; color: #aaa;">State:</span>
+      <button type="button" class="state-chip" data-state="empty">empty</button>
+      <button type="button" class="state-chip active" data-state="seeded">seeded</button>
+    </span>
+    <label><input type="checkbox" id="hide-empty"> Hide missing</label>
+    <label><input type="checkbox" id="compact"> Compact</label>
+    <label title="Stretch images to cell width"><input type="checkbox" id="fit-cell"> Fit to cell</label>
+    <label><input type="checkbox" id="only-marked"> Only marked</label>
+    <label><input type="checkbox" id="show-suppressed"> Show hidden rows</label>
+    <label><input type="checkbox" id="hide-desktop"> Hide desktop</label>
+    <label><input type="checkbox" id="hide-mobile"> Hide mobile</label>
+  </div>
+  <div class="marks-cluster">
+    <span>Marked (route):</span>
+    <span class="count" id="mark-count">0</span>
+    <button id="prefill-ds-btn" type="button" title="Mark every DS cell that has no mark yet as needs-design (gap-fill, never overwrites your existing marks)">Fill DS gaps</button>
+    <button id="export-md-btn" type="button">Export markdown</button>
+    <button id="export-json-btn" type="button">Export JSON</button>
+    <button id="import-json-btn" type="button">Import JSON</button>
+    <button id="clear-route-btn" type="button" class="danger">Clear (route)</button>
+  </div>
+</header>
+<nav class="toc" style="background:#2a2a2a;color:#ccc;padding:6px 16px;font-size:12px;display:flex;gap:8px;align-items:center;border-top:1px solid #444;">
+  <span class="nav-routes">
+    <a href="worlds-create.html">&larr; worlds-create</a>
+    <span class="current">worlds-play</span>
+    <a href="worlds-play-journal.html">worlds-play-journal &rarr;</a>
+  </span>
+</nav>
+</div>
+<main>
+<section class="route" id="route-worlds-play">
+  <h2>worlds-play</h2>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-play__global-nav__desktop__empty__develop" data-route="worlds-play" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-play__nav.png" alt="develop worlds-play/global-nav/desktop/empty" data-caption="develop -- worlds-play/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-play__page__desktop__empty__develop" data-route="worlds-play" data-component="page" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-play__page.png" alt="develop worlds-play/page/desktop/empty" data-caption="develop -- worlds-play/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-play__page__desktop__empty__DS3" data-route="worlds-play" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/worlds-play__page.png" alt="DS3 worlds-play/page/desktop/empty" data-caption="DS3 -- worlds-play/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-play__page__desktop__empty__DS1" data-route="worlds-play" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/worlds-play__page.png" alt="DS1 worlds-play/page/desktop/empty" data-caption="DS1 -- worlds-play/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-play__page__desktop__empty__DS2" data-route="worlds-play" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/worlds-play__page.png" alt="DS2 worlds-play/page/desktop/empty" data-caption="DS2 -- worlds-play/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-empty" data-viewport="mobile" data-state="empty">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-play__page__mobile__empty__develop" data-route="worlds-play" data-component="page" data-viewport="mobile" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/empty/worlds-play__page.png" alt="develop worlds-play/page/mobile/empty" data-caption="develop -- worlds-play/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-play__page__mobile__empty__DS3" data-route="worlds-play" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/empty/worlds-play__page.png" alt="DS3 worlds-play/page/mobile/empty" data-caption="DS3 -- worlds-play/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-play__page__mobile__empty__DS1" data-route="worlds-play" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/empty/worlds-play__page.png" alt="DS1 worlds-play/page/mobile/empty" data-caption="DS1 -- worlds-play/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-play__page__mobile__empty__DS2" data-route="worlds-play" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/empty/worlds-play__page.png" alt="DS2 worlds-play/page/mobile/empty" data-caption="DS2 -- worlds-play/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-play__header__desktop__empty__develop" data-route="worlds-play" data-component="header" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-play__header.png" alt="develop worlds-play/header/desktop/empty" data-caption="develop -- worlds-play/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-play__nav__desktop__empty__develop" data-route="worlds-play" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-play__nav.png" alt="develop worlds-play/nav/desktop/empty" data-caption="develop -- worlds-play/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds-play__main__desktop__empty__develop" data-route="worlds-play" data-component="main" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds-play__main.png" alt="develop worlds-play/main/desktop/empty" data-caption="develop -- worlds-play/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-play__main__desktop__empty__DS3" data-route="worlds-play" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/worlds-play__main.png" alt="DS3 worlds-play/main/desktop/empty" data-caption="DS3 -- worlds-play/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-play__main__desktop__empty__DS1" data-route="worlds-play" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/worlds-play__main.png" alt="DS1 worlds-play/main/desktop/empty" data-caption="DS1 -- worlds-play/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-play__main__desktop__empty__DS2" data-route="worlds-play" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/worlds-play__main.png" alt="DS2 worlds-play/main/desktop/empty" data-caption="DS2 -- worlds-play/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-play__global-nav__desktop__seeded__develop" data-route="worlds-play" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-play__nav.png" alt="develop worlds-play/global-nav/desktop/seeded" data-caption="develop -- worlds-play/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-play__page__desktop__seeded__develop" data-route="worlds-play" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-play__page.png" alt="develop worlds-play/page/desktop/seeded" data-caption="develop -- worlds-play/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-play__page__desktop__seeded__DS3" data-route="worlds-play" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds-play__page.png" alt="DS3 worlds-play/page/desktop/seeded" data-caption="DS3 -- worlds-play/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-play__page__desktop__seeded__DS1" data-route="worlds-play" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds-play__page.png" alt="DS1 worlds-play/page/desktop/seeded" data-caption="DS1 -- worlds-play/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-play__page__desktop__seeded__DS2" data-route="worlds-play" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds-play__page.png" alt="DS2 worlds-play/page/desktop/seeded" data-caption="DS2 -- worlds-play/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-seeded" data-viewport="mobile" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-play__page__mobile__seeded__develop" data-route="worlds-play" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/seeded/worlds-play__page.png" alt="develop worlds-play/page/mobile/seeded" data-caption="develop -- worlds-play/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-play__page__mobile__seeded__DS3" data-route="worlds-play" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/seeded/worlds-play__page.png" alt="DS3 worlds-play/page/mobile/seeded" data-caption="DS3 -- worlds-play/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-play__page__mobile__seeded__DS1" data-route="worlds-play" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/seeded/worlds-play__page.png" alt="DS1 worlds-play/page/mobile/seeded" data-caption="DS1 -- worlds-play/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-play__page__mobile__seeded__DS2" data-route="worlds-play" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/seeded/worlds-play__page.png" alt="DS2 worlds-play/page/mobile/seeded" data-caption="DS2 -- worlds-play/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-play__header__desktop__seeded__develop" data-route="worlds-play" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-play__header.png" alt="develop worlds-play/header/desktop/seeded" data-caption="develop -- worlds-play/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell ds2" data-cell-id="worlds-play__header__desktop__seeded__DS2" data-route="worlds-play" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds-play__header.png" alt="DS2 worlds-play/header/desktop/seeded" data-caption="DS2 -- worlds-play/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-play__nav__desktop__seeded__develop" data-route="worlds-play" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-play__nav.png" alt="develop worlds-play/nav/desktop/seeded" data-caption="develop -- worlds-play/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds-play__main__desktop__seeded__develop" data-route="worlds-play" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds-play__main.png" alt="develop worlds-play/main/desktop/seeded" data-caption="develop -- worlds-play/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds-play__main__desktop__seeded__DS3" data-route="worlds-play" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds-play__main.png" alt="DS3 worlds-play/main/desktop/seeded" data-caption="DS3 -- worlds-play/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds-play__main__desktop__seeded__DS1" data-route="worlds-play" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds-play__main.png" alt="DS1 worlds-play/main/desktop/seeded" data-caption="DS1 -- worlds-play/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds-play__main__desktop__seeded__DS2" data-route="worlds-play" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds-play__main.png" alt="DS2 worlds-play/main/desktop/seeded" data-caption="DS2 -- worlds-play/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+</main>
+
+<div id="lightbox" class="overlay">
+  <img id="lightbox-img" src="" alt="">
+  <div id="lightbox-caption" style="position: fixed; top: 12px; left: 50%; transform: translateX(-50%); color: #fff; font-family: ui-monospace, monospace; font-size: 13px; background: rgba(0,0,0,0.6); padding: 6px 12px; border-radius: 4px;"></div>
+</div>
+
+<div id="md-overlay" class="overlay">
+  <div class="panel">
+    <h3>Audit marks (markdown) -- this route only</h3>
+    <textarea id="md-text" readonly></textarea>
+    <div class="actions">
+      <button id="md-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="md-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-export-overlay" class="overlay">
+  <div class="panel">
+    <h3>Marks (raw JSON) -- all routes</h3>
+    <textarea id="json-export-text" readonly></textarea>
+    <div class="actions">
+      <button id="json-export-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="json-export-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-import-overlay" class="overlay">
+  <div class="panel">
+    <h3>Import marks (paste raw JSON)</h3>
+    <p class="hint">Paste JSON exported from another instance. Legacy IDs without a state segment are migrated to <code>__seeded</code>; v2 values are upgraded to v3 (category=null, why="", updatedAt=now). Existing marks with the same ID are overwritten.</p>
+    <textarea id="json-import-text" placeholder='{"home__page__desktop__seeded__DS3":{"marked":true,"note":"...","category":"bug","why":"...","updatedAt":"..."}}'></textarea>
+    <div class="err" id="json-import-err"></div>
+    <div class="actions">
+      <button id="json-import-apply" type="button">Apply</button>
+      <button class="overlay-close" data-overlay="json-import-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+<script>
+
+  const STORAGE_KEY = 'narraitor-audit-marks-v3';
+  const STORAGE_KEY_V2 = 'narraitor-audit-marks-v2';
+  const STORAGE_KEY_V1 = 'narraitor-audit-marks-v1';
+  // Tracks which routes have had their DS cells auto-prefilled as needs-design.
+  // Once a route is in here, the auto-prefill on page load is skipped.
+  const PREFILLED_KEY = 'narraitor-audit-prefilled-v1';
+  const STATES = ['empty', 'seeded'];
+  const VALID_CATEGORIES = ['needs-design','bug','tooling','intentional','unclear'];
+  const ROUTE_ORDER = ["home", "about", "worlds", "worlds-detail", "worlds-edit", "worlds-create", "worlds-play", "worlds-play-journal", "characters", "characters-detail", "characters-edit", "characters-create", "play", "settings"];
+  const COMPONENT_ORDER = {"page":0,"header":1,"nav":2,"form":3,"main":4};
+  const THEME_ORDER = ["DS3","DS1","DS2","develop"];
+  const BRANCH_META = {"develop": {"theme": "default", "mode": "light", "branchArg": "develop-default"}, "DS3": {"theme": "ds3", "mode": "light", "branchArg": "integration-ds3-light"}, "DS1": {"theme": "ds1", "mode": "light", "branchArg": "integration-ds1-light"}, "DS2": {"theme": "ds2", "mode": "light", "branchArg": "integration-ds2-light"}};
+
+  function componentSortKey(c) {
+    if (c in COMPONENT_ORDER) return [COMPONENT_ORDER[c], 0];
+    if (c.startsWith("main-section-")) {
+      const n = parseInt(c.replace("main-section-",""), 10);
+      return [5, isNaN(n) ? 0 : n];
+    }
+    return [9, c];
+  }
+
+  // Pre-v3 ID migration: v1 (4 segments) -> v2 (5 segments) by inserting __seeded.
+  function migrateLegacyId(id) {
+    const parts = id.split('__');
+    if (parts.length < 4) return id;
+    const last = parts[parts.length - 1];
+    const second = parts[parts.length - 2];
+    const third = parts[parts.length - 3];
+    const isTheme = ['DS1','DS2','DS3','develop'].includes(last);
+    const isViewport = ['desktop','mobile'].includes(second);
+    const alreadyHasState = STATES.includes(third);
+    if (isTheme && isViewport && !alreadyHasState) {
+      const head = parts.slice(0, parts.length - 1).join('__');
+      return head + '__seeded__' + last;
+    }
+    return id;
+  }
+
+  function migrateMarksV1ToV2(input) {
+    const out = {};
+    let migrated = 0;
+    for (const [id, m] of Object.entries(input || {})) {
+      const newId = migrateLegacyId(id);
+      if (newId !== id) migrated++;
+      out[newId] = m;
+    }
+    return { marks: out, migrated };
+  }
+
+  // v2 -> v3: add category, why, updatedAt; preserve marked + note.
+  function upgradeV2ValueToV3(v) {
+    if (!v || typeof v !== 'object') return null;
+    return {
+      marked: !!v.marked,
+      note: typeof v.note === 'string' ? v.note : '',
+      category: v.category && VALID_CATEGORIES.includes(v.category) ? v.category : null,
+      why: typeof v.why === 'string' ? v.why : '',
+      updatedAt: v.updatedAt || new Date().toISOString(),
+    };
+  }
+
+  function migrateV2ObjectToV3(v2obj) {
+    const out = {};
+    for (const [id, m] of Object.entries(v2obj || {})) {
+      out[id] = upgradeV2ValueToV3(m);
+    }
+    return out;
+  }
+
+  function loadMarks() {
+    try {
+      const v3 = localStorage.getItem(STORAGE_KEY);
+      if (v3) return JSON.parse(v3);
+      // No v3 yet — try v2 (lazy migrate; leave v2 untouched for rollback).
+      const v2raw = localStorage.getItem(STORAGE_KEY_V2);
+      if (v2raw) {
+        const v3marks = migrateV2ObjectToV3(JSON.parse(v2raw));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + Object.keys(v3marks).length + ' v2 marks to v3 (v2 untouched).');
+        return v3marks;
+      }
+      // No v3 or v2 — try v1 and migrate v1 -> v2 -> v3 in one pass.
+      const v1raw = localStorage.getItem(STORAGE_KEY_V1);
+      if (v1raw) {
+        const { marks: v2marks, migrated } = migrateMarksV1ToV2(JSON.parse(v1raw));
+        const v3marks = migrateV2ObjectToV3(v2marks);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + migrated + ' v1 IDs through to v3.');
+        return v3marks;
+      }
+    } catch (e) { console.warn(e); }
+    return {};
+  }
+
+  function saveMarks(m) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(m)); } catch (e) {}
+  }
+
+
+  const ROUTE = "worlds-play";
+  let marks = loadMarks();
+
+  function applyMarkState(cell) {
+    const id = cell.dataset.cellId;
+    const m = marks[id];
+    const noteInput = cell.querySelector('textarea[data-action="note"]');
+    const whyInput = cell.querySelector('input[data-action="why"]');
+    const chips = cell.querySelectorAll('.cat-chip');
+    cell.classList.remove('cat-bug','cat-tooling','cat-intentional','cat-unclear');
+    chips.forEach(c => c.classList.remove('active'));
+    if (m && m.marked) {
+      cell.classList.add('marked');
+      if (noteInput) noteInput.value = m.note || '';
+      if (whyInput) whyInput.value = m.why || '';
+      if (m.category) {
+        cell.classList.add('cat-' + m.category);
+        const chip = cell.querySelector('.cat-chip[data-cat="' + m.category + '"]');
+        if (chip) chip.classList.add('active');
+      }
+    } else {
+      cell.classList.remove('marked');
+      if (noteInput) noteInput.value = '';
+      if (whyInput) whyInput.value = '';
+    }
+  }
+
+  function updateRowSectionFlags() {
+    document.querySelectorAll('.component-row').forEach(row => {
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+    document.querySelectorAll('section.route').forEach(sec => {
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+    });
+  }
+
+  function updateCount() {
+    const n = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).length;
+    document.getElementById('mark-count').textContent = n;
+  }
+
+  function writeMark(id, partial) {
+    const existing = marks[id] || { marked: false, note: '', category: null, why: '', updatedAt: null };
+    const next = Object.assign({}, existing, partial, { updatedAt: new Date().toISOString() });
+    if (!next.marked && !next.note && !next.why && !next.category) {
+      delete marks[id];
+    } else {
+      marks[id] = next;
+    }
+    saveMarks(marks);
+    updateCount();
+  }
+
+  function buildRecaptureCommand(cell) {
+    const route = cell.dataset.route;
+    const viewport = cell.dataset.viewport;
+    const state = cell.dataset.state;
+    const themeKey = cell.dataset.theme;
+    const meta = BRANCH_META[themeKey];
+    if (!meta) return null;
+    return 'npx tsx scripts/audit/playwright-crawl.ts'
+      + ' --branch ' + meta.branchArg
+      + ' --viewport ' + viewport
+      + ' --state ' + state
+      + ' --theme ' + meta.theme
+      + ' --mode ' + meta.mode
+      + ' --route ' + route;
+  }
+
+  function loadPrefilledFlags() {
+    try { return JSON.parse(localStorage.getItem(PREFILLED_KEY) || '{}'); }
+    catch (e) { return {}; }
+  }
+  function savePrefilledFlags(f) {
+    try { localStorage.setItem(PREFILLED_KEY, JSON.stringify(f)); } catch (e) {}
+  }
+
+  // Gap-fill: only adds entries for DS cells that have no existing mark.
+  // Returns the count of cells filled. Develop is excluded (it's the baseline).
+  function prefillDsCellsAsNeedsDesign() {
+    const dsCells = Array.from(document.querySelectorAll('.cell[data-cell-id]'))
+      .filter(c => ['DS1','DS2','DS3'].includes(c.dataset.theme));
+    let added = 0;
+    const ts = new Date().toISOString();
+    for (const cell of dsCells) {
+      const id = cell.dataset.cellId;
+      if (!marks[id]) {
+        marks[id] = { marked: true, note: '', category: 'needs-design', why: '', updatedAt: ts };
+        added++;
+      }
+    }
+    if (added > 0) saveMarks(marks);
+    return added;
+  }
+
+  // Auto-prefill on first visit per route.
+  const prefillFlags = loadPrefilledFlags();
+  if (!prefillFlags[ROUTE]) {
+    const added = prefillDsCellsAsNeedsDesign();
+    prefillFlags[ROUTE] = true;
+    savePrefilledFlags(prefillFlags);
+    if (added > 0) console.info('[audit] auto-prefilled ' + added + ' DS cells for ' + ROUTE + ' as needs-design.');
+  }
+
+  document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+  updateRowSectionFlags();
+  updateCount();
+
+  // Lightbox
+  const lb = document.getElementById('lightbox');
+  const lbImg = document.getElementById('lightbox-img');
+  const lbCap = document.getElementById('lightbox-caption');
+  document.querySelectorAll('.cell img').forEach(img => {
+    img.addEventListener('click', () => {
+      lbImg.src = img.src;
+      lbCap.textContent = img.dataset.caption || '';
+      lb.classList.add('open');
+    });
+  });
+  lb.addEventListener('click', () => lb.classList.remove('open'));
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') document.querySelectorAll('.overlay.open').forEach(o => o.classList.remove('open'));
+  });
+
+  // Mark toggle
+  document.querySelectorAll('button[data-action="toggle-mark"]').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      const cell = btn.closest('.cell');
+      const id = cell.dataset.cellId;
+      const isMarked = !cell.classList.contains('marked');
+      writeMark(id, { marked: isMarked });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      const sec = cell.closest('section.route');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+      if (isMarked) {
+        const why = cell.querySelector('input[data-action="why"]');
+        if (why) setTimeout(() => why.focus(), 0);
+      }
+    });
+  });
+
+  // Why / note inputs (debounced save)
+  let saveTimer = null;
+  function bindInput(sel, field) {
+    document.querySelectorAll(sel).forEach(inp => {
+      const handler = () => {
+        const cell = inp.closest('.cell');
+        if (!cell.classList.contains('marked')) return;
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(() => {
+          writeMark(cell.dataset.cellId, { [field]: inp.value });
+        }, 250);
+      };
+      inp.addEventListener('input', handler);
+      inp.addEventListener('blur', () => {
+        const cell = inp.closest('.cell');
+        if (cell.classList.contains('marked')) writeMark(cell.dataset.cellId, { [field]: inp.value });
+      });
+    });
+  }
+  bindInput('input[data-action="why"]', 'why');
+  bindInput('textarea[data-action="note"]', 'note');
+
+  // Category chips
+  document.querySelectorAll('.cat-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const cell = chip.closest('.cell');
+      if (!cell.classList.contains('marked')) {
+        // Mark the cell first so the category sticks
+        writeMark(cell.dataset.cellId, { marked: true });
+      }
+      const cat = chip.dataset.cat;
+      const isActive = chip.classList.contains('active');
+      writeMark(cell.dataset.cellId, { category: isActive ? null : cat });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+  });
+
+  // Re-capture command (copy to clipboard, flash purple)
+  document.querySelectorAll('button[data-action="recapture"]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const cell = btn.closest('.cell');
+      const cmd = buildRecaptureCommand(cell);
+      if (!cmd) return;
+      try {
+        await navigator.clipboard.writeText(cmd);
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Copy re-capture command'; }, 1500);
+      } catch (e) {
+        prompt('Copy this command:', cmd);
+      }
+      cell.classList.remove('pending-recapture');
+      void cell.offsetWidth; // force reflow so the animation restarts
+      cell.classList.add('pending-recapture');
+    });
+  });
+
+  // Toggles
+  document.getElementById('hide-empty').addEventListener('change', e => document.body.classList.toggle('hide-empty', e.target.checked));
+  document.getElementById('compact').addEventListener('change', e => document.body.classList.toggle('compact', e.target.checked));
+  document.getElementById('fit-cell').addEventListener('change', e => document.body.classList.toggle('fit-cell', e.target.checked));
+  document.getElementById('only-marked').addEventListener('change', e => document.body.classList.toggle('only-marked', e.target.checked));
+  document.getElementById('show-suppressed').addEventListener('change', e => document.body.classList.toggle('show-suppressed', e.target.checked));
+  document.getElementById('hide-desktop').addEventListener('change', e => document.body.classList.toggle('hide-desktop', e.target.checked));
+  document.getElementById('hide-mobile').addEventListener('change', e => document.body.classList.toggle('hide-mobile', e.target.checked));
+
+  // True-scale rendering (1x for selector captures, 0.5x for retina full-page).
+  const RETINA_THRESHOLD = 1500;
+  function applyTrueScale(img) {
+    if (!img.naturalWidth) return;
+    const cssWidth = img.naturalWidth > RETINA_THRESHOLD
+      ? Math.round(img.naturalWidth / 2)
+      : img.naturalWidth;
+    img.style.maxWidth = 'min(100%, ' + cssWidth + 'px)';
+  }
+  document.querySelectorAll('.cell img').forEach(img => {
+    if (img.complete && img.naturalWidth > 0) applyTrueScale(img);
+    else img.addEventListener('load', () => applyTrueScale(img), { once: true });
+  });
+
+  // State chips
+  document.querySelectorAll('.state-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const state = chip.dataset.state;
+      chip.classList.toggle('active');
+      document.body.classList.toggle('hide-state-' + state, !chip.classList.contains('active'));
+    });
+  });
+  STATES.forEach(s => {
+    const chip = document.querySelector('.state-chip[data-state="' + s + '"]');
+    if (chip && !chip.classList.contains('active')) document.body.classList.add('hide-state-' + s);
+  });
+
+  // Manual top-up: fill any DS cells that don't have a mark yet
+  document.getElementById('prefill-ds-btn').addEventListener('click', () => {
+    const added = prefillDsCellsAsNeedsDesign();
+    if (added > 0) {
+      document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+      updateRowSectionFlags();
+      updateCount();
+      alert('Filled ' + added + ' missing DS cells as needs-design.');
+    } else {
+      alert('All DS cells in this route already have marks.');
+    }
+  });
+
+  // Clear-route. Also resets the prefilled flag so a reload re-triggers auto-prefill.
+  document.getElementById('clear-route-btn').addEventListener('click', () => {
+    const ids = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).map(([id]) => id);
+    if (!ids.length) { alert('No marks for this route.'); return; }
+    if (!confirm('Clear ' + ids.length + ' marks for route ' + ROUTE + '?\n\nReloading the page will re-prefill all DS cells as needs-design.')) return;
+    ids.forEach(id => delete marks[id]);
+    saveMarks(marks);
+    const flags = loadPrefilledFlags();
+    delete flags[ROUTE];
+    savePrefilledFlags(flags);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+  });
+
+  function buildMarkdown() {
+    const items = [];
+    Object.entries(marks).forEach(([id, m]) => {
+      if (!m || !m.marked) return;
+      if (!id.startsWith(ROUTE + '__')) return;
+      const parts = id.split('__');
+      const themeKey = parts[parts.length - 1];
+      const state = parts[parts.length - 2];
+      const viewport = parts[parts.length - 3];
+      const route = parts[0];
+      const component = parts.slice(1, parts.length - 3).join('__');
+      items.push({ component, viewport, state, theme: themeKey,
+                   note: m.note || '', why: m.why || '', category: m.category || '' });
+    });
+    items.sort((a, b) => {
+      const ak = componentSortKey(a.component);
+      const bk = componentSortKey(b.component);
+      if (ak[0] !== bk[0]) return ak[0] - bk[0];
+      if (ak[1] !== bk[1]) return ak[1] < bk[1] ? -1 : 1;
+      const sd = STATES.indexOf(a.state) - STATES.indexOf(b.state);
+      if (sd !== 0) return sd;
+      const td = THEME_ORDER.indexOf(a.theme) - THEME_ORDER.indexOf(b.theme);
+      if (td !== 0) return td;
+      return a.viewport === b.viewport ? 0 : (a.viewport === 'desktop' ? -1 : 1);
+    });
+    const date = new Date().toISOString().split('T')[0];
+    const lines = ['# Audit marks -- ' + ROUTE + ' -- ' + items.length + ' items -- ' + date, ''];
+    items.forEach(it => {
+      const catTag = it.category ? ' [' + it.category + ']' : '';
+      const whyTxt = it.why ? ': ' + it.why : '';
+      const noteTxt = it.note ? '  -- ' + it.note : '';
+      lines.push('- [ ] **' + it.theme + ' ' + it.component + '** [' + it.viewport + '/' + it.state + ']' + catTag + whyTxt + noteTxt);
+    });
+    return lines.join('\n');
+  }
+
+  function openOverlay(id) { document.getElementById(id).classList.add('open'); }
+  function closeOverlay(id) { document.getElementById(id).classList.remove('open'); }
+  document.querySelectorAll('.overlay-close').forEach(b => b.addEventListener('click', () => closeOverlay(b.dataset.overlay)));
+  document.querySelectorAll('.overlay').forEach(o => {
+    o.addEventListener('click', e => { if (e.target === o) o.classList.remove('open'); });
+  });
+
+  document.getElementById('export-md-btn').addEventListener('click', async () => {
+    const md = buildMarkdown();
+    const ta = document.getElementById('md-text');
+    ta.value = md;
+    openOverlay('md-overlay');
+    try { await navigator.clipboard.writeText(md); document.getElementById('md-copy').textContent = 'Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+  document.getElementById('md-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('md-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('md-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('export-json-btn').addEventListener('click', () => {
+    const ta = document.getElementById('json-export-text');
+    ta.value = JSON.stringify(marks, null, 2);
+    openOverlay('json-export-overlay');
+  });
+  document.getElementById('json-export-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('json-export-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('json-export-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('json-export-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('import-json-btn').addEventListener('click', () => {
+    document.getElementById('json-import-text').value = '';
+    document.getElementById('json-import-err').textContent = '';
+    openOverlay('json-import-overlay');
+  });
+  document.getElementById('json-import-apply').addEventListener('click', () => {
+    const ta = document.getElementById('json-import-text');
+    const err = document.getElementById('json-import-err');
+    err.textContent = '';
+    let parsed;
+    try { parsed = JSON.parse(ta.value); }
+    catch (e) { err.textContent = 'Invalid JSON: ' + e.message; return; }
+    if (!parsed || typeof parsed !== 'object') { err.textContent = 'Expected an object.'; return; }
+    // First migrate v1 IDs (4 segments) -> v2 IDs (5 segments)
+    const { marks: idMigrated, migrated } = migrateMarksV1ToV2(parsed);
+    // Then upgrade each value v2 -> v3 (preserves marked + note, fills new fields)
+    Object.entries(idMigrated).forEach(([id, m]) => {
+      marks[id] = upgradeV2ValueToV3(m);
+    });
+    saveMarks(marks);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+    closeOverlay('json-import-overlay');
+    alert('Imported ' + Object.keys(idMigrated).length + ' marks (' + migrated + ' legacy IDs migrated to __seeded; values upgraded to v3).');
+  });
+</script>
+</body>
+</html>

--- a/scripts/audit/review/worlds.html
+++ b/scripts/audit/review/worlds.html
@@ -1,0 +1,2065 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Cross-Theme Audit (#1129) — worlds</title>
+<style>
+
+  :root { --col-gap: 8px; --row-gap: 16px; }
+  html, body { margin: 0; padding: 0; font-family: -apple-system, system-ui, sans-serif; background: #fafafa; color: #222; }
+  .sticky-shell { position: sticky; top: 0; z-index: 100; border-bottom: 1px solid #444; }
+  header.top {
+    background: #1a1a1a; color: #fff; padding: 12px 16px;
+    display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+  }
+  header.top h1 { font-size: 14px; margin: 0; font-weight: 600; }
+  header.top .legend { display: flex; gap: 12px; font-size: 12px; }
+  header.top .legend .col { padding: 2px 8px; border-radius: 3px; }
+  header.top .legend .develop { background: #6b7280; }
+  header.top .legend .ds3 { background: #4338ca; }
+  header.top .legend .ds1 { background: #92400e; }
+  header.top .legend .ds2 { background: #166534; }
+  header.top a.back { color: #9cf; font-size: 12px; text-decoration: none; padding: 2px 6px; border-radius: 2px; }
+  header.top a.back:hover { background: #444; color: #fff; }
+  header.top .nav-routes { display: flex; gap: 4px; align-items: center; font-size: 12px; }
+  header.top .nav-routes a { color: #9cf; text-decoration: none; padding: 2px 8px; border-radius: 2px; background: #2a2a2a; }
+  header.top .nav-routes a:hover { background: #444; color: #fff; }
+  header.top .nav-routes .current { color: #fff; font-weight: 600; padding: 2px 8px; }
+  main { padding: 16px; max-width: 100%; }
+  section.route {
+    margin-bottom: 32px; background: #fff; border-radius: 6px;
+    padding: 12px 16px 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  section.route h2 {
+    font-size: 18px; margin: 0 0 12px; padding-bottom: 6px;
+    border-bottom: 1px solid #e5e5e5;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+  .component-row {
+    display: grid; grid-template-columns: 180px repeat(4, 1fr);
+    gap: var(--col-gap); margin-bottom: var(--row-gap);
+    align-items: start;
+  }
+  .component-row .label {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px; color: #555; padding-top: 28px; line-height: 1.3;
+    word-break: break-word;
+  }
+  .cell {
+    border: 1px solid #e5e5e5; border-radius: 4px; overflow: hidden;
+    background: #f3f4f6; position: relative; min-height: 100px;
+    display: flex; flex-direction: column;
+  }
+  .cell .header {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.04em; padding: 4px 8px; color: #fff;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .cell.develop .header { background: #6b7280; }
+  .cell.ds3 .header { background: #4338ca; }
+  .cell.ds1 .header { background: #92400e; }
+  .cell.ds2 .header { background: #166534; }
+  .cell img {
+    display: block; width: auto; max-width: 100%; height: auto;
+    cursor: zoom-in; background: #fff; align-self: flex-start;
+  }
+  body.fit-cell .cell img { width: 100%; max-width: 100%; }
+  .cell.empty {
+    display: flex; align-items: center; justify-content: center;
+    color: #999; font-size: 12px; padding: 24px; background: #f9f9f9;
+  }
+  .cell.empty::after { content: "(not captured)"; }
+
+  /* Lightbox */
+  #lightbox {
+    display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.92);
+    z-index: 1000; align-items: center; justify-content: center; cursor: zoom-out;
+  }
+  #lightbox.open { display: flex; }
+  #lightbox img { max-width: 96vw; max-height: 96vh; box-shadow: 0 4px 24px rgba(0,0,0,0.5); }
+
+  .controls { display: flex; gap: 12px; align-items: center; font-size: 12px; flex-wrap: wrap; }
+  .controls label { display: flex; align-items: center; gap: 4px; cursor: pointer; }
+  .controls input[type=checkbox] { margin: 0; }
+
+  .state-chips { display: inline-flex; gap: 4px; align-items: center; }
+  .state-chip {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .state-chip.active { background: #2563eb; border-color: #1d4ed8; }
+  .state-chip:hover { background: #4b5563; }
+  .state-chip.active:hover { background: #1d4ed8; }
+
+  body.hide-empty .component-row.all-empty,
+  body.hide-empty .cell.empty { display: none; }
+  body.compact .cell img { max-height: 360px; object-fit: cover; object-position: top; }
+
+  .cell .mark-btn {
+    margin-left: auto; background: rgba(255,255,255,0.18);
+    color: #fff; border: 1px solid rgba(255,255,255,0.35);
+    border-radius: 3px; font-size: 10px; font-weight: 600;
+    padding: 2px 6px; cursor: pointer;
+    text-transform: none; letter-spacing: 0; line-height: 1.2;
+  }
+  .cell .mark-btn:hover { background: rgba(255,255,255,0.28); }
+  .cell.marked { border: 3px solid #dc2626; }
+  .cell.marked .mark-btn { background: #dc2626; border-color: #b91c1c; color: #fff; }
+  .cell.marked .mark-btn::before { content: "x "; }
+  .cell.pending-recapture { animation: cellPulse 2s ease-out; }
+  @keyframes cellPulse {
+    0%   { box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.9); border-color: #7c3aed; }
+    100% { box-shadow: 0 0 0 8px rgba(124, 58, 237, 0); }
+  }
+  .cell .toolbar {
+    display: none;
+    padding: 6px 8px; background: #fef2f2; border-top: 1px solid #fecaca;
+    font-size: 11px;
+  }
+  .cell.marked .toolbar { display: block; }
+  .cell .toolbar input[type=text],
+  .cell .toolbar textarea {
+    width: 100%; box-sizing: border-box;
+    border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 4px 6px; font-size: 12px; font-family: inherit;
+    background: #fff;
+  }
+  .cell .toolbar input[type=text]:focus,
+  .cell .toolbar textarea:focus { outline: 2px solid #dc2626; outline-offset: -1px; }
+  .cell .toolbar .field { margin-bottom: 6px; }
+  .cell .toolbar .field-label {
+    display: block; font-size: 10px; font-weight: 600;
+    color: #7f1d1d; text-transform: uppercase; letter-spacing: 0.04em;
+    margin-bottom: 2px;
+  }
+  .cell .toolbar .cat-chips { display: flex; gap: 4px; flex-wrap: wrap; }
+  .cell .toolbar .cat-chip {
+    background: #fff; border: 1px solid #fca5a5; border-radius: 3px;
+    padding: 2px 8px; font-size: 11px; cursor: pointer; font-family: inherit;
+    color: #7f1d1d;
+  }
+  .cell .toolbar .cat-chip.active { background: #7f1d1d; color: #fff; border-color: #7f1d1d; }
+  .cell .toolbar .cat-chip[data-cat="needs-design"].active { background: #6d28d9; border-color: #6d28d9; }
+  .cell .toolbar .cat-chip[data-cat="bug"].active        { background: #b91c1c; border-color: #b91c1c; }
+  .cell .toolbar .cat-chip[data-cat="tooling"].active    { background: #b45309; border-color: #b45309; }
+  .cell .toolbar .cat-chip[data-cat="intentional"].active{ background: #15803d; border-color: #15803d; }
+  .cell .toolbar .cat-chip[data-cat="unclear"].active    { background: #6b7280; border-color: #6b7280; }
+  .cell .toolbar .recapture-btn {
+    background: #1d4ed8; color: #fff; border: 0; border-radius: 3px;
+    padding: 4px 10px; font-size: 11px; cursor: pointer;
+    font-family: inherit; font-weight: 600;
+  }
+  .cell .toolbar .recapture-btn:hover { background: #1e40af; }
+  .cell .toolbar textarea { min-height: 32px; resize: vertical; font-size: 11px; }
+  .cell.cat-needs-design { border-color: #6d28d9; }
+  .cell.cat-bug         { border-color: #b91c1c; }
+  .cell.cat-tooling     { border-color: #b45309; }
+  .cell.cat-intentional { border-color: #15803d; }
+  .cell.cat-unclear     { border-color: #6b7280; }
+
+  .marks-cluster {
+    display: flex; align-items: center; gap: 8px;
+    border-left: 1px solid #444; padding-left: 12px; margin-left: 4px;
+    font-size: 12px;
+  }
+  .marks-cluster .count {
+    background: #dc2626; color: #fff; border-radius: 10px;
+    padding: 2px 8px; font-weight: 600; min-width: 18px; text-align: center;
+  }
+  .marks-cluster button {
+    background: #374151; color: #fff; border: 1px solid #4b5563;
+    border-radius: 3px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    font-family: inherit;
+  }
+  .marks-cluster button:hover { background: #4b5563; }
+  .marks-cluster button.danger { background: #7f1d1d; border-color: #991b1b; }
+  .marks-cluster button.danger:hover { background: #991b1b; }
+
+  body.only-marked .component-row:not(.has-marked) { display: none; }
+  body.only-marked section.route:not(.has-marked) { display: none; }
+
+  .component-row.suppressed { display: none; }
+  body.show-suppressed .component-row.suppressed { display: grid; }
+  .component-row.suppressed .label::after { content: " (hidden)"; color: #b91c1c; font-style: italic; }
+
+  .component-row .label[data-mapped] { color: #1d4ed8; }
+  .component-row .label[data-mapped]::after { content: " *"; }
+  .mapped-tooltip {
+    display: inline-block; margin-left: 4px;
+    font-size: 10px; color: #6b7280; cursor: help; vertical-align: super;
+  }
+
+  .vp-badge, .state-badge {
+    display: inline-block; font-size: 9px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.05em;
+    padding: 1px 6px; border-radius: 8px; margin-top: 2px;
+  }
+  .vp-badge.desktop { background: #dbeafe; color: #1e3a8a; border: 1px solid #93c5fd; margin-right: 4px; }
+  .vp-badge.mobile  { background: #fef3c7; color: #78350f; border: 1px solid #fcd34d; margin-right: 4px; }
+  .state-badge.empty       { background: #f3f4f6; color: #374151; border: 1px solid #d1d5db; }
+  .state-badge.seeded      { background: #dcfce7; color: #14532d; border: 1px solid #86efac; }
+  .state-badge.mid-session { background: #ede9fe; color: #4c1d95; border: 1px solid #c4b5fd; }
+
+  .component-row.vp-mobile { background: #fffbeb; padding: 4px; border-radius: 4px; }
+  body.hide-desktop .component-row.vp-desktop { display: none; }
+  body.hide-mobile .component-row.vp-mobile { display: none; }
+
+  body.hide-state-empty       .component-row.state-empty       { display: none; }
+  body.hide-state-seeded      .component-row.state-seeded      { display: none; }
+  body.hide-state-mid-session .component-row.state-mid-session { display: none; }
+
+  .overlay {
+    display: none; position: fixed; inset: 0; z-index: 1100;
+    background: rgba(0,0,0,0.6); align-items: center; justify-content: center;
+  }
+  .overlay.open { display: flex; }
+  .overlay .panel {
+    background: #fff; border-radius: 6px; width: min(720px, 92vw);
+    max-height: 80vh; padding: 16px; display: flex; flex-direction: column; gap: 8px;
+  }
+  .overlay h3 { margin: 0; font-size: 14px; }
+  .overlay textarea {
+    flex: 1; min-height: 320px; font-family: ui-monospace, monospace; font-size: 12px;
+    border: 1px solid #ddd; border-radius: 4px; padding: 8px; resize: vertical;
+  }
+  .overlay .actions { display: flex; gap: 8px; justify-content: flex-end; }
+  .overlay button {
+    background: #1a1a1a; color: #fff; border: 0; border-radius: 3px;
+    padding: 6px 12px; font-size: 12px; cursor: pointer;
+  }
+  .overlay .hint { font-size: 11px; color: #555; }
+  .overlay .err  { font-size: 12px; color: #b91c1c; min-height: 16px; }
+
+  /* Index-page table */
+  table.routes-index {
+    width: 100%; border-collapse: collapse; background: #fff;
+    border-radius: 6px; overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  }
+  table.routes-index th, table.routes-index td {
+    padding: 8px 12px; text-align: left; font-size: 13px;
+    border-bottom: 1px solid #eee;
+  }
+  table.routes-index th { background: #f3f4f6; font-weight: 600; }
+  table.routes-index td a {
+    color: #1d4ed8; text-decoration: none; font-family: ui-monospace, monospace;
+  }
+  table.routes-index td a:hover { text-decoration: underline; }
+  table.routes-index td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  table.routes-index .marked-count.has-marks { color: #b91c1c; font-weight: 600; }
+  table.routes-index .unresolved-count.has-unresolved { color: #b45309; font-weight: 600; }
+  table.routes-index .breakdown {
+    font-size: 11px; color: #555; margin-left: 6px; font-variant-numeric: tabular-nums;
+  }
+
+
+</style>
+</head>
+<body>
+<div class="sticky-shell">
+<header class="top">
+  <a class="back" href="index.html">&larr; Index</a>
+  <h1>worlds</h1>
+  <div class="legend">
+    <span class="col develop">develop</span>
+    <span class="col ds3">DS3</span>
+    <span class="col ds1">DS1</span>
+    <span class="col ds2">DS2</span>
+  </div>
+  <div class="controls">
+    <span class="state-chips" role="group" aria-label="State filter">
+      <span style="font-size: 11px; color: #aaa;">State:</span>
+      <button type="button" class="state-chip" data-state="empty">empty</button>
+      <button type="button" class="state-chip active" data-state="seeded">seeded</button>
+    </span>
+    <label><input type="checkbox" id="hide-empty"> Hide missing</label>
+    <label><input type="checkbox" id="compact"> Compact</label>
+    <label title="Stretch images to cell width"><input type="checkbox" id="fit-cell"> Fit to cell</label>
+    <label><input type="checkbox" id="only-marked"> Only marked</label>
+    <label><input type="checkbox" id="show-suppressed"> Show hidden rows</label>
+    <label><input type="checkbox" id="hide-desktop"> Hide desktop</label>
+    <label><input type="checkbox" id="hide-mobile"> Hide mobile</label>
+  </div>
+  <div class="marks-cluster">
+    <span>Marked (route):</span>
+    <span class="count" id="mark-count">0</span>
+    <button id="prefill-ds-btn" type="button" title="Mark every DS cell that has no mark yet as needs-design (gap-fill, never overwrites your existing marks)">Fill DS gaps</button>
+    <button id="export-md-btn" type="button">Export markdown</button>
+    <button id="export-json-btn" type="button">Export JSON</button>
+    <button id="import-json-btn" type="button">Import JSON</button>
+    <button id="clear-route-btn" type="button" class="danger">Clear (route)</button>
+  </div>
+</header>
+<nav class="toc" style="background:#2a2a2a;color:#ccc;padding:6px 16px;font-size:12px;display:flex;gap:8px;align-items:center;border-top:1px solid #444;">
+  <span class="nav-routes">
+    <a href="about.html">&larr; about</a>
+    <span class="current">worlds</span>
+    <a href="worlds-detail.html">worlds-detail &rarr;</a>
+  </span>
+</nav>
+</div>
+<main>
+<section class="route" id="route-worlds">
+  <h2>worlds</h2>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds__global-nav__desktop__empty__develop" data-route="worlds" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds__nav.png" alt="develop worlds/global-nav/desktop/empty" data-caption="develop -- worlds/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds__global-nav__desktop__empty__DS3" data-route="worlds" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/worlds__nav.png" alt="DS3 worlds/global-nav/desktop/empty" data-caption="DS3 -- worlds/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds__global-nav__desktop__empty__DS1" data-route="worlds" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/worlds__nav.png" alt="DS1 worlds/global-nav/desktop/empty" data-caption="DS1 -- worlds/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds__global-nav__desktop__empty__DS2" data-route="worlds" data-component="global-nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/worlds__nav.png" alt="DS2 worlds/global-nav/desktop/empty" data-caption="DS2 -- worlds/global-nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds__page__desktop__empty__develop" data-route="worlds" data-component="page" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds__page.png" alt="develop worlds/page/desktop/empty" data-caption="develop -- worlds/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds__page__desktop__empty__DS3" data-route="worlds" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/worlds__page.png" alt="DS3 worlds/page/desktop/empty" data-caption="DS3 -- worlds/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds__page__desktop__empty__DS1" data-route="worlds" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/worlds__page.png" alt="DS1 worlds/page/desktop/empty" data-caption="DS1 -- worlds/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds__page__desktop__empty__DS2" data-route="worlds" data-component="page" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/worlds__page.png" alt="DS2 worlds/page/desktop/empty" data-caption="DS2 -- worlds/page (desktop/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-empty" data-viewport="mobile" data-state="empty">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds__page__mobile__empty__develop" data-route="worlds" data-component="page" data-viewport="mobile" data-state="empty" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/empty/worlds__page.png" alt="develop worlds/page/mobile/empty" data-caption="develop -- worlds/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds__page__mobile__empty__DS3" data-route="worlds" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/empty/worlds__page.png" alt="DS3 worlds/page/mobile/empty" data-caption="DS3 -- worlds/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds__page__mobile__empty__DS1" data-route="worlds" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/empty/worlds__page.png" alt="DS1 worlds/page/mobile/empty" data-caption="DS1 -- worlds/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds__page__mobile__empty__DS2" data-route="worlds" data-component="page" data-viewport="mobile" data-state="empty" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/empty/worlds__page.png" alt="DS2 worlds/page/mobile/empty" data-caption="DS2 -- worlds/page (mobile/empty; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds__header__desktop__empty__develop" data-route="worlds" data-component="header" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds__header.png" alt="develop worlds/header/desktop/empty" data-caption="develop -- worlds/header (desktop/empty; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+    <div class="cell empty"></div>
+  </div>
+  <div class="component-row vp-desktop state-empty suppressed" data-viewport="desktop" data-state="empty">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds__nav__desktop__empty__develop" data-route="worlds" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds__nav.png" alt="develop worlds/nav/desktop/empty" data-caption="develop -- worlds/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds__nav__desktop__empty__DS3" data-route="worlds" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/worlds__nav.png" alt="DS3 worlds/nav/desktop/empty" data-caption="DS3 -- worlds/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds__nav__desktop__empty__DS1" data-route="worlds" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/worlds__nav.png" alt="DS1 worlds/nav/desktop/empty" data-caption="DS1 -- worlds/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds__nav__desktop__empty__DS2" data-route="worlds" data-component="nav" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/worlds__nav.png" alt="DS2 worlds/nav/desktop/empty" data-caption="DS2 -- worlds/nav (desktop/empty; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-empty" data-viewport="desktop" data-state="empty">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge empty">empty</span></div>
+    <div class="cell develop" data-cell-id="worlds__main__desktop__empty__develop" data-route="worlds" data-component="main" data-viewport="desktop" data-state="empty" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/empty/worlds__main.png" alt="develop worlds/main/desktop/empty" data-caption="develop -- worlds/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds__main__desktop__empty__DS3" data-route="worlds" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/empty/worlds__main.png" alt="DS3 worlds/main/desktop/empty" data-caption="DS3 -- worlds/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds__main__desktop__empty__DS1" data-route="worlds" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/empty/worlds__main.png" alt="DS1 worlds/main/desktop/empty" data-caption="DS1 -- worlds/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds__main__desktop__empty__DS2" data-route="worlds" data-component="main" data-viewport="desktop" data-state="empty" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/empty/worlds__main.png" alt="DS2 worlds/main/desktop/empty" data-caption="DS2 -- worlds/main (desktop/empty; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label" data-mapped="1">global-nav<span class="mapped-tooltip" title="Both branches use <nav>; develop is a horizontal top bar, integration is a vertical sidebar.">i</span><br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds__global-nav__desktop__seeded__develop" data-route="worlds" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds__nav.png" alt="develop worlds/global-nav/desktop/seeded" data-caption="develop -- worlds/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds__global-nav__desktop__seeded__DS3" data-route="worlds" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds__nav.png" alt="DS3 worlds/global-nav/desktop/seeded" data-caption="DS3 -- worlds/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds__global-nav__desktop__seeded__DS1" data-route="worlds" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds__nav.png" alt="DS1 worlds/global-nav/desktop/seeded" data-caption="DS1 -- worlds/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds__global-nav__desktop__seeded__DS2" data-route="worlds" data-component="global-nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds__nav.png" alt="DS2 worlds/global-nav/desktop/seeded" data-caption="DS2 -- worlds/global-nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds__page__desktop__seeded__develop" data-route="worlds" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds__page.png" alt="develop worlds/page/desktop/seeded" data-caption="develop -- worlds/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds__page__desktop__seeded__DS3" data-route="worlds" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds__page.png" alt="DS3 worlds/page/desktop/seeded" data-caption="DS3 -- worlds/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds__page__desktop__seeded__DS1" data-route="worlds" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds__page.png" alt="DS1 worlds/page/desktop/seeded" data-caption="DS1 -- worlds/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds__page__desktop__seeded__DS2" data-route="worlds" data-component="page" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds__page.png" alt="DS2 worlds/page/desktop/seeded" data-caption="DS2 -- worlds/page (desktop/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-mobile state-seeded" data-viewport="mobile" data-state="seeded">
+    <div class="label">page<br><span class="vp-badge mobile">mobile</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds__page__mobile__seeded__develop" data-route="worlds" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="develop" data-img-scale="2">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/mobile/seeded/worlds__page.png" alt="develop worlds/page/mobile/seeded" data-caption="develop -- worlds/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds__page__mobile__seeded__DS3" data-route="worlds" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS3" data-img-scale="2">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/mobile/seeded/worlds__page.png" alt="DS3 worlds/page/mobile/seeded" data-caption="DS3 -- worlds/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds__page__mobile__seeded__DS1" data-route="worlds" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS1" data-img-scale="2">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/mobile/seeded/worlds__page.png" alt="DS1 worlds/page/mobile/seeded" data-caption="DS1 -- worlds/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds__page__mobile__seeded__DS2" data-route="worlds" data-component="page" data-viewport="mobile" data-state="seeded" data-theme="DS2" data-img-scale="2">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/mobile/seeded/worlds__page.png" alt="DS2 worlds/page/mobile/seeded" data-caption="DS2 -- worlds/page (mobile/seeded; src: page)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">header<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds__header__desktop__seeded__develop" data-route="worlds" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds__header.png" alt="develop worlds/header/desktop/seeded" data-caption="develop -- worlds/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds__header__desktop__seeded__DS3" data-route="worlds" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds__header.png" alt="DS3 worlds/header/desktop/seeded" data-caption="DS3 -- worlds/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds__header__desktop__seeded__DS1" data-route="worlds" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds__header.png" alt="DS1 worlds/header/desktop/seeded" data-caption="DS1 -- worlds/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds__header__desktop__seeded__DS2" data-route="worlds" data-component="header" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds__header.png" alt="DS2 worlds/header/desktop/seeded" data-caption="DS2 -- worlds/header (desktop/seeded; src: header)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded suppressed" data-viewport="desktop" data-state="seeded">
+    <div class="label">nav<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds__nav__desktop__seeded__develop" data-route="worlds" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds__nav.png" alt="develop worlds/nav/desktop/seeded" data-caption="develop -- worlds/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds__nav__desktop__seeded__DS3" data-route="worlds" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds__nav.png" alt="DS3 worlds/nav/desktop/seeded" data-caption="DS3 -- worlds/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds__nav__desktop__seeded__DS1" data-route="worlds" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds__nav.png" alt="DS1 worlds/nav/desktop/seeded" data-caption="DS1 -- worlds/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds__nav__desktop__seeded__DS2" data-route="worlds" data-component="nav" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds__nav.png" alt="DS2 worlds/nav/desktop/seeded" data-caption="DS2 -- worlds/nav (desktop/seeded; src: nav)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="component-row vp-desktop state-seeded" data-viewport="desktop" data-state="seeded">
+    <div class="label">main<br><span class="vp-badge desktop">desktop</span><span class="state-badge seeded">seeded</span></div>
+    <div class="cell develop" data-cell-id="worlds__main__desktop__seeded__develop" data-route="worlds" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="develop" data-img-scale="1">
+      <div class="header"><span>develop</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-develop-default/desktop/seeded/worlds__main.png" alt="develop worlds/main/desktop/seeded" data-caption="develop -- worlds/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds3" data-cell-id="worlds__main__desktop__seeded__DS3" data-route="worlds" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS3" data-img-scale="1">
+      <div class="header"><span>DS3</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds3-light/desktop/seeded/worlds__main.png" alt="DS3 worlds/main/desktop/seeded" data-caption="DS3 -- worlds/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds1" data-cell-id="worlds__main__desktop__seeded__DS1" data-route="worlds" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS1" data-img-scale="1">
+      <div class="header"><span>DS1</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds1-light/desktop/seeded/worlds__main.png" alt="DS1 worlds/main/desktop/seeded" data-caption="DS1 -- worlds/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+    <div class="cell ds2" data-cell-id="worlds__main__desktop__seeded__DS2" data-route="worlds" data-component="main" data-viewport="desktop" data-state="seeded" data-theme="DS2" data-img-scale="1">
+      <div class="header"><span>DS2</span><button type="button" class="mark-btn" data-action="toggle-mark">Mark</button></div>
+      <img src="../captures/comp-integration-ds2-light/desktop/seeded/worlds__main.png" alt="DS2 worlds/main/desktop/seeded" data-caption="DS2 -- worlds/main (desktop/seeded; src: main)" loading="lazy">
+      <div class="toolbar">
+        <div class="field">
+          <span class="field-label">Category</span>
+          <div class="cat-chips" data-action="cat-chips">
+            <button type="button" class="cat-chip" data-cat="needs-design">needs-design</button>
+            <button type="button" class="cat-chip" data-cat="bug">bug</button>
+            <button type="button" class="cat-chip" data-cat="tooling">tooling</button>
+            <button type="button" class="cat-chip" data-cat="intentional">intentional</button>
+            <button type="button" class="cat-chip" data-cat="unclear">unclear</button>
+          </div>
+        </div>
+        <div class="field">
+          <span class="field-label">Why (one-line summary)</span>
+          <input type="text" data-action="why" placeholder="e.g. header overflows mobile viewport">
+        </div>
+        <div class="field">
+          <span class="field-label">Note (freeform scratchpad)</span>
+          <textarea data-action="note" rows="2" placeholder="extra detail (optional)..."></textarea>
+        </div>
+        <div class="field" style="margin-bottom:0; display:flex; justify-content:flex-end;">
+          <button type="button" class="recapture-btn" data-action="recapture">Copy re-capture command</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+</main>
+
+<div id="lightbox" class="overlay">
+  <img id="lightbox-img" src="" alt="">
+  <div id="lightbox-caption" style="position: fixed; top: 12px; left: 50%; transform: translateX(-50%); color: #fff; font-family: ui-monospace, monospace; font-size: 13px; background: rgba(0,0,0,0.6); padding: 6px 12px; border-radius: 4px;"></div>
+</div>
+
+<div id="md-overlay" class="overlay">
+  <div class="panel">
+    <h3>Audit marks (markdown) -- this route only</h3>
+    <textarea id="md-text" readonly></textarea>
+    <div class="actions">
+      <button id="md-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="md-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-export-overlay" class="overlay">
+  <div class="panel">
+    <h3>Marks (raw JSON) -- all routes</h3>
+    <textarea id="json-export-text" readonly></textarea>
+    <div class="actions">
+      <button id="json-export-copy" type="button">Copy</button>
+      <button class="overlay-close" data-overlay="json-export-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="json-import-overlay" class="overlay">
+  <div class="panel">
+    <h3>Import marks (paste raw JSON)</h3>
+    <p class="hint">Paste JSON exported from another instance. Legacy IDs without a state segment are migrated to <code>__seeded</code>; v2 values are upgraded to v3 (category=null, why="", updatedAt=now). Existing marks with the same ID are overwritten.</p>
+    <textarea id="json-import-text" placeholder='{"home__page__desktop__seeded__DS3":{"marked":true,"note":"...","category":"bug","why":"...","updatedAt":"..."}}'></textarea>
+    <div class="err" id="json-import-err"></div>
+    <div class="actions">
+      <button id="json-import-apply" type="button">Apply</button>
+      <button class="overlay-close" data-overlay="json-import-overlay" type="button">Close</button>
+    </div>
+  </div>
+</div>
+<script>
+
+  const STORAGE_KEY = 'narraitor-audit-marks-v3';
+  const STORAGE_KEY_V2 = 'narraitor-audit-marks-v2';
+  const STORAGE_KEY_V1 = 'narraitor-audit-marks-v1';
+  // Tracks which routes have had their DS cells auto-prefilled as needs-design.
+  // Once a route is in here, the auto-prefill on page load is skipped.
+  const PREFILLED_KEY = 'narraitor-audit-prefilled-v1';
+  const STATES = ['empty', 'seeded'];
+  const VALID_CATEGORIES = ['needs-design','bug','tooling','intentional','unclear'];
+  const ROUTE_ORDER = ["home", "about", "worlds", "worlds-detail", "worlds-edit", "worlds-create", "worlds-play", "worlds-play-journal", "characters", "characters-detail", "characters-edit", "characters-create", "play", "settings"];
+  const COMPONENT_ORDER = {"page":0,"header":1,"nav":2,"form":3,"main":4};
+  const THEME_ORDER = ["DS3","DS1","DS2","develop"];
+  const BRANCH_META = {"develop": {"theme": "default", "mode": "light", "branchArg": "develop-default"}, "DS3": {"theme": "ds3", "mode": "light", "branchArg": "integration-ds3-light"}, "DS1": {"theme": "ds1", "mode": "light", "branchArg": "integration-ds1-light"}, "DS2": {"theme": "ds2", "mode": "light", "branchArg": "integration-ds2-light"}};
+
+  function componentSortKey(c) {
+    if (c in COMPONENT_ORDER) return [COMPONENT_ORDER[c], 0];
+    if (c.startsWith("main-section-")) {
+      const n = parseInt(c.replace("main-section-",""), 10);
+      return [5, isNaN(n) ? 0 : n];
+    }
+    return [9, c];
+  }
+
+  // Pre-v3 ID migration: v1 (4 segments) -> v2 (5 segments) by inserting __seeded.
+  function migrateLegacyId(id) {
+    const parts = id.split('__');
+    if (parts.length < 4) return id;
+    const last = parts[parts.length - 1];
+    const second = parts[parts.length - 2];
+    const third = parts[parts.length - 3];
+    const isTheme = ['DS1','DS2','DS3','develop'].includes(last);
+    const isViewport = ['desktop','mobile'].includes(second);
+    const alreadyHasState = STATES.includes(third);
+    if (isTheme && isViewport && !alreadyHasState) {
+      const head = parts.slice(0, parts.length - 1).join('__');
+      return head + '__seeded__' + last;
+    }
+    return id;
+  }
+
+  function migrateMarksV1ToV2(input) {
+    const out = {};
+    let migrated = 0;
+    for (const [id, m] of Object.entries(input || {})) {
+      const newId = migrateLegacyId(id);
+      if (newId !== id) migrated++;
+      out[newId] = m;
+    }
+    return { marks: out, migrated };
+  }
+
+  // v2 -> v3: add category, why, updatedAt; preserve marked + note.
+  function upgradeV2ValueToV3(v) {
+    if (!v || typeof v !== 'object') return null;
+    return {
+      marked: !!v.marked,
+      note: typeof v.note === 'string' ? v.note : '',
+      category: v.category && VALID_CATEGORIES.includes(v.category) ? v.category : null,
+      why: typeof v.why === 'string' ? v.why : '',
+      updatedAt: v.updatedAt || new Date().toISOString(),
+    };
+  }
+
+  function migrateV2ObjectToV3(v2obj) {
+    const out = {};
+    for (const [id, m] of Object.entries(v2obj || {})) {
+      out[id] = upgradeV2ValueToV3(m);
+    }
+    return out;
+  }
+
+  function loadMarks() {
+    try {
+      const v3 = localStorage.getItem(STORAGE_KEY);
+      if (v3) return JSON.parse(v3);
+      // No v3 yet — try v2 (lazy migrate; leave v2 untouched for rollback).
+      const v2raw = localStorage.getItem(STORAGE_KEY_V2);
+      if (v2raw) {
+        const v3marks = migrateV2ObjectToV3(JSON.parse(v2raw));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + Object.keys(v3marks).length + ' v2 marks to v3 (v2 untouched).');
+        return v3marks;
+      }
+      // No v3 or v2 — try v1 and migrate v1 -> v2 -> v3 in one pass.
+      const v1raw = localStorage.getItem(STORAGE_KEY_V1);
+      if (v1raw) {
+        const { marks: v2marks, migrated } = migrateMarksV1ToV2(JSON.parse(v1raw));
+        const v3marks = migrateV2ObjectToV3(v2marks);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(v3marks));
+        console.info('[audit] migrated ' + migrated + ' v1 IDs through to v3.');
+        return v3marks;
+      }
+    } catch (e) { console.warn(e); }
+    return {};
+  }
+
+  function saveMarks(m) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(m)); } catch (e) {}
+  }
+
+
+  const ROUTE = "worlds";
+  let marks = loadMarks();
+
+  function applyMarkState(cell) {
+    const id = cell.dataset.cellId;
+    const m = marks[id];
+    const noteInput = cell.querySelector('textarea[data-action="note"]');
+    const whyInput = cell.querySelector('input[data-action="why"]');
+    const chips = cell.querySelectorAll('.cat-chip');
+    cell.classList.remove('cat-bug','cat-tooling','cat-intentional','cat-unclear');
+    chips.forEach(c => c.classList.remove('active'));
+    if (m && m.marked) {
+      cell.classList.add('marked');
+      if (noteInput) noteInput.value = m.note || '';
+      if (whyInput) whyInput.value = m.why || '';
+      if (m.category) {
+        cell.classList.add('cat-' + m.category);
+        const chip = cell.querySelector('.cat-chip[data-cat="' + m.category + '"]');
+        if (chip) chip.classList.add('active');
+      }
+    } else {
+      cell.classList.remove('marked');
+      if (noteInput) noteInput.value = '';
+      if (whyInput) whyInput.value = '';
+    }
+  }
+
+  function updateRowSectionFlags() {
+    document.querySelectorAll('.component-row').forEach(row => {
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+    document.querySelectorAll('section.route').forEach(sec => {
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+    });
+  }
+
+  function updateCount() {
+    const n = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).length;
+    document.getElementById('mark-count').textContent = n;
+  }
+
+  function writeMark(id, partial) {
+    const existing = marks[id] || { marked: false, note: '', category: null, why: '', updatedAt: null };
+    const next = Object.assign({}, existing, partial, { updatedAt: new Date().toISOString() });
+    if (!next.marked && !next.note && !next.why && !next.category) {
+      delete marks[id];
+    } else {
+      marks[id] = next;
+    }
+    saveMarks(marks);
+    updateCount();
+  }
+
+  function buildRecaptureCommand(cell) {
+    const route = cell.dataset.route;
+    const viewport = cell.dataset.viewport;
+    const state = cell.dataset.state;
+    const themeKey = cell.dataset.theme;
+    const meta = BRANCH_META[themeKey];
+    if (!meta) return null;
+    return 'npx tsx scripts/audit/playwright-crawl.ts'
+      + ' --branch ' + meta.branchArg
+      + ' --viewport ' + viewport
+      + ' --state ' + state
+      + ' --theme ' + meta.theme
+      + ' --mode ' + meta.mode
+      + ' --route ' + route;
+  }
+
+  function loadPrefilledFlags() {
+    try { return JSON.parse(localStorage.getItem(PREFILLED_KEY) || '{}'); }
+    catch (e) { return {}; }
+  }
+  function savePrefilledFlags(f) {
+    try { localStorage.setItem(PREFILLED_KEY, JSON.stringify(f)); } catch (e) {}
+  }
+
+  // Gap-fill: only adds entries for DS cells that have no existing mark.
+  // Returns the count of cells filled. Develop is excluded (it's the baseline).
+  function prefillDsCellsAsNeedsDesign() {
+    const dsCells = Array.from(document.querySelectorAll('.cell[data-cell-id]'))
+      .filter(c => ['DS1','DS2','DS3'].includes(c.dataset.theme));
+    let added = 0;
+    const ts = new Date().toISOString();
+    for (const cell of dsCells) {
+      const id = cell.dataset.cellId;
+      if (!marks[id]) {
+        marks[id] = { marked: true, note: '', category: 'needs-design', why: '', updatedAt: ts };
+        added++;
+      }
+    }
+    if (added > 0) saveMarks(marks);
+    return added;
+  }
+
+  // Auto-prefill on first visit per route.
+  const prefillFlags = loadPrefilledFlags();
+  if (!prefillFlags[ROUTE]) {
+    const added = prefillDsCellsAsNeedsDesign();
+    prefillFlags[ROUTE] = true;
+    savePrefilledFlags(prefillFlags);
+    if (added > 0) console.info('[audit] auto-prefilled ' + added + ' DS cells for ' + ROUTE + ' as needs-design.');
+  }
+
+  document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+  updateRowSectionFlags();
+  updateCount();
+
+  // Lightbox
+  const lb = document.getElementById('lightbox');
+  const lbImg = document.getElementById('lightbox-img');
+  const lbCap = document.getElementById('lightbox-caption');
+  document.querySelectorAll('.cell img').forEach(img => {
+    img.addEventListener('click', () => {
+      lbImg.src = img.src;
+      lbCap.textContent = img.dataset.caption || '';
+      lb.classList.add('open');
+    });
+  });
+  lb.addEventListener('click', () => lb.classList.remove('open'));
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') document.querySelectorAll('.overlay.open').forEach(o => o.classList.remove('open'));
+  });
+
+  // Mark toggle
+  document.querySelectorAll('button[data-action="toggle-mark"]').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      const cell = btn.closest('.cell');
+      const id = cell.dataset.cellId;
+      const isMarked = !cell.classList.contains('marked');
+      writeMark(id, { marked: isMarked });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      const sec = cell.closest('section.route');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+      sec.classList.toggle('has-marked', !!sec.querySelector('.cell.marked'));
+      if (isMarked) {
+        const why = cell.querySelector('input[data-action="why"]');
+        if (why) setTimeout(() => why.focus(), 0);
+      }
+    });
+  });
+
+  // Why / note inputs (debounced save)
+  let saveTimer = null;
+  function bindInput(sel, field) {
+    document.querySelectorAll(sel).forEach(inp => {
+      const handler = () => {
+        const cell = inp.closest('.cell');
+        if (!cell.classList.contains('marked')) return;
+        clearTimeout(saveTimer);
+        saveTimer = setTimeout(() => {
+          writeMark(cell.dataset.cellId, { [field]: inp.value });
+        }, 250);
+      };
+      inp.addEventListener('input', handler);
+      inp.addEventListener('blur', () => {
+        const cell = inp.closest('.cell');
+        if (cell.classList.contains('marked')) writeMark(cell.dataset.cellId, { [field]: inp.value });
+      });
+    });
+  }
+  bindInput('input[data-action="why"]', 'why');
+  bindInput('textarea[data-action="note"]', 'note');
+
+  // Category chips
+  document.querySelectorAll('.cat-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const cell = chip.closest('.cell');
+      if (!cell.classList.contains('marked')) {
+        // Mark the cell first so the category sticks
+        writeMark(cell.dataset.cellId, { marked: true });
+      }
+      const cat = chip.dataset.cat;
+      const isActive = chip.classList.contains('active');
+      writeMark(cell.dataset.cellId, { category: isActive ? null : cat });
+      applyMarkState(cell);
+      const row = cell.closest('.component-row');
+      row.classList.toggle('has-marked', !!row.querySelector('.cell.marked'));
+    });
+  });
+
+  // Re-capture command (copy to clipboard, flash purple)
+  document.querySelectorAll('button[data-action="recapture"]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const cell = btn.closest('.cell');
+      const cmd = buildRecaptureCommand(cell);
+      if (!cmd) return;
+      try {
+        await navigator.clipboard.writeText(cmd);
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Copy re-capture command'; }, 1500);
+      } catch (e) {
+        prompt('Copy this command:', cmd);
+      }
+      cell.classList.remove('pending-recapture');
+      void cell.offsetWidth; // force reflow so the animation restarts
+      cell.classList.add('pending-recapture');
+    });
+  });
+
+  // Toggles
+  document.getElementById('hide-empty').addEventListener('change', e => document.body.classList.toggle('hide-empty', e.target.checked));
+  document.getElementById('compact').addEventListener('change', e => document.body.classList.toggle('compact', e.target.checked));
+  document.getElementById('fit-cell').addEventListener('change', e => document.body.classList.toggle('fit-cell', e.target.checked));
+  document.getElementById('only-marked').addEventListener('change', e => document.body.classList.toggle('only-marked', e.target.checked));
+  document.getElementById('show-suppressed').addEventListener('change', e => document.body.classList.toggle('show-suppressed', e.target.checked));
+  document.getElementById('hide-desktop').addEventListener('change', e => document.body.classList.toggle('hide-desktop', e.target.checked));
+  document.getElementById('hide-mobile').addEventListener('change', e => document.body.classList.toggle('hide-mobile', e.target.checked));
+
+  // True-scale rendering (1x for selector captures, 0.5x for retina full-page).
+  const RETINA_THRESHOLD = 1500;
+  function applyTrueScale(img) {
+    if (!img.naturalWidth) return;
+    const cssWidth = img.naturalWidth > RETINA_THRESHOLD
+      ? Math.round(img.naturalWidth / 2)
+      : img.naturalWidth;
+    img.style.maxWidth = 'min(100%, ' + cssWidth + 'px)';
+  }
+  document.querySelectorAll('.cell img').forEach(img => {
+    if (img.complete && img.naturalWidth > 0) applyTrueScale(img);
+    else img.addEventListener('load', () => applyTrueScale(img), { once: true });
+  });
+
+  // State chips
+  document.querySelectorAll('.state-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const state = chip.dataset.state;
+      chip.classList.toggle('active');
+      document.body.classList.toggle('hide-state-' + state, !chip.classList.contains('active'));
+    });
+  });
+  STATES.forEach(s => {
+    const chip = document.querySelector('.state-chip[data-state="' + s + '"]');
+    if (chip && !chip.classList.contains('active')) document.body.classList.add('hide-state-' + s);
+  });
+
+  // Manual top-up: fill any DS cells that don't have a mark yet
+  document.getElementById('prefill-ds-btn').addEventListener('click', () => {
+    const added = prefillDsCellsAsNeedsDesign();
+    if (added > 0) {
+      document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+      updateRowSectionFlags();
+      updateCount();
+      alert('Filled ' + added + ' missing DS cells as needs-design.');
+    } else {
+      alert('All DS cells in this route already have marks.');
+    }
+  });
+
+  // Clear-route. Also resets the prefilled flag so a reload re-triggers auto-prefill.
+  document.getElementById('clear-route-btn').addEventListener('click', () => {
+    const ids = Object.entries(marks).filter(([id, m]) => m && m.marked && id.startsWith(ROUTE + '__')).map(([id]) => id);
+    if (!ids.length) { alert('No marks for this route.'); return; }
+    if (!confirm('Clear ' + ids.length + ' marks for route ' + ROUTE + '?\n\nReloading the page will re-prefill all DS cells as needs-design.')) return;
+    ids.forEach(id => delete marks[id]);
+    saveMarks(marks);
+    const flags = loadPrefilledFlags();
+    delete flags[ROUTE];
+    savePrefilledFlags(flags);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+  });
+
+  function buildMarkdown() {
+    const items = [];
+    Object.entries(marks).forEach(([id, m]) => {
+      if (!m || !m.marked) return;
+      if (!id.startsWith(ROUTE + '__')) return;
+      const parts = id.split('__');
+      const themeKey = parts[parts.length - 1];
+      const state = parts[parts.length - 2];
+      const viewport = parts[parts.length - 3];
+      const route = parts[0];
+      const component = parts.slice(1, parts.length - 3).join('__');
+      items.push({ component, viewport, state, theme: themeKey,
+                   note: m.note || '', why: m.why || '', category: m.category || '' });
+    });
+    items.sort((a, b) => {
+      const ak = componentSortKey(a.component);
+      const bk = componentSortKey(b.component);
+      if (ak[0] !== bk[0]) return ak[0] - bk[0];
+      if (ak[1] !== bk[1]) return ak[1] < bk[1] ? -1 : 1;
+      const sd = STATES.indexOf(a.state) - STATES.indexOf(b.state);
+      if (sd !== 0) return sd;
+      const td = THEME_ORDER.indexOf(a.theme) - THEME_ORDER.indexOf(b.theme);
+      if (td !== 0) return td;
+      return a.viewport === b.viewport ? 0 : (a.viewport === 'desktop' ? -1 : 1);
+    });
+    const date = new Date().toISOString().split('T')[0];
+    const lines = ['# Audit marks -- ' + ROUTE + ' -- ' + items.length + ' items -- ' + date, ''];
+    items.forEach(it => {
+      const catTag = it.category ? ' [' + it.category + ']' : '';
+      const whyTxt = it.why ? ': ' + it.why : '';
+      const noteTxt = it.note ? '  -- ' + it.note : '';
+      lines.push('- [ ] **' + it.theme + ' ' + it.component + '** [' + it.viewport + '/' + it.state + ']' + catTag + whyTxt + noteTxt);
+    });
+    return lines.join('\n');
+  }
+
+  function openOverlay(id) { document.getElementById(id).classList.add('open'); }
+  function closeOverlay(id) { document.getElementById(id).classList.remove('open'); }
+  document.querySelectorAll('.overlay-close').forEach(b => b.addEventListener('click', () => closeOverlay(b.dataset.overlay)));
+  document.querySelectorAll('.overlay').forEach(o => {
+    o.addEventListener('click', e => { if (e.target === o) o.classList.remove('open'); });
+  });
+
+  document.getElementById('export-md-btn').addEventListener('click', async () => {
+    const md = buildMarkdown();
+    const ta = document.getElementById('md-text');
+    ta.value = md;
+    openOverlay('md-overlay');
+    try { await navigator.clipboard.writeText(md); document.getElementById('md-copy').textContent = 'Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+  document.getElementById('md-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('md-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('md-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('md-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('export-json-btn').addEventListener('click', () => {
+    const ta = document.getElementById('json-export-text');
+    ta.value = JSON.stringify(marks, null, 2);
+    openOverlay('json-export-overlay');
+  });
+  document.getElementById('json-export-copy').addEventListener('click', async () => {
+    const ta = document.getElementById('json-export-text');
+    try { await navigator.clipboard.writeText(ta.value); document.getElementById('json-export-copy').textContent='Copied!'; setTimeout(()=>{document.getElementById('json-export-copy').textContent='Copy';},1500);}
+    catch (e) { ta.focus(); ta.select(); }
+  });
+
+  document.getElementById('import-json-btn').addEventListener('click', () => {
+    document.getElementById('json-import-text').value = '';
+    document.getElementById('json-import-err').textContent = '';
+    openOverlay('json-import-overlay');
+  });
+  document.getElementById('json-import-apply').addEventListener('click', () => {
+    const ta = document.getElementById('json-import-text');
+    const err = document.getElementById('json-import-err');
+    err.textContent = '';
+    let parsed;
+    try { parsed = JSON.parse(ta.value); }
+    catch (e) { err.textContent = 'Invalid JSON: ' + e.message; return; }
+    if (!parsed || typeof parsed !== 'object') { err.textContent = 'Expected an object.'; return; }
+    // First migrate v1 IDs (4 segments) -> v2 IDs (5 segments)
+    const { marks: idMigrated, migrated } = migrateMarksV1ToV2(parsed);
+    // Then upgrade each value v2 -> v3 (preserves marked + note, fills new fields)
+    Object.entries(idMigrated).forEach(([id, m]) => {
+      marks[id] = upgradeV2ValueToV3(m);
+    });
+    saveMarks(marks);
+    document.querySelectorAll('.cell[data-cell-id]').forEach(applyMarkState);
+    updateRowSectionFlags();
+    updateCount();
+    closeOverlay('json-import-overlay');
+    alert('Imported ' + Object.keys(idMigrated).length + ' marks (' + migrated + ' legacy IDs migrated to __seeded; values upgraded to v3).');
+  });
+</script>
+</body>
+</html>

--- a/scripts/audit/run-parallel.sh
+++ b/scripts/audit/run-parallel.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Parallel capture runner for the cross-theme audit (#1129).
+#
+# Spawns playwright-crawl.ts workers (one per state) against a single dev
+# server, then waits for all to finish. Cross-state workers share the server's
+# warm route cache, so the total wall time is ~1/N of a serial pass.
+#
+# Default state set: empty + seeded. `mid-session` was dropped from the default
+# pipeline as visually redundant with `seeded`; re-enable it here if needed.
+#
+# Usage:
+#   bash scripts/audit/run-parallel.sh \
+#     --branch integration-ds3-light \
+#     --viewport desktop \
+#     --theme ds3 \
+#     --mode light
+#
+#   # develop branch (uses worktree on port 3001):
+#   bash scripts/audit/run-parallel.sh \
+#     --branch develop-default \
+#     --viewport desktop \
+#     --theme default \
+#     --mode light \
+#     --worktree /tmp/narraitor-develop-1129
+#
+# Parallelism notes:
+#   - Each worker writes to captures/comp-<branch>/<viewport>/<state>/ so
+#     there are no file-level write conflicts between workers.
+#   - Seeds (seeds/<state>.json) are regenerated ONCE before workers start and
+#     are read-only during the crawl. Never regenerate inside a worker.
+#   - Cross-branch parallelism (4 servers) isn't done here because dev-server
+#     cold-compile cost dominates. Run this script once per branch instead.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+branch=""
+viewport="desktop"
+theme="default"
+mode="light"
+worktree=""
+base_url=""
+skip_server=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --branch)   branch="$2";   shift 2 ;;
+    --viewport) viewport="$2"; shift 2 ;;
+    --theme)    theme="$2";    shift 2 ;;
+    --mode)     mode="$2";     shift 2 ;;
+    --worktree) worktree="$2"; shift 2 ;;
+    --base-url) base_url="$2"; shift 2 ;;
+    --skip-server) skip_server=1; shift ;;
+    *) echo "Unknown arg: $1"; exit 1 ;;
+  esac
+done
+
+if [[ -z "$branch" ]]; then
+  echo "Required: --branch <label>"
+  echo "Example:  --branch integration-ds3-light --theme ds3 --mode light"
+  exit 1
+fi
+
+# ---- Determine port ----
+# Convention: develop runs in a worktree on :3001; integration branches
+# share the main repo's dev server on :3000 (themes are localStorage-driven,
+# so all integration branches use the same server). Override with --base-url.
+if [[ "$theme" == "default" ]]; then
+  port=3001
+else
+  port=3000
+fi
+
+if [[ -n "$base_url" ]]; then
+  server_url="$base_url"
+else
+  server_url="http://localhost:$port"
+fi
+
+echo "=== Parallel crawl: branch=$branch viewport=$viewport theme=$theme/$mode ==="
+echo "    Server: $server_url"
+
+# Default states. mid-session is intentionally omitted; add it here for a
+# one-off re-enable.
+STATES_TO_RUN=(empty seeded)
+
+# ---- Regenerate seeds (read-only during workers) ----
+echo "--- Regenerating seeds ---"
+mkdir -p "$SCRIPT_DIR/seeds"
+for state in "${STATES_TO_RUN[@]}"; do
+  npx tsx "$SCRIPT_DIR/build-seed.ts" --state "$state" > "$SCRIPT_DIR/seeds/$state.json"
+  echo "  seeds/$state.json written"
+done
+
+# ---- Start dev server if needed ----
+server_pid=""
+server_started=0
+
+if [[ "$skip_server" -eq 0 ]]; then
+  if curl -sf "$server_url" > /dev/null 2>&1; then
+    echo "--- Dev server already running at $server_url (reusing) ---"
+  else
+    echo "--- Starting dev server on port $port ---"
+    if [[ -n "$worktree" ]]; then
+      (cd "$worktree" && npx next dev -p "$port" &> /tmp/audit-next-$port.log &)
+    else
+      (cd "$REPO_ROOT" && npx next dev -p "$port" &> /tmp/audit-next-$port.log &)
+    fi
+    server_pid=$!
+    server_started=1
+
+    echo "    Waiting for server to respond..."
+    for i in $(seq 1 60); do
+      if curl -sf "$server_url" > /dev/null 2>&1; then
+        echo "    Ready after ${i}s"
+        break
+      fi
+      sleep 1
+      if [[ $i -eq 60 ]]; then
+        echo "ERROR: Server did not start within 60s. Log: /tmp/audit-next-$port.log"
+        exit 1
+      fi
+    done
+  fi
+fi
+
+# ---- Spawn workers (one per state) ----
+echo "--- Spawning workers (states: ${STATES_TO_RUN[*]}) ---"
+pids=()
+
+for state in "${STATES_TO_RUN[@]}"; do
+  npx tsx "$SCRIPT_DIR/playwright-crawl.ts" \
+    --branch "$branch" \
+    --viewport "$viewport" \
+    --theme "$theme" \
+    --mode "$mode" \
+    --state "$state" \
+    --base-url "$server_url" \
+    &> "/tmp/audit-crawl-$branch-$viewport-$state.log" &
+  pid=$!
+  pids+=("$pid")
+  echo "  Worker $pid: $state"
+done
+
+# ---- Wait for all workers ----
+echo "--- Waiting for workers to finish ---"
+failed=0
+for i in "${!pids[@]}"; do
+  pid="${pids[$i]}"
+  state="${STATES_TO_RUN[$i]}"
+  if wait "$pid"; then
+    echo "  OK: $state (pid $pid)"
+  else
+    echo "  FAILED: $state (pid $pid) -- see /tmp/audit-crawl-$branch-$viewport-$state.log"
+    failed=1
+  fi
+done
+
+# ---- Teardown ----
+if [[ "$server_started" -eq 1 && -n "$server_pid" ]]; then
+  echo "--- Stopping dev server (pid $server_pid) ---"
+  kill "$server_pid" 2>/dev/null || true
+fi
+
+if [[ "$failed" -eq 1 ]]; then
+  echo "One or more workers failed. Check logs in /tmp/audit-crawl-*.log"
+  exit 1
+fi
+
+echo "=== Done. Captures: scripts/audit/captures/comp-$branch/$viewport/ ==="
+echo "    Regenerate review:  python3 scripts/audit/build-review-html.py"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -355,12 +355,6 @@ body > * {
   height: 12px;
 }
 
-.workshop-sidebar-theme-controls {
-  display: flex;
-  gap: var(--space-1_5);
-  flex-wrap: wrap;
-}
-
 /* Ending Screen Tone Styles */
 .ending-triumphant {
   background-color: hsl(var(--ending-triumphant));

--- a/src/app/workshop.css
+++ b/src/app/workshop.css
@@ -307,6 +307,11 @@
   font-size: 0.95rem;
   line-height: 1.2;
   color: var(--color-text-primary);
+  /* grid items need min-width: 0 to allow text-overflow: ellipsis to work */
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .workshop-sidebar-world-meta {

--- a/src/app/workshop.css
+++ b/src/app/workshop.css
@@ -189,8 +189,8 @@
 }
 
 .workshop-sidebar {
-  width: 17rem;
-  min-width: 17rem;
+  width: 18rem;
+  min-width: 18rem;
   height: 100vh;
   overflow-y: auto;
   position: sticky;
@@ -204,16 +204,12 @@
   min-height: 100%;
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
-  padding: var(--space-4) var(--space-3);
+  gap: var(--space-4);
+  padding: var(--space-5) var(--space-4) var(--space-3);
 }
 
-.workshop-sidebar-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-2);
-  padding: 0 var(--space-1) var(--space-2);
+.workshop-sidebar-brand-row {
+  padding: 0 var(--space-1) var(--space-3);
   border-bottom: 1px solid var(--color-border);
 }
 
@@ -222,38 +218,132 @@
   align-items: center;
   gap: var(--space-2);
   text-decoration: none;
+  color: var(--color-text-primary);
 }
 
-.workshop-sidebar-section {
+.workshop-sidebar-primary {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.workshop-sidebar-primary-link {
+  display: block;
+  padding: var(--space-2) var(--space-3);
+  font-family: var(--font-interface);
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  border-left: 2px solid transparent;
+  transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.workshop-sidebar-primary-link:hover {
+  color: var(--color-text-primary);
+}
+
+.workshop-sidebar-primary-link:focus-visible {
+  color: var(--color-text-primary);
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
+.workshop-sidebar-primary-link[data-active="true"] {
+  color: var(--color-text-primary);
+  border-left-color: var(--color-accent);
+  background: var(--color-accent-soft);
+}
+
+.workshop-sidebar-worlds-section {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
 }
 
-.workshop-sidebar-section-grow {
-  flex: 1;
+.workshop-sidebar-section-label {
+  margin: 0;
+  padding: 0 var(--space-1);
+  font-family: var(--font-system);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
 }
 
-.workshop-sidebar-label {
+.workshop-sidebar-worlds-list {
+  list-style: none;
   margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.workshop-sidebar-world-item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: start;
+  gap: var(--space-2) var(--space-2);
+  width: 100%;
+  min-height: auto;
+  padding: var(--space-2) var(--space-3);
+  text-align: left;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+}
+
+.workshop-sidebar-world-item[data-active="true"] {
+  background: var(--color-surface);
+  border-color: var(--color-border);
+}
+
+.workshop-sidebar-world-name {
+  grid-column: 1;
+  font-family: var(--font-narrative);
+  font-size: 0.95rem;
+  line-height: 1.2;
+  color: var(--color-text-primary);
+}
+
+.workshop-sidebar-world-meta {
+  grid-column: 1;
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   letter-spacing: 0.04em;
   color: var(--color-text-muted);
 }
 
-.workshop-nav-link,
-.workshop-world-button,
-.workshop-primary-action {
-  justify-content: flex-start;
-  width: 100%;
-  min-height: 2.5rem;
+.workshop-sidebar-world-item svg {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  align-self: center;
+  color: var(--color-accent);
 }
 
-.workshop-world-list {
+.workshop-sidebar-spacer {
+  flex: 1 1 auto;
+  min-height: var(--space-2);
+}
+
+.workshop-sidebar-toolbar {
   display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-1);
+  border-top: 1px solid var(--color-border);
+  background: var(--color-surface-hover);
+  /* Pin the toolbar to the bottom of the rail when the world list overflows the viewport. */
+  position: sticky;
+  bottom: 0;
+}
+
+.workshop-sidebar-toolbar > * {
+  flex-shrink: 0;
 }
 
 .workshop-workspace {
@@ -264,11 +354,38 @@
   flex-direction: column;
 }
 
-.workshop-mobile-header {
+.workshop-context-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  padding: var(--space-3) var(--space-5);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.workshop-context-header-left {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.workshop-context-header-right {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.workshop-context-header-mobile-trigger {
   display: none;
 }
 
-.workshop-mobile-title {
+.workshop-context-header-mobile-title {
+  display: none;
   margin: 0;
   font-family: var(--font-system);
   font-size: 0.875rem;
@@ -348,16 +465,23 @@
     z-index: 35;
   }
 
-  .workshop-mobile-header {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    position: sticky;
-    top: 0;
-    z-index: 20;
+  .workshop-context-header {
     padding: var(--space-3) var(--space-4);
-    background: var(--color-surface);
-    border-bottom: 1px solid var(--color-border);
+  }
+
+  .workshop-context-header-mobile-trigger,
+  .workshop-context-header-mobile-title {
+    display: inline-flex;
+  }
+
+  .workshop-context-header-mobile-title {
+    display: block;
+  }
+
+  /* Descendant selector needed for specificity: a generic .breadcrumbs-nav { display: flex } rule defined later in this file would otherwise win. */
+  .workshop-context-header .workshop-context-header-breadcrumbs,
+  .workshop-context-header .workshop-context-header-recent {
+    display: none;
   }
 
   .workshop-workspace-main {

--- a/src/components/Navigation/SidebarNavigation.tsx
+++ b/src/components/Navigation/SidebarNavigation.tsx
@@ -92,7 +92,8 @@ export function SidebarNavigation({ onNavigate }: SidebarNavigationProps) {
               data-active={isPrimaryActive(link.href) ? 'true' : undefined}
               className="workshop-sidebar-primary-link"
               onClick={(e) => {
-                // Cancel default <Link> nav so we route through navigateWithLoading (loading overlay); <Link href> stays for cmd-click / right-click parity.
+                // Let modifier clicks (cmd/ctrl/shift) and non-primary buttons fall through to native <Link> so the browser can open a new tab/window.
+                if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
                 e.preventDefault();
                 navigate(link.href, link.loadingMessage);
               }}

--- a/src/components/Navigation/SidebarNavigation.tsx
+++ b/src/components/Navigation/SidebarNavigation.tsx
@@ -2,22 +2,14 @@
 
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { LogoIcon, LogoText } from '@/components/ui/Logo';
 import { TutorialMenu } from './TutorialMenu';
 import { ThemeSwitcher } from './ThemeSwitcher';
 import { DarkModeToggle } from './DarkModeToggle';
-import dynamic from 'next/dynamic';
-
-const RecentPagesDropdown = dynamic(
-  () =>
-    import('./RecentPagesDropdown').then((m) => ({
-      default: m.RecentPagesDropdown,
-    })),
-  { ssr: false }
-);
 import { useNavigationData } from './useNavigationData';
-import { Globe, Users, Settings, Check, Play, Plus, Home } from 'lucide-react';
+import { Check } from 'lucide-react';
 import { getGenreLabel } from '@/lib/constants/genres';
 import type { Character } from '@/state/characterStore';
 
@@ -25,26 +17,42 @@ interface SidebarNavigationProps {
   onNavigate?: () => void;
 }
 
+const PRIMARY_LINKS: ReadonlyArray<{
+  href: string;
+  label: string;
+  loadingMessage: string;
+}> = [
+  { href: '/worlds', label: 'Worlds', loadingMessage: 'Loading worlds...' },
+  { href: '/characters', label: 'Characters', loadingMessage: 'Loading characters...' },
+  { href: '/settings', label: 'Settings', loadingMessage: 'Loading settings...' },
+];
+
 /**
- * SidebarNavigation - Workshop navigation rail for world/character/settings routes.
+ * SidebarNavigation - Workshop navigation rail (desktop ≥768) and drawer (mobile).
+ * Desktop: typographic primary list, embedded world switcher, horizontal bottom toolbar.
+ * The contextual CTA, recent pages, and breadcrumbs live in WorkshopContextualHeader.
  */
 export function SidebarNavigation({ onNavigate }: SidebarNavigationProps) {
   const {
+    pathname,
     currentWorldId,
     worlds,
     characters,
-    currentWorld,
     hasWorldsStore,
     navigateWithLoading,
     setCurrentWorld,
   } = useNavigationData();
+  // useNavigationData.pathname can lag during route transitions; usePathname() is the live-tick value used for active-link styling.
+  const livePath = usePathname() ?? pathname;
   const [mounted, setMounted] = useState(false);
   const hasWorlds = mounted && hasWorldsStore;
-  const activeWorld = mounted ? currentWorld : null;
 
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  const isPrimaryActive = (href: string) =>
+    livePath === href || livePath.startsWith(`${href}/`);
 
   const navigate = (path: string, message: string) => {
     navigateWithLoading(path, message);
@@ -59,121 +67,84 @@ export function SidebarNavigation({ onNavigate }: SidebarNavigationProps) {
   };
 
   return (
-    <nav aria-label="Workshop navigation" className="workshop-sidebar-nav">
-      <div className="workshop-sidebar-header">
-        <Link href="/" onClick={() => onNavigate?.()} className="workshop-sidebar-brand">
+    <nav
+      aria-label="Workshop navigation"
+      className="workshop-sidebar-nav"
+      data-identifier="workshop-sidebar-nav"
+    >
+      <div className="workshop-sidebar-brand-row">
+        <Link
+          href="/"
+          onClick={() => onNavigate?.()}
+          className="workshop-sidebar-brand"
+        >
           <LogoIcon size="small" className="logo-icon-inverted" />
           <LogoText size="sm" />
         </Link>
-        <TutorialMenu />
       </div>
 
-      <div className="workshop-sidebar-section">
-        <Button
-          variant="ghost"
-          className="workshop-nav-link"
-          onClick={() => navigate('/worlds', 'Loading worlds...')}
-        >
-          <Globe aria-hidden="true" />
-          Worlds
-        </Button>
-        <Button
-          variant="ghost"
-          className="workshop-nav-link"
-          onClick={() => navigate('/characters', 'Loading characters...')}
-        >
-          <Users aria-hidden="true" />
-          Characters
-        </Button>
-        <Button
-          variant="ghost"
-          className="workshop-nav-link"
-          onClick={() => navigate('/settings', 'Loading settings...')}
-        >
-          <Settings aria-hidden="true" />
-          Settings
-        </Button>
-      </div>
+      <ul className="workshop-sidebar-primary">
+        {PRIMARY_LINKS.map((link) => (
+          <li key={link.href}>
+            <Link
+              href={link.href}
+              aria-current={isPrimaryActive(link.href) ? 'page' : undefined}
+              data-active={isPrimaryActive(link.href) ? 'true' : undefined}
+              className="workshop-sidebar-primary-link"
+              onClick={(e) => {
+                // Cancel default <Link> nav so we route through navigateWithLoading (loading overlay); <Link href> stays for cmd-click / right-click parity.
+                e.preventDefault();
+                navigate(link.href, link.loadingMessage);
+              }}
+            >
+              {link.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
 
       {hasWorlds && (
-        <div className="workshop-sidebar-section">
-          <p className="workshop-sidebar-label">World Switcher</p>
-          <div className="workshop-world-list">
+        <section
+          className="workshop-sidebar-worlds-section"
+          aria-label="World switcher"
+        >
+          <p className="workshop-sidebar-section-label">Worlds</p>
+          <ul className="workshop-sidebar-worlds-list">
             {Object.values(worlds).map((world) => {
               const worldCharacters = (
                 Object.values(characters) as Character[]
               ).filter((char) => char.worldId === world.id).length;
+              const isActive = world.id === currentWorldId;
 
               return (
-                <Button
-                  key={world.id}
-                  variant="ghost"
-                  className="workshop-world-button"
-                  onClick={() => handleWorldSwitch(world.id)}
-                >
-                  <div>
-                    <div>{world.name}</div>
-                    <div>
-                      {getGenreLabel(world.genre)} • {worldCharacters} characters
-                    </div>
-                  </div>
-                  {world.id === currentWorldId && (
-                    <Check aria-hidden="true" />
-                  )}
-                </Button>
+                <li key={world.id}>
+                  <Button
+                    variant="ghost"
+                    className="workshop-sidebar-world-item"
+                    data-active={isActive ? 'true' : undefined}
+                    onClick={() => handleWorldSwitch(world.id)}
+                  >
+                    <span className="workshop-sidebar-world-name">
+                      {world.name}
+                    </span>
+                    <span className="workshop-sidebar-world-meta">
+                      {getGenreLabel(world.genre)} · {worldCharacters} characters
+                    </span>
+                    {isActive && <Check aria-hidden="true" />}
+                  </Button>
+                </li>
               );
             })}
-          </div>
-        </div>
+          </ul>
+        </section>
       )}
 
-      <div className="workshop-sidebar-section workshop-sidebar-section-grow">
-        <RecentPagesDropdown />
-      </div>
+      <div className="workshop-sidebar-spacer" aria-hidden="true" />
 
-      <div className="workshop-sidebar-section workshop-sidebar-theme-controls">
+      <div className="workshop-sidebar-toolbar">
         <ThemeSwitcher compact />
         <DarkModeToggle compact />
-      </div>
-
-      <div className="workshop-sidebar-section">
-        {activeWorld ? (
-          <Button
-            type="button"
-            variant="success"
-            className="workshop-primary-action"
-            onClick={() =>
-              navigate(
-                `/worlds/${activeWorld.id}/play`,
-                `Starting ${activeWorld.name}...`
-              )
-            }
-          >
-            <Play aria-hidden="true" />
-            Play
-          </Button>
-        ) : mounted && !hasWorldsStore ? (
-          <Button
-            type="button"
-            className="workshop-primary-action"
-            onClick={() =>
-              navigate('/worlds/create', 'Setting up world creation...')
-            }
-          >
-            <Plus aria-hidden="true" />
-            Create Your First World
-          </Button>
-        ) : (
-          <Button
-            type="button"
-            variant="ghost"
-            className="workshop-primary-action"
-            onClick={() => navigate('/worlds', 'Loading worlds...')}
-          >
-            <Home aria-hidden="true" />
-            Browse Worlds
-          </Button>
-        )}
+        <TutorialMenu />
       </div>
     </nav>
   );

--- a/src/components/Navigation/WorkshopContextualHeader.tsx
+++ b/src/components/Navigation/WorkshopContextualHeader.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import React from 'react';
+import dynamic from 'next/dynamic';
+import { Menu, X, Play, Plus, Home } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { SSRClientOnly } from '@/components/shared/SSRClientOnly';
+import { Breadcrumbs } from './Breadcrumbs';
+import { TutorialMenu } from './TutorialMenu';
+import { useNavigationData } from './useNavigationData';
+
+const RecentPagesDropdown = dynamic(
+  () =>
+    import('./RecentPagesDropdown').then((m) => ({
+      default: m.RecentPagesDropdown,
+    })),
+  { ssr: false }
+);
+
+interface WorkshopContextualHeaderProps {
+  sidebarOpen: boolean;
+  onToggleSidebar: () => void;
+}
+
+/**
+ * WorkshopContextualHeader - top chrome of the workshop workspace.
+ * Desktop: breadcrumb + recent pages + tutorial + contextual CTA.
+ * Mobile: hamburger + workshop title + contextual CTA.
+ */
+export function WorkshopContextualHeader({
+  sidebarOpen,
+  onToggleSidebar,
+}: WorkshopContextualHeaderProps) {
+  const {
+    currentWorld,
+    hasWorldsStore,
+    navigateWithLoading,
+  } = useNavigationData();
+
+  const cta = currentWorld ? (
+    <Button
+      type="button"
+      variant="success"
+      className="workshop-context-header-cta"
+      onClick={() =>
+        navigateWithLoading(
+          `/worlds/${currentWorld.id}/play`,
+          `Starting ${currentWorld.name}...`
+        )
+      }
+    >
+      <Play aria-hidden="true" />
+      Play
+    </Button>
+  ) : !hasWorldsStore ? (
+    <Button
+      type="button"
+      className="workshop-context-header-cta"
+      onClick={() =>
+        navigateWithLoading('/worlds/create', 'Setting up world creation...')
+      }
+    >
+      <Plus aria-hidden="true" />
+      Create Your First World
+    </Button>
+  ) : (
+    <Button
+      type="button"
+      variant="ghost"
+      className="workshop-context-header-cta"
+      onClick={() => navigateWithLoading('/worlds', 'Loading worlds...')}
+    >
+      <Home aria-hidden="true" />
+      Browse Worlds
+    </Button>
+  );
+
+  return (
+    <header className="workshop-context-header" data-identifier="workshop-context-header">
+      <div className="workshop-context-header-left">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label={sidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+          aria-expanded={sidebarOpen}
+          className="workshop-context-header-mobile-trigger"
+          onClick={onToggleSidebar}
+        >
+          {sidebarOpen ? <X aria-hidden="true" /> : <Menu aria-hidden="true" />}
+        </Button>
+        <p className="workshop-context-header-mobile-title">Workshop</p>
+        <SSRClientOnly>
+          <Breadcrumbs className="workshop-context-header-breadcrumbs" />
+        </SSRClientOnly>
+      </div>
+      <div className="workshop-context-header-right">
+        <TutorialMenu />
+        <SSRClientOnly>
+          <RecentPagesDropdown className="workshop-context-header-recent" />
+        </SSRClientOnly>
+        {/* SSR-defer the CTA: without it the button flickers between server-rendered "Browse Worlds" and the hydrated "Play" once the world store loads. */}
+        <SSRClientOnly>{cta}</SSRClientOnly>
+      </div>
+    </header>
+  );
+}

--- a/src/components/Navigation/__tests__/Navigation.test.tsx
+++ b/src/components/Navigation/__tests__/Navigation.test.tsx
@@ -182,11 +182,28 @@ describe('HeaderNavigation', () => {
       expect(screen.getByText('Settings')).toBeInTheDocument();
     });
 
-    it('renders theme controls in sidebar', () => {
+    it('renders theme controls in sidebar bottom toolbar', () => {
       render(<SidebarNavigation />);
 
-      expect(screen.getByRole('radiogroup', { name: 'Design system theme' })).toBeInTheDocument();
-      expect(screen.getByRole('radiogroup', { name: 'Color scheme' })).toBeInTheDocument();
+      const themeGroup = screen.getByRole('radiogroup', { name: 'Design system theme' });
+      const schemeGroup = screen.getByRole('radiogroup', { name: 'Color scheme' });
+      expect(themeGroup).toBeInTheDocument();
+      expect(schemeGroup).toBeInTheDocument();
+
+      const toolbar = themeGroup.closest('.workshop-sidebar-toolbar');
+      expect(toolbar).not.toBeNull();
+      expect(toolbar).toContainElement(schemeGroup);
+    });
+
+    it('does not render the contextual CTA inside the rail (it lives in the workspace header on desktop)', () => {
+      render(<SidebarNavigation />);
+
+      // Without seeded worlds the CTA on default surface would be "Create Your First World".
+      // The drafting-rail design moves all contextual CTAs into the workspace header,
+      // not the rail itself. Sidebar must not render any of these labels.
+      expect(screen.queryByText('Create Your First World')).not.toBeInTheDocument();
+      expect(screen.queryByText('Browse Worlds')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /^Play$/i })).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/Navigation/__tests__/WorkshopContextualHeader.test.tsx
+++ b/src/components/Navigation/__tests__/WorkshopContextualHeader.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { WorkshopContextualHeader } from '../WorkshopContextualHeader';
+
+const mockWorldStore = {
+  worlds: {} as Record<string, { id: string; name: string; genre: string }>,
+  currentWorldId: null as string | null,
+  setCurrentWorld: jest.fn(),
+};
+
+const mockSessionStore = {
+  currentCharacterId: null,
+  setCurrentCharacter: jest.fn(),
+};
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), pathname: '/worlds' }),
+  usePathname: () => '/worlds',
+}));
+
+jest.mock('@/state/worldStore', () => ({
+  useWorldStore: (selector: (s: typeof mockWorldStore) => unknown) =>
+    selector ? selector(mockWorldStore) : mockWorldStore,
+}));
+
+jest.mock('@/state/sessionStore', () => ({
+  useSessionStore: (selector: (s: typeof mockSessionStore) => unknown) =>
+    selector ? selector(mockSessionStore) : mockSessionStore,
+}));
+
+jest.mock('@/state/characterStore', () => ({
+  useCharacterStore: () => ({ characters: {} }),
+}));
+
+jest.mock('@/components/shared/NavigationLoadingProvider', () => ({
+  useNavigationLoadingContext: () => ({ navigateWithLoading: jest.fn() }),
+}));
+
+jest.mock('@/components/TutorialProvider', () => ({
+  useTutorial: () => ({
+    startTour: jest.fn(),
+    stopTour: jest.fn(),
+    setCurrentWizardStep: jest.fn(),
+    isTourActive: false,
+    currentTour: null,
+  }),
+}));
+
+jest.mock('../Breadcrumbs', () => ({
+  Breadcrumbs: () => <div data-testid="breadcrumbs">Breadcrumbs</div>,
+}));
+
+jest.mock('../RecentPagesDropdown', () => ({
+  RecentPagesDropdown: () => <div data-testid="recent-pages">Recent</div>,
+}));
+
+describe('WorkshopContextualHeader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockWorldStore.worlds = {};
+    mockWorldStore.currentWorldId = null;
+  });
+
+  it('renders the mobile sidebar trigger and workshop title', () => {
+    render(
+      <WorkshopContextualHeader
+        sidebarOpen={false}
+        onToggleSidebar={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', { name: /open sidebar/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/workshop/i)).toBeInTheDocument();
+  });
+
+  it('shows "Create Your First World" CTA when there are no worlds', () => {
+    render(
+      <WorkshopContextualHeader
+        sidebarOpen={false}
+        onToggleSidebar={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Create Your First World')).toBeInTheDocument();
+  });
+
+  it('shows the Play CTA when an active world is selected', () => {
+    mockWorldStore.worlds = {
+      'w1': { id: 'w1', name: 'Cyberpunk', genre: 'cyberpunk' },
+    };
+    mockWorldStore.currentWorldId = 'w1';
+
+    render(
+      <WorkshopContextualHeader
+        sidebarOpen={false}
+        onToggleSidebar={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /^Play$/i })).toBeInTheDocument();
+  });
+
+  it('renders breadcrumbs and recent pages on the desktop side of the header', () => {
+    render(
+      <WorkshopContextualHeader
+        sidebarOpen={false}
+        onToggleSidebar={jest.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('breadcrumbs')).toBeInTheDocument();
+    expect(screen.getByTestId('recent-pages')).toBeInTheDocument();
+  });
+});

--- a/src/components/Navigation/index.ts
+++ b/src/components/Navigation/index.ts
@@ -1,4 +1,5 @@
 export { HeaderNavigation } from './HeaderNavigation';
 export { SidebarNavigation } from './SidebarNavigation';
+export { WorkshopContextualHeader } from './WorkshopContextualHeader';
 export { Breadcrumbs } from './Breadcrumbs';
 export { MobileNavigationMenu } from './MobileNavigationMenu';

--- a/src/components/layout/AppSurfaceShell.tsx
+++ b/src/components/layout/AppSurfaceShell.tsx
@@ -2,10 +2,12 @@
 
 import React, { useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
-import { Button } from '@/components/ui/button';
-import { HeaderNavigation, SidebarNavigation } from '@/components/Navigation';
+import {
+  HeaderNavigation,
+  SidebarNavigation,
+  WorkshopContextualHeader,
+} from '@/components/Navigation';
 import { getSurfaceMode } from '@/lib/routing/surfaceMode';
-import { Menu, X } from 'lucide-react';
 
 interface AppSurfaceShellProps {
   children: React.ReactNode;
@@ -63,19 +65,10 @@ export function AppSurfaceShell({ children }: AppSurfaceShellProps) {
       )}
 
       <div className="workshop-workspace">
-        <header className="workshop-mobile-header">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            aria-label={sidebarOpen ? 'Close sidebar' : 'Open sidebar'}
-            aria-expanded={sidebarOpen}
-            onClick={() => setSidebarOpen((prev) => !prev)}
-          >
-            {sidebarOpen ? <X aria-hidden="true" /> : <Menu aria-hidden="true" />}
-          </Button>
-          <p className="workshop-mobile-title">Workshop</p>
-        </header>
+        <WorkshopContextualHeader
+          sidebarOpen={sidebarOpen}
+          onToggleSidebar={() => setSidebarOpen((prev) => !prev)}
+        />
 
         <main id="main-content" tabIndex={-1} className="workshop-workspace-main">
           <div className="workshop-workspace-inner">{children}</div>


### PR DESCRIPTION
## Description

Fixes the desktop layout regression on `/worlds`, `/characters`, `/settings` (and subroutes). The workshop surface introduced in #1075 shipped without a separate desktop nav: at 1320px the only chrome was a sticky 17rem sidebar containing the same vertical-stacked, full-width-row, mobile-drawer markup as the <768px rendering. Audit captures across DS1/DS2/DS3 showed what looked like a phone drawer pinned to the left of the page (issue #1140).

The fix splits the workshop chrome into two pieces:

- **Drafting rail** (`SidebarNavigation`, restructured): typographic `<ul>/<li>` primary nav with `aria-current="page"` and a leading ink-rule active state; embedded world-switcher list typeset as a manuscript table-of-contents; horizontal sticky bottom toolbar carrying ThemeSwitcher (compact), DarkModeToggle (compact), and TutorialMenu — the horizontal toolbar is the visual cue that breaks the phone-drawer silhouette.
- **Slim contextual header** (`WorkshopContextualHeader`, new): breadcrumb on the left, RecentPagesDropdown + contextual CTA (Play / Create / Browse) on the right; collapses at <768px to hamburger + workshop title with the CTA pinned right.

Sidebar bumped 17rem → 18rem to fit the toolbar comfortably. Mobile drawer behavior at <768px is unchanged.

## Related Issue

Closes #1140

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (code improvements without changing functionality)

## TDD Compliance

- [x] Tests written before implementation (red → green for both `SidebarNavigation` updated assertions and new `WorkshopContextualHeader` suite)
- [x] All new code is tested
- [x] All tests pass locally (full suite: 2136 passed)
- [x] Test coverage maintained or improved

## Implementation Notes

Investigation summary (full record in plan file referenced in issue):
- Static analysis ruled out the issue body's hypothesis ("viewport not applied before seed injection in `playwright-crawl.ts`") — `__page.png` for DS3 desktop seeded is 1329×1885, viewport IS being applied.
- Live-DOM bdg verification at 1320×900 with seeded localStorage + `data-theme=ds3` confirmed the actual root cause: workshop routes had no horizontal header at all; the only `<nav>` was `.workshop-sidebar-nav` at 257px width — same component, same styling, used for both desktop sidebar and mobile drawer.
- 5 WHY-only inline comments added at non-obvious decision points (live-tick pathname, Link `preventDefault`, SSR-deferred CTA flicker, sticky-bottom toolbar overflow, mobile breadcrumb specificity workaround).

Out of scope (not changed):
- `MobileNavigationMenu` and the `<768px` drawer behavior.
- Manuscript-mode routes (`/play`, `/worlds/:id/play`).
- `playwright-crawl.ts` / `build-review-html.py` audit tooling.

## Component Development

- [x] Visual consistency verified (bdg live-DOM at 1320×900 across all three DS themes; mobile baseline at 390×844)
- [ ] Storybook stories created/updated *(no existing `SidebarNavigation` stories; `HeaderNavigation`-style stories deferred)*

## Quality Checks

- [x] Linting passed (`npx next lint` — only pre-existing warnings unrelated to this diff)
- [x] Type checking passed (`tsc --noEmit` clean)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

1. Run unit tests: `npm test` (or `npx jest --testPathPattern Navigation`).
2. Visual smoke test on this branch:
   ```
   npm run dev
   # In a Chromium with debug port (or a regular browser):
   #   localStorage.setItem('narraitor-theme', 'ds3')
   #   localStorage.setItem('narraitor-color-scheme', 'light')
   #   reload, then navigate to /worlds, /characters, /settings
   # Confirm: 18rem typeset rail on the left, slim contextual header on top with breadcrumb + Tutorial + Recent + Play/Create CTA, no drawer-style chunky button rows.
   ```
3. Resize to <768px: confirm sidebar collapses behind hamburger, contextual header reduces to hamburger + WORKSHOP title + CTA, drawer slides in/out via the hamburger.
4. Audit re-run (already executed locally on DS1/DS2/DS3 × {worlds, characters, settings, worlds-detail, worlds-create, worlds-edit, characters-create, characters-detail, characters-edit}):
   ```
   npx tsx scripts/audit/playwright-crawl.ts --theme ds3 --mode light --state seeded --branch integration-ds3-light --viewport desktop --route worlds
   ```
   `worlds__nav.png` now contains the typeset rail with horizontal bottom toolbar; `worlds__header.png` contains the slim contextual header (1031×67).

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file — `WorkshopContextualHeader.tsx` ~110, `SidebarNavigation.tsx` ~140)
- [x] Self-review of code performed (pattern-alignment skill run; surfaced 2 a11y issues — focus-visible outline removed without replacement, missing `aria-current` — both fixed before commit)
- [x] Comments added for complex logic (5 WHY-only inline comments)
- [x] No new warnings generated
- [x] Accessibility considerations addressed (WCAG 2.4.7 focus indicator restored; WCAG 4.1.2 `aria-current="page"` added; mobile sidebar trigger has `aria-expanded` + `aria-label`)

## Screenshots

Before/after captures available at `/tmp/issue-1140/` locally:
- `phase1-worlds-ds3-1320-page.png` — broken phone-drawer rendering on `/worlds`
- `phase2b-worlds-ds3-1320-page.png` — fixed drafting-rail + contextual header
- `phase2-characters-ds3-1320-page.png` — `/characters` showing active-state ink rule on Characters
- `phase2c-worlds-ds3-390-page.png` — mobile baseline, drawer hidden, hamburger + WORKSHOP + Play CTA