### PR TITLE
Cleanup: top 5 embarrassments (console spam, unguarded JSON.parse, theme script, repo polish)

### DIFF
--- a/docker-compose.claude-sandbox.yml
+++ b/docker-compose.claude-sandbox.yml
@@ -1,14 +1,16 @@
 version: '3.8'
 
-# Docker Compose for Narraitor YOLO Mode
-# Usage: ISSUE_NUMBER=501 docker-compose -f docker-compose.yolo.yml up
+# Docker Compose for sandboxed Claude Code runs (no network, isolated worktree).
+# Uses Claude's --dangerously-skip-permissions inside the container — safe only
+# because network_mode is none and the container is ephemeral.
+# Usage: ISSUE_NUMBER=501 docker-compose -f docker-compose.claude-sandbox.yml up
 
 services:
-  claude-yolo:
+  claude-sandbox:
     build:
       context: .
-      dockerfile: .claude/docker/Dockerfile.yolo
-    container_name: claude-yolo-${ISSUE_NUMBER:-000}
+      dockerfile: .claude/docker/Dockerfile.sandbox
+    container_name: claude-sandbox-${ISSUE_NUMBER:-000}
     volumes:
       # Mount the specific worktree
       - ${WORKTREE_PATH:-./}:/app
@@ -32,7 +34,7 @@ services:
     tty: true
     command: |
       sh -c "
-        echo '🚀 Starting YOLO mode for issue #${ISSUE_NUMBER}' &&
+        echo 'Starting sandboxed Claude run for issue #${ISSUE_NUMBER}' &&
         cd /app &&
         claude --dangerously-skip-permissions /project:do-issue-auto ${ISSUE_NUMBER}
       "
@@ -46,8 +48,8 @@ services:
   #   working_dir: /app
   #   command: node api-mock-server.js
   #   networks:
-  #     - yolo-internal
+  #     - claude-sandbox-internal
 
 # networks:
