### PR TITLE
docs: introduce tagged releases — main = stable, develop = rolling (#1170)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ AI-powered storytelling app that basically lets you play through narrative RPG e
 
 The core idea came from wanting tabletop RPG experiences that could happen anytime, without coordinating schedules or finding a game master. Narraitor uses Google's Gemini AI to generate dynamic stories that respond to your choices, but here's the key part: it's not just generic fantasy. You define your world's rules, attributes, and tone, and the AI storytelling adapts to match exactly what you're going for.
 
+## Branches
+
+The repo has two branches that matter. `main` is the latest tagged release and the default clone target — pin here if you want something stable. `develop` is the rolling integration line where in-flight work lands, so it may include partial features at any given moment. Contributor PRs should target `develop`.
+
+Release notes for each tagged version live in [RELEASES.md](RELEASES.md).
+
 ## Key Features
 
 **World Creation**: You can define any fictional universe with custom attributes (like "Force Sensitivity" for Star Wars or "Sanity" for Lovecraft) and skills that make sense for your setting. The AI wizard helps suggest appropriate mechanics based on your world's theme.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,26 @@
+# Releases
+
+Narraitor is pre-1.0, so releases get tagged manually from `develop` and fast-forwarded to `main`. Each entry below covers what's in the tag, what's known to still be in flight, and what's lined up next. The full release process lives in [release-process.md](public_docs/development/release-process.md).
+
+---
+
+## v0.4.0-pre-design-system — 2026-05-10
+
+This is the baseline tag, cut right before the multi-theme design system migration lands publicly. The idea is to give anyone who's pinned to a SHA today a stable point they can keep using while the design work plays out on `develop`.
+
+**What's in this release**
+
+- World creation wizard with AI-assisted attributes and skills
+- Character creation, journal, and the AI-driven narrative engine (Gemini-backed, all calls routed server-side)
+- IndexedDB persistence so sessions survive a refresh
+- Three template worlds out of the box: Western, Sitcom, Adventure
+- Secure API key handling and per-IP rate limiting (#478)
+
+**Known incomplete**
+
+The design system migration is mid-flight on `develop`. Phases 0–2 already merged via #1081, the structural differentiation piece is tracked in #1165, and #1020 is the umbrella epic that ties the whole thing together. A few smaller items are also still open — AI-inferred skill checks (#918, with #1207 as related context) and a stale `narraitor-character-store` localStorage cleanup that hasn't gotten its own issue yet.
+
+**What's next**
+
+- `v0.5.0-design-system` — cuts as soon as the #1020 epic closes out, brings the multi-theme tokens public
+- `v0.6.0-theme-differentiation` — structural differentiation work from #1165 follows that

--- a/public_docs/development/release-process.md
+++ b/public_docs/development/release-process.md
@@ -1,0 +1,41 @@
+# Release Process
+
+Narraitor's release model is intentionally lightweight. `develop` is where all the merge-in-progress work lives, and `main` only ever moves forward when a release is tagged. This doc covers when to cut a release and the exact mechanics for doing it.
+
+## When to cut a release
+
+A release should mark something meaningful that a public user would care about — the design system migration shipping, structural theme differentiation landing, an MVP milestone closing. It's not a per-PR thing. If a stargazer pulled `main` today, they should be able to tell from the release notes what shifted since last time.
+
+Rule of thumb: if there's a clean story to tell about what's in this slice of work, it's release-worthy.
+
+## Version naming
+
+Tags follow `vMAJOR.MINOR.PATCH[-suffix]`. Pre-1.0 the version numbers are loose — they signal scope, not a stability promise. The optional suffix is for tags that benefit from a one-word label, like `v0.4.0-pre-design-system` or `v0.6.0-theme-differentiation`. Skip the suffix when the version is self-explanatory.
+
+## Cutting the release
+
+The process has three moving parts: write the release notes, tag the commit, and fast-forward `main`. Doing them in that order avoids the awkward state where `main` points at a tag that has no release notes yet.
+
+1. **Update `RELEASES.md`.** Add a new section at the top with the version, the date, a scope summary, what's known incomplete, and what's next. Link PRs and issues directly.
+2. **Tag `develop` HEAD.** From an up-to-date `develop`:
+   ```
+   git tag -a vX.Y.Z -m "Release notes summary here." <sha>
+   git push origin vX.Y.Z
+   ```
+3. **Fast-forward `main`.** This should always be a clean fast-forward — if it isn't, something has gone sideways and the release shouldn't proceed until that's understood.
+   ```
+   git checkout main
+   git pull --ff-only
+   git merge --ff-only vX.Y.Z
+   git push origin main
+   ```
+4. **Publish the GitHub release.** Either paste the matching section from `RELEASES.md` or pipe it in:
+   ```
+   gh release create vX.Y.Z --title "vX.Y.Z" --notes-file <path-to-notes-fragment>
+   ```
+
+That's it. The release is live, `main` reflects it, and the next round of work continues on `develop`.
+
+## What's intentionally not in scope
+
+Automated tooling (release-please, semantic-release, conventional-commits enforcement) is a deliberate skip — the solo-dev cadence doesn't need the overhead yet. Same goes for pre-release channels like alpha or beta; one stable channel keeps things simple.


### PR DESCRIPTION
## Description

Acceptance criteria 1, 4–7 of #1170. This is the content-only piece — it adds the public-facing docs so stargazers can pin to something stable, while the actual tag, default-branch switch, and `main` fast-forward happen after this merges.

Three files added or touched:

- `RELEASES.md` (new, repo root) — heading-per-version format with the baseline `v0.4.0-pre-design-system` entry already filled in. Calls out what's in this release, what's known incomplete (DS migration in flight, #918/#1207, the localStorage cleanup), and what's lined up next.
- `README.md` — short "Branches" section right after "What This Actually Does". Tells stargazers `main` is the stable target, `develop` is rolling, contributor PRs target `develop`.
- `public_docs/development/release-process.md` (new — also creates the directory) — one-page doc covering when to cut a release, the version naming convention, and the exact tag/fast-forward steps.

## Related Issue

Closes #1170 (partial — criteria 1, 4–7; criteria 2, 3 happen after merge; criterion 8 lands with the next release).

## Type of Change

- [x] Documentation update

## Implementation Notes

A few things worth flagging:

**Baseline SHA changed during execution.** The handoff assumed local `develop` was ahead of origin at `b4e38347`; pulling showed origin was actually ahead at `958229ec` (PR #1209 merge). The baseline tag will point at `958229ec` — same intent, just the actual current `develop` tip.

**CLAUDE.md is gitignored.** Criterion 7 calls for updating `CLAUDE.md` so future agent work treats `main` as release-only. That file isn't tracked in this repo (it's in `.gitignore` along with `CLAUDE.local.md`). The release-only framing now lives in the README "Branches" section and `release-process.md` instead, which are the public-facing surface. A personal memory entry was also added locally so future agent sessions absorb the posture. If there's a tracked agent-instructions file that should also reflect this (`AGENTS.md` is currently untracked), happy to follow up.

**No automated release tooling.** Per the issue body, release-please / semantic-release / conventional-commits enforcement is intentionally out of scope. Manual tagging stays the model.

## Testing Instructions

Doc-only PR. Spot checks:

- `RELEASES.md` reads cleanly at the repo root and the baseline section makes sense in isolation.
- The README "Branches" section appears between "What This Actually Does" and "Key Features" and the RELEASES.md link works.
- `public_docs/development/release-process.md` is reachable from the RELEASES.md and CLAUDE.md insert (once the latter exists in whatever tracked file ends up holding it).

## Post-merge steps (out of scope for this PR but tracked here)

After this merges to `develop`:

1. `git tag -a v0.4.0-pre-design-system 958229ec -m "..."` and push the tag.
2. `gh repo edit jerseycheese/Narraitor --default-branch main` to flip the default.
3. Fast-forward `main` to the tag and push.
4. `gh release create v0.4.0-pre-design-system` with the RELEASES.md entry as the notes.
5. Smoke-test by cloning fresh into `/tmp` and confirming the default branch is `main` with the tag at HEAD.

Each of those happens with explicit confirmation, not as part of this PR.