### PR TITLE
fix(ds): collapse redundant shorthand on GFTE DS2 padding

### DIFF
--- a/src/app/wizard.css
+++ b/src/app/wizard.css
@@ -1640,8 +1640,7 @@
 
 [data-theme="ds2"] .component-guided-first-time {
   border-radius: 1rem;
-  padding: clamp(var(--space-5), 3vw, var(--space-6))
-    clamp(var(--space-5), 3vw, var(--space-6));
+  padding: clamp(var(--space-5), 3vw, var(--space-6));
 }
 
 [data-theme="ds2"] .component-guided-first-time .wizard-title {


### PR DESCRIPTION
## Summary

Tiny stylelint fix to unblock CI on PR #1081.

`shorthand-property-no-redundant-values` flagged `padding: clamp(...) clamp(...)` at [wizard.css:1643](https://github.com/jerseycheese/Narraitor/blob/1020-design-system-integration/src/app/wizard.css#L1643) since both axes are identical. Collapsed to single-value shorthand — produces identical layout.

```diff
-  padding: clamp(var(--space-5), 3vw, var(--space-6))
-    clamp(var(--space-5), 3vw, var(--space-6));
+  padding: clamp(var(--space-5), 3vw, var(--space-6));
```

Slipped past local lint earlier because I ran `npm run lint` (ESLint) but not `npx stylelint` separately.

## Test plan

- [x] `npx stylelint "src/**/*.css"` clean locally
- [x] No visual change (both shorthand forms resolve to the same box)
- [ ] CI Lint Check green