### PR TITLE
chore: clear residual CodeQL alerts on #1081

### DIFF
--- a/scripts/audit/playwright-crawl.ts
+++ b/scripts/audit/playwright-crawl.ts
@@ -13,7 +13,7 @@
  * Output: scripts/audit/captures/comp-<branch>/<viewport>/<state>/<route>__*.png
  */
 import { chromium, type Browser, type Page } from '@playwright/test';
-import { mkdir, writeFile, rm } from 'node:fs/promises';
+import { mkdir, rm } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/scripts/audit/review/worlds-play.html
+++ b/scripts/audit/review/worlds-play.html
@@ -1611,7 +1611,6 @@
       const themeKey = parts[parts.length - 1];
       const state = parts[parts.length - 2];
       const viewport = parts[parts.length - 3];
-      const route = parts[0];
       const component = parts.slice(1, parts.length - 3).join('__');
       items.push({ component, viewport, state, theme: themeKey,
                    note: m.note || '', why: m.why || '', category: m.category || '' });


### PR DESCRIPTION
## Summary
- Removes unused `writeFile` import from `scripts/audit/playwright-crawl.ts` (alert 612)
- Removes unused `route` local in `scripts/audit/review/worlds-play.html` `buildMarkdown` loop (alert 625)

These are the only two non-false-positive CodeQL alerts left on #1081. The rest (cssClasses imports, useless `buttonSize` assignments, `endingError` conditional, unused `useCallback`/`Section`/`SubSection`) were already cleaned up by earlier commits in the integration branch. Alerts 580/581 (`toggleTheme`/`toggleNav` in `public_docs/design-system/redesign-planning/src/scripts/design-system.js`) are false positives — both functions are referenced from inline `onclick=""` handlers in sibling HTML files.

Targeting the integration branch so it lands inside #1081 rather than racing the merge.

## Test plan
- [x] `npm run lint` — passes (no new warnings)
- [x] `npx tsc --noEmit` — passes
- No runtime changes; both files are tooling/audit-output only