### PR TITLE
fix: wrap worlds page header actions on mobile (#1139)

### DIFF
--- a/src/app/workshop.css
+++ b/src/app/workshop.css
@@ -1841,6 +1841,7 @@
 
 .page-layout-actions {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--space-3);
 }
@@ -1849,6 +1850,19 @@
 .page-layout-actions .action-button-group,
 .characters-toolbar .action-button-group {
   width: auto;
+}
+
+@media (width <= 640px) {
+  .page-layout-actions {
+    width: 100%;
+  }
+  .page-layout-actions .action-button-group {
+    width: 100%;
+  }
+  .page-layout-actions .action-button-group .button {
+    flex: 1 1 0;
+    min-width: 0;
+  }
 }
 
 /* ─── Characters Page Layout ─── */

--- a/src/components/world/WorldViewToggle.tsx
+++ b/src/components/world/WorldViewToggle.tsx
@@ -25,7 +25,7 @@ interface WorldViewToggleProps {
  */
 export function WorldViewToggle({ mode, onModeChange }: WorldViewToggleProps) {
   return (
-    <div role="group" aria-label="View mode toggle">
+    <div className="view-mode-toggle" role="group" aria-label="View mode toggle">
       <Button
         variant={mode === 'grid' ? 'default' : 'outline'}
         size="sm"


### PR DESCRIPTION
Closes #1139.

## Summary
- At 390px, the `/worlds` header collapsed into a 2-column mess: the view-mode toggle stacked its own icons vertically on the left, while Create World / Generate World stacked vertically on the right. The page description got shoved well below the fold.
- Two independent layout omissions caused it: `.page-layout-actions` was `flex-wrap: nowrap`, and `WorldViewToggle` was a bare `<div role="group">` with no flex container (and no `.view-mode-toggle` className, so the existing styles for that class never applied).

## Changes
- **`src/app/workshop.css`** — added `flex-wrap: wrap` to `.page-layout-actions` so the toggle and the button group can drop onto separate rows. Added a `@media (width <= 640px)` block that makes the actions container and its action-button-group full-width, and stretches the inner buttons with `flex: 1 1 0; min-width: 0` so they fill the row at equal width.
- **`src/components/world/WorldViewToggle.tsx`** — added the missing `className=\"view-mode-toggle\"`, which activates the existing `.view-mode-toggle` rules (inline-flex, rounded outer chrome, no per-button border) so the icons stay side-by-side at any width.

No JS / API / prop changes. The shared `PageLayout` and `ActionButtonGroup` components are untouched; the wrap is handled entirely in CSS.

## Test plan
- [x] Reproduce bug at 390×812 against `/worlds` (logged in, with seeded worlds) — confirmed malformed 2-column header before the fix.
- [x] After fix at 390×812: title → toggle (icons side-by-side) → Create + Generate equal-width on one row → description directly below; no horizontal scroll.
- [x] 768×1024 (tablet): title row 1, toggle + buttons row 2 side-by-side, no scroll.
- [x] 1280×800 (desktop): unchanged — title left, toggle + buttons all on one row on the right.
- [x] `/characters` at 390px: unaffected (uses `.characters-toolbar`, not `.page-layout-actions`).
- [x] `npm test -- --testPathPattern WorldViewToggle` — 8/8 pass.
- [x] `next lint`, `tsc --noEmit`, `stylelint src/app/workshop.css` — all clean.
- [ ] If a visual baseline exists for the seeded `/worlds` mobile cell (audit #1129), update it; this fix intentionally changes the rendered output.

## Out of scope
- Icon-only buttons at narrow widths (overkill for #1139).
- Other audit cells from #1129 — any sibling page using `PageLayout` actions on mobile may quietly improve from the shared CSS rule, but that's a happy side effect, not a tracked deliverable here.