### PR TITLE
docs: add Action Groups component rules

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -244,6 +244,13 @@ Component rules apply to all three themes. The token references resolve per-them
 - Height **36px** to match button default. Background `surface`, border `1px solid var(--color-border)`, radius `var(--radius-md)`, padding `8px 12px`.
 - Focus: `2px` accent outline, no border color change.
 
+### Action Groups
+
+- **Never use floating or adjacent raw `<Button>` tags** for toolbars or card footers. Wrap them in `<ActionButtonGroup>` or `<CardActionGroup>`.
+- **Layout & Spacing**: Use `layout="horizontal" | "vertical"` and `gap="sm" | "md" | "lg"` props on the group to rely on strict design system spacing tokens instead of ad-hoc padding/margins.
+- **Responsive Flex**: For buttons that should stretch to fill available width (like "Play" or "Save"), pass `flex: true` to the action definition. Do not use custom `flex-1` classes.
+- **Page-Level Placement**: Primary "create" actions on list routes must be placed in the `actions` prop of the `<PageLayout>` component to ensure consistent top-right alignment.
+
 ### Badge
 
 - Pill shape (`var(--radius-full)`), padding `2px 8px`, font `font-interface` at `0.75rem` weight 500.

--- a/public_docs/development/ui-ux-guidelines.md
+++ b/public_docs/development/ui-ux-guidelines.md
@@ -57,6 +57,14 @@ See [design-tokens.md](../design-system/design-tokens.md) for the full token ref
 
 ## Component Design
 
+### Action Groups & Buttons
+To maintain consistent spacing and unified flexbox behavior across all design systems:
+- **Action Groups**: Never use raw floating `<Button>` clusters for toolbars or card footers. Always wrap buttons in the `<ActionButtonGroup>` or `<CardActionGroup>` components.
+- **Layout Attributes**: Use `layout="horizontal"` or `layout="vertical"` and `gap="sm" | "md" | "lg"` props on action groups to rely on standard design system space tokens instead of ad-hoc padding/margins.
+- **Flexible Primary Actions**: For buttons that should fill available width (like "Play" or "Save"), pass `flex: true` to the action definition. This uses a standardized `flex: 1 1 0%` CSS rule without requiring custom classes.
+- **Page-Level Actions**: Place primary page actions (like "Create World" or "Generate Character") inside the `actions` prop of the `<PageLayout>` component. This ensures they align to the top-right of the page header consistently.
+- **Segmented Controls**: For view toggles (like grid vs. table), wrap buttons in a `.view-mode-toggle` container and set the buttons to `size="icon"`.
+
 ### Interactive Elements
 - **Buttons**: Clear states (default, hover, active, disabled) with proper ARIA attributes
 - **Inputs**: Consistent styling with clear focus states and proper labeling


### PR DESCRIPTION
## Summary

- Adds `### Action Groups` subsection to `DESIGN.md` under the Component Rules section (between Input and Badge)
- Adds `### Action Groups & Buttons` subsection to `public_docs/development/ui-ux-guidelines.md` under Component Design (before Interactive Elements)

Both sections document the `ActionButtonGroup`/`CardActionGroup` pattern — use the group components for all button clusters, rely on `layout` and `gap` props for spacing, `flex: true` for primary actions that should stretch, and `PageLayout`'s `actions` prop for page-level CTA placement.

These rules were written during PR #1217 (button alignment fix) and removed during a KISS pass. This PR adds them in a dedicated docs-only home.

## Test plan
- [ ] Verify both sections render correctly in GitHub's markdown preview
- [ ] Confirm insertion points don't break surrounding section structure