### PR TITLE
fix: guard wizard state restore against non-wizard persisted values (#1228)

### DIFF
--- a/src/components/shared/wizard/hooks/__tests__/useWizardState.migration.test.ts
+++ b/src/components/shared/wizard/hooks/__tests__/useWizardState.migration.test.ts
@@ -131,9 +131,9 @@ describe('useWizardState - localStorage migration', () => {
   });
 
   test('ignores persisted value that is not a wizard state', () => {
-    // Older app versions stored an onboarding completion flag under the same
-    // key the wizard now uses for persistence. It is not a WizardState and
-    // must not be spread into state (it lacks `errors`, `currentStep`, etc.).
+    // A persistKey can hold a value that isn't a WizardState (foreign writer,
+    // manual edit, corruption). It must not be spread into state, since it
+    // lacks required fields like `errors` and `currentStep`.
     localStorageMock.getItem.mockReturnValue(
       JSON.stringify({ completed: true, completedAt: 1778435386391 })
     );

--- a/src/components/shared/wizard/hooks/__tests__/useWizardState.migration.test.ts
+++ b/src/components/shared/wizard/hooks/__tests__/useWizardState.migration.test.ts
@@ -130,6 +130,83 @@ describe('useWizardState - localStorage migration', () => {
     expect(result.current.state.currentStep).toBe(0);
   });
 
+  test('ignores persisted value that is not a wizard state', () => {
+    // Older app versions stored an onboarding completion flag under the same
+    // key the wizard now uses for persistence. It is not a WizardState and
+    // must not be spread into state (it lacks `errors`, `currentStep`, etc.).
+    localStorageMock.getItem.mockReturnValue(
+      JSON.stringify({ completed: true, completedAt: 1778435386391 })
+    );
+
+    const initialData: TestData = {
+      name: '',
+      genre: 'fantasy',
+      worldTypeData: {
+        worldType: 'original',
+        worldReference: '',
+        additionalDetails: ''
+      }
+    };
+
+    const { result } = renderHook(() =>
+      useWizardState({
+        steps: [{ id: 'test', label: 'Test' }],
+        initialData,
+        onComplete: () => {},
+        persistKey: 'test-wizard',
+      })
+    );
+
+    expect(result.current.state.data).toEqual(initialData);
+    expect(result.current.state.currentStep).toBe(0);
+    expect(result.current.state.errors).toEqual({});
+    expect(result.current.currentError).toBeUndefined();
+  });
+
+  test('rebuilds missing top-level fields from a partial persisted state', () => {
+    // Persisted state missing `errors` (e.g. from an older schema) must not
+    // leave `state.errors` undefined.
+    localStorageMock.getItem.mockReturnValue(
+      JSON.stringify({
+        currentStep: 1,
+        data: {
+          name: 'Partial World',
+          genre: 'fantasy',
+          worldTypeData: {
+            worldType: 'original',
+            worldReference: '',
+            additionalDetails: ''
+          }
+        },
+      })
+    );
+
+    const initialData: TestData = {
+      name: '',
+      genre: 'fantasy',
+      worldTypeData: {
+        worldType: 'original',
+        worldReference: '',
+        additionalDetails: ''
+      }
+    };
+
+    const { result } = renderHook(() =>
+      useWizardState({
+        steps: [{ id: 'test', label: 'Test' }],
+        initialData,
+        onComplete: () => {},
+        persistKey: 'test-wizard',
+      })
+    );
+
+    expect(result.current.state.currentStep).toBe(1);
+    expect(result.current.state.data.name).toBe('Partial World');
+    expect(result.current.state.errors).toEqual({});
+    expect(result.current.state.validation).toEqual({});
+    expect(result.current.state.isProcessing).toBe(false);
+  });
+
   test('computes initial step validation on first render when validateStep is provided', () => {
     localStorageMock.getItem.mockReturnValue(null);
 

--- a/src/components/shared/wizard/hooks/useWizardState.ts
+++ b/src/components/shared/wizard/hooks/useWizardState.ts
@@ -61,10 +61,10 @@ export function useWizardState<T>(config: WizardConfig<T>) {
           const parsed = JSON.parse(saved);
 
           // Only restore if the persisted value is actually a wizard state.
-          // Older app versions stored unrelated data under some persist keys
-          // (e.g. an onboarding completion flag under 'narraitor-onboarding'),
-          // which would otherwise produce a state object missing required
-          // fields like `errors` and crash downstream consumers.
+          // localStorage under a persistKey is untrusted input — it can hold
+          // a value that isn't a WizardState (foreign writer, manual edit,
+          // corruption). Spreading that produced a state missing required
+          // fields like `errors`, which crashed downstream consumers.
           const isWizardState =
             parsed !== null &&
             typeof parsed === 'object' &&

--- a/src/components/shared/wizard/hooks/useWizardState.ts
+++ b/src/components/shared/wizard/hooks/useWizardState.ts
@@ -59,27 +59,44 @@ export function useWizardState<T>(config: WizardConfig<T>) {
       if (saved) {
         try {
           const parsed = JSON.parse(saved);
-          // Merge saved state with initial data to handle schema migrations
-          // This ensures new fields in initialData are present even if not in saved state
-          const mergedData = { ...initialData, ...parsed.data };
-          // State restored from persistence with migration
-          const initialState = {
-            ...parsed,
-            data: mergedData,
-          };
 
-          if (validateStep) {
-            const validation = validateStep(initialState.currentStep, initialState.data);
-            return {
-              ...initialState,
-              validation: {
-                ...initialState.validation,
-                [initialState.currentStep]: { ...validation, touched: true },
-              },
+          // Only restore if the persisted value is actually a wizard state.
+          // Older app versions stored unrelated data under some persist keys
+          // (e.g. an onboarding completion flag under 'narraitor-onboarding'),
+          // which would otherwise produce a state object missing required
+          // fields like `errors` and crash downstream consumers.
+          const isWizardState =
+            parsed !== null &&
+            typeof parsed === 'object' &&
+            typeof parsed.currentStep === 'number' &&
+            typeof parsed.data === 'object';
+
+          if (isWizardState) {
+            // Merge saved data with initial data to handle schema migrations.
+            // This ensures new fields in initialData are present even if not
+            // in the saved state. Each top-level field is rebuilt explicitly
+            // so a partial persisted state can never yield an undefined field.
+            const initialState: WizardState<T> = {
+              currentStep: parsed.currentStep,
+              data: { ...initialData, ...parsed.data },
+              errors: parsed.errors ?? {},
+              isProcessing: false,
+              validation: parsed.validation ?? {},
             };
-          }
 
-          return initialState;
+            if (validateStep) {
+              const validation = validateStep(initialState.currentStep, initialState.data);
+              return {
+                ...initialState,
+                validation: {
+                  ...initialState.validation,
+                  [initialState.currentStep]: { ...validation, touched: true },
+                },
+              };
+            }
+
+            return initialState;
+          }
         } catch {
           // Failed to parse saved state, will use initial state
         }


### PR DESCRIPTION
## Summary

Fixes #1228 — the home route (`/`) crashed to an error boundary ("Cannot read properties of undefined (reading 'submit')") for a browser carrying a `narraitor-onboarding` localStorage value that wasn't a `WizardState`.

- `useWizardState` restored persisted state by spreading `JSON.parse(saved)` directly and only merging `data`. When the persisted value wasn't a `WizardState` — the affected browser had `{ completed: true, completedAt: <ts> }` under the `narraitor-onboarding` key the wizard uses as its `persistKey` — the resulting state was missing `errors`/`currentStep`/`validation`, and reading `state.errors.submit` threw.
- The restore path now validates the persisted value looks like a `WizardState` (`currentStep` is a number, `data` is an object) before using it, and rebuilds each top-level field with an explicit default so a partial persisted state can never yield an undefined field.
- Invalid values fall through to fresh initial state; the persist effect then self-heals the stale key on next render.

This is **input validation, not a migration** — no version gating, no shape transforms. It treats persisted localStorage as untrusted input. The provenance of the bad value is unknown (git history shows `narraitor-onboarding` has only ever been the wizard `persistKey`, and the value's timestamp is recent, not legacy), but the fix is correct regardless of where it came from.

Unblocks visual validation of #1222 / #1223 / #1224 / #1225 (epic #1165) — anything that has to load `/` first.

## Test plan

- [x] `useWizardState.migration.test.ts` — added cases for a non-wizard persisted value and a partial persisted state missing `errors`
- [x] Existing wizard / dashboard / GuidedFirstTimeExperience suites pass (51 tests)
- [x] Lint clean on changed files
- [x] Browser: injected a non-wizard value into `narraitor-onboarding`, reloaded `/` — wizard renders cleanly, no error boundary, console clean, localStorage self-heals to a valid `WizardState`