### PR TITLE
refactor: convert 5 single-method classes to free functions (overengineering audit round 3)

### DIFF
--- a/src/app/api/ai/generate-template/route.ts
+++ b/src/app/api/ai/generate-template/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { TemplateGenerator } from '@/lib/ai/templateGenerator';
+import { generateWorldTemplate } from '@/lib/ai/templateGenerator';
 import { TemplateGenerationContext } from '@/lib/ai/templatePrompts';
 import { GeminiClient } from '@/lib/ai/geminiClient';
 import { getAIConfig, getGenerationConfig, getSafetySettings } from '@/lib/ai/config';
@@ -66,15 +66,13 @@ export async function POST(request: NextRequest) {
       generationConfig: getGenerationConfig(),
       safetySettings: getSafetySettings()
     });
-    const templateGenerator = new TemplateGenerator(client);
-    
     // Add timeout wrapper to prevent hanging requests
     const timeoutPromise = new Promise((_, reject) =>
       setTimeout(() => reject(new Error('Template generation timeout')), TEMPLATE_GENERATION_TIMEOUT_MS)
     );
-    
+
     const template = await Promise.race([
-      templateGenerator.generateWorldTemplate(context),
+      generateWorldTemplate(client, context),
       timeoutPromise
     ]);
     

--- a/src/app/api/generate-portrait/route.ts
+++ b/src/app/api/generate-portrait/route.ts
@@ -26,14 +26,13 @@ async function buildPortraitPrompt(
     );
 
     // Use only the character detection part, not the full image generation
-    const { PortraitGenerator } = await import('@/lib/ai/portraitGenerator');
+    const { buildPortraitPrompt: buildPortraitPromptFn } = await import('@/lib/ai/portraitGenerator');
     const { createDefaultGeminiClient } = await import(
       '@/lib/ai/defaultGeminiClient'
     );
 
     logger.debug('generate-portrait API', 'Creating AI client and generator');
     const aiClient = createDefaultGeminiClient();
