### PR TITLE
Fix play action row overflow on mobile viewports

### DIFF
--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -825,7 +825,9 @@ body.manuscript-overlay-open {
 }
 
 .manuscript-custom-input {
-  width: 100%;
+  flex: 1;
+  width: auto;
+  min-width: 12.5rem;
   height: 2.375rem;
   padding: 0 var(--space-2);
   border-radius: var(--radius-sm);
@@ -1948,6 +1950,7 @@ body.manuscript-overlay-open {
 
   .manuscript-input-row {
     align-items: stretch;
+    flex-wrap: wrap;
   }
 
 }

--- a/tests/visual/mobile-overflow.spec.ts
+++ b/tests/visual/mobile-overflow.spec.ts
@@ -4,59 +4,67 @@ import { mockApiEndpoints } from './utils/mockApi';
 
 test.describe('Mobile Action Row Layout', () => {
   const themes = ['ds1', 'ds2', 'ds3'] as const;
+  const mobileViewports = [
+    { name: 'narrow-mobile', width: 320, height: 568 },
+    { name: 'mobile', width: 375, height: 667 },
+  ] as const;
 
   for (const theme of themes) {
-    test(`Mobile action row should not have horizontal overflow in ${theme}`, async ({ page }) => {
-      // Seed test data and mock APIs
-      await seedTestData(page);
-      await mockApiEndpoints(page);
+    for (const viewport of mobileViewports) {
+      test(`Mobile action row should not have horizontal overflow in ${theme} at ${viewport.width}px`, async ({ page }) => {
+        // Seed test data and mock APIs
+        await seedTestData(page);
+        await mockApiEndpoints(page);
 
-      // Set mobile viewport
-      await page.setViewportSize({ width: 375, height: 667 }); // iPhone SE
-      
-      // Go to play page
-      await page.goto('/worlds/world-cyberpunk-2077/play');
+        await page.setViewportSize({
+          width: viewport.width,
+          height: viewport.height,
+        });
 
-      // Set theme
-      await page.evaluate((t) => {
-        localStorage.setItem('narraitor-theme', t);
-        document.documentElement.setAttribute('data-theme', t);
-      }, theme);
-      
-      await page.reload();
+        // Go to play page
+        await page.goto('/worlds/world-cyberpunk-2077/play');
 
-      // Wait for the main manuscript shell to load
-      await page.waitForSelector('[data-testid="manuscript-session-shell"]', { timeout: 15000 });
-      
-      // Check if suggested actions are present
-      await expect(page.locator('.manuscript-suggested-action').first()).toBeVisible();
+        // Set theme
+        await page.evaluate((t) => {
+          localStorage.setItem('narraitor-theme', t);
+          document.documentElement.setAttribute('data-theme', t);
+        }, theme);
 
-      // Check for horizontal overflow
-      const overflow = await page.evaluate(() => {
-        const doc = document.documentElement;
-        const body = document.body;
-        const rail = document.querySelector('#manuscript-action-rail');
-        
-        const results = {
-          docScrollWidth: doc.scrollWidth,
-          docClientWidth: doc.clientWidth,
-          bodyScrollWidth: body.scrollWidth,
-          bodyClientWidth: body.clientWidth,
-          railScrollWidth: rail ? rail.scrollWidth : 0,
-          railClientWidth: rail ? rail.clientWidth : 0,
-          hasOverflow: false
-        };
-        
-        results.hasOverflow = doc.scrollWidth > doc.clientWidth || 
-                             body.scrollWidth > body.clientWidth ||
-                             (rail ? rail.scrollWidth > rail.clientWidth : false);
-                             
-        return results;
+        await page.reload();
+
+        // Wait for the main manuscript shell to load
+        await page.waitForSelector('[data-testid="manuscript-session-shell"]', { timeout: 15000 });
+
+        // Check if suggested actions are present
+        await expect(page.locator('.manuscript-suggested-action').first()).toBeVisible();
+
+        // Check for horizontal overflow
+        const overflow = await page.evaluate(() => {
+          const doc = document.documentElement;
+          const body = document.body;
+          const rail = document.querySelector('#manuscript-action-rail');
+
+          const results = {
+            docScrollWidth: doc.scrollWidth,
+            docClientWidth: doc.clientWidth,
+            bodyScrollWidth: body.scrollWidth,
+            bodyClientWidth: body.clientWidth,
+            railScrollWidth: rail ? rail.scrollWidth : 0,
+            railClientWidth: rail ? rail.clientWidth : 0,
+            hasOverflow: false
+          };
+
+          results.hasOverflow = doc.scrollWidth > doc.clientWidth ||
+                               body.scrollWidth > body.clientWidth ||
+                               (rail ? rail.scrollWidth > rail.clientWidth : false);
+
+          return results;
+        });
+
+        console.log(`Overflow results for ${theme} at ${viewport.width}px:`, JSON.stringify(overflow, null, 2));
+
+        expect(overflow.hasOverflow, `Should not have horizontal overflow in ${theme} at ${viewport.width}px`).toBe(false);
       });
-
-      console.log(`Overflow results for ${theme}:`, JSON.stringify(overflow, null, 2));
-
-      expect(overflow.hasOverflow, `Should not have horizontal overflow in ${theme}`).toBe(false);
-    });
+    }
   }
 });

--- a/tests/visual/mobile-overflow.spec.ts
+++ b/tests/visual/mobile-overflow.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { seedTestData } from './utils/seedTestData';
+import { mockApiEndpoints } from './utils/mockApi';
+
+test.describe('Mobile Action Row Layout', () => {
+  const themes = ['ds1', 'ds2', 'ds3'] as const;
+
+  for (const theme of themes) {
+    test(`Mobile action row should not have horizontal overflow in ${theme}`, async ({ page }) => {
+      // Seed test data and mock APIs
+      await seedTestData(page);
+      await mockApiEndpoints(page);
+
+      // Set mobile viewport
+      await page.setViewportSize({ width: 375, height: 667 }); // iPhone SE
+      
+      // Go to play page
+      await page.goto('/worlds/world-cyberpunk-2077/play');
+
+      // Set theme
+      await page.evaluate((t) => {
+        localStorage.setItem('narraitor-theme', t);
+        document.documentElement.setAttribute('data-theme', t);
+      }, theme);
+      
+      await page.reload();
+
+      // Wait for the main manuscript shell to load
+      await page.waitForSelector('[data-testid="manuscript-session-shell"]', { timeout: 15000 });
+      
+      // Check if suggested actions are present
+      await expect(page.locator('.manuscript-suggested-action').first()).toBeVisible();
+
+      // Check for horizontal overflow
+      const overflow = await page.evaluate(() => {
+        const doc = document.documentElement;
+        const body = document.body;
+        const rail = document.querySelector('#manuscript-action-rail');
+        
+        const results = {
+          docScrollWidth: doc.scrollWidth,
+          docClientWidth: doc.clientWidth,
+          bodyScrollWidth: body.scrollWidth,
+          bodyClientWidth: body.clientWidth,
+          railScrollWidth: rail ? rail.scrollWidth : 0,
+          railClientWidth: rail ? rail.clientWidth : 0,
+          hasOverflow: false
+        };
+        
+        results.hasOverflow = doc.scrollWidth > doc.clientWidth || 
+                             body.scrollWidth > body.clientWidth ||
+                             (rail ? rail.scrollWidth > rail.clientWidth : false);
+                             
+        return results;
+      });
+
+      console.log(`Overflow results for ${theme}:`, JSON.stringify(overflow, null, 2));
+
+      expect(overflow.hasOverflow, `Should not have horizontal overflow in ${theme}`).toBe(false);
+    });
+  }
+});


### PR DESCRIPTION
This PR addresses the layout bug where the play page action row was too wide on mobile viewports, causing horizontal overflow.

**Changes:**
- Added `flex-wrap: wrap` to `.manuscript-input-row` on mobile viewports.
- Updated `.manuscript-custom-input` to be flexible (`flex: 1`) with a `min-width: 12.5rem` (200px) instead of a fixed 100% width. This ensures it only wraps when strictly necessary while maintaining a usable size.
- Added a multi-theme regression test at `tests/visual/mobile-overflow.spec.ts`.

Closes #1148