### PR TITLE
chore: clean up audit-flagged cringe (window-any, silent catch, magic timeout)

### DIFF
--- a/src/app/api/ai/generate-template/route.ts
+++ b/src/app/api/ai/generate-template/route.ts
@@ -8,6 +8,8 @@ import Logger from '@/lib/utils/logger';
 
 const logger = new Logger('API');
 
+const TEMPLATE_GENERATION_TIMEOUT_MS = 45_000;
+
 interface GenerateTemplateRequest {
   type: 'inspired-by' | 'genre-mix' | 'surprise-me';
   userInput?: string;
@@ -67,8 +69,8 @@ export async function POST(request: NextRequest) {
     const templateGenerator = new TemplateGenerator(client);
     
     // Add timeout wrapper to prevent hanging requests
-    const timeoutPromise = new Promise((_, reject) => 
-      setTimeout(() => reject(new Error('Template generation timeout')), 45000)
+    const timeoutPromise = new Promise((_, reject) =>
+      setTimeout(() => reject(new Error('Template generation timeout')), TEMPLATE_GENERATION_TIMEOUT_MS)
     );
     
     const template = await Promise.race([

--- a/src/state/characterStore.ts
+++ b/src/state/characterStore.ts
@@ -874,8 +874,7 @@ export const useCharacterStore: UseBoundStore<StoreApi<CharacterStore>> =
 
 // Expose store globally in development for testing and debugging
 if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (window as any).useCharacterStore = useCharacterStore;
+  window.useCharacterStore = useCharacterStore;
 }
 
 // Subscribe to store events

--- a/src/state/inventoryStore.ts
+++ b/src/state/inventoryStore.ts
@@ -991,8 +991,7 @@ export const useInventoryStore = create<InventoryStore>()(
 
 // Expose store globally in development for easier debugging & manual seeding
 if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (window as any).useInventoryStore = useInventoryStore;
+  window.useInventoryStore = useInventoryStore;
 }
 
 // Subscribe to store events

--- a/src/state/journalStore.ts
+++ b/src/state/journalStore.ts
@@ -264,6 +264,5 @@ export const useJournalStore = create<JournalStore>()(
 
 // Expose store globally in development for easier debugging & manual seeding
 if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (window as any).useJournalStore = useJournalStore;
+  window.useJournalStore = useJournalStore;
 }

--- a/src/state/narrativeStore.ts
+++ b/src/state/narrativeStore.ts
@@ -339,7 +339,11 @@ async function applyWorldStateThreadUpdates({
     }
 
     worldStore.updateWorldState(effectiveWorldId, updatePayload, sessionId);
-  } catch {
+  } catch (error) {
+    console.error('[narrativeStore] applyWorldStateThreadUpdates failed', {
+      sessionId,
+      error,
+    });
   }
 }
 
@@ -1460,6 +1464,5 @@ export const useNarrativeStore = create<NarrativeStore>()(
 
 // Expose store globally in development for manual testing
 if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (window as any).useNarrativeStore = useNarrativeStore;
+  window.useNarrativeStore = useNarrativeStore;
 }

--- a/src/state/npcStore.ts
+++ b/src/state/npcStore.ts
@@ -241,6 +241,5 @@ export const useNPCStore = create<NPCStore>()(
 // Expose store globally in development to support test data seeding
 // and debugging via window.useNPCStore in dev tools.
 if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (window as any).useNPCStore = useNPCStore;
+  window.useNPCStore = useNPCStore;
 }

--- a/src/state/sessionStore.ts
+++ b/src/state/sessionStore.ts
@@ -911,6 +911,5 @@ export const useSessionStore = create<SessionStore>()(
 // Named export for consistent usage
 // Also expose store globally for dev/test to allow direct state seeding
 if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (window as any).useSessionStore = useSessionStore;
+  window.useSessionStore = useSessionStore;
 }

--- a/src/state/worldStore.ts
+++ b/src/state/worldStore.ts
@@ -602,6 +602,5 @@ export const useWorldStore = create<WorldStore>()(
 // Expose store globally in development to support test data seeding
 // and debugging via window.useWorldStore in dev tools.
 if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (window as any).useWorldStore = useWorldStore;
+  window.useWorldStore = useWorldStore;
 }

--- a/src/stories/03-organisms/navigation/Navigation.stories.tsx
+++ b/src/stories/03-organisms/navigation/Navigation.stories.tsx
@@ -277,7 +277,7 @@ export const WorldSwitcherOpen: Story = {
 
       // Simulate opened dropdown by adding CSS to show it
       const style = document.createElement('style');
-      style.textContent = `[data-testid="world-switcher-dropdown"] { display: !important; }`;
+      style.textContent = `[data-testid="world-switcher-dropdown"] { display: block !important; }`;
       document.head.appendChild(style);
 
       return <Story />;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -9,6 +9,14 @@ declare global {
     };
     /** Flag set by Playwright tests to disable DevTools during test runs */
     __PLAYWRIGHT__?: boolean;
+    /** Stores exposed on window in development for manual debugging only — see each store file */
+    useCharacterStore?: typeof import('@/state/characterStore').useCharacterStore;
+    useWorldStore?: typeof import('@/state/worldStore').useWorldStore;
+    useNarrativeStore?: typeof import('@/state/narrativeStore').useNarrativeStore;
+    useInventoryStore?: typeof import('@/state/inventoryStore').useInventoryStore;
+    useJournalStore?: typeof import('@/state/journalStore').useJournalStore;
+    useSessionStore?: typeof import('@/state/sessionStore').useSessionStore;
+    useNPCStore?: typeof import('@/state/npcStore').useNPCStore;
   }
 }
 

--- a/tests/visual/utils/game-session-page-seeder.ts
+++ b/tests/visual/utils/game-session-page-seeder.ts
@@ -331,7 +331,11 @@ export async function seedInventoryItemsForVisual(page: Page): Promise<void> {
       }));
     }
 