-    const generator = new PortraitGenerator(aiClient);
 
     // Create a minimal character object for detection
     const mockCharacter: Character = {
@@ -74,7 +73,7 @@ async function buildPortraitPrompt(
     );
 
     // Call buildPortraitPrompt directly to avoid the image generation requirement
-    const prompt = await generator.buildPortraitPrompt(mockCharacter, {
+    const prompt = await buildPortraitPromptFn(aiClient, mockCharacter, {
       worldGenre: worldGenre,
     });
 

--- a/src/app/api/narrative/ending/route.ts
+++ b/src/app/api/narrative/ending/route.ts
@@ -1,7 +1,7 @@
 // src/app/api/narrative/ending/route.ts
 
 import { NextRequest, NextResponse } from 'next/server';
-import { endingGenerator } from '../../../../lib/ai/endingGenerator';
+import { generateEnding } from '../../../../lib/ai/endingGenerator';
 import { logger } from '../../../../lib/utils/logger';
 import type { EndingGenerationRequest, EndingType, EndingTone } from '../../../../types/narrative.types';
 
@@ -63,7 +63,7 @@ export async function POST(request: NextRequest) {
     });
 
     // Generate the ending
-    const result = await endingGenerator.generateEnding(endingRequest);
+    const result = await generateEnding(endingRequest);
 
     logger.info('Story ending generated successfully', { 
       sessionId,

--- a/src/app/characters/page.tsx
+++ b/src/app/characters/page.tsx
@@ -7,7 +7,7 @@ import { useCharacterStore, type Character } from '@/state/characterStore';
 import { useWorldStore } from '@/state/worldStore';
 import { useSessionStore } from '@/state/sessionStore';
 import { useNarrativeStore } from '@/state/narrativeStore';
-import { CharacterDeletionService } from '@/services/characterDeletionService';
+import { deleteCharacterWithCleanup } from '@/services/characterDeletionService';
 import { getTimestamp } from '@/lib/utils';
 import { CharacterCard } from '@/components/CharacterCard';
 import { CharacterTable } from '@/components/character/CharacterTable';
@@ -410,9 +410,7 @@ export default function CharactersPage() {
 
     try {
       const characterName = deleteDialog.characterName;
-      await CharacterDeletionService.deleteCharacterWithCleanup(
-        deleteDialog.characterId
-      );
+      await deleteCharacterWithCleanup(deleteDialog.characterId);
       addToast({
         title: 'Character Deleted',
         description: `${characterName} has been permanently deleted`,

--- a/src/components/devtools/PortraitDebugSection/PortraitDebugSection.tsx
+++ b/src/components/devtools/PortraitDebugSection/PortraitDebugSection.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from 'react';
 import Image from 'next/image';
 import { CollapsibleSection } from '@/components/ui/CollapsibleSection';
-import { PortraitGenerator } from '@/lib/ai/portraitGenerator';
+import { generatePortrait as generatePortraitDirect } from '@/lib/ai/portraitGenerator';
 import { createAIClient } from '@/lib/ai';
 import {
   useCharacterStore,
@@ -200,11 +200,11 @@ export function PortraitDebugSection({
     setIsGenerating(true);
     try {
       const aiClient = createAIClient();
-      const generator = new PortraitGenerator(aiClient);
 
       const mockCharacter = createMockCharacter('test');
 
-      const result = await generator.generatePortrait(
+      const result = await generatePortraitDirect(
+        aiClient,
         mockCharacter as unknown as Character,
         {
           worldGenre: effectiveWorldConfig?.genre,

--- a/src/lib/ai/__tests__/endingGenerator.advanced.test.ts
+++ b/src/lib/ai/__tests__/endingGenerator.advanced.test.ts
@@ -22,7 +22,7 @@ jest.mock('../../../state/journalStore', () => ({
   }
 }));
 
-import { endingGenerator } from '../endingGenerator';
+import { generateEnding } from '../endingGenerator';
 import { buildEndingContext } from '../contextManager';
 import type { EndingGenerationRequest } from '../../../types/narrative.types';
 import {
@@ -133,7 +133,7 @@ describe('EndingGenerator - Advanced Features', () => {
     mockBuildEndingContext.mockResolvedValue(mockContext);
     mockGeminiClient.generateContent.mockResolvedValue({ content: mockResponse });
 
-    const result = await endingGenerator.generateEnding(mockRequest);
+    const result = await generateEnding(mockRequest);
 
     expect(result.playTime).toBeGreaterThan(3500); // Close to 1 hour in seconds
     expect(result.playTime).toBeLessThan(3700);
@@ -167,7 +167,7 @@ describe('EndingGenerator - Advanced Features', () => {
       }` });
     });
 
-    await endingGenerator.generateEnding(mockRequest);
+    await generateEnding(mockRequest);
 
     expect(mockGeminiClient.generateContent).toHaveBeenCalled();
   });
@@ -204,7 +204,7 @@ describe('EndingGenerator - Advanced Features', () => {
         "achievements": ["Completed"]
       }` });
 
-      const result = await endingGenerator.generateEnding(mockRequest);
+      const result = await generateEnding(mockRequest);
 
       expect(result.epilogue).toContain(expectedContent);
     }

--- a/src/lib/ai/__tests__/endingGenerator.basic.test.ts
+++ b/src/lib/ai/__tests__/endingGenerator.basic.test.ts
@@ -22,7 +22,7 @@ jest.mock('../../../state/journalStore', () => ({
   }
 }));
 
-import { endingGenerator } from '../endingGenerator';
+import { generateEnding } from '../endingGenerator';
 import { buildEndingContext } from '../contextManager';
 import type { EndingGenerationRequest } from '../../../types/narrative.types';
 import {
@@ -125,7 +125,7 @@ describe('EndingGenerator - Basic Generation', () => {
     mockBuildEndingContext.mockResolvedValue(mockContext);
     mockGeminiClient.generateContent.mockResolvedValue({ content: mockResponse });
 
-    const result = await endingGenerator.generateEnding(mockRequest);
+    const result = await generateEnding(mockRequest);
 
     expect(result).toMatchObject({
       epilogue: expect.any(String),
@@ -166,7 +166,7 @@ describe('EndingGenerator - Basic Generation', () => {
     mockBuildEndingContext.mockResolvedValue(mockContext);
     mockGeminiClient.generateContent.mockResolvedValue({ content: mockResponse });
 
-    const result = await endingGenerator.generateEnding(mockRequest);
+    const result = await generateEnding(mockRequest);
 
     expect(result.tone).toBe('triumphant');
     expect(result.epilogue).toContain('cost');

--- a/src/lib/ai/__tests__/endingGenerator.errors.test.ts
+++ b/src/lib/ai/__tests__/endingGenerator.errors.test.ts
@@ -22,7 +22,7 @@ jest.mock('../../../state/journalStore', () => ({
   }
 }));
 
-import { endingGenerator } from '../endingGenerator';
+import { generateEnding } from '../endingGenerator';
 import { buildEndingContext } from '../contextManager';
 import type { EndingGenerationRequest } from '../../../types/narrative.types';
 import {
@@ -113,7 +113,7 @@ describe('EndingGenerator - Error Handling and Retry', () => {
         new Error('Failed to build context')
       );
 
-      await expect(endingGenerator.generateEnding(mockRequest)).rejects.toThrow(
+      await expect(generateEnding(mockRequest)).rejects.toThrow(
         'Failed to create ending'
       );
     });
@@ -150,7 +150,7 @@ describe('EndingGenerator - Error Handling and Retry', () => {
           "achievements": ["Never Give Up"]
         }` });
 
-      const result = await endingGenerator.generateEnding(mockRequest);
+      const result = await generateEnding(mockRequest);
 
       expect(result.epilogue).toContain('Success after retry');
       expect(mockGeminiClient.generateContent).toHaveBeenCalledTimes(2);

--- a/src/lib/ai/__tests__/portraitGenerator.test.ts
+++ b/src/lib/ai/__tests__/portraitGenerator.test.ts
@@ -1,6 +1,6 @@
 // src/lib/ai/__tests__/portraitGenerator.test.ts
 
-import { PortraitGenerator } from '../portraitGenerator';
+import { generatePortrait, buildPortraitPrompt } from '../portraitGenerator';
 import { Character } from '../../../types/character.types';
 import { AIClient } from '../types';
 import { getTimestamp } from '@/lib/utils/timestamp';
@@ -11,13 +11,11 @@ const mockAIClient: AIClient = {
   generateImage: jest.fn(),
 };
 
-describe('PortraitGenerator', () => {
-  let generator: PortraitGenerator;
+describe('portraitGenerator', () => {
   let mockCharacter: Character;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    generator = new PortraitGenerator(mockAIClient);
 
     // Mock detection and enhancement responses
     (mockAIClient.generateContent as jest.Mock).mockImplementation(
@@ -111,7 +109,7 @@ describe('PortraitGenerator', () => {
         prompt: 'portrait of Elara Moonshadow',
       });
 
-      const result = await generator.generatePortrait(mockCharacter);
+      const result = await generatePortrait(mockAIClient,mockCharacter);
 
       expect(result.type).toBe('ai-generated');
       expect(result.url).toBe(mockImageData);
@@ -125,7 +123,7 @@ describe('PortraitGenerator', () => {
         prompt: '',
       });
 
-      await generator.generatePortrait(mockCharacter);
+      await generatePortrait(mockAIClient,mockCharacter);
 
       const callArgs = (mockAIClient.generateImage as jest.Mock).mock
         .calls[0][0];
@@ -148,7 +146,7 @@ describe('PortraitGenerator', () => {
         new Error('Image generation failed')
       );
 
-      await expect(generator.generatePortrait(mockCharacter)).rejects.toThrow(
+      await expect(generatePortrait(mockAIClient,mockCharacter)).rejects.toThrow(
         'Failed to generate character portrait'
       );
     });
@@ -161,7 +159,7 @@ describe('PortraitGenerator', () => {
         prompt: '',
       });
 
-      await generator.generatePortrait(mockCharacter, {});
+      await generatePortrait(mockAIClient,mockCharacter, {});
 
       const callArgs = (mockAIClient.generateImage as jest.Mock).mock
         .calls[0][0];
@@ -172,7 +170,7 @@ describe('PortraitGenerator', () => {
 
   describe('buildPortraitPrompt', () => {
     it('should create detailed prompt from character data', async () => {
-      const prompt = await generator.buildPortraitPrompt(mockCharacter);
+      const prompt = await buildPortraitPrompt(mockAIClient,mockCharacter);
 
       expect(prompt).toContain('Elara Moonshadow');
       expect(prompt).toContain('expressing wise mysterious character');
@@ -195,7 +193,7 @@ describe('PortraitGenerator', () => {
         prompt: 'Photorealistic portrait of Nathan Fielder',
       });
 
-      await generator.generatePortrait(comedianCharacter);
+      await generatePortrait(mockAIClient,comedianCharacter);
 
       // Check that detection was called
       expect(mockAIClient.generateContent).toHaveBeenCalledWith(
@@ -223,14 +221,14 @@ describe('PortraitGenerator', () => {
         },
       };
 
-      const prompt = await generator.buildPortraitPrompt(longCharacter);
+      const prompt = await buildPortraitPrompt(mockAIClient,longCharacter);
 
       // Gemini has 480 token limit, roughly 1920 characters
       expect(prompt.length).toBeLessThan(1920);
     });
 
     it('should include style keywords for quality', async () => {
-      const prompt = await generator.buildPortraitPrompt(mockCharacter);
+      const prompt = await buildPortraitPrompt(mockAIClient,mockCharacter);
 
       expect(prompt).toMatch(/portrait|character art|fantasy art/i);
       expect(prompt).toMatch(/photorealistic|documentary photography/i);

--- a/src/lib/ai/endingGenerator.ts
+++ b/src/lib/ai/endingGenerator.ts
@@ -12,233 +12,204 @@ import type {
 } from '../../types/narrative.types';
 import type { JournalEntry } from '../../types/journal.types';
 
-class EndingGenerator {
-  private maxRetries = 2;
-  private retryDelay = 1000;
+const MAX_RETRIES = 2;
+const RETRY_DELAY_MS = 1000;
 
-  async generateEnding(request: EndingGenerationRequest): Promise<EndingGenerationResult> {
+function extractRecentNarrative(segments: NarrativeSegment[]): string[] {
+  const recentSegments = segments
+    .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+    .slice(0, 10);
+
+  return recentSegments.map(segment => {
+    const prefix = segment.type === 'dialogue' ? 'Dialogue: ' : '';
+    return prefix + segment.content;
+  });
+}
+
+function extractJournalSummary(entries?: JournalEntry[]): string[] {
+  if (!entries || entries.length === 0) return [];
+
+  const importantEntries = entries
+    .filter(entry => entry.significance === 'major' || entry.type === 'achievement')
+    .slice(0, 5);
+
+  return importantEntries.map(entry => entry.content);
+}
+
+function renderTemplate(template: string, variables: Record<string, string | number>): string {
+  let rendered = template;
+
+  Object.entries(variables).forEach(([key, value]) => {
+    const regex = new RegExp(`{{${key}}}`, 'g');
+    rendered = rendered.replace(regex, String(value));
+  });
+
+  rendered = rendered.replace(/{{#if (\w+)}}([\s\S]*?){{\/if}}/g, (_, variable, content) => {
+    return variables[variable] ? content : '';
+  });
+
+  return rendered;
+}
+
+function extractJsonFromText(text: string): string | null {
+  const firstBrace = text.indexOf('{');
+  const lastBrace = text.lastIndexOf('}');
+
+  if (firstBrace === -1 || lastBrace === -1 || lastBrace <= firstBrace) {
+    return null;
+  }
+
+  return text.substring(firstBrace, lastBrace + 1);
+}
+
+function validateAndCleanParsedResult(parsed: unknown): EndingGenerationResult {
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error('Parsed result is not an object');
+  }
+
+  const data = parsed as Record<string, unknown>;
+
+  if (!data.epilogue || !data.characterLegacy || !data.worldImpact) {
+    throw new Error('Missing required fields in response');
+  }
+
+  const validTones: EndingTone[] = ['triumphant', 'mysterious', 'tragic', 'hopeful'];
+  let cleanTone: EndingTone = 'hopeful';
+
+  if (data.tone && typeof data.tone === 'string') {
+    const toneString = data.tone.toLowerCase().trim();
+    const foundTone = validTones.find(tone => toneString.includes(tone));
+    if (foundTone) {
+      cleanTone = foundTone;
+    }
+  }
+
+  return {
+    epilogue: String(data.epilogue),
+    characterLegacy: String(data.characterLegacy),
+    worldImpact: String(data.worldImpact),
+    tone: cleanTone,
+    achievements: Array.isArray(data.achievements) ? data.achievements.map(String) : [],
+    playTime: typeof data.playTime === 'number' ? data.playTime : undefined
+  };
+}
+
+function extractFromPlainText(response: string): EndingGenerationResult {
+  const sections = response.split(/\n\n+/);
+
+  return {
+    epilogue: sections[0] || 'The story comes to an end...',
+    characterLegacy: sections[1] || 'A hero remembered...',
+    worldImpact: sections[2] || 'The world was forever changed...',
+    tone: 'hopeful',
+    achievements: [],
+    playTime: undefined
+  };
+}
+
+function parseResponse(response: string): EndingGenerationResult {
+  try {
+    let cleanResponse = response.trim();
+    cleanResponse = cleanResponse.replace(/^```json\s*/i, '').replace(/\s*```$/, '');
+
     try {
-      logger.debug('Generating story ending', { request });
-
-      // Build context for ending generation
-      const context = await buildEndingContext(request);
-      
-      // Prepare template variables
-      const recentNarrative = this.extractRecentNarrative(context.narrativeSegments);
-      const journalSummary = this.extractJournalSummary(context.journalEntries);
-      
-      // Transform character to match template expectations
-      const characterForTemplate = {
-        name: context.character.name,
-        class: 'Adventurer', // Default class since it's not in the interface
-        level: 1, // Default level since it's not in the character interface
-        background: context.character.background.history,
-        personality: context.character.background.personality,
-        goals: context.character.background.goals.join(', ')
-      };
-
-      const templateVariables = prepareEndingTemplateVariables(
-        context.world,
-        characterForTemplate,
-        request.endingType,
-        recentNarrative,
-        journalSummary,
-        request.customPrompt,
-        request.desiredTone
-      );
-
-      // Render the template with variables
-      const renderedPrompt = this.renderTemplate(endingTemplate.content, templateVariables);
-
-      // Add custom prompt if provided
-      let finalPrompt = request.customPrompt
-        ? `${renderedPrompt}\n\nAdditional instruction: ${request.customPrompt}`
-        : renderedPrompt;
-
-      // Add JSON-only instruction to ensure clean response
-      finalPrompt += '\n\nIMPORTANT: Return ONLY valid JSON with no additional text, markdown formatting, or commentary. The response must be parseable JSON.';
-
-      // Generate with retries
-      let lastError: Error | null = null;
-      for (let i = 0; i <= this.maxRetries; i++) {
-        try {
-          const client = createDefaultGeminiClient();
-          const response = await client.generateContent(finalPrompt);
-          const result = this.parseResponse(response.content);
-          
-          // Calculate play time if session data available
-          if (context.sessionStartTime) {
-            result.playTime = Math.floor((Date.now() - context.sessionStartTime.getTime()) / 1000);
-          }
-
-          // Token usage tracking could be added here if needed
-
-          logger.debug('Story ending generated successfully', { 
-            tone: result.tone,
-            achievementCount: result.achievements.length 
-          });
-
-          return result;
-        } catch (error) {
-          lastError = error as Error;
-          logger.warn(`Ending generation attempt ${i + 1} failed`, { error });
-          
-          if (i < this.maxRetries) {
-            await this.delay(this.retryDelay * (i + 1));
-          }
-        }
-      }
-
-      throw new Error(`Failed to create ending after ${this.maxRetries + 1} attempts: ${lastError?.message}`);
-    } catch (error) {
-      logger.error('Failed to create ending', { 
-        error,
-        requestType: request.endingType,
-        tone: request.desiredTone,
-        characterId: request.characterId,
-        worldId: request.worldId 
-      });
-      throw new Error('Failed to create ending: ' + (error as Error).message);
-    }
-  }
-
-  private extractRecentNarrative(segments: NarrativeSegment[]): string[] {
-    // Get the last 5-10 segments for context
-    const recentSegments = segments
-      .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
-      .slice(0, 10);
-
-    return recentSegments.map(segment => {
-      const prefix = segment.type === 'dialogue' ? 'Dialogue: ' : '';
-      return prefix + segment.content;
-    });
-  }
-
-  private extractJournalSummary(entries?: JournalEntry[]): string[] {
-    if (!entries || entries.length === 0) return [];
-
-    // Get important journal entries (use significance instead of importance)
-    const importantEntries = entries
-      .filter(entry => entry.significance === 'major' || entry.type === 'achievement')
-      .slice(0, 5);
-
-    return importantEntries.map(entry => entry.content);
-  }
-
-
-  private renderTemplate(template: string, variables: Record<string, string | number>): string {
-    // Simple template rendering (replace with proper template engine if needed)
-    let rendered = template;
-    
-    Object.entries(variables).forEach(([key, value]) => {
-      const regex = new RegExp(`{{${key}}}`, 'g');
-      rendered = rendered.replace(regex, String(value));
-    });
-
-    // Handle conditionals
-    rendered = rendered.replace(/{{#if (\w+)}}([\s\S]*?){{\/if}}/g, (_, variable, content) => {
-      return variables[variable] ? content : '';
-    });
-
-    return rendered;
-  }
-
-  private parseResponse(response: string): EndingGenerationResult {
-    try {
-      // Clean up the response - remove markdown code blocks if present
-      let cleanResponse = response.trim();
-      cleanResponse = cleanResponse.replace(/^```json\s*/i, '').replace(/\s*```$/, '');
-
-      // Try to parse the entire response as JSON first
-      try {
-        const parsed = JSON.parse(cleanResponse);
-        return this.validateAndCleanParsedResult(parsed);
-      } catch {
-        // If that fails, try to extract JSON with more precise regex
-        // Match from first { to last } with proper nesting
-        const jsonMatch = this.extractJsonFromText(cleanResponse);
-        if (jsonMatch) {
-          const parsed = JSON.parse(jsonMatch);
-          return this.validateAndCleanParsedResult(parsed);
-        }
-      }
-
-      throw new Error('No valid JSON found in response');
-    } catch (error) {
-      logger.error('Failed to parse ending response', {
-        error,
-        response: response.substring(0, 200) + '...' // Log only first 200 chars
-      });
-
-      // Fallback: try to extract content from response
-      return this.extractFromPlainText(response);
-    }
-  }
-
-  private extractJsonFromText(text: string): string | null {
-    // Find the first { and last } to handle nested objects properly
-    const firstBrace = text.indexOf('{');
-    const lastBrace = text.lastIndexOf('}');
-
-    if (firstBrace === -1 || lastBrace === -1 || lastBrace <= firstBrace) {
-      return null;
-    }
-
-    return text.substring(firstBrace, lastBrace + 1);
-  }
-
-  private validateAndCleanParsedResult(parsed: unknown): EndingGenerationResult {
-    if (typeof parsed !== 'object' || parsed === null) {
-      throw new Error('Parsed result is not an object');
-    }
-
-    const data = parsed as Record<string, unknown>;
-
-    // Validate required fields
-    if (!data.epilogue || !data.characterLegacy || !data.worldImpact) {
-      throw new Error('Missing required fields in response');
-    }
-
-    // Validate and clean the tone value
-    const validTones: EndingTone[] = ['triumphant', 'mysterious', 'tragic', 'hopeful'];
-    let cleanTone: EndingTone = 'hopeful'; // default
-
-    if (data.tone && typeof data.tone === 'string') {
-      const toneString = data.tone.toLowerCase().trim();
-      // Check if the tone contains any of the valid tones
-      const foundTone = validTones.find(tone => toneString.includes(tone));
-      if (foundTone) {
-        cleanTone = foundTone;
+      const parsed = JSON.parse(cleanResponse);
+      return validateAndCleanParsedResult(parsed);
+    } catch {
+      const jsonMatch = extractJsonFromText(cleanResponse);
+      if (jsonMatch) {
+        const parsed = JSON.parse(jsonMatch);
+        return validateAndCleanParsedResult(parsed);
       }
     }
 
-    return {
-      epilogue: String(data.epilogue),
-      characterLegacy: String(data.characterLegacy),
-      worldImpact: String(data.worldImpact),
-      tone: cleanTone,
-      achievements: Array.isArray(data.achievements) ? data.achievements.map(String) : [],
-      playTime: typeof data.playTime === 'number' ? data.playTime : undefined
-    };
-  }
+    throw new Error('No valid JSON found in response');
+  } catch (error) {
+    logger.error('Failed to parse ending response', {
+      error,
+      response: response.substring(0, 200) + '...'
+    });
 
-  private extractFromPlainText(response: string): EndingGenerationResult {
-    // Basic extraction if JSON parsing fails
-    const sections = response.split(/\n\n+/);
-    
-    return {
-      epilogue: sections[0] || 'The story comes to an end...',
-      characterLegacy: sections[1] || 'A hero remembered...',
-      worldImpact: sections[2] || 'The world was forever changed...',
-      tone: 'hopeful',
-      achievements: [],
-      playTime: undefined
-    };
-  }
-
-  private delay(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
+    return extractFromPlainText(response);
   }
 }
 
-export const endingGenerator = new EndingGenerator();
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function generateEnding(request: EndingGenerationRequest): Promise<EndingGenerationResult> {
+  try {
+    logger.debug('Generating story ending', { request });
+
+    const context = await buildEndingContext(request);
+
+    const recentNarrative = extractRecentNarrative(context.narrativeSegments);
+    const journalSummary = extractJournalSummary(context.journalEntries);
+
+    const characterForTemplate = {
+      name: context.character.name,
+      class: 'Adventurer',
+      level: 1,
+      background: context.character.background.history,
+      personality: context.character.background.personality,
+      goals: context.character.background.goals.join(', ')
+    };
+
+    const templateVariables = prepareEndingTemplateVariables(
+      context.world,
+      characterForTemplate,
+      request.endingType,
+      recentNarrative,
+      journalSummary,
+      request.customPrompt,
+      request.desiredTone
+    );
+
+    const renderedPrompt = renderTemplate(endingTemplate.content, templateVariables);
+
+    let finalPrompt = request.customPrompt
+      ? `${renderedPrompt}\n\nAdditional instruction: ${request.customPrompt}`
+      : renderedPrompt;
+
+    finalPrompt += '\n\nIMPORTANT: Return ONLY valid JSON with no additional text, markdown formatting, or commentary. The response must be parseable JSON.';
+
+    let lastError: Error | null = null;
+    for (let i = 0; i <= MAX_RETRIES; i++) {
+      try {
+        const client = createDefaultGeminiClient();
+        const response = await client.generateContent(finalPrompt);
+        const result = parseResponse(response.content);
+
+        if (context.sessionStartTime) {
+          result.playTime = Math.floor((Date.now() - context.sessionStartTime.getTime()) / 1000);
+        }
+
+        logger.debug('Story ending generated successfully', {
+          tone: result.tone,
+          achievementCount: result.achievements.length
+        });
+
+        return result;
+      } catch (error) {
+        lastError = error as Error;
+        logger.warn(`Ending generation attempt ${i + 1} failed`, { error });
+
+        if (i < MAX_RETRIES) {
+          await delay(RETRY_DELAY_MS * (i + 1));
+        }
+      }
+    }
+
+    throw new Error(`Failed to create ending after ${MAX_RETRIES + 1} attempts: ${lastError?.message}`);
+  } catch (error) {
+    logger.error('Failed to create ending', {
+      error,
+      requestType: request.endingType,
+      tone: request.desiredTone,
+      characterId: request.characterId,
+      worldId: request.worldId
+    });
+    throw new Error('Failed to create ending: ' + (error as Error).message);
+  }
+}

--- a/src/lib/ai/narrativeGenerator.budget.ts
+++ b/src/lib/ai/narrativeGenerator.budget.ts
@@ -1,8 +1,7 @@
 import {
-  TokenBudgetManager,
+  RequestBudget,
   DEFAULT_ALLOCATIONS,
   DEFAULT_TOTAL_BUDGET,
-  type RequestBudget,
 } from '@/lib/promptContext/tokenBudgetManager';
 import {
   estimateTokenCount,
@@ -13,8 +12,7 @@ import { safeTrim } from '@/lib/utils';
 
 export const createRequestBudget = (): RequestBudget => {
   const enabled = process.env.ENABLE_TOKEN_BUDGET_MANAGER === 'true';
-  const manager = new TokenBudgetManager({ enabled });
-  return manager.createBudget(DEFAULT_ALLOCATIONS, DEFAULT_TOTAL_BUDGET);
+  return new RequestBudget(DEFAULT_ALLOCATIONS, DEFAULT_TOTAL_BUDGET, enabled);
 };
 
 export const applyBudget = (

--- a/src/lib/ai/narrativeGenerator.ts
+++ b/src/lib/ai/narrativeGenerator.ts
@@ -17,7 +17,11 @@ import { ChoiceGenerator } from './choiceGenerator';
 import { getLoreContextForPrompt, checkAndRecordLoreMentions } from './loreContextHelper';
 import { extractStructuredLore } from './structuredLoreExtractor';
 import { DEFAULT_TONE_SETTINGS } from '@/types/tone-settings.types';
-import { TemplateGenerator, WorldTemplate } from './templateGenerator';
+import {
+  generateWorldTemplate as generateWorldTemplateFn,
+  convertTemplateToWorld as convertTemplateToWorldFn,
+  type WorldTemplate,
+} from './templateGenerator';
 import { TemplateGenerationContext } from './templatePrompts';
 import { PersonalizationEngine } from './personalizationEngine';
 import { processAcquiredItems } from '@/lib/narrative/itemAcquisitionProcessor';
@@ -53,7 +57,6 @@ import { buildNpcRoster, syncNpcMetadata } from './narrativeGenerator.npc';
 
 export class NarrativeGenerator {
   private choiceGenerator: ChoiceGenerator;
-  private templateGenerator: TemplateGenerator;
   private personalizationEngine: PersonalizationEngine;
 
   private staticContentCache: NarrativeStaticContentCache = {
@@ -62,7 +65,6 @@ export class NarrativeGenerator {
 
   constructor(private geminiClient: AIClient) {
     this.choiceGenerator = new ChoiceGenerator(geminiClient);
-    this.templateGenerator = new TemplateGenerator(geminiClient);
     this.personalizationEngine = new PersonalizationEngine();
   }
 
@@ -748,13 +750,13 @@ export class NarrativeGenerator {
   async generateWorldTemplate(
     context: TemplateGenerationContext
   ): Promise<WorldTemplate> {
-    return this.templateGenerator.generateWorldTemplate(context);
+    return generateWorldTemplateFn(this.geminiClient, context);
   }
 
   convertTemplateToWorld(
     template: WorldTemplate
   ): Omit<World, 'id' | 'createdAt' | 'updatedAt'> {
-    return this.templateGenerator.convertTemplateToWorld(template);
+    return convertTemplateToWorldFn(template);
   }
 
   private syncNpcMetadata(

--- a/src/lib/ai/portraitGenerator.ts
+++ b/src/lib/ai/portraitGenerator.ts
@@ -9,8 +9,8 @@ import { normalizeText, NORM_NAME, NORM_DESC } from '@/lib/utils/textNormalizati
 interface PortraitGenerationOptions {
   worldGenre?: string;
   isKnownFigure?: boolean;
-  knownFigureContext?: string; // e.g., "historical figure", "fictional character", "celebrity"
-  actorName?: string; // For fictional characters played by specific actors
+  knownFigureContext?: string;
+  actorName?: string;
   detection?: {
     isKnownFigure: boolean;
     figureType?: string;
@@ -19,697 +19,121 @@ interface PortraitGenerationOptions {
   };
 }
 
-export class PortraitGenerator {
-  constructor(private aiClient: AIClient) {}
-
-  /**
-   * Detect if a character name is a known figure and if they're played by a specific actor
-   * This will be determined by the AI based on the name
-   */
-  private async detectKnownFigure(characterName: string): Promise<{ 
-    isKnownFigure: boolean; 
-    figureType?: string;
-    actorName?: string;
-    figureName?: string;
-  }> {
-    try {
-      // First, check if this is a known character
-      const detectPrompt = `Is "${characterName}" a character from any form of media (movie, TV, book, game, etc.) or a real person?
+async function detectKnownFigure(
+  aiClient: AIClient,
+  characterName: string
+): Promise<{
+  isKnownFigure: boolean;
+  figureType?: string;
+  actorName?: string;
+  figureName?: string;
+}> {
+  try {
+    const detectPrompt = `Is "${characterName}" a character from any form of media (movie, TV, book, game, etc.) or a real person?
 
 Answer with JSON only: {"isKnownFigure": true/false, "figureType": "fictional/celebrity/historical/other" or null}`;
 
-      const detectResponse = await this.aiClient.generateContent(detectPrompt);
-      const detectText = detectResponse.content;
-      
-      // Parse initial detection
-      let isKnown = false;
-      let figureType = null;
-      
-      try {
-        const detectJson = JSON.parse(detectText.match(/\{[\s\S]*?\}/)?.[0] || '{}');
-        isKnown = detectJson.isKnownFigure || false;
-        figureType = detectJson.figureType;
-      } catch {
-        // Failed to parse initial detection, continue with defaults
-      }
-      
-      // If it's a known fictional character, ask specifically who played them
-      let actorName = null;
-      let figureName = null;
-      
-      if (isKnown && figureType === 'fictional') {
-        const actorPrompt = `Who played the character "${characterName}" in the movie or TV show? What is the name of the movie/show?
+    const detectResponse = await aiClient.generateContent(detectPrompt);
+    const detectText = detectResponse.content;
+
+    let isKnown = false;
+    let figureType = null;
+
+    try {
+      const detectJson = JSON.parse(detectText.match(/\{[\s\S]*?\}/)?.[0] || '{}');
+      isKnown = detectJson.isKnownFigure || false;
+      figureType = detectJson.figureType;
+    } catch {
+      // Failed to parse initial detection, continue with defaults
+    }
+
+    let actorName = null;
+    let figureName = null;
+
+    if (isKnown && figureType === 'fictional') {
+      const actorPrompt = `Who played the character "${characterName}" in the movie or TV show? What is the name of the movie/show?
 
 Answer with JSON only: {"actorName": "actor's full name" or null, "figureName": "movie/show title" or null}`;
-        
-        const actorResponse = await this.aiClient.generateContent(actorPrompt);
-        const actorText = actorResponse.content;
-        
-        try {
-          const actorJson = JSON.parse(actorText.match(/\{[\s\S]*?\}/)?.[0] || '{}');
-          actorName = actorJson.actorName;
-          figureName = actorJson.figureName;
-        } catch {
-          // Failed to parse actor lookup, continue with defaults
-        }
+
+      const actorResponse = await aiClient.generateContent(actorPrompt);
+      const actorText = actorResponse.content;
+
+      try {
+        const actorJson = JSON.parse(actorText.match(/\{[\s\S]*?\}/)?.[0] || '{}');
+        actorName = actorJson.actorName;
+        figureName = actorJson.figureName;
+      } catch {
+        // Failed to parse actor lookup, continue with defaults
       }
-      
-      const result = {
-        isKnownFigure: isKnown,
-        figureType: figureType,
-        actorName: actorName,
-        figureName: figureName
-      };
-      
-      return result;
-    } catch (error) {
-      // If detection fails, assume not a known figure
-      console.error('Character detection failed:', error);
-      return { isKnownFigure: false };
     }
+
+    return {
+      isKnownFigure: isKnown,
+      figureType: figureType,
+      actorName: actorName,
+      figureName: figureName,
+    };
+  } catch (error) {
+    console.error('Character detection failed:', error);
+    return { isKnownFigure: false };
   }
+}
 
-  /**
-   * Generate a portrait for a character
-   */
-  async generatePortrait(
-    character: Character,
-    options: PortraitGenerationOptions = {}
-  ): Promise<GeneratedImage> {
-    if (!this.aiClient.generateImage) {
-      throw new Error('AI client does not support image generation');
-    }
+function extractKeyTraits(personality: string): string {
+  const words = personality.toLowerCase().split(/\s+/);
+  const descriptiveWords = words.filter(word =>
+    word.length > 3 &&
+    !['with', 'and', 'the', 'very', 'quite', 'rather'].includes(word)
+  ).slice(0, 3);
 
-    try {
-      // Check if we're in Storybook environment
-      const isStorybook = typeof window !== 'undefined' && window.location.port === '6006';
-      
-      if (isStorybook) {
-        // Use mock data in Storybook
-        await new Promise(resolve => setTimeout(resolve, 1500)); // Simulate delay
-        
-        const mockPortraits: Record<string, string> = {
-          fantasy: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjI1MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZGVmcz4KICAgIDxyYWRpYWxHcmFkaWVudCBpZD0iZmFjZSIgY3g9IjUwJSIgY3k9IjMwJSI+CiAgICAgIDxzdG9wIG9mZnNldD0iMCUiIHN0eWxlPSJzdG9wLWNvbG9yOiNGRkUwQjI7c3RvcC1vcGFjaXR5OjEiIC8+CiAgICAgIDxzdG9wIG9mZnNldD0iMTAwJSIgc3R5bGU9InN0b3AtY29sb3I6I0Q4OTg2ODtzdG9wLW9wYWNpdHk6MSIgLz4KICAgIDwvcmFkaWFsR3JhZGllbnQ+CiAgPC9kZWZzPgogIDxyZWN0IHdpZHRoPSIyMDAiIGhlaWdodD0iMjUwIiBmaWxsPSIjMmY0ZjJmIi8+CiAgPGVsbGlwc2UgY3g9IjEwMCIgY3k9IjEwMCIgcng9IjYwIiByeT0iODAiIGZpbGw9InVybCgjZmFjZSkiLz4KICA8Y2lyY2xlIGN4PSI4NSIgY3k9Ijg1IiByPSI1IiBmaWxsPSIjMzMzIi8+CiAgPGNpcmNsZSBjeD0iMTE1IiBjeT0iODUiIHI9IjUiIGZpbGw9IiMzMzMiLz4KICA8cGF0aCBkPSJNOTAgMTA1IFEgMTAwIDExNSAxMTAgMTA1IiBzdHJva2U9IiMzMzMiIGZpbGw9Im5vbmUiIHN0cm9rZS13aWR0aD0iMiIvPgogIDx0ZXh0IHg9IjEwMCIgeT0iMjMwIiBmb250LWZhbWlseT0iQXJpYWwiIGZvbnQtc2l6ZT0iMTYiIGZpbGw9IiNGRkZGRkYiIHRleHQtYW5jaG9yPSJtaWRkbGUiPkZBTlRBU1kgUE9SVFJBSVQ8L3RleHQ+Cjwvc3ZnPg==',
-          modern: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjI1MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZGVmcz4KICAgIDxyYWRpYWxHcmFkaWVudCBpZD0iZmFjZTIiIGN4PSI1MCUiIGN5PSIzMCUiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAlIiBzdHlsZT0ic3RvcC1jb2xvcjojRkZEQkIyO3N0b3Atb3BhY2l0eToxIiAvPgogICAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0eWxlPSJzdG9wLWNvbG9yOiNEOEE4Nzg7c3RvcC1vcGFjaXR5OjEiIC8+CiAgICA8L3JhZGlhbEdyYWRpZW50PgogIDwvZGVmcz4KICA8cmVjdCB3aWR0aD0iMjAwIiBoZWlnaHQ9IjI1MCIgZmlsbD0iI2Y1ZjVmNSIvPgogIDxlbGxpcHNlIGN4PSIxMDAiIGN5PSIxMDAiIHJ4PSI2MCIgcnk9IjgwIiBmaWxsPSJ1cmwoI2ZhY2UyKSIvPgogIDxyZWN0IHg9IjQwIiB5PSI5NSIgd2lkdGg9IjEyMCIgaGVpZ2h0PSI0IiBmaWxsPSIjNDQ0IiBvcGFjaXR5PSIwLjMiLz4KICA8Y2lyY2xlIGN4PSI4NSIgY3k9Ijg1IiByPSI1IiBmaWxsPSIjMzMzIi8+CiAgPGNpcmNsZSBjeD0iMTE1IiBjeT0iODUiIHI9IjUiIGZpbGw9IiMzMzMiLz4KICA8cGF0aCBkPSJNOTAgMTA1IFEgMTAwIDExNSAxMTAgMTA1IiBzdHJva2U9IiMzMzMiIGZpbGw9Im5vbmUiIHN0cm9rZS13aWR0aD0iMiIvPgogIDx0ZXh0IHg9IjEwMCIgeT0iMjMwIiBmb250LWZhbWlseT0iQXJpYWwiIGZvbnQtc2l6ZT0iMTYiIGZpbGw9IiMzMzMiIHRleHQtYW5jaG9yPSJtaWRkbGUiPk1PREVSTU4gUE9SVFJBSVQ8L3RleHQ+Cjwvc3ZnPg==',
-          default: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjI1MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZGVmcz4KICAgIDxyYWRpYWxHcmFkaWVudCBpZD0iZmFjZTMiIGN4PSI1MCUiIGN5PSIzMCUiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAlIiBzdHlsZT0ic3RvcC1jb2xvcjojRkZFNEMyO3N0b3Atb3BhY2l0eToxIiAvPgogICAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0eWxlPSJzdG9wLWNvbG9yOiNEOEE4Nzg7c3RvcC1vcGFjaXR5OjEiIC8+CiAgICA8L3JhZGlhbEdyYWRpZW50PgogIDwvZGVmcz4KICA8cmVjdCB3aWR0aD0iMjAwIiBoZWlnaHQ9IjI1MCIgZmlsbD0iIzMzMzMzMyIvPgogIDxlbGxpcHNlIGN4PSIxMDAiIGN5PSIxMDAiIHJ4PSI2MCIgcnk9IjgwIiBmaWxsPSJ1cmwoI2ZhY2UzKSIvPgogIDxjaXJjbGUgY3g9Ijg1IiBjeT0iODUiIHI9IjUiIGZpbGw9IiMzMzMiLz4KICA8Y2lyY2xlIGN4PSIxMTUiIGN5PSI4NSIgcj0iNSIgZmlsbD0iIzMzMyIvPgogIDxwYXRoIGQ9Ik05MCD2NTMgUaEwIDExNSAMIDSNIHN0cm9rZT0iIzMzMyIgZmlsbD0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIyIi8+CiAgPHRleHQgeD0iMTAwIiB5PSIyMzAiIGZvbnQtZmFtaWx5PSJBcmlhbCIgZm9udC1zaXplPSIxNiIgZmlsbD0iI0ZGRkZGRiIgdGV4dC1hbmNob3I9Im1pZGRsZSI+UE9SVFJBSVQ8L3RleHQ+Cjwvc3ZnPg=='
-        };
-        
-        const genreLC = options.worldGenre?.toLowerCase() || 'default';
-        let mockPortrait = mockPortraits.default;
-        if (genreLC.includes('fantasy') || genreLC.includes('medieval')) {
-          mockPortrait = mockPortraits.fantasy;
-        } else if (genreLC.includes('modern') || genreLC.includes('contemporary')) {
-          mockPortrait = mockPortraits.modern;
-        }
-        
-        return {
-          type: 'ai-generated',
-          url: mockPortrait,
-          generatedAt: getTimestamp(),
-          prompt: `Mock portrait for ${character.name} in Storybook`
-        };
-      }
-      // Automatically detect if this is a known figure
-      const detection = await this.detectKnownFigure(character.name);
-      
-      // If it's a known figure with missing background info, enhance the character data
-      if (detection.isKnownFigure && (
-        !character.background?.physicalDescription || 
-        !character.background?.personality || 
-        !character.background?.history
-      )) {
-        character = await this.enhanceKnownCharacter(character, detection);
-      }
-      
-      // Store detection result for test page
-      if (typeof window !== 'undefined') {
-        const windowWithDetection = window as Window & { lastDetectionResult?: typeof detection };
-        windowWithDetection.lastDetectionResult = detection;
-      }
-      
-      // Merge detected info with any provided options
-      const mergedOptions = {
-        ...options,
-        isKnownFigure: detection.isKnownFigure,
-        knownFigureContext: detection.figureType || options.knownFigureContext,
-        actorName: detection.actorName || options.actorName,
-        detection
-      };
-      
-      const prompt = await this.buildPortraitPrompt(character, mergedOptions);
-      
-      const response = await this.aiClient.generateImage(prompt);
+  return descriptiveWords.length > 0 ? descriptiveWords.join(' ') + ' expression' : '';
+}
 
-      return {
-        type: 'ai-generated',
-        url: response.image,
-        generatedAt: getTimestamp(),
-        prompt: response.prompt
-      };
-    } catch (error) {
-      throw new Error(
-        `Failed to generate character portrait: ${error instanceof Error ? error.message : 'Unknown error'}`
-      );
-    }
-  }
+async function convertPersonalityToVisualTraits(
+  aiClient: AIClient,
+  personality: string
+): Promise<string> {
+  try {
+    const prompt = `Convert these personality traits into visible physical expressions and body language: "${personality}"
 
-  /**
-   * Build a descriptive prompt for portrait generation following Gemini's guidelines
-   * Structure: Subject, Context, Style
-   */
-  async buildPortraitPrompt(
-    character: Character,
-    options: PortraitGenerationOptions = {}
-  ): Promise<string> {
-    // If no detection options provided, run AI detection
-    if (!options.detection && !options.isKnownFigure) {
-      const detection = await this.detectKnownFigure(character.name);
-      
-      // Merge detection results into options
-      options = {
-        ...options,
-        isKnownFigure: detection.isKnownFigure,
-        knownFigureContext: detection.figureType || options.knownFigureContext,
-        actorName: detection.actorName || options.actorName,
-        detection
-      };
-    }
-    
-    const subject: string[] = [];
-    const context: string[] = [];
-    const style: string[] = [];
-    
-    // Determine if this is a fantasy setting (needed for multiple parts of the prompt)
-    const isFantasy = options.worldGenre && 
-      ['fantasy', 'medieval', 'magic', 'mystical', 'epic'].some(term => 
-        options.worldGenre?.toLowerCase().includes(term)
-      );
-    
-    // Extract key visual elements for emphasis
-    const physicalDesc = character.background?.physicalDescription || '';
-    
-    // Extract specific clothing items
-    const clothingMatch = physicalDesc.match(/wearing\s+([^,\.]+)/i);
-    const specificClothing = clothingMatch ? safeTrim(clothingMatch[1]) : null;
-    
-    // Extract distinctive features
-    const distinctiveFeatures: string[] = [];
-    if (physicalDesc.match(/missing teeth/i)) distinctiveFeatures.push('missing teeth');
-    if (physicalDesc.match(/deformed|misshapen/i)) distinctiveFeatures.push('facial deformity');
-    if (physicalDesc.match(/one eye higher/i)) distinctiveFeatures.push('asymmetrical eyes');
-    if (physicalDesc.match(/scar/i)) distinctiveFeatures.push('visible scars');
-    if (physicalDesc.match(/bald/i)) distinctiveFeatures.push('bald head');
-    
-    // Check if description has very specific details that need emphasis
-    const hasSpecificDetails = specificClothing || distinctiveFeatures.length > 0;
-
-    if (options.isKnownFigure) {
-      // Known figures - photorealistic approach
-      
-      if (options.knownFigureContext === 'fictional' || options.knownFigureContext === 'videogame' || options.knownFigureContext === 'anime') {
-        // Fictional characters (movies, games, anime, etc.)
-        
-        if (options.actorName) {
-          // Live-action character with specific actor (e.g., Bob Wiley)
-          // Put actor name FIRST with heavy emphasis for better recognition
-          subject.push(`((${options.actorName})) as ${character.name}`);
-          
-          if (options.detection?.figureName) {
-            subject.push(`from ${options.detection?.figureName}`);
-          }
-          
-          if (character.background?.physicalDescription) {
-            const cleanedDesc = normalizeText(character.background.physicalDescription, NORM_DESC);
-            context.push(cleanedDesc);
-          }
-          
-          // Add specific costume/clothing details if present
-          if (specificClothing) {
-            context.push(`wearing ${specificClothing}`);
-          }
-          if (distinctiveFeatures.length > 0) {
-            context.push(`showing ${distinctiveFeatures.join(', ')}`);
-          }
-        } else {
-          // Video game/animated character (e.g., Arthur Morgan)
-          subject.push(`Character portrait of ${character.name}`);
-          if (options.knownFigureContext === 'videogame') {
-            // Use detected figureName if available, otherwise try to extract from history
-            if (options.detection?.figureName) {
-              subject.push(`from ${options.detection?.figureName}`);
-            } else if (character?.background?.history) {
-              // More flexible regex patterns to extract game names
-              let gameName = null;
-              
-              // Try multiple patterns to extract game/media titles
-              const patterns = [
-                /from\s+([^.]+)/i,           // "from [Game Name]"
-                /in\s+([^.]+)/i,             // "in [Game Name]"
-                /of\s+([^.]+)/i,             // "of [Game Name]"
-                /([A-Z][a-zA-Z0-9\s:]+(?:\d+)?)/i // Title Case Names with numbers/colons
-              ];
-              
-              for (const pattern of patterns) {
-                const match = character.background?.history?.match(pattern);
-                if (match && match[1]) {
-                  gameName = safeTrim(match[1]);
-                  break;
-                }
-              }
-              
-              if (gameName) {
-                subject.push(`from ${gameName}`);
-              } else {
-                subject.push(`from the video game`);
-              }
-            } else {
-              subject.push(`from the video game`);
-            }
-          }
-          
-          if (character.background?.physicalDescription) {
-            const cleanedDesc = normalizeText(character.background.physicalDescription, NORM_DESC).toLowerCase();
-            context.push(cleanedDesc);
-          }
-          
-          context.push(`authentic game character appearance`);
-          context.push(`recognizable character design`);
-          context.push(`official character look`);
-          
-          // Add specific details if present
-          if (hasSpecificDetails && character?.background?.physicalDescription) {
-            if (specificClothing) {
-              context.push(`wearing ${specificClothing}`);
-            }
-            if (distinctiveFeatures.length > 0) {
-              context.push(`with ${distinctiveFeatures.join(', ')}`);
-            }
-          }
-          
-          // Add world theme styling if provided
-          if (options.worldGenre) {
-            context.push(`${options.worldGenre} style atmosphere`);
-          }
-        }
-        
-        // Add personality converted to visual traits
-        if (character.background?.personality) {
-          const visualTraits = await this.convertPersonalityToVisualTraits(character.background.personality);
-          if (visualTraits) {
-            context.push(visualTraits);
-          }
-        }
-      } else {
-        // Real historical figures or celebrities
-        subject.push(`Photorealistic portrait of ${character.name}`);
-        if (options.knownFigureContext) {
-          subject.push(`the ${options.knownFigureContext}`);
-        }
-        
-        // Add physical description to help ensure accuracy
-        if (character.background?.physicalDescription) {
-          const cleanedDesc = normalizeText(character.background.physicalDescription, NORM_DESC).toLowerCase();
-          context.push(cleanedDesc);
-        }
-        
-        // CONTEXT: Character-appropriate environment
-        if (options.knownFigureContext === 'comedian') {
-          context.push(`comedy club or casual setting`);
-        } else if (options.knownFigureContext === 'videogame') {
-          context.push(`game world environment`);
-        } else if (options.knownFigureContext === 'fictional' && character.background?.history) {
-          // Extract setting context from history
-          if (character.background.history.toLowerCase().includes('vacation')) {
-            context.push(`vacation resort setting`);
-          } else if (character.background.history.toLowerCase().includes('film')) {
-            context.push(`movie scene environment`);
-          } else {
-            context.push(`appropriate scene setting`);
-          }
-        } else {
-          context.push(`appropriate environment for character`);
-        }
-        context.push(`ambient lighting`);
-        context.push(`contextual background`);
-        
-        // Add world theme styling if provided
-        if (options.worldGenre) {
-          context.push(`${options.worldGenre} style atmosphere`);
-        }
-      }
-      
-      // STYLE: Keep it minimal - ensure headshot
-      style.push(`headshot portrait photograph`);
-      
-    } else {
-      // Unknown/original characters - context-based approach
-      
-      if (isFantasy) {
-        // SUBJECT: Fantasy character
-        subject.push(`Fantasy character portrait of ${character.name}`);
-        
-        // Add physical description with enhanced diversity
-        let physicalDesc = character.background?.physicalDescription || '';
-        
-        // Enhance diversity for original characters
-        if (!options.isKnownFigure || !options.actorName) {
-          physicalDesc = await this.enhancePhysicalDiversity(physicalDesc, character.name);
-        }
-        
-        if (physicalDesc) {
-          const cleanedDesc = normalizeText(physicalDesc, NORM_NAME);
-          if (cleanedDesc) {
-            subject.push(`a ${cleanedDesc}`);
-          }
-        }
-        
-        // Extract profession/class from history
-        if (character.background?.history) {
-          const professionMatch = character.background.history.match(
-            /\b(warrior|mage|wizard|rogue|thief|cleric|priest|ranger|bard|druid|paladin|sorcerer|fighter|monk|archer|knight|barbarian|necromancer)\b/i
-          );
-          if (professionMatch) {
-            subject.push(`${professionMatch[0].toLowerCase()} character`);
-          }
-        }
-        
-        // Add personality-based appearance
-        if (character.background?.personality) {
-          const visualTraits = await this.convertPersonalityToVisualTraits(character.background.personality);
-          if (visualTraits) {
-            context.push(visualTraits);
-          }
-        }
-        
-        // CONTEXT: Fantasy setting
-        context.push(`${options.worldGenre} world setting`);
-        if (character.background?.history && character.background.history.toLowerCase().includes('battle')) {
-          context.push(`battle-worn appearance`);
-        }
-      } else {
-        // SUBJECT: Realistic character portrait
-        subject.push(`Character portrait of ${character.name}`);
-        
-        // Add physical description with enhanced diversity for non-actor characters
-        let physicalDesc = character.background?.physicalDescription || '';
-        
-        // Enhance diversity for original characters (not known figures without actors)
-        if (!options.isKnownFigure || !options.actorName) {
-          physicalDesc = await this.enhancePhysicalDiversity(physicalDesc, character.name);
-        }
-        
-        if (physicalDesc) {
-          const cleanedDesc = normalizeText(physicalDesc, NORM_NAME);
-          if (cleanedDesc) {
-            subject.push(`${cleanedDesc}`);
-          }
-        }
-        
-        // Add personality-based traits
-        if (character.background?.personality) {
-          const visualTraits = await this.convertPersonalityToVisualTraits(character.background.personality);
-          if (visualTraits) {
-            context.push(visualTraits);
-          }
-        }
-        
-        // CONTEXT: World-appropriate setting
-        if (options.worldGenre) {
-          // Only add theme context if it's meaningful for the portrait
-          const genreLC = options.worldGenre?.toLowerCase();
-          if (genreLC === 'modern' || genreLC === 'contemporary') {
-            // Don't add generic "modern setting" - it's not helpful
-            // The physical description should provide enough context
-          } else {
-            context.push(`${options.worldGenre} world environment`);
-          }
-        }
-      }
-      
-      // STYLE: Based on fantasy vs realistic - ensure headshot
-      if (isFantasy) {
-        style.push(`fantasy art headshot portrait`);
-        style.push(`face close-up digital painting`);
-      } else {
-        style.push(`headshot portrait`);
-      }
-      
-      // Add strong emphasis on realistic diversity for non-actor characters
-      if (!options.isKnownFigure || !options.actorName) {
-        style.push(`realistic average person`);
-        style.push(`NOT a model or actor`);
-        style.push(`photorealistic imperfections visible`);
-        
-        // Extract specific imperfections from the description and emphasize them
-        const imperfections = [];
-        const physicalDesc = subject.join(' ') + ' ' + context.join(' ');
-        
-        // Weight-related
-        if (physicalDesc.match(/\b(pot belly|beer gut|double chin|jowls|overweight|heavy|barrel chest)\b/i)) {
-          imperfections.push('visible weight');
-        }
-        
-        // Hair-related
-        if (physicalDesc.match(/\b(bald|balding|receding|thinning hair|bald spot)\b/i)) {
-          imperfections.push('realistic hair loss');
-        }
-        
-        // Skin-related
-        if (physicalDesc.match(/\b(acne|pockmark|scar|wrinkle|liver spot|sun damage|weathered)\b/i)) {
-          imperfections.push('skin imperfections clearly visible');
-        }
-        
-        // Face-related
-        if (physicalDesc.match(/\b(crooked|uneven|droopy|weak chin|heavy brow|gaunt|sunken)\b/i)) {
-          imperfections.push('asymmetrical or non-ideal facial features');
-        }
-        
-        if (imperfections.length > 0) {
-          style.push(imperfections.join(', '));
-        }
-      }
-    }
-
-    // Combine all parts following Gemini's best practices: Subject, Context, Style
-    const promptParts: string[] = [];
-    
-    // SUBJECT - Most important, comes first
-    if (subject.length > 0) {
-      let subjectText = subject.join(', ');
-      
-      // If there's an actor name, add extra emphasis
-      if (options.actorName) {
-        subjectText = `${options.actorName}, ${subjectText}`;
-      }
-      
-      promptParts.push(subjectText);
-    }
-    
-    // Handle photography style based on whether we have an actor - ensure headshot
-    if (options.actorName) {
-      // For actor-based portraits, use high-quality photography to capture likeness
-      promptParts.push('professional headshot photography');
-      promptParts.push('face close-up high resolution');
-      promptParts.push('accurate facial likeness');
-    } else if (!options.isKnownFigure) {
-      // For non-actor characters, add photographic specifics for realism
-      const physicalDesc = subject.join(' ') + ' ' + context.join(' ');
-      const hasAttractiveDescriptor = physicalDesc.match(/\b(beautiful|handsome|pretty|gorgeous|attractive|stunning)\b/i);
-
-      if (!hasAttractiveDescriptor) {
-        // For average/imperfect characters, use documentary photography style
-        promptParts.push('35mm headshot portrait');
-        promptParts.push('documentary photography');
-        promptParts.push('candid face close-up with visible skin texture and imperfections');
-      } else {
-        // For attractive characters, use standard portrait style
-        promptParts.push('35mm headshot portrait');
-      }
-    }
-    
-    // CONTEXT - Setting and additional details
-    if (context.length > 0) {
-      promptParts.push(context.join(', '));
-    }
-    
-    // STYLE - Photography style and technical details - ensure headshot
-    if (isFantasy) {
-      promptParts.push('fantasy art headshot portrait, face close-up digital painting');
-    } else {
-      promptParts.push('photorealistic headshot portrait');
-    }
-    
-    // For non-beautiful characters, emphasize the imperfections
-    if (!options.isKnownFigure || !options.actorName) {
-      const physicalDesc = subject.join(' ') + ' ' + context.join(' ');
-      const hasAttractiveDescriptor = physicalDesc.match(/\b(beautiful|handsome|pretty|gorgeous|attractive|stunning)\b/i);
-      
-      if (!hasAttractiveDescriptor && style.some(s => s.includes('imperfections'))) {
-        promptParts.push('showing realistic flaws and asymmetry');
-      }
-    }
-    
-    // Build final prompt
-    const fullPrompt = promptParts.join(', ');
-    
-    // Ensure under token limit
-    return this.truncateText(fullPrompt, 1900);
-  }
-
-  /**
-   * Enhance a known character with generated background information
-   */
-  private async enhanceKnownCharacter(
-    character: Character, 
-    detection: { isKnownFigure: boolean; figureType?: string; actorName?: string }
-  ): Promise<Character> {
-    try {
-      const contextHint = detection.figureType === 'videogame' ? 'video game character' :
-                         detection.figureType === 'fictional' ? 'fictional character' :
-                         detection.figureType === 'comedian' ? 'comedian' :
-                         'person';
-      
-      // Prepare prompts for missing fields
-      const enhancements: { physicalDescription?: string; personality?: string; history?: string } = {};
-      
-      // Generate or enhance physical description
-      if (!character?.background?.physicalDescription || safeTrim(character?.background?.physicalDescription ?? '').length === 0) {
-        // No user input - generate from scratch
-        const prompt = `Provide an accurate physical description of ${character.name} (the ${contextHint}) in 30-35 words. 
-        ${detection.figureType === 'fictional' && detection.actorName ? `As portrayed by ${detection.actorName} in the film/show.` : ''}
-        MUST include: age, race/ethnicity, hair length (short/medium/long/shoulder-length/etc), hair style, hair color, facial features, build/body type, and typical clothing. 
-        ${!detection.actorName ? 'Include realistic imperfections like weight, balding, scars, or plain features - not everyone is beautiful.' : ''}
-        Be accurate to their actual appearance. Answer with just the description, no extra text.`;
-        
-        const response = await this.aiClient.generateContent(prompt);
-        let description = normalizeText(response.content, NORM_DESC);
-        
-        // Clean up the description
-        // Remove character name if it starts with it (case insensitive)
-        const namePattern = new RegExp(`^${character.name}\\s+(is\\s+)?`, 'i');
-        description = description.replace(namePattern, '');
-        
-        // Capitalize first letter
-        description = capitalize(description);
-        
-        // Fix multiple periods
-        enhancements.physicalDescription = description.replace(/\.+$/, '.');
-      } else {
-        // User provided input - enhance it with AI knowledge
-        const prompt = `Enhance this physical description of ${character.name} (the ${contextHint}) with accurate details: "${character?.background?.physicalDescription}"
-        ${detection.figureType === 'fictional' && detection.actorName ? `As portrayed by ${detection.actorName} in the film/show.` : ''}
-        Keep the user's description but add missing details like specific hair length/style/color, facial features, or typical clothing if not specified.
-        Maximum 40 words. Answer with just the enhanced description, no extra text.`;
-        
-        const response = await this.aiClient.generateContent(prompt);
-        enhancements.physicalDescription = normalizeText(response.content, NORM_DESC).replace(/\.+$/, '.');
-      }
-      
-      // Generate or enhance personality
-      if (!character?.background?.personality || safeTrim(character?.background?.personality ?? '').length === 0) {
-        // No user input - generate from scratch
-        const prompt = `Describe ${character.name}'s (the ${contextHint}) personality in 15 words or less. 
-        Focus on their key character traits. 
-        Answer with just the description, no extra text.`;
-        
-        const response = await this.aiClient.generateContent(prompt);
-        enhancements.personality = normalizeText(response.content, NORM_DESC).replace(/\.+$/, '.');
-      } else {
-        // User provided input - enhance it with AI knowledge
-        const prompt = `Enhance this personality description of ${character.name} (the ${contextHint}): "${character?.background?.personality}"
-        Keep the user's description but add accurate character traits if missing or expand on provided traits.
-        Maximum 20 words. Answer with just the enhanced description, no extra text.`;
-        
-        const response = await this.aiClient.generateContent(prompt);
-        enhancements.personality = normalizeText(response.content, NORM_DESC).replace(/\.+$/, '.');
-      }
-      
-      // Generate or enhance history
-      if (!character?.background?.history || safeTrim(character?.background?.history ?? '').length === 0) {
-        // No user input - generate from scratch
-        const prompt = `Provide a one-sentence background for ${character.name} (the ${contextHint}). 
-        ${detection.figureType === 'videogame' ? 'MUST include the specific video game title they are from (e.g., "from Red Dead Redemption 2", "from The Legend of Zelda", etc.).' : ''}
-        ${detection.figureType === 'fictional' ? 'MUST include the specific movie or TV show title they are from.' : ''}
-        Answer with just one sentence, no extra text.`;
-        
-        const response = await this.aiClient.generateContent(prompt);
-        enhancements.history = normalizeText(response.content, NORM_DESC).replace(/\.+$/, '.');
-      } else {
-        // User provided input - enhance it with AI knowledge
-        const prompt = `Enhance this background for ${character.name} (the ${contextHint}): "${character?.background?.history}"
-        ${detection.figureType === 'videogame' ? 'Add the specific video game title if missing.' : ''}
-        ${detection.figureType === 'fictional' ? 'Add the specific movie or TV show title if missing.' : ''}
-        Keep the user's content but add missing context or details. One sentence maximum. Answer with just the enhanced background, no extra text.`;
-        
-        const response = await this.aiClient.generateContent(prompt);
-        enhancements.history = normalizeText(response.content, NORM_DESC).replace(/\.+$/, '.');
-      }
-      
-      // Return a new character object with the generated enhancements
-      return {
-        ...character,
-        background: {
-          ...character.background,
-          physicalDescription: character?.background?.physicalDescription || enhancements.physicalDescription || '',
-          personality: character?.background?.personality || enhancements.personality || '',
-          history: character?.background?.history || enhancements.history || ''
-        }
-      };
-    } catch (error) {
-      // If enhancement fails, return original character
-      console.error('Failed to enhance character:', error);
-      return character;
-    }
-  }
-
-  /**
-   * Convert personality traits to visual expressions using AI
-   */
-  private async convertPersonalityToVisualTraits(personality: string): Promise<string> {
-    try {
-      const prompt = `Convert these personality traits into visible physical expressions and body language: "${personality}"
-      
       Examples:
       - "desperate and anxious" → "wide eyes, tense shoulders, fidgeting hands"
       - "confident leader" → "straight posture, steady gaze, slight smile"
       - "exhausted workaholic" → "dark circles under eyes, disheveled hair, loosened tie"
-      
+
       Provide only visual cues that a portrait artist could depict. 20 words max. Answer with just the visual description.`;
-      
-      const response = await this.aiClient.generateContent(prompt);
-      return normalizeText(response.content, NORM_DESC);
-    } catch {
-      // Fallback to simple extraction
-      return this.extractKeyTraits(personality);
-    }
+
+    const response = await aiClient.generateContent(prompt);
+    return normalizeText(response.content, NORM_DESC);
+  } catch {
+    return extractKeyTraits(personality);
+  }
+}
+
+async function enhancePhysicalDiversity(
+  aiClient: AIClient,
+  description: string,
+  characterName: string
+): Promise<string> {
+  const hasAttractiveDescriptor = description && description.match(/\b(beautiful|handsome|pretty|gorgeous|attractive|stunning|hot|cute)\b/i);
+
+  if (hasAttractiveDescriptor) {
+    return description;
   }
 
-  /**
-   * Add realistic physical diversity to character descriptions
-   */
-  private async enhancePhysicalDiversity(description: string, characterName: string): Promise<string> {
-    // Check if description explicitly mentions attractiveness
-    const hasAttractiveDescriptor = description && description.match(/\b(beautiful|handsome|pretty|gorgeous|attractive|stunning|hot|cute)\b/i);
-    
-    // If they're explicitly described as attractive, keep it
-    if (hasAttractiveDescriptor) {
-      return description;
-    }
-    
-    // If description already has realistic/non-idealized features, return as-is
-    if (description && (
-      description.match(/\b(overweight|obese|fat|chubby|stocky|thin|gaunt|skinny|bald|balding|ugly|plain|homely|scarred|weathered|wrinkled|aged)\b/i) ||
-      description.match(/\b(crooked|missing|gap|acne|blemish|scar|mole|birthmark)\b/i)
-    )) {
-      return description;
-    }
+  if (description && (
+    description.match(/\b(overweight|obese|fat|chubby|stocky|thin|gaunt|skinny|bald|balding|ugly|plain|homely|scarred|weathered|wrinkled|aged)\b/i) ||
+    description.match(/\b(crooked|missing|gap|acne|blemish|scar|mole|birthmark)\b/i)
+  )) {
+    return description;
+  }
 
-    try {
-      const prompt = `Given this character description: "${description || 'No description provided'}"
-      
+  try {
+    const prompt = `Given this character description: "${description || 'No description provided'}"
+
       Add specific, non-idealized physical features that make the character look like a real, average person.
       Be VERY SPECIFIC about imperfections. Don't just say "weathered" - say what makes them weathered.
-      
+
       Choose 2-3 from these categories:
       - Weight: "pot belly", "beer gut", "double chin", "jowls", "skinny arms", "bony shoulders"
       - Face: "uneven eyes", "crooked nose", "thin lips", "weak chin", "heavy brow", "droopy eyelids"
@@ -717,58 +141,524 @@ Answer with JSON only: {"actorName": "actor's full name" or null, "figureName": 
       - Hair: "receding hairline", "bald spot on crown", "thinning at temples", "greasy hair", "unkempt beard"
       - Teeth: "yellowed teeth", "missing molar", "gap between front teeth", "crooked bottom teeth"
       - Other: "slouched posture", "rounded shoulders", "thick glasses", "hearing aid"
-      
+
       Keep the original description but add specific imperfections. 50 words max total. Answer with just the enhanced description.`;
-      
-      const response = await this.aiClient.generateContent(prompt);
-      return normalizeText(response.content, NORM_DESC);
-    } catch {
-      // Fallback - add very specific variety based on character name hash
-      const hash = characterName.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0);
-      const varieties = [
-        'pot belly and double chin',
-        'gaunt face with sunken cheeks',
-        'heavy jowls and thick neck',
-        'bony frame with protruding collarbones',
-        'pear-shaped body with narrow shoulders',
-        'barrel chest and beer gut'
-      ];
-      
-      const additionalFeatures = [
-        'receding hairline with bald spot',
-        'thinning hair at temples',
-        'pockmarked cheeks from old acne',
-        'deep crow\'s feet and forehead lines',
-        'yellowed, crooked teeth',
-        'large nose with visible pores'
-      ];
-      
-      const bodyType = varieties[hash % varieties.length];
-      const feature = additionalFeatures[(hash * 3) % additionalFeatures.length];
-      
-      return description ? `${description}, ${bodyType}, ${feature}` : `${bodyType}, ${feature}`;
+
+    const response = await aiClient.generateContent(prompt);
+    return normalizeText(response.content, NORM_DESC);
+  } catch {
+    const hash = characterName.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0);
+    const varieties = [
+      'pot belly and double chin',
+      'gaunt face with sunken cheeks',
+      'heavy jowls and thick neck',
+      'bony frame with protruding collarbones',
+      'pear-shaped body with narrow shoulders',
+      'barrel chest and beer gut',
+    ];
+
+    const additionalFeatures = [
+      'receding hairline with bald spot',
+      'thinning hair at temples',
+      'pockmarked cheeks from old acne',
+      'deep crow\'s feet and forehead lines',
+      'yellowed, crooked teeth',
+      'large nose with visible pores',
+    ];
+
+    const bodyType = varieties[hash % varieties.length];
+    const feature = additionalFeatures[(hash * 3) % additionalFeatures.length];
+
+    return description ? `${description}, ${bodyType}, ${feature}` : `${bodyType}, ${feature}`;
+  }
+}
+
+async function enhanceKnownCharacter(
+  aiClient: AIClient,
+  character: Character,
+  detection: { isKnownFigure: boolean; figureType?: string; actorName?: string }
+): Promise<Character> {
+  try {
+    const contextHint = detection.figureType === 'videogame' ? 'video game character' :
+                       detection.figureType === 'fictional' ? 'fictional character' :
+                       detection.figureType === 'comedian' ? 'comedian' :
+                       'person';
+
+    const enhancements: { physicalDescription?: string; personality?: string; history?: string } = {};
+
+    if (!character?.background?.physicalDescription || safeTrim(character?.background?.physicalDescription ?? '').length === 0) {
+      const prompt = `Provide an accurate physical description of ${character.name} (the ${contextHint}) in 30-35 words.
+        ${detection.figureType === 'fictional' && detection.actorName ? `As portrayed by ${detection.actorName} in the film/show.` : ''}
+        MUST include: age, race/ethnicity, hair length (short/medium/long/shoulder-length/etc), hair style, hair color, facial features, build/body type, and typical clothing.
+        ${!detection.actorName ? 'Include realistic imperfections like weight, balding, scars, or plain features - not everyone is beautiful.' : ''}
+        Be accurate to their actual appearance. Answer with just the description, no extra text.`;
+
+      const response = await aiClient.generateContent(prompt);
+      let description = normalizeText(response.content, NORM_DESC);
+
+      const namePattern = new RegExp(`^${character.name}\\s+(is\\s+)?`, 'i');
+      description = description.replace(namePattern, '');
+
+      description = capitalize(description);
+
+      enhancements.physicalDescription = description.replace(/\.+$/, '.');
+    } else {
+      const prompt = `Enhance this physical description of ${character.name} (the ${contextHint}) with accurate details: "${character?.background?.physicalDescription}"
+        ${detection.figureType === 'fictional' && detection.actorName ? `As portrayed by ${detection.actorName} in the film/show.` : ''}
+        Keep the user's description but add missing details like specific hair length/style/color, facial features, or typical clothing if not specified.
+        Maximum 40 words. Answer with just the enhanced description, no extra text.`;
+
+      const response = await aiClient.generateContent(prompt);
+      enhancements.physicalDescription = normalizeText(response.content, NORM_DESC).replace(/\.+$/, '.');
+    }
+
+    if (!character?.background?.personality || safeTrim(character?.background?.personality ?? '').length === 0) {
+      const prompt = `Describe ${character.name}'s (the ${contextHint}) personality in 15 words or less.
+        Focus on their key character traits.
+        Answer with just the description, no extra text.`;
+
+      const response = await aiClient.generateContent(prompt);
+      enhancements.personality = normalizeText(response.content, NORM_DESC).replace(/\.+$/, '.');
+    } else {
+      const prompt = `Enhance this personality description of ${character.name} (the ${contextHint}): "${character?.background?.personality}"
+        Keep the user's description but add accurate character traits if missing or expand on provided traits.
+        Maximum 20 words. Answer with just the enhanced description, no extra text.`;
+
+      const response = await aiClient.generateContent(prompt);
+      enhancements.personality = normalizeText(response.content, NORM_DESC).replace(/\.+$/, '.');
+    }
+
+    if (!character?.background?.history || safeTrim(character?.background?.history ?? '').length === 0) {
+      const prompt = `Provide a one-sentence background for ${character.name} (the ${contextHint}).
+        ${detection.figureType === 'videogame' ? 'MUST include the specific video game title they are from (e.g., "from Red Dead Redemption 2", "from The Legend of Zelda", etc.).' : ''}
+        ${detection.figureType === 'fictional' ? 'MUST include the specific movie or TV show title they are from.' : ''}
+        Answer with just one sentence, no extra text.`;
+
+      const response = await aiClient.generateContent(prompt);
+      enhancements.history = normalizeText(response.content, NORM_DESC).replace(/\.+$/, '.');
+    } else {
+      const prompt = `Enhance this background for ${character.name} (the ${contextHint}): "${character?.background?.history}"
+        ${detection.figureType === 'videogame' ? 'Add the specific video game title if missing.' : ''}
+        ${detection.figureType === 'fictional' ? 'Add the specific movie or TV show title if missing.' : ''}
+        Keep the user's content but add missing context or details. One sentence maximum. Answer with just the enhanced background, no extra text.`;
+
+      const response = await aiClient.generateContent(prompt);
+      enhancements.history = normalizeText(response.content, NORM_DESC).replace(/\.+$/, '.');
+    }
+
+    return {
+      ...character,
+      background: {
+        ...character.background,
+        physicalDescription: character?.background?.physicalDescription || enhancements.physicalDescription || '',
+        personality: character?.background?.personality || enhancements.personality || '',
+        history: character?.background?.history || enhancements.history || '',
+      },
+    };
+  } catch (error) {
+    console.error('Failed to enhance character:', error);
+    return character;
+  }
+}
+
+/**
+ * Build a descriptive prompt for portrait generation following Gemini's guidelines.
+ * Structure: Subject, Context, Style
+ */
+export async function buildPortraitPrompt(
+  aiClient: AIClient,
+  character: Character,
+  options: PortraitGenerationOptions = {}
+): Promise<string> {
+  // If no detection options provided, run AI detection
+  if (!options.detection && !options.isKnownFigure) {
+    const detection = await detectKnownFigure(aiClient, character.name);
+
+    options = {
+      ...options,
+      isKnownFigure: detection.isKnownFigure,
+      knownFigureContext: detection.figureType || options.knownFigureContext,
+      actorName: detection.actorName || options.actorName,
+      detection,
+    };
+  }
+
+  const subject: string[] = [];
+  const context: string[] = [];
+  const style: string[] = [];
+
+  const isFantasy = options.worldGenre &&
+    ['fantasy', 'medieval', 'magic', 'mystical', 'epic'].some(term =>
+      options.worldGenre?.toLowerCase().includes(term)
+    );
+
+  const physicalDesc = character.background?.physicalDescription || '';
+
+  const clothingMatch = physicalDesc.match(/wearing\s+([^,\.]+)/i);
+  const specificClothing = clothingMatch ? safeTrim(clothingMatch[1]) : null;
+
+  const distinctiveFeatures: string[] = [];
+  if (physicalDesc.match(/missing teeth/i)) distinctiveFeatures.push('missing teeth');
+  if (physicalDesc.match(/deformed|misshapen/i)) distinctiveFeatures.push('facial deformity');
+  if (physicalDesc.match(/one eye higher/i)) distinctiveFeatures.push('asymmetrical eyes');
+  if (physicalDesc.match(/scar/i)) distinctiveFeatures.push('visible scars');
+  if (physicalDesc.match(/bald/i)) distinctiveFeatures.push('bald head');
+
+  const hasSpecificDetails = specificClothing || distinctiveFeatures.length > 0;
+
+  if (options.isKnownFigure) {
+    if (options.knownFigureContext === 'fictional' || options.knownFigureContext === 'videogame' || options.knownFigureContext === 'anime') {
+      if (options.actorName) {
+        subject.push(`((${options.actorName})) as ${character.name}`);
+
+        if (options.detection?.figureName) {
+          subject.push(`from ${options.detection?.figureName}`);
+        }
+
+        if (character.background?.physicalDescription) {
+          const cleanedDesc = normalizeText(character.background.physicalDescription, NORM_DESC);
+          context.push(cleanedDesc);
+        }
+
+        if (specificClothing) {
+          context.push(`wearing ${specificClothing}`);
+        }
+        if (distinctiveFeatures.length > 0) {
+          context.push(`showing ${distinctiveFeatures.join(', ')}`);
+        }
+      } else {
+        subject.push(`Character portrait of ${character.name}`);
+        if (options.knownFigureContext === 'videogame') {
+          if (options.detection?.figureName) {
+            subject.push(`from ${options.detection?.figureName}`);
+          } else if (character?.background?.history) {
+            let gameName = null;
+
+            const patterns = [
+              /from\s+([^.]+)/i,
+              /in\s+([^.]+)/i,
+              /of\s+([^.]+)/i,
+              /([A-Z][a-zA-Z0-9\s:]+(?:\d+)?)/i,
+            ];
+
+            for (const pattern of patterns) {
+              const match = character.background?.history?.match(pattern);
+              if (match && match[1]) {
+                gameName = safeTrim(match[1]);
+                break;
+              }
+            }
+
+            if (gameName) {
+              subject.push(`from ${gameName}`);
+            } else {
+              subject.push(`from the video game`);
+            }
+          } else {
+            subject.push(`from the video game`);
+          }
+        }
+
+        if (character.background?.physicalDescription) {
+          const cleanedDesc = normalizeText(character.background.physicalDescription, NORM_DESC).toLowerCase();
+          context.push(cleanedDesc);
+        }
+
+        context.push(`authentic game character appearance`);
+        context.push(`recognizable character design`);
+        context.push(`official character look`);
+
+        if (hasSpecificDetails && character?.background?.physicalDescription) {
+          if (specificClothing) {
+            context.push(`wearing ${specificClothing}`);
+          }
+          if (distinctiveFeatures.length > 0) {
+            context.push(`with ${distinctiveFeatures.join(', ')}`);
+          }
+        }
+
+        if (options.worldGenre) {
+          context.push(`${options.worldGenre} style atmosphere`);
+        }
+      }
+
+      if (character.background?.personality) {
+        const visualTraits = await convertPersonalityToVisualTraits(aiClient, character.background.personality);
+        if (visualTraits) {
+          context.push(visualTraits);
+        }
+      }
+    } else {
+      subject.push(`Photorealistic portrait of ${character.name}`);
+      if (options.knownFigureContext) {
+        subject.push(`the ${options.knownFigureContext}`);
+      }
+
+      if (character.background?.physicalDescription) {
+        const cleanedDesc = normalizeText(character.background.physicalDescription, NORM_DESC).toLowerCase();
+        context.push(cleanedDesc);
+      }
+
+      if (options.knownFigureContext === 'comedian') {
+        context.push(`comedy club or casual setting`);
+      } else if (options.knownFigureContext === 'videogame') {
+        context.push(`game world environment`);
+      } else if (options.knownFigureContext === 'fictional' && character.background?.history) {
+        if (character.background.history.toLowerCase().includes('vacation')) {
+          context.push(`vacation resort setting`);
+        } else if (character.background.history.toLowerCase().includes('film')) {
+          context.push(`movie scene environment`);
+        } else {
+          context.push(`appropriate scene setting`);
+        }
+      } else {
+        context.push(`appropriate environment for character`);
+      }
+      context.push(`ambient lighting`);
+      context.push(`contextual background`);
+
+      if (options.worldGenre) {
+        context.push(`${options.worldGenre} style atmosphere`);
+      }
+    }
+
+    style.push(`headshot portrait photograph`);
+  } else {
+    if (isFantasy) {
+      subject.push(`Fantasy character portrait of ${character.name}`);
+
+      let physicalDesc = character.background?.physicalDescription || '';
+
+      if (!options.isKnownFigure || !options.actorName) {
+        physicalDesc = await enhancePhysicalDiversity(aiClient, physicalDesc, character.name);
+      }
+
+      if (physicalDesc) {
+        const cleanedDesc = normalizeText(physicalDesc, NORM_NAME);
+        if (cleanedDesc) {
+          subject.push(`a ${cleanedDesc}`);
+        }
+      }
+
+      if (character.background?.history) {
+        const professionMatch = character.background.history.match(
+          /\b(warrior|mage|wizard|rogue|thief|cleric|priest|ranger|bard|druid|paladin|sorcerer|fighter|monk|archer|knight|barbarian|necromancer)\b/i
+        );
+        if (professionMatch) {
+          subject.push(`${professionMatch[0].toLowerCase()} character`);
+        }
+      }
+
+      if (character.background?.personality) {
+        const visualTraits = await convertPersonalityToVisualTraits(aiClient, character.background.personality);
+        if (visualTraits) {
+          context.push(visualTraits);
+        }
+      }
+
+      context.push(`${options.worldGenre} world setting`);
+      if (character.background?.history && character.background.history.toLowerCase().includes('battle')) {
+        context.push(`battle-worn appearance`);
+      }
+    } else {
+      subject.push(`Character portrait of ${character.name}`);
+
+      let physicalDesc = character.background?.physicalDescription || '';
+
+      if (!options.isKnownFigure || !options.actorName) {
+        physicalDesc = await enhancePhysicalDiversity(aiClient, physicalDesc, character.name);
+      }
+
+      if (physicalDesc) {
+        const cleanedDesc = normalizeText(physicalDesc, NORM_NAME);
+        if (cleanedDesc) {
+          subject.push(`${cleanedDesc}`);
+        }
+      }
+
+      if (character.background?.personality) {
+        const visualTraits = await convertPersonalityToVisualTraits(aiClient, character.background.personality);
+        if (visualTraits) {
+          context.push(visualTraits);
+        }
+      }
+
+      if (options.worldGenre) {
+        const genreLC = options.worldGenre?.toLowerCase();
+        if (genreLC === 'modern' || genreLC === 'contemporary') {
+          // skip generic "modern setting" — physical desc carries context
+        } else {
+          context.push(`${options.worldGenre} world environment`);
+        }
+      }
+    }
+
+    if (isFantasy) {
+      style.push(`fantasy art headshot portrait`);
+      style.push(`face close-up digital painting`);
+    } else {
+      style.push(`headshot portrait`);
+    }
+
+    if (!options.isKnownFigure || !options.actorName) {
+      style.push(`realistic average person`);
+      style.push(`NOT a model or actor`);
+      style.push(`photorealistic imperfections visible`);
+
+      const imperfections = [];
+      const physicalDescAll = subject.join(' ') + ' ' + context.join(' ');
+
+      if (physicalDescAll.match(/\b(pot belly|beer gut|double chin|jowls|overweight|heavy|barrel chest)\b/i)) {
+        imperfections.push('visible weight');
+      }
+
+      if (physicalDescAll.match(/\b(bald|balding|receding|thinning hair|bald spot)\b/i)) {
+        imperfections.push('realistic hair loss');
+      }
+
+      if (physicalDescAll.match(/\b(acne|pockmark|scar|wrinkle|liver spot|sun damage|weathered)\b/i)) {
+        imperfections.push('skin imperfections clearly visible');
+      }
+
+      if (physicalDescAll.match(/\b(crooked|uneven|droopy|weak chin|heavy brow|gaunt|sunken)\b/i)) {
+        imperfections.push('asymmetrical or non-ideal facial features');
+      }
+
+      if (imperfections.length > 0) {
+        style.push(imperfections.join(', '));
+      }
     }
   }
 
-  /**
-   * Extract key personality traits in a concise format (fallback method)
-   */
-  private extractKeyTraits(personality: string): string {
-    // Take first 2-3 descriptive words from personality
-    const words = personality.toLowerCase().split(/\s+/);
-    const descriptiveWords = words.filter(word => 
-      word.length > 3 && 
-      !['with', 'and', 'the', 'very', 'quite', 'rather'].includes(word)
-    ).slice(0, 3);
-    
-    return descriptiveWords.length > 0 ? descriptiveWords.join(' ') + ' expression' : '';
+  const promptParts: string[] = [];
+
+  if (subject.length > 0) {
+    let subjectText = subject.join(', ');
+
+    if (options.actorName) {
+      subjectText = `${options.actorName}, ${subjectText}`;
+    }
+
+    promptParts.push(subjectText);
   }
 
+  if (options.actorName) {
+    promptParts.push('professional headshot photography');
+    promptParts.push('face close-up high resolution');
+    promptParts.push('accurate facial likeness');
+  } else if (!options.isKnownFigure) {
+    const physicalDescAll = subject.join(' ') + ' ' + context.join(' ');
+    const hasAttractiveDescriptor = physicalDescAll.match(/\b(beautiful|handsome|pretty|gorgeous|attractive|stunning)\b/i);
 
-  /**
-   * Truncate text to specified length
-   */
-  private truncateText(text: string, maxLength: number): string {
-    return truncate(text, maxLength);
+    if (!hasAttractiveDescriptor) {
+      promptParts.push('35mm headshot portrait');
+      promptParts.push('documentary photography');
+      promptParts.push('candid face close-up with visible skin texture and imperfections');
+    } else {
+      promptParts.push('35mm headshot portrait');
+    }
+  }
+
+  if (context.length > 0) {
+    promptParts.push(context.join(', '));
+  }
+
+  if (isFantasy) {
+    promptParts.push('fantasy art headshot portrait, face close-up digital painting');
+  } else {
+    promptParts.push('photorealistic headshot portrait');
+  }
+
+  if (!options.isKnownFigure || !options.actorName) {
+    const physicalDescAll = subject.join(' ') + ' ' + context.join(' ');
+    const hasAttractiveDescriptor = physicalDescAll.match(/\b(beautiful|handsome|pretty|gorgeous|attractive|stunning)\b/i);
+
+    if (!hasAttractiveDescriptor && style.some(s => s.includes('imperfections'))) {
+      promptParts.push('showing realistic flaws and asymmetry');
+    }
+  }
+
+  const fullPrompt = promptParts.join(', ');
+
+  return truncate(fullPrompt, 1900);
+}
+
+/**
+ * Generate a portrait image for a character.
+ */
+export async function generatePortrait(
+  aiClient: AIClient,
+  character: Character,
+  options: PortraitGenerationOptions = {}
+): Promise<GeneratedImage> {
+  if (!aiClient.generateImage) {
+    throw new Error('AI client does not support image generation');
+  }
+
+  try {
+    const isStorybook = typeof window !== 'undefined' && window.location.port === '6006';
+
+    if (isStorybook) {
+      await new Promise(resolve => setTimeout(resolve, 1500));
+
+      const mockPortraits: Record<string, string> = {
+        fantasy: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjI1MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZGVmcz4KICAgIDxyYWRpYWxHcmFkaWVudCBpZD0iZmFjZSIgY3g9IjUwJSIgY3k9IjMwJSI+CiAgICAgIDxzdG9wIG9mZnNldD0iMCUiIHN0eWxlPSJzdG9wLWNvbG9yOiNGRkUwQjI7c3RvcC1vcGFjaXR5OjEiIC8+CiAgICAgIDxzdG9wIG9mZnNldD0iMTAwJSIgc3R5bGU9InN0b3AtY29sb3I6I0Q4OTg2ODtzdG9wLW9wYWNpdHk6MSIgLz4KICAgIDwvcmFkaWFsR3JhZGllbnQ+CiAgPC9kZWZzPgogIDxyZWN0IHdpZHRoPSIyMDAiIGhlaWdodD0iMjUwIiBmaWxsPSIjMmY0ZjJmIi8+CiAgPGVsbGlwc2UgY3g9IjEwMCIgY3k9IjEwMCIgcng9IjYwIiByeT0iODAiIGZpbGw9InVybCgjZmFjZSkiLz4KICA8Y2lyY2xlIGN4PSI4NSIgY3k9Ijg1IiByPSI1IiBmaWxsPSIjMzMzIi8+CiAgPGNpcmNsZSBjeD0iMTE1IiBjeT0iODUiIHI9IjUiIGZpbGw9IiMzMzMiLz4KICA8cGF0aCBkPSJNOTAgMTA1IFEgMTAwIDExNSAxMTAgMTA1IiBzdHJva2U9IiMzMzMiIGZpbGw9Im5vbmUiIHN0cm9rZS13aWR0aD0iMiIvPgogIDx0ZXh0IHg9IjEwMCIgeT0iMjMwIiBmb250LWZhbWlseT0iQXJpYWwiIGZvbnQtc2l6ZT0iMTYiIGZpbGw9IiNGRkZGRkYiIHRleHQtYW5jaG9yPSJtaWRkbGUiPkZBTlRBU1kgUE9SVFJBSVQ8L3RleHQ+Cjwvc3ZnPg==',
+        modern: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjI1MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZGVmcz4KICAgIDxyYWRpYWxHcmFkaWVudCBpZD0iZmFjZTIiIGN4PSI1MCUiIGN5PSIzMCUiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAlIiBzdHlsZT0ic3RvcC1jb2xvcjojRkZEQkIyO3N0b3Atb3BhY2l0eToxIiAvPgogICAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0eWxlPSJzdG9wLWNvbG9yOiNEOEE4Nzg7c3RvcC1vcGFjaXR5OjEiIC8+CiAgICA8L3JhZGlhbEdyYWRpZW50PgogIDwvZGVmcz4KICA8cmVjdCB3aWR0aD0iMjAwIiBoZWlnaHQ9IjI1MCIgZmlsbD0iI2Y1ZjVmNSIvPgogIDxlbGxpcHNlIGN4PSIxMDAiIGN5PSIxMDAiIHJ4PSI2MCIgcnk9IjgwIiBmaWxsPSJ1cmwoI2ZhY2UyKSIvPgogIDxyZWN0IHg9IjQwIiB5PSI5NSIgd2lkdGg9IjEyMCIgaGVpZ2h0PSI0IiBmaWxsPSIjNDQ0IiBvcGFjaXR5PSIwLjMiLz4KICA8Y2lyY2xlIGN4PSI4NSIgY3k9Ijg1IiByPSI1IiBmaWxsPSIjMzMzIi8+CiAgPGNpcmNsZSBjeD0iMTE1IiBjeT0iODUiIHI9IjUiIGZpbGw9IiMzMzMiLz4KICA8cGF0aCBkPSJNOTAgMTA1IFEgMTAwIDExNSAxMTAgMTA1IiBzdHJva2U9IiMzMzMiIGZpbGw9Im5vbmUiIHN0cm9rZS13aWR0aD0iMiIvPgogIDx0ZXh0IHg9IjEwMCIgeT0iMjMwIiBmb250LWZhbWlseT0iQXJpYWwiIGZvbnQtc2l6ZT0iMTYiIGZpbGw9IiMzMzMiIHRleHQtYW5jaG9yPSJtaWRkbGUiPk1PREVSTU4gUE9SVFJBSVQ8L3RleHQ+Cjwvc3ZnPg==',
+        default: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjI1MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZGVmcz4KICAgIDxyYWRpYWxHcmFkaWVudCBpZD0iZmFjZTMiIGN4PSI1MCUiIGN5PSIzMCUiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAlIiBzdHlsZT0ic3RvcC1jb2xvcjojRkZFNEMyO3N0b3Atb3BhY2l0eToxIiAvPgogICAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0eWxlPSJzdG9wLWNvbG9yOiNEOEE4Nzg7c3RvcC1vcGFjaXR5OjEiIC8+CiAgICA8L3JhZGlhbEdyYWRpZW50PgogIDwvZGVmcz4KICA8cmVjdCB3aWR0aD0iMjAwIiBoZWlnaHQ9IjI1MCIgZmlsbD0iIzMzMzMzMyIvPgogIDxlbGxpcHNlIGN4PSIxMDAiIGN5PSIxMDAiIHJ4PSI2MCIgcnk9IjgwIiBmaWxsPSJ1cmwoI2ZhY2UzKSIvPgogIDxjaXJjbGUgY3g9Ijg1IiBjeT0iODUiIHI9IjUiIGZpbGw9IiMzMzMiLz4KICA8Y2lyY2xlIGN4PSIxMTUiIGN5PSI4NSIgcj0iNSIgZmlsbD0iIzMzMyIvPgogIDxwYXRoIGQ9Ik05MCD2NTMgUaEwIDExNSAMIDSNIHN0cm9rZT0iIzMzMyIgZmlsbD0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIyIi8+CiAgPHRleHQgeD0iMTAwIiB5PSIyMzAiIGZvbnQtZmFtaWx5PSJBcmlhbCIgZm9udC1zaXplPSIxNiIgZmlsbD0iI0ZGRkZGRiIgdGV4dC1hbmNob3I9Im1pZGRsZSI+UE9SVFJBSVQ8L3RleHQ+Cjwvc3ZnPg==',
+      };
+
+      const genreLC = options.worldGenre?.toLowerCase() || 'default';
+      let mockPortrait = mockPortraits.default;
+      if (genreLC.includes('fantasy') || genreLC.includes('medieval')) {
+        mockPortrait = mockPortraits.fantasy;
+      } else if (genreLC.includes('modern') || genreLC.includes('contemporary')) {
+        mockPortrait = mockPortraits.modern;
+      }
+
+      return {
+        type: 'ai-generated',
+        url: mockPortrait,
+        generatedAt: getTimestamp(),
+        prompt: `Mock portrait for ${character.name} in Storybook`,
+      };
+    }
+
+    const detection = await detectKnownFigure(aiClient, character.name);
+
+    if (detection.isKnownFigure && (
+      !character.background?.physicalDescription ||
+      !character.background?.personality ||
+      !character.background?.history
+    )) {
+      character = await enhanceKnownCharacter(aiClient, character, detection);
+    }
+
+    if (typeof window !== 'undefined') {
+      const windowWithDetection = window as Window & { lastDetectionResult?: typeof detection };
+      windowWithDetection.lastDetectionResult = detection;
+    }
+
+    const mergedOptions = {
+      ...options,
+      isKnownFigure: detection.isKnownFigure,
+      knownFigureContext: detection.figureType || options.knownFigureContext,
+      actorName: detection.actorName || options.actorName,
+      detection,
+    };
+
+    const prompt = await buildPortraitPrompt(aiClient, character, mergedOptions);
+
+    const response = await aiClient.generateImage(prompt);
+
+    return {
+      type: 'ai-generated',
+      url: response.image,
+      generatedAt: getTimestamp(),
+      prompt: response.prompt,
+    };
+  } catch (error) {
+    throw new Error(
+      `Failed to generate character portrait: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
   }
 }

--- a/src/lib/ai/templateGenerator.test.ts
+++ b/src/lib/ai/templateGenerator.test.ts
@@ -1,6 +1,6 @@
 // src/lib/ai/templateGenerator.test.ts
 
-import { TemplateGenerator } from './templateGenerator';
+import { generateWorldTemplate, validateTemplate } from './templateGenerator';
 import { generateWorldTemplatePrompt } from './templatePrompts';
 import { AIClient } from './types';
 
@@ -9,11 +9,8 @@ const mockAIClient = {
   generateContent: jest.fn()
 };
 
-describe('TemplateGenerator', () => {
-  let templateGenerator: TemplateGenerator;
-
+describe('templateGenerator', () => {
   beforeEach(() => {
-    templateGenerator = new TemplateGenerator(mockAIClient as AIClient);
     jest.clearAllMocks();
   });
 
@@ -36,7 +33,7 @@ describe('TemplateGenerator', () => {
 
       mockAIClient.generateContent.mockResolvedValue(mockResponse);
 
-      const result = await templateGenerator.generateWorldTemplate({
+      const result = await generateWorldTemplate(mockAIClient as AIClient, {
         userInput: 'Steampunk flying cities',
         type: 'inspired-by'
       });
@@ -79,7 +76,7 @@ describe('TemplateGenerator', () => {
 
       mockAIClient.generateContent.mockResolvedValue(mockResponse);
 
-      const result = await templateGenerator.generateWorldTemplate({
+      const result = await generateWorldTemplate(mockAIClient as AIClient, {
         genres: ['Cyberpunk', 'Western'],
         type: 'genre-mix'
       });
@@ -87,7 +84,7 @@ describe('TemplateGenerator', () => {
       expect(result.genre).toBe('other');
       expect(result.attributes).toHaveLength(2);
       expect(result.skills).toHaveLength(2);
-      
+
       expect(mockAIClient.generateContent).toHaveBeenCalledWith(
         expect.stringContaining('Cyberpunk + Western')
       );
@@ -111,13 +108,13 @@ describe('TemplateGenerator', () => {
 
       mockAIClient.generateContent.mockResolvedValue(mockResponse);
 
-      const result = await templateGenerator.generateWorldTemplate({
+      const result = await generateWorldTemplate(mockAIClient as AIClient, {
         type: 'surprise-me'
       });
 
       expect(result.name).toBe('Microscopic Empire');
       expect(result.genre).toBe('other');
-      
+
       expect(mockAIClient.generateContent).toHaveBeenCalledWith(
         expect.stringContaining('completely unexpected')
       );
@@ -129,7 +126,7 @@ describe('TemplateGenerator', () => {
       });
 
       await expect(
-        templateGenerator.generateWorldTemplate({ type: 'surprise-me' })
+        generateWorldTemplate(mockAIClient as AIClient, { type: 'surprise-me' })
       ).rejects.toThrow('Failed to parse world template');
     });
 
@@ -137,7 +134,7 @@ describe('TemplateGenerator', () => {
       mockAIClient.generateContent.mockRejectedValue(new Error('AI service unavailable'));
 
       await expect(
-        templateGenerator.generateWorldTemplate({ type: 'surprise-me' })
+        generateWorldTemplate(mockAIClient as AIClient, { type: 'surprise-me' })
       ).rejects.toThrow('AI service unavailable');
     });
   });
@@ -157,16 +154,15 @@ describe('TemplateGenerator', () => {
         explanation: 'Test explanation'
       };
 
-      expect(() => templateGenerator.validateTemplate(validTemplate)).not.toThrow();
+      expect(() => validateTemplate(validTemplate)).not.toThrow();
     });
 
     test('throws error for missing required fields', () => {
       const invalidTemplate = {
         name: 'Test World',
-        // Missing other required fields
       };
 
-      expect(() => templateGenerator.validateTemplate(invalidTemplate as unknown))
+      expect(() => validateTemplate(invalidTemplate as unknown))
         .toThrow('Invalid template structure: missing description');
     });
 
@@ -184,7 +180,7 @@ describe('TemplateGenerator', () => {
         explanation: 'Test explanation'
       };
 
-      templateGenerator.validateTemplate(templateWithCapsGenre);
+      validateTemplate(templateWithCapsGenre);
       expect(templateWithCapsGenre.genre).toBe('fantasy');
     });
 
@@ -202,7 +198,7 @@ describe('TemplateGenerator', () => {
         explanation: 'Test explanation'
       };
 
-      templateGenerator.validateTemplate(templateWithMixedGenre);
+      validateTemplate(templateWithMixedGenre);
       expect(templateWithMixedGenre.genre).toBe('other');
     });
   });

--- a/src/lib/ai/templateGenerator.ts
+++ b/src/lib/ai/templateGenerator.ts
@@ -9,104 +9,99 @@ import { toGenreValue } from '@/lib/constants/genres';
 
 export type { WorldTemplate } from '@/types/world-template.types';
 
-export class TemplateGenerator {
-  constructor(private geminiClient: AIClient) {}
+export async function generateWorldTemplate(
+  geminiClient: AIClient,
+  context: TemplateGenerationContext
+): Promise<WorldTemplate> {
+  return handleAIRequest(
+    () => {
+      const prompt = generateWorldTemplatePrompt(context);
+      return geminiClient.generateContent(prompt);
+    },
+    (response) => {
+      const templateData = parseAIJsonResponse<WorldTemplate>(response, 'Failed to parse world template');
+      validateTemplate(templateData);
+      return templateData;
+    }
+  );
+}
 
-  async generateWorldTemplate(context: TemplateGenerationContext): Promise<WorldTemplate> {
-    return handleAIRequest(
-      () => {
-        const prompt = generateWorldTemplatePrompt(context);
-        return this.geminiClient.generateContent(prompt);
-      },
-      (response) => {
-        const templateData = parseAIJsonResponse<WorldTemplate>(response, 'Failed to parse world template');
-        this.validateTemplate(templateData);
-        return templateData;
-      }
-    );
-  }
+export function validateTemplate(template: unknown): asserts template is WorldTemplate {
+  const requiredFields = ['name', 'description', 'genre', 'attributes', 'skills', 'explanation'];
+  const arrayFields = ['attributes', 'skills'];
 
-  validateTemplate(template: unknown): asserts template is WorldTemplate {
-    const requiredFields = ['name', 'description', 'genre', 'attributes', 'skills', 'explanation'];
-    const arrayFields = ['attributes', 'skills'];
-    
-    validateRequiredFields(template, requiredFields, 'template structure');
-    const templateRecord = template as Record<string, unknown>;
-    validateArrayFields(templateRecord, arrayFields, 'template structure');
+  validateRequiredFields(template, requiredFields, 'template structure');
+  const templateRecord = template as Record<string, unknown>;
+  validateArrayFields(templateRecord, arrayFields, 'template structure');
 
-    // Coerce genre to a supported value
-    templateRecord.genre = toGenreValue(String(templateRecord.genre));
+  templateRecord.genre = toGenreValue(String(templateRecord.genre));
 
-    // Validate and fix each attribute
-    const attributes = (templateRecord.attributes as Record<string, unknown>[]).map((attr, index) => {
-      if (!attr.name) {
-        throw new Error(`Attribute ${index} missing name`);
-      }
-      return {
-        ...attr,
-        baseValue: typeof attr.baseValue === 'number' ? attr.baseValue : 50,
-        minValue: typeof attr.minValue === 'number' ? attr.minValue : 0,
-        maxValue: typeof attr.maxValue === 'number' ? attr.maxValue : 100,
-        category: attr.category || 'General'
-      };
-    });
-
-    // Validate and fix each skill
-    const skills = (templateRecord.skills as Record<string, unknown>[]).map((skill, index) => {
-      if (!skill.name) {
-        throw new Error(`Skill ${index} missing name`);
-      }
-      const difficulty = ['easy', 'medium', 'hard'].includes(skill.difficulty as string) 
-        ? skill.difficulty as string 
-        : 'medium';
-      
-      return {
-        ...skill,
-        baseValue: typeof skill.baseValue === 'number' ? skill.baseValue : 40,
-        minValue: typeof skill.minValue === 'number' ? skill.minValue : 0,
-        maxValue: typeof skill.maxValue === 'number' ? skill.maxValue : 100,
-        difficulty,
-        category: skill.category || 'General'
-      };
-    });
-
-    // Update the template with validated data
-    templateRecord.attributes = attributes;
-    templateRecord.skills = skills;
-  }
-
-  convertTemplateToWorld(template: WorldTemplate): Omit<World, 'id' | 'createdAt' | 'updatedAt'> {
+  const attributes = (templateRecord.attributes as Record<string, unknown>[]).map((attr, index) => {
+    if (!attr.name) {
+      throw new Error(`Attribute ${index} missing name`);
+    }
     return {
-      name: template.name,
-      description: template.description,
-      genre: toGenreValue(template.genre),
-      attributes: template.attributes.map((attr, index) => ({
-        id: `attr-${index}`,
-        worldId: '', // Will be set when world is created
-        name: attr.name,
-        description: attr.description || '',
-        baseValue: attr.baseValue,
-        minValue: attr.minValue,
-        maxValue: attr.maxValue,
-        category: attr.category,
-      })),
-      skills: template.skills.map((skill, index) => ({
-        id: `skill-${index}`,
-        worldId: '', // Will be set when world is created
-        name: skill.name,
-        description: skill.description || '',
-        baseValue: skill.baseValue,
-        minValue: skill.minValue,
-        maxValue: skill.maxValue,
-        difficulty: skill.difficulty,
-        category: skill.category,
-      })),
-      settings: {
-        maxAttributes: 8,
-        maxSkills: 12,
-        attributePointPool: 150,
-        skillPointPool: 100,
-      },
+      ...attr,
+      baseValue: typeof attr.baseValue === 'number' ? attr.baseValue : 50,
+      minValue: typeof attr.minValue === 'number' ? attr.minValue : 0,
+      maxValue: typeof attr.maxValue === 'number' ? attr.maxValue : 100,
+      category: attr.category || 'General'
     };
-  }
+  });
+
+  const skills = (templateRecord.skills as Record<string, unknown>[]).map((skill, index) => {
+    if (!skill.name) {
+      throw new Error(`Skill ${index} missing name`);
+    }
+    const difficulty = ['easy', 'medium', 'hard'].includes(skill.difficulty as string)
+      ? skill.difficulty as string
+      : 'medium';
+
+    return {
+      ...skill,
+      baseValue: typeof skill.baseValue === 'number' ? skill.baseValue : 40,
+      minValue: typeof skill.minValue === 'number' ? skill.minValue : 0,
+      maxValue: typeof skill.maxValue === 'number' ? skill.maxValue : 100,
+      difficulty,
+      category: skill.category || 'General'
+    };
+  });
+
+  templateRecord.attributes = attributes;
+  templateRecord.skills = skills;
+}
+
+export function convertTemplateToWorld(template: WorldTemplate): Omit<World, 'id' | 'createdAt' | 'updatedAt'> {
+  return {
+    name: template.name,
+    description: template.description,
+    genre: toGenreValue(template.genre),
+    attributes: template.attributes.map((attr, index) => ({
+      id: `attr-${index}`,
+      worldId: '',
+      name: attr.name,
+      description: attr.description || '',
+      baseValue: attr.baseValue,
+      minValue: attr.minValue,
+      maxValue: attr.maxValue,
+      category: attr.category,
+    })),
+    skills: template.skills.map((skill, index) => ({
+      id: `skill-${index}`,
+      worldId: '',
+      name: skill.name,
+      description: skill.description || '',
+      baseValue: skill.baseValue,
+      minValue: skill.minValue,
+      maxValue: skill.maxValue,
+      difficulty: skill.difficulty,
+      category: skill.category,
+    })),
+    settings: {
+      maxAttributes: 8,
+      maxSkills: 12,
+      attributePointPool: 150,
+      skillPointPool: 100,
+    },
+  };
 }

--- a/src/lib/promptContext/__tests__/tokenBudgetManager.test.ts
+++ b/src/lib/promptContext/__tests__/tokenBudgetManager.test.ts
@@ -2,28 +2,27 @@ import {
   ComponentPriority,
   DEFAULT_ALLOCATIONS,
   DEFAULT_TOTAL_BUDGET,
-  TokenBudgetManager,
+  RequestBudget,
 } from '../tokenBudgetManager';
 
-describe('TokenBudgetManager (MVP)', () => {
+describe('RequestBudget (MVP)', () => {
   it('returns Infinity allocations when disabled', () => {
-    const manager = new TokenBudgetManager({ enabled: false });
-    const budget = manager.createBudget(DEFAULT_ALLOCATIONS, DEFAULT_TOTAL_BUDGET);
+    const budget = new RequestBudget(DEFAULT_ALLOCATIONS, DEFAULT_TOTAL_BUDGET, false);
 
     expect(budget.isEnabled()).toBe(false);
     expect(budget.getAllocation('lore-context')).toBe(Infinity);
   });
 
   it('resolves allocations within a small total budget, prioritizing CRITICAL mins', () => {
-    const manager = new TokenBudgetManager({ enabled: true });
     const tinyBudget = 500;
-    const budget = manager.createBudget(
+    const budget = new RequestBudget(
       [
         { componentId: 'base-template', priority: ComponentPriority.CRITICAL, min: 200, target: 300, max: 500 },
         { componentId: 'character-context', priority: ComponentPriority.CRITICAL, min: 100, target: 200, max: 400 },
         { componentId: 'lore-context', priority: ComponentPriority.MEDIUM, min: 0, target: 800, max: 1500 },
       ],
-      tinyBudget
+      tinyBudget,
+      true
     );
 
     expect(budget.getAllocation('base-template')).toBeGreaterThanOrEqual(200);
@@ -31,4 +30,3 @@ describe('TokenBudgetManager (MVP)', () => {
     expect(budget.getAllocation('lore-context')).toBeLessThanOrEqual(tinyBudget);
   });
 });
-

--- a/src/lib/promptContext/tokenBudgetManager.ts
+++ b/src/lib/promptContext/tokenBudgetManager.ts
@@ -20,13 +20,6 @@ export interface BudgetAllocation {
 }
 
 /**
- * Configuration options for TokenBudgetManager
- */
-export interface TokenBudgetManagerOptions {
-  enabled?: boolean;
-}
-
-/**
  * Request budget instance for tracking allocations during a single request
  */
 export class RequestBudget {
@@ -143,37 +136,6 @@ export class RequestBudget {
    */
   recordUsage(componentId: string, tokens: number): void {
     this.usage.set(componentId, tokens);
-  }
-}
-
-/**
- * Token Budget Manager
- *
- * Centralized manager for creating and tracking token budgets across
- * prompt generation. Supports feature flag for safe rollback.
- */
-export class TokenBudgetManager {
-  private enabled: boolean;
-
-  constructor(options?: TokenBudgetManagerOptions) {
-    this.enabled = options?.enabled ?? true;
-  }
-
-  /**
-   * Create a new request budget with the given allocations
-   */
-  createBudget(
-    allocations: BudgetAllocation[],
-    totalBudget: number
-  ): RequestBudget {
-    return new RequestBudget(allocations, totalBudget, this.enabled);
-  }
-
-  /**
-   * Check if budget tracking is enabled
-   */
-  isEnabled(): boolean {
-    return this.enabled;
   }
 }
 

--- a/src/services/__tests__/characterDeletionService.test.ts
+++ b/src/services/__tests__/characterDeletionService.test.ts
@@ -1,4 +1,4 @@
-import { CharacterDeletionService } from '../characterDeletionService';
+import { deleteCharacterWithCleanup } from '../characterDeletionService';
 import { useJournalStore } from '@/state/journalStore';
 import { useCharacterStore } from '@/state/characterStore';
 import { JournalEntryType } from '@/types/journal.types';
@@ -123,7 +123,7 @@ describe('CharacterDeletionService', () => {
 
   describe('deleteCharacterWithCleanup', () => {
     test('deletes character and cleans up related journal sessions', async () => {
-      await CharacterDeletionService.deleteCharacterWithCleanup('char-1');
+      await deleteCharacterWithCleanup('char-1');
 
       // Should clean up journal sessions for this character
       expect(mockJournalStore.deleteSessionEntries).toHaveBeenCalledWith(
@@ -147,7 +147,7 @@ describe('CharacterDeletionService', () => {
 
       // Should not throw an error
       await expect(
-        CharacterDeletionService.deleteCharacterWithCleanup('char-1')
+        deleteCharacterWithCleanup('char-1')
       ).resolves.toBeUndefined();
 
       // Character deletion should still proceed
@@ -156,7 +156,7 @@ describe('CharacterDeletionService', () => {
 
     test('handles character with no journal entries', async () => {
       // Character with no journal entries
-      await CharacterDeletionService.deleteCharacterWithCleanup('char-3');
+      await deleteCharacterWithCleanup('char-3');
 
       // Should not call any journal cleanup
       expect(mockJournalStore.deleteSessionEntries).not.toHaveBeenCalled();
@@ -174,7 +174,7 @@ describe('CharacterDeletionService', () => {
 
       // Should not throw an error
       await expect(
-        CharacterDeletionService.deleteCharacterWithCleanup('char-1')
+        deleteCharacterWithCleanup('char-1')
       ).resolves.toBeUndefined();
 
       // Character deletion should still proceed

--- a/src/services/characterDeletionService.ts
+++ b/src/services/characterDeletionService.ts
@@ -4,113 +4,96 @@ import { useWorldStore } from '@/state/worldStore';
 import type { PlayerCharacterThreadUpdate, CharacterRelationshipRemoval, WorldStateUpdate } from '@/types/world-state.types';
 
 /**
- * Service layer for character deletion that handles related data cleanup
- * This decouples the character store from the journal store
+ * Deletes a character and all related data (journal entries, world state).
+ *
+ * Attempts to clean up all journal entries associated with the given character.
+ * If journal cleanup fails, a warning is logged and deletion still proceeds.
  */
-export class CharacterDeletionService {
-  /**
-   * Deletes a character and all related journal entries.
-   *
-   * This method attempts to clean up all journal entries associated with the given character.
-   * If an error occurs during journal cleanup, a warning is logged, but the character will still be deleted.
-   * This ensures that character deletion proceeds even if related journal entries cannot be fully cleaned up.
-   *
-   * @param characterId - The ID of the character to delete.
-   * @returns Promise<void>
-   */
-  static async deleteCharacterWithCleanup(characterId: string): Promise<void> {
-    try {
-      // Clean up related journal entries
-      const journalStore = useJournalStore.getState();
-      
-      // Find all journal entries for this character using the characterId field
-      const allEntries = Object.values(journalStore.entries);
-      const characterSessions = new Set<string>();
-      
-      // Find sessions that have entries for this character
-      allEntries.forEach((entry) => {
-        if (entry.characterId === characterId) {
-          characterSessions.add(entry.sessionId);
-        }
-      });
-      
-      // Delete all sessions for this character
-      characterSessions.forEach(sessionId => {
-        try {
-          journalStore.deleteSessionEntries(sessionId);
-        } catch (error) {
-          console.warn('Failed to clean up journal session:', sessionId, error);
-        }
-      });
-    } catch (error) {
-      console.warn('Failed to clean up journal entries for character:', characterId, error);
-      // Continue with deletion even if journal cleanup fails
-    }
+export async function deleteCharacterWithCleanup(characterId: string): Promise<void> {
+  try {
+    const journalStore = useJournalStore.getState();
+    const allEntries = Object.values(journalStore.entries);
+    const characterSessions = new Set<string>();
 
-    // Delete character from character store and clean related world state
-    const characterStore = useCharacterStore.getState();
-    const character = characterStore.characters[characterId];
-    const worldId = character?.worldId;
+    allEntries.forEach((entry) => {
+      if (entry.characterId === characterId) {
+        characterSessions.add(entry.sessionId);
+      }
+    });
 
-    if (worldId) {
+    characterSessions.forEach(sessionId => {
       try {
-        const worldStore = useWorldStore.getState();
-        const worldState = worldStore.worldStates?.[worldId];
+        journalStore.deleteSessionEntries(sessionId);
+      } catch (error) {
+        console.warn('Failed to clean up journal session:', sessionId, error);
+      }
+    });
+  } catch (error) {
+    console.warn('Failed to clean up journal entries for character:', characterId, error);
+  }
 
-        const threadKey = Object.entries(worldState?.playerCharacterThreads ?? {}).find(
-          ([, thread]) => thread.characterId === characterId
-        )?.[0];
+  const characterStore = useCharacterStore.getState();
+  const character = characterStore.characters[characterId];
+  const worldId = character?.worldId;
 
-        const relatedCharacterIds = Object.keys(
-          worldState?.characterRelationships?.[characterId] ?? {}
+  if (worldId) {
+    try {
+      const worldStore = useWorldStore.getState();
+      const worldState = worldStore.worldStates?.[worldId];
+
+      const threadKey = Object.entries(worldState?.playerCharacterThreads ?? {}).find(
+        ([, thread]) => thread.characterId === characterId
+      )?.[0];
+
+      const relatedCharacterIds = Object.keys(
+        worldState?.characterRelationships?.[characterId] ?? {}
+      );
+
+      const relationshipRemovals: CharacterRelationshipRemoval[] = relatedCharacterIds.flatMap((otherId) => ([
+        { sourceId: characterId, targetId: otherId },
+        { sourceId: otherId, targetId: characterId },
+      ]));
+
+      const impactedThreadsUpdates: Record<string, PlayerCharacterThreadUpdate> = {};
+
+      Object.values(worldState?.playerCharacterThreads ?? {}).forEach((thread) => {
+        if (!thread || thread.characterId === characterId) {
+          return;
+        }
+
+        const filteredReferences = (thread.crossCharacterReferences ?? []).filter(
+          (reference) => reference.characterId !== characterId
         );
 
-        const relationshipRemovals: CharacterRelationshipRemoval[] = relatedCharacterIds.flatMap((otherId) => ([
-          { sourceId: characterId, targetId: otherId },
-          { sourceId: otherId, targetId: characterId },
-        ]));
-
-        const impactedThreadsUpdates: Record<string, PlayerCharacterThreadUpdate> = {};
-
-        Object.values(worldState?.playerCharacterThreads ?? {}).forEach((thread) => {
-          if (!thread || thread.characterId === characterId) {
-            return;
-          }
-
-          const filteredReferences = (thread.crossCharacterReferences ?? []).filter(
-            (reference) => reference.characterId !== characterId
-          );
-
-          if (filteredReferences.length !== (thread.crossCharacterReferences?.length ?? 0)) {
-            impactedThreadsUpdates[thread.id] = {
-              id: thread.id,
-              characterId: thread.characterId,
-              crossCharacterReferences: filteredReferences,
-              replaceCrossCharacterReferences: true,
-            };
-          }
-        });
-
-        const updatePayload: WorldStateUpdate = {};
-
-        if (threadKey) {
-          updatePayload.removePlayerCharacterThreads = [threadKey];
+        if (filteredReferences.length !== (thread.crossCharacterReferences?.length ?? 0)) {
+          impactedThreadsUpdates[thread.id] = {
+            id: thread.id,
+            characterId: thread.characterId,
+            crossCharacterReferences: filteredReferences,
+            replaceCrossCharacterReferences: true,
+          };
         }
-        if (relationshipRemovals.length > 0) {
-          updatePayload.removeCharacterRelationships = relationshipRemovals;
-        }
-        if (Object.keys(impactedThreadsUpdates).length > 0) {
-          updatePayload.playerCharacterThreads = impactedThreadsUpdates;
-        }
+      });
 
-        if (Object.keys(updatePayload).length > 0) {
-          worldStore.updateWorldState(worldId, updatePayload, 'system-cleanup');
-        }
-      } catch (error) {
-        console.warn('Failed to clean up world state for character:', characterId, error);
+      const updatePayload: WorldStateUpdate = {};
+
+      if (threadKey) {
+        updatePayload.removePlayerCharacterThreads = [threadKey];
       }
-    }
+      if (relationshipRemovals.length > 0) {
+        updatePayload.removeCharacterRelationships = relationshipRemovals;
+      }
+      if (Object.keys(impactedThreadsUpdates).length > 0) {
+        updatePayload.playerCharacterThreads = impactedThreadsUpdates;
+      }
 
-    await characterStore.deleteCharacter(characterId);
+      if (Object.keys(updatePayload).length > 0) {
+        worldStore.updateWorldState(worldId, updatePayload, 'system-cleanup');
+      }
+    } catch (error) {
+      console.warn('Failed to clean up world state for character:', characterId, error);
+    }
   }
+
+  await characterStore.deleteCharacter(characterId);
 }


### PR DESCRIPTION
## Summary

Third round of overengineering cleanup, following the playbook from [#1236](https://github.com/jerseycheese/Narraitor/pull/1236). Removes five wrapper classes that held no real instance state — each was effectively a namespace with extra syntax.

- `PortraitGenerator` → `generatePortrait` / `buildPortraitPrompt` (module-private helpers take `aiClient` as a param)
- `EndingGenerator` → `generateEnding`
- `TemplateGenerator` → `generateWorldTemplate` / `validateTemplate` / `convertTemplateToWorld`
- `CharacterDeletionService` (static class, one method) → `deleteCharacterWithCleanup`
- `TokenBudgetManager` deleted entirely — the one call site now does `new RequestBudget(...)` directly

Follows the same pattern as the Round 2 `worldImageGenerator` conversion. Net: **-212 LOC**.

## What's not in this PR

The original "top 5" had two items I dropped on inspection — rationale documented in case it's useful next round:

- **Auto-save hook consolidation:** `useAutoSave` writes to IndexedDB via a service with toast UX; `useCharacterCreationAutoSave` writes raw drafts to localStorage with recovery preview. They don't actually share logic. Consolidating would create a misleading abstraction.
- **API route pass-throughs:** `narrative/choices` and `narrative/generate` are 12-line minimum-boilerplate Next.js routes; `narrative/ending` is 118 LOC of real validation. Consolidating would push complexity to clients without removing real engineering.

A substitute (merging trivial single-type files) was also dropped — 20 import sites to update for the gain of deleting 3 small files, poor ratio.

## Test plan

- [x] Affected unit suites pass (35 tests across 7 files)
- [x] Full test suite passes (2134 tests, 298 suites)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on touched files
- [x] Grep sweep confirms no remaining references to removed class names

🤖 Generated with [Claude Code](https://claude.com/claude-code)