### PR TITLE
fix: stack character detail action buttons on mobile (#1143)

### DIFF
--- a/src/app/workshop.css
+++ b/src/app/workshop.css
@@ -1860,8 +1860,7 @@
     width: 100%;
   }
   .page-layout-actions .action-button-group .button {
-    flex: 1 1 0;
-    min-width: 0;
+    flex: 1 1 auto;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #1143. On `/characters/[id]` at 390px, the action button row's three buttons (Edit Character, Play with Character, Delete Character) had their labels clip past their button backgrounds — "Play with Character" bled into the next button, "Delete Character" spilled past the viewport edge.

The shared `.page-layout-actions` mobile rule introduced in #1220 used `flex: 1 1 0; min-width: 0`, which forces equal-width buttons that can shrink below their content. That worked for 2 short-label buttons on `/worlds` but not for 3 longer labels here.

Changed to `flex: 1 1 auto` so each button reserves its content width as a minimum. The existing `flex-flow: row wrap` on `.action-button-group[data-layout="horizontal"]` then wraps buttons that can't fit on one row. Worlds layout is preserved: 2 buttons still share one row, each sized to its content with extra space distributed by `flex-grow`.

- One-line CSS change in `src/app/workshop.css` inside the existing `@media (width <= 640px)` block.
- No new components, no per-page selectors — keeps the shared slot as the single source of truth.

## Test plan

- [x] Reproduce at 390x812 with seeded character — confirmed labels clipping before fix
- [x] After fix at 390x812: 3 buttons stack, full labels visible, no horizontal scroll
- [x] Smoke test `/worlds` at 390x812: Create World + Generate World still share one row (#1139 not regressed)
- [x] Tablet 768x1024 and desktop 1280x800: no clipping, no horizontal scroll
- [x] `npm run lint` clean (only pre-existing warnings)
- [x] `npx jest src/app/characters/ src/components/shared/`: 12 suites, 69 tests pass
- [ ] Update stale audit baseline cell `characters-detail__page__mobile__seeded__develop` in `scripts/audit/review/characters-detail.html` (deferred — separate baseline-refresh task)

Local screenshots available at `narraitor-1143-{mobile-before,mobile-after,worlds-mobile-after,tablet-after,desktop-after}.png` for attachment.