-    const sessionState = sessionStore?.getState?.() || {};
+    const sessionState = (sessionStore?.getState?.() ?? {}) as {
+      id?: string | null;
+      worldId?: string | null;
+      characterId?: string | null;
+    };
     const sessionId = sessionState.id ?? 'session-cyberpunk-ghost';
     const worldId = sessionState.worldId ?? resolvedWorldId ?? 'world-cyberpunk-2077';
     const characterId = sessionState.characterId ?? resolvedCharacterId ?? 'char-cyberpunk-hacker';
@@ -771,7 +775,6 @@ export async function seedStorySummaryForVisual(page: Page): Promise<void> {
       worldStore.currentWorldId ||
       Object.keys(worldStore.worlds || {})[0];
     const sessionId =
-      sessionStore.currentSessionId ||
       sessionStore.id ||
       'session-visual-story';
     const characterId =


### PR DESCRIPTION
## Summary

Knocks out a handful of small embarrassments surfaced by [the codebase audit](/Users/jackhaas/.claude/plans/whats-the-5-most-floating-lerdorf.md). Specifically:

- **Drops the `(window as any)` + `eslint-disable @typescript-eslint/no-explicit-any` pair from 7 stores** by adding the 7 dev-only window handles to `src/types/global.d.ts`. The dev-guard (`process.env.NODE_ENV !== 'production'`) was already in place — the audit's "leaks into prod" framing was wrong — but the type pollution was real.
- **Replaces an empty `catch {}` in `narrativeStore.applyWorldStateThreadUpdates`** with a `console.error` carrying the `sessionId`. The second silent catch in that file already had a comment explaining the intentional fail-open, so it's left alone.
- **Extracts a 45000ms magic number** in the template-generation API to `TEMPLATE_GENERATION_TIMEOUT_MS`.
- **Fixes a broken `display: !important;` (missing value)** in the `WorldSwitcherOpen` Storybook decorator — the rule was intended to force-show the dropdown but had no value, so the story has been silently broken.
- **Fixes one latent bug in the visual test seeder** that the stricter Window typing exposed: `sessionStore.currentSessionId` doesn't exist on `SessionStore` (and never has) — it's always been `sessionStore.id`.

## Deferred (intentionally)

The bigger items from the audit are real projects, not drive-bys, and shouldn't ride along here:

- #1 `!important` audit across `manuscript-session.css` (~12 hits, all with explanatory comments about hide/show toggle override patterns)
- #2 The 8 skipped tutorial spec files (almost certainly Joyride spotlight drift — already tracked in memory)
- #6 God files (`NarrativeController.tsx` 1,365 lines, `narrativeStore.ts` 1,465 lines)
- #5 Visual regression theater (`maxDiffPixels: 10000` + Chromium-only)
- #7/#8 `npm audit || true` and `knip || true` in CI

## Test plan

- [x] `npx tsc --noEmit` — clean (4 baseline errors removed by the seeder fix)
- [x] `npx jest src/state/__tests__` — 351/351 passing
- [x] Lint clean on every file touched (pre-existing `any` errors in `game-session-page-seeder.ts` are not from this PR)
- [ ] Manual sanity: open dev console and confirm `window.useCharacterStore` still resolves in development mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)