### PR TITLE
ci: scope storybook pages deploy to develop only

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -2,7 +2,7 @@ name: Deploy Storybook to GitHub Pages
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ develop ]
 
 permissions:
   contents: read
@@ -50,7 +50,7 @@ jobs:
         path: ./storybook-static
 
   deploy:
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- Stop triggering the Storybook Pages deploy on `main` pushes
- `github-pages` environment branch policy only allows `develop`, so any push to `main` fails with: `Branch "main" is not allowed to deploy to github-pages due to environment protection rules.`
- This matches the release model where `main` is release-only and `develop` is rolling.

## Failing run
https://github.com/jerseycheese/Narraitor/actions/runs/25665146433/job/75336177523

## Test plan
- [ ] Merge to `develop` triggers the workflow and deploys Storybook successfully.
- [ ] Next develop→main release merge does NOT trigger a failing deploy on `main`.