### PR TITLE
feat(ds): apply DS1/DS2/DS3 treatment to settings page (#1161)

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -30,10 +30,10 @@ export default function SettingsPage() {
       description="Manage your application settings and backup your game data. Export creates a downloadable backup file, and import restores your data from a previously exported file."
     >
       {/* Data Management Section */}
-      <div>
-        <section>
+      <div className="settings-page">
+        <section className="settings-section">
           <h2>Data Management</h2>
-          <Card>
+          <Card className="settings-card">
             <CardHeader>
               <CardTitle>Backup & Restore</CardTitle>
               <CardDescription>

--- a/src/app/workshop.css
+++ b/src/app/workshop.css
@@ -2707,6 +2707,227 @@
   opacity: 0.6;
 }
 
+/* ═══════════════════════════════════════════════════════════════
+   Settings Page — DS1/DS2/DS3 treatment for the data-management
+   section card and the export/import action surface. Mirrors the
+   world-detail-section / character-detail-section vocabulary.
+   ═══════════════════════════════════════════════════════════════ */
+
+.settings-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.settings-section h2 {
+  margin: 0;
+  font-family: var(--font-interface);
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.settings-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-5);
+}
+
+.settings-export-import {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.settings-export-import-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.settings-export-import-files {
+  display: inline-flex;
+  align-items: center;
+}
+
+.settings-export-import-help {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+}
+
+.settings-export-import-help p {
+  margin: 0;
+}
+
+@media (width <= 640px) {
+  .settings-card {
+    padding: var(--space-4);
+  }
+
+  .settings-export-import-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .settings-export-import-files {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-2);
+  }
+}
+
+/* DS1 — Drafting Table: tight, sharp, hairline eyebrow */
+
+[data-theme="ds1"] .settings-card {
+  border-radius: 2px;
+  border-left: 2px solid var(--color-accent);
+}
+
+[data-theme="ds1"] .settings-section h2 {
+  position: relative;
+  padding-top: var(--space-3);
+  font-weight: 500;
+  letter-spacing: -0.005em;
+}
+
+[data-theme="ds1"] .settings-section h2::before {
+  content: "Section";
+  display: block;
+  margin-bottom: var(--space-2);
+  font-family: var(--font-system);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+[data-theme="ds1"] .settings-section h2::after {
+  content: "";
+  display: block;
+  width: 2px;
+  height: 18px;
+  margin: var(--space-2) 0 var(--space-1);
+  background: linear-gradient(to bottom, var(--color-accent), transparent);
+}
+
+[data-theme="ds1"] .settings-export-import-help {
+  font-family: var(--font-system);
+  font-size: 0.8125rem;
+}
+
+/* DS2 — Warm Earth: airy, soft radii, serif heading, fade-up */
+
+[data-theme="ds2"] .settings-page {
+  gap: clamp(var(--space-5), 3vw, var(--space-8));
+}
+
+[data-theme="ds2"] .settings-section {
+  gap: clamp(var(--space-3), 2vw, var(--space-5));
+}
+
+[data-theme="ds2"] .settings-card {
+  border-radius: 1rem;
+  padding: clamp(var(--space-5), 3vw, var(--space-6));
+  animation: characters-fade-up 0.7s cubic-bezier(0.19, 1, 0.22, 1) both;
+}
+
+[data-theme="ds2"] .settings-section h2 {
+  font-family: var(--font-narrative);
+  font-weight: 400;
+  font-size: 1.375rem;
+  letter-spacing: -0.005em;
+}
+
+[data-theme="ds2"] .settings-export-import-actions {
+  gap: clamp(var(--space-3), 2vw, var(--space-5));
+}
+
+[data-theme="ds2"] .settings-export-import-help {
+  font-family: var(--font-narrative);
+  font-style: italic;
+  font-size: 0.9375rem;
+}
+
+/* DS3 — Mechanical Manuscript: dotted dividers, monospace bullet eyebrow */
+
+[data-theme="ds3"] .settings-card {
+  border-radius: 6px;
+}
+
+[data-theme="ds3"] .settings-section h2 {
+  position: relative;
+  padding-top: var(--space-3);
+  padding-bottom: var(--space-3);
+  font-family: var(--font-narrative);
+  font-style: italic;
+  font-weight: 400;
+}
+
+[data-theme="ds3"] .settings-section h2::before {
+  content: "• Section";
+  display: block;
+  margin-bottom: var(--space-1);
+  font-family: var(--font-system);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  font-style: normal;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+[data-theme="ds3"] .settings-section h2::after {
+  content: "";
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background-image: radial-gradient(
+    circle,
+    var(--color-border-strong) 1.5px,
+    transparent 1.5px
+  );
+  background-size: 12px 4px;
+  background-repeat: repeat-x;
+  opacity: 0.6;
+}
+
+[data-theme="ds3"] .settings-export-import {
+  gap: var(--space-5);
+}
+
+[data-theme="ds3"] .settings-export-import-help {
+  font-family: var(--font-system);
+  font-size: 0.8125rem;
+}
+
+[data-theme="ds3"] .settings-export-import-help p + p {
+  padding-top: var(--space-2);
+  background-image: radial-gradient(
+    circle,
+    var(--color-border-strong) 1.5px,
+    transparent 1.5px
+  );
+  background-size: 12px 4px;
+  background-repeat: repeat-x;
+  background-position: top left;
+}
+
 /* Reduced-motion override — placed after all DS2 fade-up rules so the
    later same-specificity selectors don't win the cascade. */
 
@@ -2714,6 +2935,7 @@
   [data-theme="ds2"] .characters-empty,
   [data-theme="ds2"] .character-detail-section,
   [data-theme="ds2"] .world-detail-section,
+  [data-theme="ds2"] .settings-card,
   [data-theme="ds2"] .component-character-editor .component-collapsible-section,
   [data-theme="ds2"] .component-world-editor .component-collapsible-section {
     animation: none;

--- a/src/components/shared/ExportImportControls.tsx
+++ b/src/components/shared/ExportImportControls.tsx
@@ -73,18 +73,18 @@ export function ExportImportControls({ className = '' }: ExportImportControlsPro
   const isLoading = isExporting || isImporting;
 
   return (
-    <div className={`${className}`}>
-      <div>
+    <div className={`settings-export-import ${className}`.trim()}>
+      <div className="settings-export-import-actions">
         <Button
           onClick={handleExport}
           disabled={isLoading}
           variant="outline"
-          
+
         >
           {isExporting ? 'Exporting...' : 'Export Game Data'}
         </Button>
 
-        <div>
+        <div className="settings-export-import-files">
           <label htmlFor="import-file" >
             Import Game Data
           </label>
@@ -95,14 +95,14 @@ export function ExportImportControls({ className = '' }: ExportImportControlsPro
             accept=".json"
             onChange={handleFileChange}
             disabled={isLoading}
-            
+
             aria-label="Import game data from file"
           />
           <Button
             onClick={() => fileInputRef.current?.click()}
             disabled={isLoading}
             variant="outline"
-            
+
           >
             {isImporting ? 'Importing...' : 'Import Game Data'}
           </Button>
@@ -119,7 +119,7 @@ export function ExportImportControls({ className = '' }: ExportImportControlsPro
         />
       )}
 
-      <div>
+      <div className="settings-export-import-help">
         <p>
           <strong>Export:</strong> Creates a backup file of your complete game state including worlds, characters, and progress.
         </p>


### PR DESCRIPTION
## Description
Brings the settings page (`/settings`) to parity with the other audited info pages (worlds detail, character detail) so DS1, DS2, and DS3 read distinctly at desktop and mobile, in both empty and seeded states. Mirrors the existing `.world-detail-section` / `.character-detail-section` vocabulary.

## Related Issue
Closes #1161

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Implementation Notes
- Added identifying class hooks to `src/app/settings/page.tsx` wrappers and to the `ExportImportControls` action/files/help groups (no `PageLayout` or `Card` primitive changes).
- Extended `src/app/workshop.css` (per recent precedent — PRs #1191, #1192, #1193, #1194 all extended workshop.css; only the wizard surface earned its own file). Avoids new stylelint allowlist or layout import changes.
- Vocabulary applied:
  - **DS1** — 2px sharp radii, 2px accent left-border on the card, IBM Plex Mono "SECTION" hairline eyebrow above the h2, 2×18 vertical accent rule below it, IBM Plex Mono help text.
  - **DS2** — 1rem soft radii, Crimson Pro serif h2 (weight 400), `characters-fade-up` entry, italic Crimson Pro help text, clamp-based airy gaps.
  - **DS3** — 6px medium radius, italic Newsreader serif h2, "• Section" Fira Code bullet eyebrow, radial-gradient dotted divider beneath the h2 and between the help paragraphs.
- Mobile rule stacks the action row and wraps the import file picker so the Import button no longer overflows at 375px.
- Added `.settings-card` to the existing reduced-motion override (placed after all DS2 fade-up rules, per the cascade fix from PR #1195) so the entry animation respects user preference.
- `settings__nav` (workshop chrome) already lifts via `workshop.css` — verified via bdg.

## Quality Checks
- [x] Linting passed (`npm run lint`)
- [x] CSS linting passed (`npm run lint:css`)
- [x] Type checking passed
- [x] No new warnings generated
- [x] Tests pass (`npx jest --testPathPattern='settings|ExportImport'` — 64 tests across 9 suites)
- [x] Tokens only — no `--space-7`, no `!important`, no Tailwind utilities

## Testing Instructions
1. Pull the branch and `npm run dev`.
2. Visit `/settings` and switch the theme via the floating DS toggle in the bottom-left.
3. Confirm at 1280×900:
   - DS1: hairline "SECTION" eyebrow above "Data Management", 2×18 accent rule below, sharp 2px corners on the card, accent left-border, mono help text.
   - DS2: quiet Crimson Pro serif heading, soft 1rem corners, italic serif help text, fade-up on first paint.
   - DS3: "• SECTION" Fira Code eyebrow, italic Newsreader heading, dotted divider beneath h2, dotted divider between Export/Import help paragraphs.
4. Resize to 375×812 and confirm the action row stacks and the Import group wraps cleanly across all three themes.
5. With `prefers-reduced-motion: reduce`, confirm DS2 no longer animates the card on entry.

## Acceptance — audit cells
- [x] `settings__page` — DS1 / DS2 / DS3 read distinctly at desktop and mobile (empty + seeded).
- [x] `settings__nav` — lifts via existing workshop chrome canon.
- [x] `settings__main` — DS1 / DS2 / DS3 read distinctly at desktop and mobile (empty + seeded).

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (workshop.css extension; no oversized new files)
- [x] Self-review of code performed
- [x] No new warnings generated
- [x] Accessibility considerations addressed (reduced-motion override, identifying class hooks on every wrapper)