### PR TITLE
fix(session): replace eval(require()) with static imports in store cross-references (#1206)

### DIFF
--- a/src/state/__tests__/narrativeStore.markSessionEnded.test.ts
+++ b/src/state/__tests__/narrativeStore.markSessionEnded.test.ts
@@ -1,0 +1,64 @@
+// src/state/__tests__/narrativeStore.markSessionEnded.test.ts
+//
+// Regression test for #1206: markSessionEnded used to call `eval('require(...)')`
+// to defer-load sessionStore. That throws `require is not defined` in the
+// Next.js client bundle, but the surrounding try/catch swallowed it so the
+// failure was silent. We replaced it with a static ESM import.
+//
+// Asserts:
+//   1. markSessionEnded updates endedSessions synchronously
+//   2. It propagates lifecycle status to sessionStore in the same tick
+//   3. It does not throw
+
+import { useNarrativeStore } from '../narrativeStore';
+import { useSessionStore } from '../sessionStore';
+
+const SESSION_ID = 'session-mark-ended-1206';
+const WORLD_ID = 'world-1206';
+const CHARACTER_ID = 'char-1206';
+
+const seedLifecycle = () => {
+  useSessionStore.setState({
+    sessionLifecycle: {
+      [SESSION_ID]: {
+        id: SESSION_ID,
+        worldId: WORLD_ID,
+        characterId: CHARACTER_ID,
+        status: 'active',
+        lastActivity: new Date().toISOString(),
+      },
+    },
+  });
+};
+
+describe('narrativeStore.markSessionEnded (#1206 regression)', () => {
+  beforeEach(() => {
+    useNarrativeStore.setState({ endedSessions: {} });
+    useSessionStore.setState({ sessionLifecycle: {} });
+  });
+
+  it('marks the session ended in narrativeStore synchronously', () => {
+    seedLifecycle();
+
+    expect(() => {
+      useNarrativeStore.getState().markSessionEnded(SESSION_ID);
+    }).not.toThrow();
+
+    expect(useNarrativeStore.getState().isSessionEnded(SESSION_ID)).toBe(true);
+  });
+
+  it('propagates lifecycle status to sessionStore', () => {
+    seedLifecycle();
+
+    useNarrativeStore.getState().markSessionEnded(SESSION_ID);
+
+    expect(useSessionStore.getState().getSessionLifecycle(SESSION_ID)?.status).toBe('ended');
+  });
+
+  it('does not throw if lifecycle entry is missing in sessionStore', () => {
+    expect(() => {
+      useNarrativeStore.getState().markSessionEnded('unknown-session');
+    }).not.toThrow();
+    expect(useNarrativeStore.getState().isSessionEnded('unknown-session')).toBe(true);
+  });
+});

--- a/src/state/narrativeStore.ts
+++ b/src/state/narrativeStore.ts
@@ -19,9 +19,9 @@ import {
   PlayerCharacterThreadUpdate,
   CharacterRelationshipUpdate,
 } from '../types/world-state.types';
+import { useWorldStore } from './worldStore';
+import { useSessionStore } from './sessionStore';
 
-let worldStoreModule: typeof import('./worldStore') | null = null;
-let sessionStoreModule: typeof import('./sessionStore') | null = null;
 let characterStoreModule: typeof import('./characterStore') | null = null;
 let journalStoreModule: typeof import('./journalStore') | null = null;
 
@@ -139,18 +139,10 @@ async function applyWorldStateThreadUpdates({
   isFirstSegment,
 }: WorldStateUpdateParams): Promise<void> {
   try {
-    if (!sessionStoreModule) {
-      sessionStoreModule = await import('./sessionStore');
-    }
-    if (!worldStoreModule) {
-      worldStoreModule = await import('./worldStore');
-    }
     if (!characterStoreModule) {
       characterStoreModule = await import('./characterStore');
     }
 
-    const { useSessionStore } = sessionStoreModule!;
-    const { useWorldStore } = worldStoreModule!;
     const { useCharacterStore } = characterStoreModule!;
 
     const sessionStore = useSessionStore.getState();
@@ -1105,10 +1097,6 @@ export const useNarrativeStore = create<NarrativeStore>()(
     const payload = worldStatePayload;
     if (payload) {
       try {
-        if (!worldStoreModule) {
-          worldStoreModule = eval('require("./worldStore")');
-        }
-        const { useWorldStore } = worldStoreModule!;
         useWorldStore.getState().updateWorldState(
           payload.worldId,
           {
@@ -1371,10 +1359,6 @@ export const useNarrativeStore = create<NarrativeStore>()(
     }));
 
     try {
-      if (!sessionStoreModule) {
-        sessionStoreModule = eval('require("./sessionStore")');
-      }
-      const { useSessionStore } = sessionStoreModule!;
       useSessionStore.getState().setSessionLifecycleStatus(sessionId, 'ended');
     } catch (error) {
       logger.warn('Failed to propagate session lifecycle status on ending', error);

--- a/src/state/worldStore.ts
+++ b/src/state/worldStore.ts
@@ -12,16 +12,12 @@ import { WorldState, WorldStateUpdate, createEmptyWorldState } from '../types/wo
 import { applyWorldStateUpdate, getActiveWorldState, mergeState } from '@/lib/world';
 import Logger from '@/lib/utils/logger';
 import { storeEvents, StoreEventTypes, type WorldDeletedEvent } from '@/lib/state/storePubSub';
+import { useSessionStore } from './sessionStore';
 
 const logger = new Logger('WorldStore');
-let sessionStoreModule: typeof import('./sessionStore') | null = null;
 
 const resolveSessionStatus = (sessionId: EntityID) => {
   try {
-    if (!sessionStoreModule) {
-      sessionStoreModule = eval('require("./sessionStore")');
-    }
-    const { useSessionStore } = sessionStoreModule!;
     return useSessionStore.getState().getSessionLifecycle(sessionId)?.status;
   } catch (error) {
     logger.warn('Failed to resolve session status', { sessionId, error });


### PR DESCRIPTION
## Summary

- Three Zustand store cross-references used `eval('require("./module")')` to defer-load peer stores. In the Next.js client bundle `require` is undefined at runtime, so each call threw silently inside the surrounding try/catch — closes #1206.
- Verified no static circular deps exist between sessionStore / worldStore / narrativeStore today; switched to plain ESM `import` statements rather than swapping in another async workaround.
- Adds a unit test exercising the `markSessionEnded` -> `sessionStore` propagation so this can't regress silently again.

## Root cause

Three call sites had the same anti-pattern:

| File | Function | Cross-store call |
|---|---|---|
| `src/state/narrativeStore.ts` | `markSessionEnded` | `useSessionStore.setSessionLifecycleStatus` |
| `src/state/narrativeStore.ts` | `recordDecision` (worldState branch) | `useWorldStore.updateWorldState` |
| `src/state/worldStore.ts` | `resolveSessionStatus` | `useSessionStore.getSessionLifecycle` |

The `eval('require(...)')` trick was added back when the dependency-cruiser graph showed real cycles. Those have since been broken via `lib/state/storePubSub`, so the workaround is no longer load-bearing.

## Also

- Closing #1204 separately as **not a bug as filed**. The "Generate New Random Character" flow correctly creates a fresh fantasy character and routes straight to `/play` by design (PR #569 / issue #561). The "Raven from cyberpunk world" report conflated a stock fantasy Ranger archetype name with an unrelated cyberpunk NPC fixture. See [issue #1204](https://github.com/jerseycheese/Narraitor/issues/1204) for the forensic write-up.

## Out of scope

- Stale `narraitor-character-store` localStorage entries from an old persistence migration (active storage is IndexedDB; the localStorage keys are harmless leftovers). Worth a follow-up issue to ship a one-time cleanup on app startup.
- The remaining `eval('require')`-style indirection in `src/lib/utils/errorUtils.ts:194` — server-only path inside a try/catch, not affecting client.

## Test plan

- [x] `npx jest src/state/` — 351 pass (incl. new `narrativeStore.markSessionEnded.test.ts`)
- [x] `npx jest` — full suite, 2139 pass
- [x] `npx tsc --noEmit` — clean
- [x] Live browser repro via headless Chrome on the running dev server: seeded a session lifecycle, called `useNarrativeStore.getState().markSessionEnded(...)`, confirmed `endedSessions` updated and `sessionStore.sessionLifecycle[id].status === "ended"` synchronously, no `require is not defined` in the console.