### PR TITLE
feat(ds): apply DS1/DS2/DS3 treatment to /play route + fix hydration race

### DIFF
--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -12,19 +12,66 @@ import { PageLayout } from '@/components/shared/PageLayout';
 import { getGenreLabel } from '@/lib/constants/genres';
 import { Button } from '@/components/ui/button';
 
+type PersistApi = {
+  persist?: {
+    hasHydrated?: () => boolean;
+    onFinishHydration?: (callback: () => void) => () => void;
+  };
+};
+
+const getPersist = (store: unknown): PersistApi['persist'] =>
+  (store as PersistApi).persist;
+
 export default function PlayPage() {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  
+  const [hydrated, setHydrated] = useState(false);
+
   const currentWorldId = useWorldStore(state => state.currentWorldId);
   const currentWorld = useWorldStore(state => state.worlds[currentWorldId || '']);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const currentCharacterId = useCharacterStore((state: any) => state.currentCharacterId);
   const initializeSession = useSessionStore(state => state.initializeSession);
   const currentSessionId = useSessionStore(state => state.id);
-  
+
+  // Wait for all three persisted stores to finish hydrating before reading
+  // their values for redirect decisions. Reading pre-hydration causes a
+  // redirect race that lands users on /worlds and surfaces a Next.js error.
   useEffect(() => {
+    const persists = [
+      getPersist(useWorldStore),
+      getPersist(useCharacterStore),
+      getPersist(useSessionStore),
+    ];
+
+    const allHydrated = persists.every(p => p?.hasHydrated?.() ?? true);
+    if (allHydrated) {
+      setHydrated(true);
+      return;
+    }
+
+    let pending = persists.filter(p => p?.hasHydrated && !p.hasHydrated()).length;
+    const unsubscribes: Array<() => void> = [];
+
+    persists.forEach(p => {
+      if (p?.onFinishHydration && p.hasHydrated && !p.hasHydrated()) {
+        const unsub = p.onFinishHydration(() => {
+          pending -= 1;
+          if (pending <= 0) setHydrated(true);
+        });
+        unsubscribes.push(unsub);
+      }
+    });
+
+    return () => {
+      unsubscribes.forEach(unsub => unsub());
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) return;
+
     const setupSession = async () => {
       try {
         // Check prerequisites
@@ -32,7 +79,7 @@ export default function PlayPage() {
           router.push('/worlds');
           return;
         }
-        
+
         if (!currentCharacterId) {
           router.push('/characters');
           return;
@@ -52,11 +99,11 @@ export default function PlayPage() {
     };
 
     setupSession();
-  }, [currentWorldId, currentCharacterId, currentSessionId, initializeSession, router]);
+  }, [hydrated, currentWorldId, currentCharacterId, currentSessionId, initializeSession, router]);
 
-  if (isLoading) {
+  if (!hydrated || isLoading) {
     return (
-      <main>
+      <main className="play-page play-page-loading">
         <LoadingPulse message="Preparing your adventure..." />
       </main>
     );
@@ -64,39 +111,43 @@ export default function PlayPage() {
 
   if (error) {
     return (
-      <PageLayout title="Game Session Error">
-        <SectionError
-          title="Failed to Start Game"
-          message={error}
-          severity="error"
-        />
-        <div className="error-display-actions">
-          <Button
-            variant="outline"
-            onClick={() => router.push('/worlds')}
-          >
-            Select World
-          </Button>
-          <Button
-            variant="outline"
-            onClick={() => router.push('/characters')}
-          >
-            Select Character
-          </Button>
-        </div>
-      </PageLayout>
+      <div className="play-page play-page-shell play-page-shell-error">
+        <PageLayout title="Game Session Error">
+          <SectionError
+            title="Failed to Start Game"
+            message={error}
+            severity="error"
+          />
+          <div className="error-display-actions">
+            <Button
+              variant="outline"
+              onClick={() => router.push('/worlds')}
+            >
+              Select World
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => router.push('/characters')}
+            >
+              Select Character
+            </Button>
+          </div>
+        </PageLayout>
+      </div>
     );
   }
 
   if (!currentSessionId) {
     return (
-      <PageLayout title="No Active Session">
-        <SectionError
-          title="No Active Session"
-          message="Unable to create or resume a game session."
-          severity="warning"
-        />
-      </PageLayout>
+      <div className="play-page play-page-shell play-page-shell-warning">
+        <PageLayout title="No Active Session">
+          <SectionError
+            title="No Active Session"
+            message="Unable to create or resume a game session."
+            severity="warning"
+          />
+        </PageLayout>
+      </div>
     );
   }
 
@@ -104,8 +155,10 @@ export default function PlayPage() {
   const pageDescription = currentWorld?.genre ? getGenreLabel(currentWorld.genre) : undefined;
 
   return (
-    <PageLayout title={pageTitle} description={pageDescription}>
-      <GameSession worldId={currentWorldId!} />
-    </PageLayout>
+    <div className="play-page play-page-active">
+      <PageLayout title={pageTitle} description={pageDescription}>
+        <GameSession worldId={currentWorldId!} />
+      </PageLayout>
+    </div>
   );
 }

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -139,6 +139,140 @@ body.manuscript-overlay-open {
   min-height: 100vh;
 }
 
+/* ─── /play route wrapper ───
+   `.play-page` wraps every render path of /src/app/play/page.tsx so per-theme
+   typography lands on PageLayout's unstyled <header>/<h1>/<p>. DS3 = base;
+   DS1 + DS2 add overrides below. */
+
+.play-page {
+  min-height: 100vh;
+  background: var(--color-canvas);
+}
+
+.play-page-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.play-page-shell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-8) var(--space-4);
+}
+
+.play-page-shell > div {
+  width: 100%;
+  max-width: 42rem;
+}
+
+.play-page-shell header {
+  text-align: center;
+  margin-bottom: var(--space-6);
+}
+
+.play-page-shell h1 {
+  font-family: var(--font-interface);
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.25;
+  color: var(--color-text-primary);
+  margin: 0 0 var(--space-2);
+}
+
+.play-page-shell header p {
+  font-family: var(--font-interface);
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.play-page-active > div {
+  width: 100%;
+}
+
+.play-page-active header {
+  padding: var(--space-6) var(--space-4) var(--space-3);
+}
+
+.play-page-active header h1 {
+  font-family: var(--font-narrative);
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 1.25;
+  color: var(--color-text-primary);
+  margin: 0 0 var(--space-1);
+}
+
+.play-page-active header p {
+  font-family: var(--font-interface);
+  font-size: 0.8125rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+/* DS1 — Lora serif on a paper canvas, archival ink */
+[data-theme="ds1"] .play-page-shell h1 {
+  font-family: var(--font-narrative);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--color-text-primary);
+}
+
+[data-theme="ds1"] .play-page-shell header p {
+  font-family: var(--font-system);
+  font-size: 0.6875rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+[data-theme="ds1"] .play-page-active header h1 {
+  font-family: var(--font-narrative);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+[data-theme="ds1"] .play-page-active header p {
+  font-family: var(--font-system);
+  font-size: 0.6875rem;
+  letter-spacing: 0.08em;
+}
+
+/* DS2 — Crimson Pro book heading, sage-tinted muted text */
+[data-theme="ds2"] .play-page-shell h1 {
+  font-family: var(--font-narrative);
+  font-size: 1.75rem;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  line-height: 1.2;
+}
+
+[data-theme="ds2"] .play-page-shell header p {
+  font-family: var(--font-interface);
+  color: var(--color-text-secondary);
+}
+
+[data-theme="ds2"] .play-page-active header h1 {
+  font-family: var(--font-narrative);
+  font-size: 1.75rem;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+}
+
+[data-theme="ds2"] .play-page-active header p {
+  font-family: var(--font-interface);
+  font-size: 0.8125rem;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  color: var(--color-accent);
+}
+
 .manuscript-main-stage {
   display: grid;
   gap: var(--space-4);

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -168,12 +168,17 @@ body.manuscript-overlay-open {
   max-width: 42rem;
 }
 
-.play-page-shell header {
+/* Selectors below use the `> div > div > header` chain so they match only
+   PageLayout's own header (the one /play renders for the page title) and
+   not nested <header> elements that GameSession descendants render
+   (e.g. EndingScreen, ManuscriptSessionShell). */
+
+.play-page-shell > div > div > header {
   text-align: center;
   margin-bottom: var(--space-6);
 }
 
-.play-page-shell h1 {
+.play-page-shell > div > div > header h1 {
   font-family: var(--font-interface);
   font-size: 1.5rem;
   font-weight: 700;
@@ -182,7 +187,7 @@ body.manuscript-overlay-open {
   margin: 0 0 var(--space-2);
 }
 
-.play-page-shell header p {
+.play-page-shell > div > div > header p {
   font-family: var(--font-interface);
   font-size: 0.9375rem;
   line-height: 1.5;
@@ -194,11 +199,11 @@ body.manuscript-overlay-open {
   width: 100%;
 }
 
-.play-page-active header {
+.play-page-active > div > div > header {
   padding: var(--space-6) var(--space-4) var(--space-3);
 }
 
-.play-page-active header h1 {
+.play-page-active > div > div > header h1 {
   font-family: var(--font-narrative);
   font-size: 1.5rem;
   font-weight: 600;
@@ -207,7 +212,7 @@ body.manuscript-overlay-open {
   margin: 0 0 var(--space-1);
 }
 
-.play-page-active header p {
+.play-page-active > div > div > header p {
   font-family: var(--font-interface);
   font-size: 0.8125rem;
   letter-spacing: 0.04em;
@@ -217,14 +222,14 @@ body.manuscript-overlay-open {
 }
 
 /* DS1 — Lora serif on a paper canvas, archival ink */
-[data-theme="ds1"] .play-page-shell h1 {
+[data-theme="ds1"] .play-page-shell > div > div > header h1 {
   font-family: var(--font-narrative);
   font-weight: 600;
   letter-spacing: 0.01em;
   color: var(--color-text-primary);
 }
 
-[data-theme="ds1"] .play-page-shell header p {
+[data-theme="ds1"] .play-page-shell > div > div > header p {
   font-family: var(--font-system);
   font-size: 0.6875rem;
   letter-spacing: 0.08em;
@@ -232,20 +237,20 @@ body.manuscript-overlay-open {
   color: var(--color-text-muted);
 }
 
-[data-theme="ds1"] .play-page-active header h1 {
+[data-theme="ds1"] .play-page-active > div > div > header h1 {
   font-family: var(--font-narrative);
   font-weight: 600;
   letter-spacing: 0.01em;
 }
 
-[data-theme="ds1"] .play-page-active header p {
+[data-theme="ds1"] .play-page-active > div > div > header p {
   font-family: var(--font-system);
   font-size: 0.6875rem;
   letter-spacing: 0.08em;
 }
 
 /* DS2 — Crimson Pro book heading, sage-tinted muted text */
-[data-theme="ds2"] .play-page-shell h1 {
+[data-theme="ds2"] .play-page-shell > div > div > header h1 {
   font-family: var(--font-narrative);
   font-size: 1.75rem;
   font-weight: 600;
@@ -253,19 +258,19 @@ body.manuscript-overlay-open {
   line-height: 1.2;
 }
 
-[data-theme="ds2"] .play-page-shell header p {
+[data-theme="ds2"] .play-page-shell > div > div > header p {
   font-family: var(--font-interface);
   color: var(--color-text-secondary);
 }
 
-[data-theme="ds2"] .play-page-active header h1 {
+[data-theme="ds2"] .play-page-active > div > div > header h1 {
   font-family: var(--font-narrative);
   font-size: 1.75rem;
   font-weight: 600;
   letter-spacing: -0.005em;
 }
 
-[data-theme="ds2"] .play-page-active header p {
+[data-theme="ds2"] .play-page-active > div > div > header p {
   font-family: var(--font-interface);
   font-size: 0.8125rem;
   letter-spacing: 0.02em;


### PR DESCRIPTION
## Summary

- `/play` route's `PageLayout` wrapper rendered no classes on `<header>`/`<h1>`/`<p>`, so titles and descriptions fell back to browser defaults under DS1/DS2/DS3. Wrapped each return path in a classed `<div>` (`.play-page-loading`, `.play-page-shell`, `.play-page-active`) and added base + DS1 + DS2 rules to `manuscript-session.css`, mirroring the SectionError pattern.
- Fixed the zustand `persist()` hydration race that landed seeded audit captures on `/worlds` with a Next.js error overlay. Gated the redirect `useEffect` on a `hydrated` flag that flips once worldStore, characterStore, and sessionStore have all called `onFinishHydration`.
- PageLayout itself is left alone — other routes have parallel issues under #1129.

## Verification

Inspected via `bdg` against the running dev server, switching `data-theme` between ds1/ds2/ds3 and reading computed styles on `.play-page-active header h1` and an injected `.play-page-shell` probe:

| Theme | h1 font | h1 size | canvas |
|---|---|---|---|
| DS1 | Lora | 24px | `rgb(253,251,247)` paper |
| DS2 | Crimson Pro | 28px | `rgb(250,248,243)` warm earth |
| DS3 | Newsreader (active) / DM Sans (shell) | 24px | `rgb(247,243,237)` parchment |

DS1 metadata renders in IBM Plex Mono uppercase; DS2 metadata is sage-tinted Manrope, no uppercase; DS3 is DM Sans muted — three distinct typographic systems.

- No browser console errors after the hydration gate landed.
- `npx tsc --noEmit`, `npx eslint src/app/play/page.tsx`, and `npx stylelint src/styles/manuscript-session.css` all clean.
- No unit tests directly cover `src/app/play/page.tsx`; visual regression captures should be regenerated as part of the next audit pass.

## Test plan

- [ ] Cold-reload `/play` in DS1, DS2, DS3 with seeded localStorage — confirm no redirect to `/worlds` and no Next.js dev error indicator.
- [ ] Force the error path (kill `initializeSession`) and the no-session path — confirm both render the centered themed shell.
- [ ] Re-run the audit crawl and compare `scripts/audit/captures/comp-integration-ds{1,2,3}-light/desktop/seeded/play__page.png` against the prior captures.
- [ ] Regenerate visual regression snapshots that touch `/play`.

Closes #1146. Refs #1129, #1133.