-#   yolo-internal:
+#   claude-sandbox-internal:
 #     internal: true  # No external connectivity

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,6 +23,7 @@ const eslintConfig = [
     },
     rules: {
       "design-tokens/no-hardcoded-colors": "error",
+      "no-console": ["error", { "allow": ["warn", "error"] }],
       "@typescript-eslint/no-unused-vars": ["warn", {
         "argsIgnorePattern": "^_",
         "varsIgnorePattern": "^_",
@@ -32,8 +33,11 @@ const eslintConfig = [
   },
   {
     files: [
-      "**/*.test.{js,jsx,ts,tsx}", 
-      "**/__tests__/**/*.{js,jsx,ts,tsx}", 
+      "**/*.test.{js,jsx,ts,tsx}",
+      "**/__tests__/**/*.{js,jsx,ts,tsx}",
+      "**/__mocks__/**/*.{js,jsx,ts,tsx}",
+      "**/*.stories.{js,jsx,ts,tsx}",
+      "**/*.stories.helpers.{js,jsx,ts,tsx}",
       "src/app/dev/**/*.{js,jsx,ts,tsx}",
       "src/components/devtools/**/*.{js,jsx,ts,tsx}",
       "src/lib/design-tokens/**/*.{js,jsx,ts,tsx}",
@@ -42,6 +46,7 @@ const eslintConfig = [
     rules: {
       "@typescript-eslint/no-require-imports": "off", // Allow require() in test files for Jest mocking
       "design-tokens/no-hardcoded-colors": "off", // Allow hardcoded colors in tests, dev tools, design tokens, and stories
+      "no-console": "off", // Dev tooling, tests, and stories legitimately use console
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
       "plugin:storybook/recommended"
     ]
   },
-  "description": "This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).",
+  "description": "AI-powered storytelling app that runs narrative RPG experiences in any world — fictional or real — with mechanics and tone tailored to that world.",
   "main": "index.js",
   "directories": {
     "doc": "docs",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,6 +28,7 @@ import { SkipLinks } from '@/components/shared/SkipLinks';
 import { ToastProvider, Toaster } from '@/components/ui/toast';
 import { TutorialProvider } from '@/components/TutorialProvider';
 import { ThemeProvider } from '@/lib/theme';
+import { THEME_INIT_SCRIPT } from '@/lib/theme/themeInitScript';
 
 /* DS1 fonts (preloaded - default theme) */
 const lora = Lora({
@@ -106,8 +107,6 @@ const fontVariables = [
   dmSans.variable,
 ].join(' ');
 
-const themeScript = `(function(){try{var t=localStorage.getItem('narraitor-theme');if(t)document.documentElement.setAttribute('data-theme',t);var c=localStorage.getItem('narraitor-color-scheme');if(c==='dark'||(c==='system'&&matchMedia('(prefers-color-scheme:dark)').matches)){document.documentElement.classList.add('dark')}}catch(e){}})()`;
-
 export const metadata: Metadata = {
   title: 'Narraitor',
   description: 'A narrative-driven RPG framework using AI',
@@ -128,7 +127,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="en" data-theme="ds1" className={fontVariables} suppressHydrationWarning>
       <head>
-        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
       </head>
       <body suppressHydrationWarning>
         <SkipLinks />

--- a/src/components/GameSession/GameSession.tsx
+++ b/src/components/GameSession/GameSession.tsx
@@ -251,7 +251,6 @@ const GameSession: React.FC<GameSessionProps> = ({
       // In development mode with fast refresh, don't end sessions
       // This prevents the infinite reset loop during hot reloading
       if (process.env.NODE_ENV === 'development') {
-        console.log('🔧 Development mode: Skipping session cleanup to prevent fast refresh issues');
         return;
       }
       

--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -17,7 +17,8 @@ import {
   NarrativeSegment,
   SkillCheckRoll,
 } from '@/types/narrative.types';
-import { truncate, safeTrim } from '@/lib/utils';
+import { truncate } from '@/lib/utils';
+import { safeParseNarrativeAnalysis } from '@/lib/ai/parseNarrativeResponse';
 import { useCharacterStore } from '@/state/characterStore';
 import { useWorldStore } from '@/state/worldStore';
 import { useNPCStore } from '@/state/npcStore';
@@ -257,46 +258,16 @@ Respond with JSON format:
 
       const response = await client.generateContent(analysisPrompt);
 
-      try {
-        // Extract JSON from response, handling markdown code blocks
-        let jsonContent = response.content;
+      const analysis = safeParseNarrativeAnalysis(response.content);
 
-        // Remove markdown code blocks if present
-        if (jsonContent.includes('```json')) {
-          jsonContent = jsonContent
-            .replace(/```json\s*/g, '')
-            .replace(/```\s*/g, '');
-        } else if (jsonContent.includes('```')) {
-          jsonContent = jsonContent.replace(/```\s*/g, '');
-        }
-
-        // Trim whitespace
-        jsonContent = safeTrim(jsonContent);
-
-        const analysis = JSON.parse(jsonContent);
-
-        // Only suggest ending if AI has medium or high confidence
-        if (
-          analysis.suggestEnding &&
-          ['high', 'medium'].includes(analysis.confidence)
-        ) {
-          endingSuggestedRef.current = true;
-
-          // Determine ending type based on AI analysis or default to story-complete
-          const endingType = [
-            'story-complete',
-            'character-retirement',
-            'session-limit',
-          ].includes(analysis.endingType)
-            ? analysis.endingType
-            : 'story-complete';
-
-          onEndingSuggested(analysis.reason, endingType);
-        }
-      } catch (parseError) {
-        console.error('Failed to parse AI ending analysis:', parseError);
-        // If JSON parsing fails, do not suggest ending
-        // Pure AI approach means no fallback to rules
+      // Only suggest ending if AI has medium or high confidence
+      if (
+        analysis &&
+        analysis.suggestEnding &&
+        analysis.confidence !== 'low'
+      ) {
+        endingSuggestedRef.current = true;
+        onEndingSuggested(analysis.reason, analysis.endingType);
       }
     } catch (error) {
       console.error('Failed to analyze ending indicators with AI:', error);
@@ -444,6 +415,7 @@ Respond with JSON format:
     const recentSegments = currentSegments.slice(-5);
 
     // Create fallback choices upfront - we'll use these immediately if something fails
+    let usedFallbackDecision = false;
     const fallbackId = `decision-fallback-${Date.now()}`;
     const fallbackDecision: Decision = {
       id: fallbackId,
@@ -517,6 +489,7 @@ Respond with JSON format:
       } catch {
         // Choice generation failed, using fallback choices
         decision = fallbackDecision;
+        usedFallbackDecision = true;
       }
 
       // Skip if component unmounted during async operation
@@ -531,6 +504,7 @@ Respond with JSON format:
         (decision.options?.length || 0) === 0
       ) {
         decision = fallbackDecision;
+        usedFallbackDecision = true;
       }
 
       // Add decision to store and get the actual stored ID
@@ -547,14 +521,11 @@ Respond with JSON format:
       decision.id = storedDecisionId;
 
       // Only notify parent component if we have AI-generated choices (not fallback)
-      // Check if this is a fallback decision by comparing the ID pattern
-      const isFallbackDecision = decision.id.includes('decision-fallback-');
-
-      if (!isFallbackDecision) {
+      if (!usedFallbackDecision) {
         if (onChoicesGenerated) {
           try {
             // Create a deep copy of the decision to ensure React state updates
-            const decisionCopy = JSON.parse(JSON.stringify(decision));
+            const decisionCopy = structuredClone(decision);
             onChoicesGenerated(decisionCopy);
           } catch (error) {
             console.error('Error calling onChoicesGenerated callback:', error);
@@ -620,7 +591,7 @@ Respond with JSON format:
 
           // Notify parent
           if (onChoicesGenerated && mountedRef.current) {
-            const decisionCopy = JSON.parse(JSON.stringify(fallbackDecision));
+            const decisionCopy = structuredClone(fallbackDecision);
             onChoicesGenerated(decisionCopy);
           }
         }

--- a/src/components/WorldCreationWizard/WorldCreationWizard.tsx
+++ b/src/components/WorldCreationWizard/WorldCreationWizard.tsx
@@ -31,6 +31,18 @@ import { Button } from '@/components/ui/button';
 import { ensureWorldNpcRoster } from '@/lib/services/worldCreationService';
 import { useTutorial } from '@/components/TutorialProvider';
 import { tourStepToWizardStep } from '@/lib/tutorial/worldCreationTour';
+import { safeJsonParse } from '@/lib/safeJsonParse';
+
+type PersistedWorldSummary = {
+  id: string;
+  name?: string;
+  genre?: string;
+  description?: string;
+  createdAt: string;
+  attributes: unknown[];
+  skills: unknown[];
+  image?: unknown;
+};
 
 // Efficient deep comparison for arrays of objects
 const areArraysEqual = <T extends object>(a: T[] = [], b: T[] = []): boolean => {
@@ -420,7 +432,10 @@ export default function WorldCreationWizard({
       
       // Save to localStorage as temporary solution
       if (typeof window !== 'undefined') {
-        const worlds = JSON.parse(localStorage.getItem('worlds') || '[]');
+        const worlds = safeJsonParse<PersistedWorldSummary[]>(
+          localStorage.getItem('worlds'),
+          []
+        );
         worlds.push({
           id: worldId,
           name: data.name,
@@ -438,11 +453,15 @@ export default function WorldCreationWizard({
 
       // Move to quick start step instead of completing
       wizard.goNext();
-    } catch {
-      // Fallback error handling
+    } catch (error) {
+      // Fallback error handling — log so failures are observable
+      console.error('[WorldCreationWizard] handleComplete failed, using fallback world id:', error);
       const worldId = `world-${Date.now()}`;
       if (typeof window !== 'undefined') {
-        const worlds = JSON.parse(localStorage.getItem('worlds') || '[]');
+        const worlds = safeJsonParse<PersistedWorldSummary[]>(
+          localStorage.getItem('worlds'),
+          []
+        );
         worlds.push({
           id: worldId,
           name: data.name,
@@ -455,7 +474,7 @@ export default function WorldCreationWizard({
         });
         localStorage.setItem('worlds', JSON.stringify(worlds));
       }
-      
+
       // Store the world ID and move to quick start
       wizard.updateData({ createdWorldId: worldId });
       wizard.goNext();

--- a/src/components/WorldCreationWizard/steps/FinalizeStep.tsx
+++ b/src/components/WorldCreationWizard/steps/FinalizeStep.tsx
@@ -35,6 +35,7 @@ export default function FinalizeStep({
   // Logger function that can be easily disabled for production
   const log = (message: string, data?: unknown) => {
     if (process.env.NODE_ENV === 'development') {
+      // eslint-disable-next-line no-console -- dev-only debug, gated on NODE_ENV
       console.log(message, data);
     }
   };

--- a/src/components/devtools/TestDataGeneratorSection/TestDataGeneratorSection.tsx
+++ b/src/components/devtools/TestDataGeneratorSection/TestDataGeneratorSection.tsx
@@ -33,7 +33,6 @@ export const TestDataGeneratorSection: React.FC = () => {
 
       if (worldTypeRandom < 0.33) {
         // 33% - Original worlds (no reference)
-        console.log(`[DevTools] Generating original world...`);
       } else if (worldTypeRandom < 0.66) {
         // 33% - "Set in" worlds (existing universe)
         const tvMovieUniverses = [
@@ -54,9 +53,6 @@ export const TestDataGeneratorSection: React.FC = () => {
         randomReference =
           tvMovieUniverses[Math.floor(Math.random() * tvMovieUniverses.length)];
         randomRelationship = 'set_within';
-        console.log(
-          `[DevTools] Generating "set in" world for ${randomReference} (canonical theme will be applied)...`
-        );
       } else {
         // 34% - "Based on" worlds (inspired by existing universe)
         const tvMovieUniverses = [
@@ -77,9 +73,6 @@ export const TestDataGeneratorSection: React.FC = () => {
         randomReference =
           tvMovieUniverses[Math.floor(Math.random() * tvMovieUniverses.length)];
         randomRelationship = 'inspired_by';
-        console.log(
-          `[DevTools] Generating "based on" world inspired by ${randomReference}...`
-        );
       }
 
       const existingNames = Object.values(worlds).map((w) => w.name);
@@ -140,23 +133,15 @@ export const TestDataGeneratorSection: React.FC = () => {
 
       const worldId = createWorld(worldDataForStore);
       await ensureWorldNpcRoster(worldId);
-      console.log(
-        `Test world "${testWorldData.name}" created with ID: ${worldId}`
-      );
 
       // Set the newly created world as the active world
       const { setCurrentWorld } = useWorldStore.getState();
       setCurrentWorld(worldId);
-      console.log(`[DevTools] Set newly generated world as active: ${worldId}`);
 
       // Generate world image asynchronously using my enhanced API
       try {
         // Get the created world from store
         const world = useWorldStore.getState().worlds[worldId];
-        console.log(
-          `[DevTools] Attempting to generate image for world:`,
-          world?.name
-        );
         if (world) {
           const response = await fetch('/api/generate-world-image', {
             method: 'POST',
@@ -165,7 +150,7 @@ export const TestDataGeneratorSection: React.FC = () => {
           });
 
           if (response.ok) {
-            const { imageUrl, aiGenerated, service } = await response.json();
+            const { imageUrl, aiGenerated } = await response.json();
             // Update the world with the generated image in GeneratedImage format (my enhancement)
             const image: GeneratedImage = {
               type: aiGenerated
@@ -175,10 +160,6 @@ export const TestDataGeneratorSection: React.FC = () => {
               generatedAt: getTimestamp(),
             };
             useWorldStore.getState().updateWorld(worldId, { image });
-            console.log(
-              `[DevTools] Generated ${service} image for test world "${testWorldData.name}":`,
-              imageUrl
-            );
           } else {
             const errorText = await response.text();
             console.warn(
@@ -206,8 +187,6 @@ export const TestDataGeneratorSection: React.FC = () => {
       const existingNames = Object.values(worlds).map((w) => w.name);
 
       for (let i = 0; i < 5; i++) {
-        console.log(`[DevTools] Generating diverse world ${i + 1}/5...`);
-
         // Generate a diverse mix of world types for testing (my enhancement)
         const worldTypeRandom = Math.random();
         let randomReference;
@@ -215,7 +194,6 @@ export const TestDataGeneratorSection: React.FC = () => {
 
         if (worldTypeRandom < 0.33) {
           // 33% - Original worlds (no reference)
-          console.log(`[DevTools] Generating original world ${i + 1}/5...`);
           randomReference = undefined;
           randomRelationship = undefined;
         } else if (worldTypeRandom < 0.66) {
@@ -240,9 +218,6 @@ export const TestDataGeneratorSection: React.FC = () => {
               Math.floor(Math.random() * tvMovieUniverses.length)
             ];
           randomRelationship = 'set_within';
-          console.log(
-            `[DevTools] Generating "set in" world ${i + 1}/5 for ${randomReference} (canonical theme will be applied)...`
-          );
         } else {
           // 34% - "Based on" worlds (inspired by existing universe)
           const tvMovieUniverses = [
@@ -265,9 +240,6 @@ export const TestDataGeneratorSection: React.FC = () => {
               Math.floor(Math.random() * tvMovieUniverses.length)
             ];
           randomRelationship = 'inspired_by';
-          console.log(
-            `[DevTools] Generating "based on" world ${i + 1}/5 inspired by ${randomReference}...`
-          );
         }
 
         // Include existing names plus already created worlds in this batch to avoid duplicates
@@ -333,25 +305,17 @@ export const TestDataGeneratorSection: React.FC = () => {
         const worldId = createWorld(worldDataForStore);
         await ensureWorldNpcRoster(worldId);
         createdWorlds.push({ id: worldId, name: testWorldData.name });
-        console.log(`Created test world: ${testWorldData.name}`);
 
         // Set the first created world as active (for batch generation)
         if (i === 0) {
           const { setCurrentWorld } = useWorldStore.getState();
           setCurrentWorld(worldId);
-          console.log(
-            `[DevTools] Set first generated world as active: ${worldId}`
-          );
         }
 
         // Generate world image asynchronously for each world using my enhanced API
         try {
           // Get the created world from store
           const world = useWorldStore.getState().worlds[worldId];
-          console.log(
-            `[DevTools] Attempting to generate image for world ${i + 1}/5:`,
-            world?.name
-          );
           if (world) {
             const response = await fetch('/api/generate-world-image', {
               method: 'POST',
@@ -360,7 +324,7 @@ export const TestDataGeneratorSection: React.FC = () => {
             });
 
             if (response.ok) {
-              const { imageUrl, aiGenerated, service } = await response.json();
+              const { imageUrl, aiGenerated } = await response.json();
               // Update the world with the generated image in GeneratedImage format (my enhancement)
               const image: GeneratedImage = {
                 type: aiGenerated
@@ -370,10 +334,6 @@ export const TestDataGeneratorSection: React.FC = () => {
                 generatedAt: getTimestamp(),
               };
               useWorldStore.getState().updateWorld(worldId, { image });
-              console.log(
-                `[DevTools] Generated ${service} image for test world "${testWorldData.name}":`,
-                imageUrl
-              );
             } else {
               const errorText = await response.text();
               console.warn(
@@ -391,10 +351,6 @@ export const TestDataGeneratorSection: React.FC = () => {
       }
 
       const worldNames = createdWorlds.map((w) => w.name).join(', ');
-      console.log(
-        `[DevTools] Generated 5 test worlds with images:`,
-        createdWorlds
-      );
       alert(`Successfully generated 5 test worlds with images: ${worldNames}`);
     } catch (error) {
       console.error('[DevTools] Error generating test worlds:', error);
@@ -481,10 +437,6 @@ export const TestDataGeneratorSection: React.FC = () => {
     const storageKey = `character-creation-${currentWorld.id}`;
     try {
       sessionStorage.setItem(storageKey, JSON.stringify(wizardState));
-      console.log(
-        `[TestDataGenerator] Stored test character data with key: ${storageKey}`,
-        wizardState
-      );
 
       // Verify it was stored
       const stored = sessionStorage.getItem(storageKey);
@@ -550,17 +502,9 @@ export const TestDataGeneratorSection: React.FC = () => {
 
     try {
       for (let i = 0; i < 5; i++) {
-        console.log(
-          `[DevTools] Generating character ${i + 1}/5 for world "${currentWorld.name}"...`
-        );
-
         // Random character type selection (50/50 between known and original)
         const types: Array<'known' | 'original'> = ['known', 'original'];
         const characterType = types[Math.floor(Math.random() * types.length)];
-
-        console.log(
-          `[DevTools] Generating ${characterType} character for world "${currentWorld.name}"`
-        );
 
         // Use the AI character generator via API route (secure approach from develop)
         const response: Response = await fetch('/api/generate-character', {
@@ -649,9 +593,6 @@ export const TestDataGeneratorSection: React.FC = () => {
 
         const characterId = createCharacter(characterData);
         createdCharacters.push({ id: characterId, name: characterData.name });
-        console.log(
-          `[DevTools] Created AI ${characterType} character: ${characterData.name}`
-        );
 
         // Generate portrait asynchronously via API route (secure approach)
         try {
@@ -659,10 +600,6 @@ export const TestDataGeneratorSection: React.FC = () => {
           const storeCharacter =
             useCharacterStore.getState().characters[characterId];
           if (storeCharacter) {
-            console.log(
-              `[DevTools] Generating portrait for ${characterType} character "${characterData.name}"...`
-            );
-
             const response = await fetch('/api/generate-portrait', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
@@ -727,9 +664,6 @@ export const TestDataGeneratorSection: React.FC = () => {
               useCharacterStore
                 .getState()
                 .updateCharacter(characterId, { portrait });
-              console.log(
-                `[DevTools] Generated portrait for ${characterType} character "${characterData.name}"`
-              );
             } else {
               console.warn(
                 `[DevTools] Portrait generation failed for ${characterType} character "${characterData.name}"`
@@ -746,10 +680,6 @@ export const TestDataGeneratorSection: React.FC = () => {
       }
 
       const characterNames = createdCharacters.map((c) => c.name).join(', ');
-      console.log(
-        `[DevTools] Generated 5 AI characters (random type selection) with portraits for world "${currentWorld.name}":`,
-        createdCharacters
-      );
       alert(
         `Successfully generated 5 AI characters (random type selection) with portraits: ${characterNames}`
       );
@@ -797,9 +727,6 @@ export const TestDataGeneratorSection: React.FC = () => {
         worldStoreState.setCurrentWorld('');
       }
 
-      console.log(
-        `[DevTools] Deleted all ${worldCount} worlds and their characters`
-      );
       alert(
         `Successfully deleted all ${worldCount} worlds and their characters`
       );
@@ -841,11 +768,6 @@ export const TestDataGeneratorSection: React.FC = () => {
         await new Promise((resolve) => setTimeout(resolve, 1));
       }
 
-      const characterNames = worldCharacters.map((c) => c.name).join(', ');
-      console.log(
-        `[DevTools] Deleted ${worldCharacters.length} characters from world "${currentWorld.name}":`,
-        characterNames
-      );
       alert(
         `Successfully deleted ${worldCharacters.length} characters from "${currentWorld.name}"`
       );
@@ -902,9 +824,6 @@ export const TestDataGeneratorSection: React.FC = () => {
         }
       }
 
-      console.log(
-        `[DevTools] NUKED EVERYTHING: Reset both stores, deleted ${worldCount} worlds and ${characterCount} characters`
-      );
       alert(
         `NUCLEAR OPTION COMPLETE\\n\\nDeleted ${worldCount} worlds and ${characterCount} characters.\\n\\nDatabase is now empty.`
       );

--- a/src/components/shared/wizard/hooks/useWizardState.ts
+++ b/src/components/shared/wizard/hooks/useWizardState.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { safeJsonParse } from '@/lib/safeJsonParse';
 
 export interface WizardStep {
   id: string;
@@ -55,51 +56,51 @@ export function useWizardState<T>(config: WizardConfig<T>) {
   // Initialize state from localStorage if persist key provided
   const [state, setState] = useState<WizardState<T>>(() => {
     if (persistKey && typeof window !== 'undefined') {
-      const saved = localStorage.getItem(persistKey);
-      if (saved) {
-        try {
-          const parsed = JSON.parse(saved);
+      const parsed = safeJsonParse<unknown>(
+        localStorage.getItem(persistKey),
+        null
+      );
 
-          // Only restore if the persisted value is actually a wizard state.
-          // localStorage under a persistKey is untrusted input — it can hold
-          // a value that isn't a WizardState (foreign writer, manual edit,
-          // corruption). Spreading that produced a state missing required
-          // fields like `errors`, which crashed downstream consumers.
-          const isWizardState =
-            parsed !== null &&
-            typeof parsed === 'object' &&
-            typeof parsed.currentStep === 'number' &&
-            typeof parsed.data === 'object';
+      // Only restore if the persisted value is actually a wizard state.
+      // localStorage under a persistKey is untrusted input — it can hold
+      // a value that isn't a WizardState (foreign writer, manual edit,
+      // corruption). Spreading that produced a state missing required
+      // fields like `errors`, which crashed downstream consumers.
+      const isWizardState =
+        parsed !== null &&
+        typeof parsed === 'object' &&
+        typeof (parsed as { currentStep?: unknown }).currentStep === 'number' &&
+        typeof (parsed as { data?: unknown }).data === 'object';
 
-          if (isWizardState) {
-            // Merge saved data with initial data to handle schema migrations.
-            // This ensures new fields in initialData are present even if not
-            // in the saved state. Each top-level field is rebuilt explicitly
-            // so a partial persisted state can never yield an undefined field.
-            const initialState: WizardState<T> = {
-              currentStep: parsed.currentStep,
-              data: { ...initialData, ...parsed.data },
-              errors: parsed.errors ?? {},
-              isProcessing: false,
-              validation: parsed.validation ?? {},
-            };
+      if (isWizardState) {
+        const persisted = parsed as Partial<WizardState<T>> & {
+          currentStep: number;
+          data: Partial<T>;
+        };
+        // Merge saved data with initial data to handle schema migrations.
+        // This ensures new fields in initialData are present even if not
+        // in the saved state. Each top-level field is rebuilt explicitly
+        // so a partial persisted state can never yield an undefined field.
+        const initialState: WizardState<T> = {
+          currentStep: persisted.currentStep,
+          data: { ...initialData, ...persisted.data },
+          errors: persisted.errors ?? {},
+          isProcessing: false,
+          validation: persisted.validation ?? {},
+        };
 
-            if (validateStep) {
-              const validation = validateStep(initialState.currentStep, initialState.data);
-              return {
-                ...initialState,
-                validation: {
-                  ...initialState.validation,
-                  [initialState.currentStep]: { ...validation, touched: true },
-                },
-              };
-            }
-
-            return initialState;
-          }
-        } catch {
-          // Failed to parse saved state, will use initial state
+        if (validateStep) {
+          const validation = validateStep(initialState.currentStep, initialState.data);
+          return {
+            ...initialState,
+            validation: {
+              ...initialState.validation,
+              [initialState.currentStep]: { ...validation, touched: true },
+            },
+          };
         }
+
+        return initialState;
       }
     }
 

--- a/src/lib/__tests__/safeJsonParse.test.ts
+++ b/src/lib/__tests__/safeJsonParse.test.ts
@@ -1,0 +1,33 @@
+import { safeJsonParse } from '../safeJsonParse';
+
+describe('safeJsonParse', () => {
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('parses valid JSON', () => {
+    expect(safeJsonParse<{ a: number }>('{"a":1}', { a: 0 })).toEqual({ a: 1 });
+    expect(safeJsonParse<number[]>('[1,2,3]', [])).toEqual([1, 2, 3]);
+  });
+
+  it('returns the fallback for malformed JSON and logs an error', () => {
+    expect(safeJsonParse<number[]>('{not json', [])).toEqual([]);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the fallback for null without logging', () => {
+    expect(safeJsonParse<string[]>(null, ['default'])).toEqual(['default']);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns the fallback for undefined without logging', () => {
+    expect(safeJsonParse<string[]>(undefined, [])).toEqual([]);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/ai/__tests__/parseNarrativeResponse.test.ts
+++ b/src/lib/ai/__tests__/parseNarrativeResponse.test.ts
@@ -1,0 +1,67 @@
+import { safeParseNarrativeAnalysis } from '../parseNarrativeResponse';
+
+describe('safeParseNarrativeAnalysis', () => {
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('parses a well-formed payload', () => {
+    const raw = JSON.stringify({
+      suggestEnding: true,
+      confidence: 'high',
+      endingType: 'story-complete',
+      reason: 'The arc has resolved.',
+    });
+    expect(safeParseNarrativeAnalysis(raw)).toEqual({
+      suggestEnding: true,
+      confidence: 'high',
+      endingType: 'story-complete',
+      reason: 'The arc has resolved.',
+    });
+  });
+
+  it('strips ```json markdown fences', () => {
+    const raw = '```json\n{"suggestEnding":false,"confidence":"low","endingType":"none","reason":"Not yet."}\n```';
+    const parsed = safeParseNarrativeAnalysis(raw);
+    expect(parsed?.suggestEnding).toBe(false);
+    expect(parsed?.endingType).toBe('story-complete'); // "none" falls back to default
+  });
+
+  it('strips bare ``` fences', () => {
+    const raw = '```\n{"suggestEnding":true,"confidence":"medium","endingType":"character-retirement","reason":"x"}\n```';
+    const parsed = safeParseNarrativeAnalysis(raw);
+    expect(parsed?.endingType).toBe('character-retirement');
+  });
+
+  it('returns null on malformed JSON', () => {
+    expect(safeParseNarrativeAnalysis('{not json')).toBeNull();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('returns null when required fields are missing', () => {
+    expect(
+      safeParseNarrativeAnalysis(JSON.stringify({ suggestEnding: 'yes' }))
+    ).toBeNull();
+    expect(
+      safeParseNarrativeAnalysis(
+        JSON.stringify({ suggestEnding: true, confidence: 'maybe', reason: 'x' })
+      )
+    ).toBeNull();
+  });
+
+  it('defaults endingType to story-complete when unrecognised', () => {
+    const raw = JSON.stringify({
+      suggestEnding: true,
+      confidence: 'high',
+      endingType: 'totally-made-up',
+      reason: 'x',
+    });
+    expect(safeParseNarrativeAnalysis(raw)?.endingType).toBe('story-complete');
+  });
+});

--- a/src/lib/ai/parseNarrativeResponse.ts
+++ b/src/lib/ai/parseNarrativeResponse.ts
@@ -1,0 +1,66 @@
+import { safeTrim } from '@/lib/utils';
+import type { EndingType } from '@/types/narrative.types';
+
+export interface NarrativeEndingAnalysis {
+  suggestEnding: boolean;
+  confidence: 'high' | 'medium' | 'low';
+  endingType: EndingType;
+  reason: string;
+}
+
+const VALID_CONFIDENCES = new Set(['high', 'medium', 'low']);
+const VALID_ENDING_TYPES = new Set<EndingType>([
+  'story-complete',
+  'character-retirement',
+  'session-limit',
+  'player-choice',
+]);
+
+function stripMarkdownFences(raw: string): string {
+  let content = raw;
+  if (content.includes('```json')) {
+    content = content.replace(/```json\s*/g, '').replace(/```\s*/g, '');
+  } else if (content.includes('```')) {
+    content = content.replace(/```\s*/g, '');
+  }
+  return safeTrim(content);
+}
+
+/**
+ * Parses an AI ending-analysis response, tolerating markdown code fences and
+ * unexpected shapes. Returns null when the payload is unparseable or doesn't
+ * match the expected schema; callers should treat null as "no suggestion."
+ */
+export function safeParseNarrativeAnalysis(
+  raw: string
+): NarrativeEndingAnalysis | null {
+  const cleaned = stripMarkdownFences(raw);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch (error) {
+    console.error('safeParseNarrativeAnalysis: invalid JSON', error);
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== 'object') return null;
+  const obj = parsed as Record<string, unknown>;
+
+  if (typeof obj.suggestEnding !== 'boolean') return null;
+  if (typeof obj.confidence !== 'string' || !VALID_CONFIDENCES.has(obj.confidence)) {
+    return null;
+  }
+  if (typeof obj.reason !== 'string') return null;
+
+  const endingType: EndingType = VALID_ENDING_TYPES.has(obj.endingType as EndingType)
+    ? (obj.endingType as EndingType)
+    : 'story-complete';
+
+  return {
+    suggestEnding: obj.suggestEnding,
+    confidence: obj.confidence as NarrativeEndingAnalysis['confidence'],
+    endingType,
+    reason: obj.reason,
+  };
+}

--- a/src/lib/safeJsonParse.ts
+++ b/src/lib/safeJsonParse.ts
@@ -1,0 +1,14 @@
+/**
+ * Parses JSON safely, returning the fallback if the input is null/undefined
+ * or fails to parse. Logs malformed input via console.error so corruption
+ * doesn't disappear silently.
+ */
+export function safeJsonParse<T>(raw: string | null | undefined, fallback: T): T {
+  if (raw == null) return fallback;
+  try {
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    console.error('safeJsonParse: failed to parse JSON, using fallback', error);
+    return fallback;
+  }
+}

--- a/src/lib/theme/themeInitScript.ts
+++ b/src/lib/theme/themeInitScript.ts
@@ -1,0 +1,21 @@
+// Runs in <head> via dangerouslySetInnerHTML before first paint so the
+// document picks up the persisted theme / color scheme without flashing
+// the default. Must stay inline (no external fetch) to preserve no-FOUC.
+export const THEME_INIT_SCRIPT = `(function () {
+  try {
+    var theme = localStorage.getItem('narraitor-theme');
+    if (theme) {
+      document.documentElement.setAttribute('data-theme', theme);
+    }
+    var scheme = localStorage.getItem('narraitor-color-scheme');
+    var systemPrefersDark =
+      scheme === 'system' &&
+      matchMedia('(prefers-color-scheme: dark)').matches;
+    if (scheme === 'dark' || systemPrefersDark) {
+      document.documentElement.classList.add('dark');
+    }
+  } catch (e) {
+    // localStorage unavailable (SSR, private mode, or storage disabled).
+    // Fall through with the document's default theme.
+  }
+})();`;

--- a/src/lib/utils/logger.ts
+++ b/src/lib/utils/logger.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console -- this module is the console wrapper */
 /**
  * Logger utility for standardized debug logging across the application.
  * Provides severity levels, environment-based toggling, and formatted output.

--- a/src/state/narrativeStore.ts
+++ b/src/state/narrativeStore.ts
@@ -1,3 +1,5 @@
+// TODO: this store is ~1,400 lines and should be split into slices
+// (segments / decisions / endings / npc-roster). Tracked separately.
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { Decision, NarrativeSegment, StoryEnding, EndingType, EndingTone, ChoiceAlignment, NarrativeMetadata, Consequence, PromptDebugInfo } from '../types/narrative.types';


### PR DESCRIPTION
## Summary

Targeted cleanup of the top five embarrassments from a recent audit. Five small, reviewable commits — one per fix.

| # | Commit | Fix |
|---|---|---|
| 1 | `chore(lint)` | Removed ~25 narration `console.log`s from `TestDataGeneratorSection` (debug-button handlers retained, since their purpose is logging). Added global `no-console` ESLint rule (`allow: warn, error`). Override extended for `__mocks__`/`.stories.helpers`. Fixed 3 surfaced production logs. |
| 2 | `fix(safe-parse)` | New `src/lib/safeJsonParse.ts` + tests. Applied at the two `WorldCreationWizard` localStorage sites and the empty-`catch` in `useWizardState`. The remaining swallowing `catch` in `handleComplete` now logs the underlying error. |
| 3 | `refactor(narrative)` | Extracted `src/lib/ai/parseNarrativeResponse.ts` (schema-validates AI ending analysis, returns null on bad input). Replaced the brittle `decision.id.includes('decision-fallback-')` string sniff with a local `usedFallbackDecision` flag. Swapped two `JSON.parse(JSON.stringify())` deep clones for `structuredClone()`. Added a TODO at the top of `narrativeStore.ts` (1,465 lines) about the eventual slice split. |
| 4 | `refactor(theme)` | Moved the 240-character minified inline script out of `layout.tsx` into `src/lib/theme/themeInitScript.ts` (readable function, real comment on the swallowed `catch`). Kept it inlined via `dangerouslySetInnerHTML` rather than `public/` + `next/script` — external would add a network roundtrip for ~400 bytes and risk FOUC. |
| 5 | `chore(repo)` | Renamed `docker-compose.yolo.yml` → `docker-compose.claude-sandbox.yml` (also renamed service / container / referenced Dockerfile to match — nothing else referenced the old name). Replaced the create-next-app boilerplate `package.json#description` with one line about what Narraitor actually does. |

## Out of scope (still on the audit punch list)

Deferred to follow-up PRs: full `narrativeStore.ts` slice split, dependency bumps (`@google/genai` is 18 majors behind), `Math.random()`-for-IDs, the 35+ `as any` casts in test mocks, etc.

## Test plan

- [x] `npm run lint` — 0 errors (only pre-existing unrelated warnings)
- [x] `npx tsc --noEmit` — exit 0
- [x] `npx jest` — 2,149/2,149 tests passing across 299 suites (including new tests for `safeJsonParse` and `safeParseNarrativeAnalysis`)
- [ ] Manual smoke (couldn't run in this environment — no graphical browser):
  - Open `/dev` tools page; console quiet, generator buttons still functional
  - Theme: hard refresh light/dark, then fresh incognito (no localStorage) — no FOUC, no thrown errors
  - World creation: corrupt `localStorage.setItem('worlds','{bad')` → app survives, falls back to `[]`
  - Narrative flow: walk through a decision, confirm AI response parses end-to-end

https://claude.ai/code/session_01Y7m8zhTTEHtm1fpvw9VB42

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7m8zhTTEHtm1fpvw9VB42)_