### PR TITLE
refactor: overengineering audit Round 4 (6 picks, −567 LOC)

### DIFF
--- a/src/app/api/generate-item-image/route.ts
+++ b/src/app/api/generate-item-image/route.ts
@@ -3,7 +3,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import Logger from '@/lib/utils/logger';
 import type { InventoryItem } from '@/types/inventory.types';
-import { ItemImageGenerator } from '@/lib/ai/itemImageGenerator';
+import { buildItemPrompt } from '@/lib/ai/itemImageGenerator';
 import { generateImageWithFallback } from '@/lib/api/imageGenerationHelpers';
 
 const logger = new Logger('API');
@@ -30,13 +30,10 @@ export async function POST(request: NextRequest) {
     }
 
     const item: InventoryItem = body.item;
-    const genre: string | undefined = body.genre;
 
     logger.debug('generate-item-image API', 'Generating image for item:', item.name);
 
-    // Build the prompt using ItemImageGenerator
-    const generator = new ItemImageGenerator();
-    const prompt = await generator.buildItemPrompt(item, genre);
+    const prompt = buildItemPrompt(item);
 
     logger.debug('generate-item-image API', 'Generated prompt:', prompt.substring(0, 100) + '...');
 

--- a/src/components/CharacterCreationWizard/CharacterCreationWizard.tsx
+++ b/src/components/CharacterCreationWizard/CharacterCreationWizard.tsx
@@ -199,7 +199,7 @@ export const CharacterCreationWizard: React.FC<CharacterCreationWizardProps> = (
     for (let i = 0; i < steps.length; i++) {
       const validator = stepValidators[i];
       if (validator) {
-        const validation = validator.validate(wizard.state.data);
+        const validation = validator(wizard.state.data);
         if (!validation.valid) {
           wizard.goToStep(i);
           wizard.setValidation(i, validation);

--- a/src/components/GameStartWizard/GameStartWizard.tsx
+++ b/src/components/GameStartWizard/GameStartWizard.tsx
@@ -7,10 +7,7 @@ import {
   useWizardState,
   WizardStep as WizardStepType,
 } from '@/hooks/useWizardState';
-import {
-  createWizardValidator,
-  WizardStepValidator,
-} from '@/lib/utils/wizardValidation';
+import { Validator, alwaysValid } from '@/lib/utils/wizardValidation';
 import { WorldSelectionStep } from './steps/WorldSelectionStep';
 import { CharacterSelectionStep } from './steps/CharacterSelectionStep';
 import { GameReadyStep } from './steps/GameReadyStep';
@@ -61,26 +58,19 @@ export function GameStartWizard({
   );
 
   // Create step validators
-  const stepValidators = useMemo((): Record<
-    number,
-    WizardStepValidator<GameStartData>
-  > => {
+  const stepValidators = useMemo((): Record<number, Validator<GameStartData>> => {
     return {
-      0: createWizardValidator<GameStartData>()
-        .customValidation((data) => ({
-          valid: !!data.selectedWorldId,
-          errors: data.selectedWorldId ? [] : ['Please select a world'],
-          touched: true,
-        }))
-        .build(),
-      1: createWizardValidator<GameStartData>()
-        .customValidation((data) => ({
-          valid: !!data.selectedCharacterId,
-          errors: data.selectedCharacterId ? [] : ['Please select a character'],
-          touched: true,
-        }))
-        .build(),
-      2: createWizardValidator<GameStartData>().build(), // Ready step is always valid
+      0: (data) => ({
+        valid: !!data.selectedWorldId,
+        errors: data.selectedWorldId ? [] : ['Please select a world'],
+        touched: true,
+      }),
+      1: (data) => ({
+        valid: !!data.selectedCharacterId,
+        errors: data.selectedCharacterId ? [] : ['Please select a character'],
+        touched: true,
+      }),
+      2: alwaysValid, // Ready step is always valid
     };
   }, []);
 
@@ -92,7 +82,7 @@ export function GameStartWizard({
     onStepValidation: (stepIndex, data) => {
       const validator = stepValidators[stepIndex];
       return validator
-        ? validator.validate(data)
+        ? validator(data)
         : { valid: true, errors: [], touched: true };
     },
   });

--- a/src/components/TutorialProvider/TutorialProvider.tsx
+++ b/src/components/TutorialProvider/TutorialProvider.tsx
@@ -8,13 +8,11 @@ import { TutorialPhase } from '@/types/tutorial.types';
 import { TutorialProgressWidget } from '@/components/TutorialProgress/TutorialProgressWidget';
 import Logger from '@/lib/utils/logger';
 import { useTutorialAutoScroll } from './useTutorialAutoScroll';
+import { useTourTargetRetry } from './useTourTargetRetry';
 
 type PauseReason = 'end-of-page' | 'missing-target' | null;
 
 const logger = new Logger('TutorialProvider');
-
-const MAX_TARGET_RETRIES = 40; // 10 seconds total (40 * 250ms)
-const RETRY_INTERVAL_MS = 250;
 
 interface TutorialContextValue {
   startTour: (tourId: TutorialPhase | string, stepIndex?: number) => void;
@@ -293,47 +291,15 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
   
   const lastWizardStepRef = useRef<number | null>(null);
 
-  // Sync tour with wizard (only when the wizard actually changes steps)
-  useEffect(() => {
-    if (!isPaused || pauseReason !== 'missing-target' || !stepMapping) return;
-    const missingTarget = missingTargetRef.current;
-    if (!missingTarget?.target) return;
-
-    let retries = 0;
-
-    const retryInterval = window.setInterval(() => {
-      if (!isPausedRef.current || pauseReason !== 'missing-target') {
-         window.clearInterval(retryInterval);
-         return;
-      }
-
-      const element = document.querySelector(missingTarget.target as string);
-      if (element) {
-        // Check if element is truly ready for Joyride (has dimensions and is visible)
-        const rect = element.getBoundingClientRect();
-        const isActuallyMounted = rect.width > 0 && rect.height > 0;
-        const style = window.getComputedStyle(element);
-        const isVisible = style.display !== 'none' && style.visibility !== '';
-
-        if (isActuallyMounted && isVisible) {
-          missingTargetRef.current = null;
-          resumeTour();
-          window.clearInterval(retryInterval);
-          return;
-        }
-      }
-
-      retries++;
-      if (retries >= MAX_TARGET_RETRIES) {
-        logger.warn('Tutorial missing target timeout', { target: missingTarget.target });
-        window.clearInterval(retryInterval);
-      }
-    }, RETRY_INTERVAL_MS);
-
-    return () => {
-      window.clearInterval(retryInterval);
-    };
-  }, [isPaused, pauseReason, activeTour, resumeTour, stepMapping]);
+  // Poll for missing target elements when tour is paused waiting for them
+  useTourTargetRetry({
+    isPaused,
+    pauseReason,
+    stepMapping,
+    missingTargetRef,
+    isPausedRef,
+    resumeTour,
+  });
 
   useEffect(() => {
     if (!activeTour || !stepMapping) return;

--- a/src/components/TutorialProvider/useTourTargetRetry.ts
+++ b/src/components/TutorialProvider/useTourTargetRetry.ts
@@ -1,0 +1,72 @@
+import { useEffect, MutableRefObject } from 'react';
+import Logger from '@/lib/utils/logger';
+
+const logger = new Logger('TutorialProvider');
+
+const MAX_TARGET_RETRIES = 40; // 10 seconds total (40 * 250ms)
+const RETRY_INTERVAL_MS = 250;
+
+type PauseReason = 'end-of-page' | 'missing-target' | null;
+
+type MissingTarget = { index: number; target: string | null } | null;
+
+/**
+ * When the tour is paused because a step's target element is missing,
+ * poll the DOM for it to appear (and become measurable+visible). On
+ * success, clear the ref and resume the tour. On timeout, log and stop.
+ */
+export function useTourTargetRetry({
+  isPaused,
+  pauseReason,
+  stepMapping,
+  missingTargetRef,
+  isPausedRef,
+  resumeTour,
+}: {
+  isPaused: boolean;
+  pauseReason: PauseReason;
+  stepMapping: Record<number, number> | undefined;
+  missingTargetRef: MutableRefObject<MissingTarget>;
+  isPausedRef: MutableRefObject<boolean>;
+  resumeTour: () => void;
+}) {
+  useEffect(() => {
+    if (!isPaused || pauseReason !== 'missing-target' || !stepMapping) return;
+    const missingTarget = missingTargetRef.current;
+    if (!missingTarget?.target) return;
+
+    let retries = 0;
+
+    const retryInterval = window.setInterval(() => {
+      if (!isPausedRef.current || pauseReason !== 'missing-target') {
+        window.clearInterval(retryInterval);
+        return;
+      }
+
+      const element = document.querySelector(missingTarget.target as string);
+      if (element) {
+        const rect = element.getBoundingClientRect();
+        const isActuallyMounted = rect.width > 0 && rect.height > 0;
+        const style = window.getComputedStyle(element);
+        const isVisible = style.display !== 'none' && style.visibility !== '';
+
+        if (isActuallyMounted && isVisible) {
+          missingTargetRef.current = null;
+          resumeTour();
+          window.clearInterval(retryInterval);
+          return;
+        }
+      }
+
+      retries++;
+      if (retries >= MAX_TARGET_RETRIES) {
+        logger.warn('Tutorial missing target timeout', { target: missingTarget.target });
+        window.clearInterval(retryInterval);
+      }
+    }, RETRY_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(retryInterval);
+    };
+  }, [isPaused, pauseReason, stepMapping, missingTargetRef, isPausedRef, resumeTour]);
+}

--- a/src/components/WorldCreationWizard/WorldCreationWizard.tsx
+++ b/src/components/WorldCreationWizard/WorldCreationWizard.tsx
@@ -7,7 +7,13 @@ import { useSessionStore } from '@/state/sessionStore';
 import { World } from '@/types/world.types';
 import { DEFAULT_TONE_SETTINGS } from '@/types/tone-settings.types';
 import { useWizardState, WizardStep as WizardStepType } from '@/hooks/useWizardState';
-import { createWizardValidator, WizardStepValidator } from '@/lib/utils/wizardValidation';
+import {
+  Validator,
+  ValidationRule,
+  alwaysValid,
+  validateFields,
+  createValidationRules,
+} from '@/lib/utils/wizardValidation';
 import { 
   WizardContainer, 
   WizardProgress, 
@@ -135,55 +141,45 @@ export default function WorldCreationWizard({
   }), [initialData]);
 
   // Create step validators
-  const stepValidators = useMemo((): Record<number, WizardStepValidator<WorldCreationData>> => {
+  const stepValidators = useMemo((): Record<number, Validator<WorldCreationData>> => {
     return {
-      0: createWizardValidator<WorldCreationData>()
-        .customValidation((data) => {
-          const isValid = data.selectedTemplateId !== null || data.createOwnWorld === true;
-          return {
-            valid: isValid,
-            errors: isValid ? [] : ['Please select a template or choose to create your own world'],
-            touched: true,
-          };
-        })
-        .build(),
-      1: createWizardValidator<WorldCreationData>()
-        .field('genre')
-        .required('World genre is required')
-        .build(),
-      2: createWizardValidator<WorldCreationData>()
-        .field('description')
-        .required('World description is required')
-        .minLength(50, 'Description must be at least 50 characters')
-        .build(),
-      3: createWizardValidator<WorldCreationData>()
-        .customValidation((data) => {
-          if (data.createOwnWorld) {
-            return { valid: true, errors: [], touched: true };
-          }
-          const hasAttributes = (data.attributes?.length || 0) > 0;
-          return {
-            valid: hasAttributes,
-            errors: hasAttributes ? [] : ['At least one attribute is required'],
-            touched: true,
-          };
-        })
-        .build(),
-      4: createWizardValidator<WorldCreationData>()
-        .customValidation((data) => {
-          if (data.createOwnWorld) {
-            return { valid: true, errors: [], touched: true };
-          }
-          const hasSkills = (data.skills?.length || 0) > 0;
-          return {
-            valid: hasSkills,
-            errors: hasSkills ? [] : ['At least one skill is required'],
-            touched: true,
-          };
-        })
-        .build(),
-      5: createWizardValidator<WorldCreationData>().build(), // Finalize step is always valid
-      6: createWizardValidator<WorldCreationData>().build(), // Quick start step is always valid
+      0: (data) => {
+        const isValid = data.selectedTemplateId !== null || data.createOwnWorld === true;
+        return {
+          valid: isValid,
+          errors: isValid ? [] : ['Please select a template or choose to create your own world'],
+          touched: true,
+        };
+      },
+      1: validateFields<WorldCreationData>({
+        genre: [createValidationRules.required('World genre is required')],
+      }),
+      2: validateFields<WorldCreationData>({
+        description: [
+          createValidationRules.required<string | undefined>('World description is required'),
+          createValidationRules.minLength(50, 'Description must be at least 50 characters') as ValidationRule<string | undefined>,
+        ],
+      }),
+      3: (data) => {
+        if (data.createOwnWorld) return { valid: true, errors: [], touched: true };
+        const hasAttributes = (data.attributes?.length || 0) > 0;
+        return {
+          valid: hasAttributes,
+          errors: hasAttributes ? [] : ['At least one attribute is required'],
+          touched: true,
+        };
+      },
+      4: (data) => {
+        if (data.createOwnWorld) return { valid: true, errors: [], touched: true };
+        const hasSkills = (data.skills?.length || 0) > 0;
+        return {
+          valid: hasSkills,
+          errors: hasSkills ? [] : ['At least one skill is required'],
+          touched: true,
+        };
+      },
+      5: alwaysValid, // Finalize step is always valid
+      6: alwaysValid, // Quick start step is always valid
     };
   }, []);
 
@@ -194,7 +190,7 @@ export default function WorldCreationWizard({
     steps: WIZARD_STEPS,
     onStepValidation: (stepIndex, data) => {
       const validator = stepValidators[stepIndex];
-      return validator ? validator.validate(data) : { valid: true, errors: [], touched: true };
+      return validator ? validator(data) : { valid: true, errors: [], touched: true };
     },
   });
 

--- a/src/components/devtools/TestDataGeneratorSection/TestDataGeneratorSection.tsx
+++ b/src/components/devtools/TestDataGeneratorSection/TestDataGeneratorSection.tsx
@@ -10,6 +10,85 @@ import type { GeneratedImage } from '@/types/common.types';
 import { getTimestamp } from '@/lib/utils';
 import { ensureWorldNpcRoster } from '@/lib/services/worldCreationService';
 
+const TV_MOVIE_UNIVERSES = [
+  'Game of Thrones',
+  'Lord of the Rings',
+  'Star Wars',
+  'Twin Peaks',
+  'Stranger Things',
+  'Deadwood',
+  'The Walking Dead',
+  'Black Mirror',
+  'The Matrix',
+  'Mad Max',
+  'Westworld',
+  'Star Trek',
+  'Dune',
+];
+
+type WorldRelationship = 'set_within' | 'inspired_by' | undefined;
+
+/** Pick a random reference/relationship: 33% original, 33% set_within, 34% inspired_by. */
+function pickRandomWorldType(): { reference?: string; relationship: WorldRelationship } {
+  const roll = Math.random();
+  if (roll < 0.33) return { reference: undefined, relationship: undefined };
+  const reference = TV_MOVIE_UNIVERSES[Math.floor(Math.random() * TV_MOVIE_UNIVERSES.length)];
+  return { reference, relationship: roll < 0.66 ? 'set_within' : 'inspired_by' };
+}
+
+/** Transform API-generated world data to the shape expected by `worldStore.createWorld`. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function buildWorldDataForStore(testWorldData: any, reference: string | undefined, relationship: WorldRelationship): any {
+  return {
+    ...testWorldData,
+    reference,
+    relationship,
+    universeReference: reference,
+    universeRelationship: relationship,
+    attributes: testWorldData.attributes.map((attr: Record<string, unknown>) => ({
+      ...attr,
+      id: generateUniqueId('attr'),
+      worldId: '',
+    })),
+    skills: testWorldData.skills.map((skill: Record<string, unknown>) => ({
+      ...skill,
+      id: generateUniqueId('skill'),
+      worldId: '',
+    })),
+  };
+}
+
+/** Fire-and-await world image generation via API, swallowing failures so world creation isn't blocked. */
+async function generateWorldImageAsync(worldId: string, worldName: string): Promise<void> {
+  try {
+    const world = useWorldStore.getState().worlds[worldId];
+    if (!world) return;
+
+    const response = await fetch('/api/generate-world-image', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ world }),
+    });
+
+    if (response.ok) {
+      const { imageUrl, aiGenerated } = await response.json();
+      const image: GeneratedImage = {
+        type: aiGenerated ? 'ai-generated' : 'placeholder',
+        url: imageUrl,
+        generatedAt: getTimestamp(),
+      };
+      useWorldStore.getState().updateWorld(worldId, { image });
+    } else {
+      const errorText = await response.text();
+      console.warn(
+        `[DevTools] Failed to generate world image for "${worldName}": ${response.status} - ${errorText}`
+      );
+    }
+  } catch (error) {
+    console.error(`Failed to generate world image for test world "${worldName}":`, error);
+  }
+}
+
 export const TestDataGeneratorSection: React.FC = () => {
   const router = useRouter();
   const pathname = usePathname();
@@ -26,66 +105,15 @@ export const TestDataGeneratorSection: React.FC = () => {
 
   const handleGenerateWorld = async () => {
     try {
-      // Generate a diverse mix of world types for testing (my enhancement)
-      const worldTypeRandom = Math.random();
-      let randomReference;
-      let randomRelationship;
-
-      if (worldTypeRandom < 0.33) {
-        // 33% - Original worlds (no reference)
-      } else if (worldTypeRandom < 0.66) {
-        // 33% - "Set in" worlds (existing universe)
-        const tvMovieUniverses = [
-          'Game of Thrones',
-          'Lord of the Rings',
-          'Star Wars',
-          'Twin Peaks',
-          'Stranger Things',
-          'Deadwood',
-          'The Walking Dead',
-          'Black Mirror',
-          'The Matrix',
-          'Mad Max',
-          'Westworld',
-          'Star Trek',
-          'Dune',
-        ];
-        randomReference =
-          tvMovieUniverses[Math.floor(Math.random() * tvMovieUniverses.length)];
-        randomRelationship = 'set_within';
-      } else {
-        // 34% - "Based on" worlds (inspired by existing universe)
-        const tvMovieUniverses = [
-          'Game of Thrones',
-          'Lord of the Rings',
-          'Star Wars',
-          'Twin Peaks',
-          'Stranger Things',
-          'Deadwood',
-          'The Walking Dead',
-          'Black Mirror',
-          'The Matrix',
-          'Mad Max',
-          'Westworld',
-          'Star Trek',
-          'Dune',
-        ];
-        randomReference =
-          tvMovieUniverses[Math.floor(Math.random() * tvMovieUniverses.length)];
-        randomRelationship = 'inspired_by';
-      }
-
+      const { reference, relationship } = pickRandomWorldType();
       const existingNames = Object.values(worlds).map((w) => w.name);
 
-      // Use the secure API route approach from develop branch
       const response = await fetch('/api/generate-world', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          worldReference: randomReference,
-          worldRelationship: randomRelationship,
+          worldReference: reference,
+          worldRelationship: relationship,
           existingNames,
         }),
       });
@@ -95,82 +123,12 @@ export const TestDataGeneratorSection: React.FC = () => {
       }
 
       const testWorldData = await response.json();
-
-      // Transform the generated data to match the store's expected format
-      const worldDataForStore = {
-        ...testWorldData,
-        // Support both property patterns for compatibility
-        reference: randomReference,
-        relationship: randomRelationship,
-        universeReference: randomReference,
-        universeRelationship: randomRelationship,
-        attributes: testWorldData.attributes.map(
-          (attr: {
-            name: string;
-            description: string;
-            minValue: number;
-            maxValue: number;
-            defaultValue: number;
-          }) => ({
-            ...attr,
-            id: generateUniqueId('attr'),
-            worldId: '', // Will be set by store
-          })
-        ),
-        skills: testWorldData.skills.map(
-          (skill: {
-            name: string;
-            description: string;
-            difficulty: string;
-            category: string;
-          }) => ({
-            ...skill,
-            id: generateUniqueId('skill'),
-            worldId: '', // Will be set by store
-          })
-        ),
-      };
-
-      const worldId = createWorld(worldDataForStore);
+      const worldId = createWorld(buildWorldDataForStore(testWorldData, reference, relationship));
       await ensureWorldNpcRoster(worldId);
 
-      // Set the newly created world as the active world
-      const { setCurrentWorld } = useWorldStore.getState();
-      setCurrentWorld(worldId);
+      useWorldStore.getState().setCurrentWorld(worldId);
 
-      // Generate world image asynchronously using my enhanced API
-      try {
-        // Get the created world from store
-        const world = useWorldStore.getState().worlds[worldId];
-        if (world) {
-          const response = await fetch('/api/generate-world-image', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ world }),
-          });
-
-          if (response.ok) {
-            const { imageUrl, aiGenerated } = await response.json();
-            // Update the world with the generated image in GeneratedImage format (my enhancement)
-            const image: GeneratedImage = {
-              type: aiGenerated
-                ? ('ai-generated' as const)
-                : ('placeholder' as const),
-              url: imageUrl,
-              generatedAt: getTimestamp(),
-            };
-            useWorldStore.getState().updateWorld(worldId, { image });
-          } else {
-            const errorText = await response.text();
-            console.warn(
-              `[DevTools] Failed to generate world image: ${response.status} - ${errorText}`
-            );
-          }
-        }
-      } catch (error) {
-        console.error('Failed to generate world image for test world:', error);
-        // Don't block world creation if image generation fails
-      }
+      await generateWorldImageAsync(worldId, testWorldData.name);
     } catch (error) {
       console.error('[DevTools] Error generating test world:', error);
       alert(
@@ -180,83 +138,25 @@ export const TestDataGeneratorSection: React.FC = () => {
   };
 
   const handleGenerate5Worlds = async () => {
-    const createdWorlds = [];
+    const createdWorlds: Array<{ id: string; name: string }> = [];
 
     try {
-      // Get existing world names to ensure uniqueness
       const existingNames = Object.values(worlds).map((w) => w.name);
 
       for (let i = 0; i < 5; i++) {
-        // Generate a diverse mix of world types for testing (my enhancement)
-        const worldTypeRandom = Math.random();
-        let randomReference;
-        let randomRelationship;
+        const { reference, relationship } = pickRandomWorldType();
 
-        if (worldTypeRandom < 0.33) {
-          // 33% - Original worlds (no reference)
-          randomReference = undefined;
-          randomRelationship = undefined;
-        } else if (worldTypeRandom < 0.66) {
-          // 33% - "Set in" worlds (existing universe)
-          const tvMovieUniverses = [
-            'Game of Thrones',
-            'Lord of the Rings',
-            'Star Wars',
-            'Twin Peaks',
-            'Stranger Things',
-            'Deadwood',
-            'The Walking Dead',
-            'Black Mirror',
-            'The Matrix',
-            'Mad Max',
-            'Westworld',
-            'Star Trek',
-            'Dune',
-          ];
-          randomReference =
-            tvMovieUniverses[
-              Math.floor(Math.random() * tvMovieUniverses.length)
-            ];
-          randomRelationship = 'set_within';
-        } else {
-          // 34% - "Based on" worlds (inspired by existing universe)
-          const tvMovieUniverses = [
-            'Game of Thrones',
-            'Lord of the Rings',
-            'Star Wars',
-            'Twin Peaks',
-            'Stranger Things',
-            'Deadwood',
-            'The Walking Dead',
-            'Black Mirror',
-            'The Matrix',
-            'Mad Max',
-            'Westworld',
-            'Star Trek',
-            'Dune',
-          ];
-          randomReference =
-            tvMovieUniverses[
-              Math.floor(Math.random() * tvMovieUniverses.length)
-            ];
-          randomRelationship = 'inspired_by';
-        }
-
-        // Include existing names plus already created worlds in this batch to avoid duplicates
-        const allExistingNames: string[] = [
+        const allExistingNames = [
           ...existingNames,
           ...createdWorlds.map((w) => w.name),
         ];
 
-        // Use the secure API route approach from develop branch
         const response = await fetch('/api/generate-world', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            worldReference: randomReference,
-            worldRelationship: randomRelationship,
+            worldReference: reference,
+            worldRelationship: relationship,
             existingNames: allExistingNames,
           }),
         });
@@ -266,88 +166,15 @@ export const TestDataGeneratorSection: React.FC = () => {
         }
 
         const testWorldData = await response.json();
-
-        // Transform the generated data to match the store's expected format
-        const worldDataForStore = {
-          ...testWorldData,
-          // Support both property patterns for compatibility
-          reference: randomReference,
-          relationship: randomRelationship,
-          universeReference: randomReference,
-          universeRelationship: randomRelationship,
-          attributes: testWorldData.attributes.map(
-            (attr: {
-              name: string;
-              description: string;
-              minValue: number;
-              maxValue: number;
-              defaultValue: number;
-            }) => ({
-              ...attr,
-              id: generateUniqueId('attr'),
-              worldId: '', // Will be set by store
-            })
-          ),
-          skills: testWorldData.skills.map(
-            (skill: {
-              name: string;
-              description: string;
-              difficulty: string;
-              category: string;
-            }) => ({
-              ...skill,
-              id: generateUniqueId('skill'),
-              worldId: '', // Will be set by store
-            })
-          ),
-        };
-
-        const worldId = createWorld(worldDataForStore);
+        const worldId = createWorld(buildWorldDataForStore(testWorldData, reference, relationship));
         await ensureWorldNpcRoster(worldId);
         createdWorlds.push({ id: worldId, name: testWorldData.name });
 
-        // Set the first created world as active (for batch generation)
         if (i === 0) {
-          const { setCurrentWorld } = useWorldStore.getState();
-          setCurrentWorld(worldId);
+          useWorldStore.getState().setCurrentWorld(worldId);
         }
 
-        // Generate world image asynchronously for each world using my enhanced API
-        try {
-          // Get the created world from store
-          const world = useWorldStore.getState().worlds[worldId];
-          if (world) {
-            const response = await fetch('/api/generate-world-image', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ world }),
-            });
-
-            if (response.ok) {
-              const { imageUrl, aiGenerated } = await response.json();
-              // Update the world with the generated image in GeneratedImage format (my enhancement)
-              const image: GeneratedImage = {
-                type: aiGenerated
-                  ? ('ai-generated' as const)
-                  : ('placeholder' as const),
-                url: imageUrl,
-                generatedAt: getTimestamp(),
-              };
-              useWorldStore.getState().updateWorld(worldId, { image });
-            } else {
-              const errorText = await response.text();
-              console.warn(
-                `[DevTools] Failed to generate world image for "${testWorldData.name}": ${response.status} - ${errorText}`
-              );
-            }
-          }
-        } catch (error) {
-          console.error(
-            `Failed to generate world image for test world "${testWorldData.name}":`,
-            error
-          );
-          // Don't block world creation if image generation fails
-        }
+        await generateWorldImageAsync(worldId, testWorldData.name);
       }
 
       const worldNames = createdWorlds.map((w) => w.name).join(', ');

--- a/src/hooks/__tests__/useAutoSave.test.ts
+++ b/src/hooks/__tests__/useAutoSave.test.ts
@@ -16,7 +16,7 @@ const mockAutoSaveService = {
 };
 
 jest.mock('../../lib/services/autoSaveService', () => ({
-  AutoSaveService: jest.fn().mockImplementation(() => mockAutoSaveService)
+  createAutoSave: jest.fn(() => mockAutoSaveService)
 }));
 
 const mockSessionStore: SessionStore = {

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -47,7 +47,7 @@ import { useCharacterStore } from '@/state/characterStore';
 import { useNarrativeStore } from '@/state/narrativeStore';
 import { getTimestamp } from '@/lib/utils';
 import { useJournalStore } from '@/state/journalStore';
-import { AutoSaveService, SaveTriggerReason, GameState } from '@/lib/services/autoSaveService';
+import { createAutoSave, AutoSave, SaveTriggerReason, GameState } from '@/lib/services/autoSaveService';
 import { useToast } from '@/components/ui/toast';
 
 /**
@@ -76,7 +76,7 @@ export const useAutoSave = () => {
   const sessionStatus = useSessionStore(state => state.status);
   const toast = useToast();
   
-  const autoSaveServiceRef = useRef<AutoSaveService | null>(null);
+  const autoSaveServiceRef = useRef<AutoSave | null>(null);
 
   // Create state provider function using direct store accessors to avoid re-subscribing
   const stateProvider = useCallback(async (): Promise<GameState> => {
@@ -106,7 +106,7 @@ export const useAutoSave = () => {
   // Initialize auto-save service
   useEffect(() => {
     if (!autoSaveServiceRef.current) {
-      autoSaveServiceRef.current = new AutoSaveService(stateProvider, {
+      autoSaveServiceRef.current = createAutoSave(stateProvider, {
         onSaveStart: (reason) => {
           // Manual saves set the status before calling triggerSave
           if (reason !== 'manual') {

--- a/src/hooks/useCharacterCreationWizard.ts
+++ b/src/hooks/useCharacterCreationWizard.ts
@@ -1,6 +1,11 @@
 import { useMemo } from 'react';
 import { useWizardState, WizardStep as WizardStepType } from '@/hooks/useWizardState';
-import { createWizardValidator, WizardStepValidator } from '@/lib/utils/wizardValidation';
+import {
+  Validator,
+  alwaysValid,
+  validateFields,
+  createValidationRules,
+} from '@/lib/utils/wizardValidation';
 import { EntityID } from '@/types/common.types';
 import { World } from '@/types/world.types';
 import { validateCharacterName, validateAttributes, validateSkills, validateBackground } from '@/components/CharacterCreationWizard/utils/validation';
@@ -76,45 +81,40 @@ export function useCharacterCreationWizard({
   world
 }: UseCharacterCreationWizardProps) {
   // Create step validators
-  const stepValidators = useMemo((): Record<number, WizardStepValidator<CharacterCreationData>> => {
+  const stepValidators = useMemo((): Record<number, Validator<CharacterCreationData>> => {
     return {
-      0: createWizardValidator<CharacterCreationData>().build(), // Template selection - always valid (optional)
-      1: createWizardValidator<CharacterCreationData>()          // Basic Info (was step 0)
-        .field('name')
-        .required('Character name is required')
-        .minLength(2, 'Character name must be at least 2 characters')
-        .custom((name) => {
-          const result = validateCharacterName(name, worldId);
-          return result.valid;
-        }, 'A character with this name already exists in this world')
-        .build(),
-      2: createWizardValidator<CharacterCreationData>()          // Attributes (was step 1)
-        .customValidation((data) => {
-          const result = validateAttributes(data.attributes, world?.settings.attributePointPool || 0);
-          return { ...result, touched: true };
-        })
-        .build(),
-      3: createWizardValidator<CharacterCreationData>()          // Skills (was step 2)
-        .customValidation((data) => {
-          const result = validateSkills(
-            data.skills,
-            world?.settings.skillPointPool || 0,
-            world?.skills?.map(skill => ({
-              id: skill.id,
-              minValue: skill.minValue,
-              maxValue: skill.maxValue,
-            })) || []
-          );
-          return { ...result, touched: true };
-        })
-        .build(),
-      4: createWizardValidator<CharacterCreationData>()         // Background (was step 3)
-        .customValidation((data) => {
-          const result = validateBackground(data.background);
-          return { ...result, touched: true };
-        })
-        .build(),
-      5: createWizardValidator<CharacterCreationData>().build(), // Portrait (was step 4) - optional
+      0: alwaysValid, // Template selection - always valid (optional)
+      1: validateFields<CharacterCreationData>({
+        name: [
+          createValidationRules.required('Character name is required'),
+          createValidationRules.minLength(2, 'Character name must be at least 2 characters'),
+          createValidationRules.custom<string>(
+            (name) => validateCharacterName(name, worldId).valid,
+            'A character with this name already exists in this world'
+          ),
+        ],
+      }),
+      2: (data) => {
+        const result = validateAttributes(data.attributes, world?.settings.attributePointPool || 0);
+        return { ...result, touched: true };
+      },
+      3: (data) => {
+        const result = validateSkills(
+          data.skills,
+          world?.settings.skillPointPool || 0,
+          world?.skills?.map(skill => ({
+            id: skill.id,
+            minValue: skill.minValue,
+            maxValue: skill.maxValue,
+          })) || []
+        );
+        return { ...result, touched: true };
+      },
+      4: (data) => {
+        const result = validateBackground(data.background);
+        return { ...result, touched: true };
+      },
+      5: alwaysValid, // Portrait - optional
     };
   }, [worldId, world]);
 
@@ -125,7 +125,7 @@ export function useCharacterCreationWizard({
     steps,
     onStepValidation: (stepIndex, data) => {
       const validator = stepValidators[stepIndex];
-      return validator ? validator.validate(data) : { valid: true, errors: [], touched: true };
+      return validator ? validator(data) : { valid: true, errors: [], touched: true };
     },
   });
 

--- a/src/lib/ai/__tests__/itemImageGenerator.test.ts
+++ b/src/lib/ai/__tests__/itemImageGenerator.test.ts
@@ -1,146 +1,103 @@
-// src/lib/ai/__tests__/itemImageGenerator.test.ts
-
-import { ItemImageGenerator } from '../itemImageGenerator';
+import { buildItemPrompt } from '../itemImageGenerator';
 import type { InventoryItem } from '@/types/inventory.types';
 
-describe('ItemImageGenerator', () => {
-  let generator: ItemImageGenerator;
+describe('buildItemPrompt', () => {
+  const baseItem: Partial<InventoryItem> = {
+    id: 'item-1',
+    name: 'Health Potion',
+    description: 'A red liquid',
+    categoryId: 'consumables',
+  };
 
-  beforeEach(() => {
-    generator = new ItemImageGenerator();
+  test('builds basic prompt with item name', () => {
+    const prompt = buildItemPrompt(baseItem as InventoryItem);
+    expect(prompt).toContain('Health Potion');
   });
 
-  describe('buildItemPrompt', () => {
-    const baseItem: Partial<InventoryItem> = {
-      id: 'item-1',
-      name: 'Health Potion',
-      description: 'A red liquid',
-      categoryId: 'consumables',
+  test('includes short descriptions', () => {
+    const prompt = buildItemPrompt(baseItem as InventoryItem);
+    expect(prompt).toContain('A red liquid');
+  });
+
+  test('excludes long descriptions to keep prompts simple', () => {
+    const itemWithLongDesc: Partial<InventoryItem> = {
+      ...baseItem,
+      description: 'This is a very long description that goes on and on about the item',
     };
 
-    test('builds basic prompt with item name', async () => {
-      const prompt = await generator.buildItemPrompt(baseItem as InventoryItem);
+    const prompt = buildItemPrompt(itemWithLongDesc as InventoryItem);
 
-      expect(prompt).toContain('Health Potion');
-    });
+    expect(prompt).toContain('Health Potion');
+    expect(prompt).not.toContain('very long description');
+  });
 
-    test('includes short descriptions', async () => {
-      const prompt = await generator.buildItemPrompt(baseItem as InventoryItem);
+  test('handles items without description gracefully', () => {
+    const itemWithoutDesc: Partial<InventoryItem> = {
+      ...baseItem,
+      description: '',
+    };
 
-      expect(prompt).toContain('A red liquid');
-    });
+    const prompt = buildItemPrompt(itemWithoutDesc as InventoryItem);
 
-    test('excludes long descriptions to keep prompts simple', async () => {
-      const itemWithLongDesc: Partial<InventoryItem> = {
-        ...baseItem,
-        description: 'This is a very long description that goes on and on about the item',
-      };
+    expect(prompt).toContain('Health Potion');
+    expect(prompt).toBeTruthy();
+  });
 
-      const prompt = await generator.buildItemPrompt(itemWithLongDesc as InventoryItem);
+  test('generates simple prompt for equipment items', () => {
+    const sword: Partial<InventoryItem> = {
+      id: 'item-2',
+      name: 'Iron Sword',
+      description: 'A sturdy blade',
+      categoryId: 'equipment',
+    };
 
-      expect(prompt).toContain('Health Potion');
-      expect(prompt).not.toContain('very long description');
-    });
+    const prompt = buildItemPrompt(sword as InventoryItem);
 
-    test('does not include genre styling even when provided', async () => {
-      const prompt = await generator.buildItemPrompt(
-        baseItem as InventoryItem,
-        'fantasy'
-      );
+    expect(prompt).toContain('Iron Sword');
+    expect(prompt).toContain('A sturdy blade');
+  });
 
-      expect(prompt).not.toContain('fantasy');
-    });
+  test('generates simple prompt for valuables', () => {
+    const gem: Partial<InventoryItem> = {
+      id: 'item-3',
+      name: 'Ruby',
+      description: 'A precious gemstone',
+      categoryId: 'valuables',
+    };
 
-    test('handles items without description gracefully', async () => {
-      const itemWithoutDesc: Partial<InventoryItem> = {
-        ...baseItem,
-        description: '',
-      };
+    const prompt = buildItemPrompt(gem as InventoryItem);
 
-      const prompt = await generator.buildItemPrompt(itemWithoutDesc as InventoryItem);
+    expect(prompt).toContain('Ruby');
+    expect(prompt).toContain('A precious gemstone');
+  });
 
-      expect(prompt).toContain('Health Potion');
-      expect(prompt).toBeTruthy();
-    });
+  test('includes realistic style directive', () => {
+    const prompt = buildItemPrompt(baseItem as InventoryItem);
+    expect(prompt).toContain('realistic style');
+  });
 
-    test('generates simple prompt for equipment items', async () => {
-      const sword: Partial<InventoryItem> = {
-        id: 'item-2',
-        name: 'Iron Sword',
-        description: 'A sturdy blade',
-        categoryId: 'equipment',
-      };
+  test('includes white background directive', () => {
+    const prompt = buildItemPrompt(baseItem as InventoryItem);
+    expect(prompt).toContain('white background');
+  });
 
-      const prompt = await generator.buildItemPrompt(sword as InventoryItem, 'fantasy');
+  test('includes professional photography directives', () => {
+    const prompt = buildItemPrompt(baseItem as InventoryItem);
+    expect(prompt).toContain('centered');
+    expect(prompt).toContain('professional lighting');
+  });
 
-      expect(prompt).toContain('Iron Sword');
-      expect(prompt).toContain('A sturdy blade');
-      expect(prompt).not.toContain('fantasy');
-    });
+  test('normalizes item name and description', () => {
+    const messyItem: Partial<InventoryItem> = {
+      id: 'item-5',
+      name: '  Ancient   Scroll  ',
+      description: '  Old   parchment  ',
+      categoryId: 'documents',
+    };
 
-    test('generates simple prompt for valuables', async () => {
-      const gem: Partial<InventoryItem> = {
-        id: 'item-3',
-        name: 'Ruby',
-        description: 'A precious gemstone',
-        categoryId: 'valuables',
-      };
+    const prompt = buildItemPrompt(messyItem as InventoryItem);
 
-      const prompt = await generator.buildItemPrompt(gem as InventoryItem);
-
-      expect(prompt).toContain('Ruby');
-      expect(prompt).toContain('A precious gemstone');
-    });
-
-    test('does not use genre styling even for sci-fi genre', async () => {
-      const energyCell: Partial<InventoryItem> = {
-        id: 'item-4',
-        name: 'Energy Cell',
-        description: 'Battery pack',
-        categoryId: 'consumables',
-      };
-
-      const prompt = await generator.buildItemPrompt(
-        energyCell as InventoryItem,
-        'sci-fi'
-      );
-
-      expect(prompt).toContain('Energy Cell');
-      expect(prompt).not.toContain('sci-fi');
-    });
-
-    test('includes realistic style directive', async () => {
-      const prompt = await generator.buildItemPrompt(baseItem as InventoryItem);
-
-      expect(prompt).toContain('realistic style');
-    });
-
-    test('includes white background directive', async () => {
-      const prompt = await generator.buildItemPrompt(baseItem as InventoryItem);
-
-      expect(prompt).toContain('white background');
-    });
-
-    test('includes professional photography directives', async () => {
-      const prompt = await generator.buildItemPrompt(baseItem as InventoryItem);
-
-      expect(prompt).toContain('centered');
-      expect(prompt).toContain('professional lighting');
-    });
-
-    test('normalizes item name and description', async () => {
-      const messyItem: Partial<InventoryItem> = {
-        id: 'item-5',
-        name: '  Ancient   Scroll  ',
-        description: '  Old   parchment  ',
-        categoryId: 'documents',
-      };
-
-      const prompt = await generator.buildItemPrompt(messyItem as InventoryItem);
-
-      // Should clean up extra spaces
-      expect(prompt).not.toMatch(/\s{2,}/);
-      expect(prompt).toContain('Ancient Scroll');
-    });
+    expect(prompt).not.toMatch(/\s{2,}/);
+    expect(prompt).toContain('Ancient Scroll');
   });
 });

--- a/src/lib/ai/__tests__/toneSettingsGenerator.test.ts
+++ b/src/lib/ai/__tests__/toneSettingsGenerator.test.ts
@@ -1,8 +1,7 @@
-import { ToneSettingsGenerator, extractWorldAnalysisData, WorldAnalysisData } from '../toneSettingsGenerator';
+import { generateToneSettings, extractWorldAnalysisData, WorldAnalysisData } from '../toneSettingsGenerator';
 import { AIClient, AIResponse } from '../types';
 import { World } from '@/types/world.types';
 
-// Mock the logger
 jest.mock('@/lib/utils/logger', () => ({
   logger: {
     error: jest.fn(),
@@ -11,16 +10,14 @@ jest.mock('@/lib/utils/logger', () => ({
   }
 }));
 
-describe('ToneSettingsGenerator', () => {
+describe('generateToneSettings', () => {
   let mockClient: jest.Mocked<AIClient>;
-  let generator: ToneSettingsGenerator;
 
   beforeEach(() => {
     mockClient = {
       generateContent: jest.fn(),
       generateImage: jest.fn()
     };
-    generator = new ToneSettingsGenerator(mockClient);
   });
 
   describe('generateToneSettings', () => {
@@ -45,7 +42,7 @@ describe('ToneSettingsGenerator', () => {
 
       mockClient.generateContent.mockResolvedValueOnce(mockResponse);
 
-      const result = await generator.generateToneSettings(sampleWorldData);
+      const result = await generateToneSettings(mockClient, sampleWorldData);
 
       expect(result).toEqual({
         contentRating: 'R',
@@ -67,7 +64,7 @@ describe('ToneSettingsGenerator', () => {
 
       mockClient.generateContent.mockResolvedValueOnce(mockResponse);
 
-      const result = await generator.generateToneSettings(sampleWorldData);
+      const result = await generateToneSettings(mockClient, sampleWorldData);
 
       expect(result.contentRating).toBe('PG-13');
       expect(result.narrativeStyle).toBe('action-packed');
@@ -77,14 +74,14 @@ describe('ToneSettingsGenerator', () => {
     it('should throw specific error for rate limiting', async () => {
       mockClient.generateContent.mockRejectedValueOnce(new Error('rate limit exceeded - 429'));
 
-      await expect(generator.generateToneSettings(sampleWorldData))
+      await expect(generateToneSettings(mockClient, sampleWorldData))
         .rejects.toThrow('AI service is currently busy. Please try again in a moment.');
     });
 
     it('should throw specific error for network issues', async () => {
       mockClient.generateContent.mockRejectedValueOnce(new Error('network timeout occurred'));
 
-      await expect(generator.generateToneSettings(sampleWorldData))
+      await expect(generateToneSettings(mockClient, sampleWorldData))
         .rejects.toThrow('Network error occurred. Please check your connection and try again.');
     });
 
@@ -96,7 +93,7 @@ describe('ToneSettingsGenerator', () => {
 
       mockClient.generateContent.mockResolvedValueOnce(mockResponse);
 
-      await expect(generator.generateToneSettings(sampleWorldData))
+      await expect(generateToneSettings(mockClient, sampleWorldData))
         .rejects.toThrow('AI response was invalid. Please try generating again.');
     });
 
@@ -108,7 +105,7 @@ describe('ToneSettingsGenerator', () => {
 
       mockClient.generateContent.mockResolvedValueOnce(mockResponse);
 
-      await expect(generator.generateToneSettings(sampleWorldData))
+      await expect(generateToneSettings(mockClient, sampleWorldData))
         .rejects.toThrow('AI service returned empty response');
     });
 
@@ -125,7 +122,7 @@ describe('ToneSettingsGenerator', () => {
 
       mockClient.generateContent.mockResolvedValueOnce(mockResponse);
 
-      await expect(generator.generateToneSettings(sampleWorldData))
+      await expect(generateToneSettings(mockClient, sampleWorldData))
         .rejects.toThrow('Invalid content rating: INVALID');
     });
 
@@ -142,7 +139,7 @@ describe('ToneSettingsGenerator', () => {
 
       mockClient.generateContent.mockResolvedValueOnce(mockResponse);
 
-      await expect(generator.generateToneSettings(sampleWorldData))
+      await expect(generateToneSettings(mockClient, sampleWorldData))
         .rejects.toThrow('Invalid narrative style: invalid-style');
     });
 
@@ -158,7 +155,7 @@ describe('ToneSettingsGenerator', () => {
 
       mockClient.generateContent.mockResolvedValueOnce(mockResponse);
 
-      await expect(generator.generateToneSettings(sampleWorldData))
+      await expect(generateToneSettings(mockClient, sampleWorldData))
         .rejects.toThrow('Missing or invalid reasoning in response');
     });
 
@@ -175,7 +172,7 @@ describe('ToneSettingsGenerator', () => {
 
       mockClient.generateContent.mockResolvedValueOnce(mockResponse);
 
-      await generator.generateToneSettings(sampleWorldData);
+      await generateToneSettings(mockClient, sampleWorldData);
 
       const calledPrompt = mockClient.generateContent.mock.calls[0][0];
       expect(calledPrompt).toContain('Name: Cyberpunk City');
@@ -204,7 +201,7 @@ describe('ToneSettingsGenerator', () => {
 
       mockClient.generateContent.mockResolvedValueOnce(mockResponse);
 
-      const result = await generator.generateToneSettings(worldDataWithoutRef);
+      const result = await generateToneSettings(mockClient, worldDataWithoutRef);
 
       expect(result.narrativeStyle).toBe('epic');
       const calledPrompt = mockClient.generateContent.mock.calls[0][0];

--- a/src/lib/ai/itemImageGenerator.ts
+++ b/src/lib/ai/itemImageGenerator.ts
@@ -1,52 +1,23 @@
-// src/lib/ai/itemImageGenerator.ts
-
 import type { InventoryItem } from '@/types/inventory.types';
 import { normalizeText, NORM_NAME, NORM_DESC } from '@/lib/utils/textNormalization';
 
 /**
- * Generates optimized prompts for AI image generation of inventory items.
- *
- * Creates "product photography" style prompts with realistic constraints.
+ * Build a "product photography" prompt for AI image generation of an inventory item.
  * Uses simple, direct descriptions to avoid fantasy interpretation.
  */
-export class ItemImageGenerator {
-  /**
-   * Build an image generation prompt for an inventory item.
-   *
-   * @param item - The inventory item to generate an image for
-   * @param genre - Optional world genre (unused, kept for API compatibility)
-   * @returns Optimized prompt string for image generation
-   */
-  async buildItemPrompt(
-    item: InventoryItem,
-    genre?: string
-  ): Promise<string> {
-    void genre;
-    const parts: string[] = [];
+export function buildItemPrompt(item: InventoryItem): string {
+  const itemName = normalizeText(item.name, NORM_NAME);
+  const itemDesc = item.description
+    ? normalizeText(item.description, NORM_DESC)
+    : '';
 
-    // Normalize and clean item data
-    const itemName = normalizeText(item.name, NORM_NAME);
-    const itemDesc = item.description
-      ? normalizeText(item.description, NORM_DESC)
-      : '';
+  const parts: string[] = ['Product photography', itemName];
 
-    // Build the prompt - simple and direct
-    parts.push('Product photography');
-    parts.push(itemName);
-
-    // Use description only if it adds clarity
-    if (itemDesc && itemDesc.length < 50) {
-      parts.push(itemDesc);
-    }
-
-    // Realistic constraint to prevent fantasy interpretation
-    parts.push('realistic style');
-    parts.push('white background');
-    parts.push('centered');
-    parts.push('clear details');
-    parts.push('professional lighting');
-
-    return parts.join(', ');
+  if (itemDesc && itemDesc.length < 50) {
+    parts.push(itemDesc);
   }
 
+  parts.push('realistic style', 'white background', 'centered', 'clear details', 'professional lighting');
+
+  return parts.join(', ');
 }

--- a/src/lib/ai/toneSettingsGenerator.ts
+++ b/src/lib/ai/toneSettingsGenerator.ts
@@ -3,9 +3,6 @@ import { ContentRating, NarrativeStyle, LanguageComplexity } from '@/types/tone-
 import { World } from '@/types/world.types';
 import { logger } from '@/lib/utils/logger';
 
-/**
- * World data subset used for tone analysis
- */
 export interface WorldAnalysisData {
   name: string;
   description: string;
@@ -14,9 +11,6 @@ export interface WorldAnalysisData {
   relationship?: 'set_within' | 'inspired_by';
 }
 
-/**
- * Result of AI tone settings analysis
- */
 export interface ToneAnalysisResult {
   contentRating: ContentRating;
   narrativeStyle: NarrativeStyle;
@@ -24,58 +18,15 @@ export interface ToneAnalysisResult {
   reasoning: string;
 }
 
-/**
- * Service for AI-generated tone settings based on world analysis
- */
-export class ToneSettingsGenerator {
-  constructor(private client: AIClient) {}
+const VALID_CONTENT_RATINGS: ContentRating[] = ['G', 'PG', 'PG-13', 'R', 'NC-17'];
+const VALID_NARRATIVE_STYLES: NarrativeStyle[] = [
+  'serious', 'humorous', 'dramatic', 'lighthearted', 'mysterious',
+  'action-packed', 'contemplative', 'epic', 'balanced'
+];
+const VALID_LANGUAGE_COMPLEXITIES: LanguageComplexity[] = ['simple', 'moderate', 'advanced', 'literary'];
 
-  /**
-   * Analyze world data and generate appropriate tone settings
-   */
-  async generateToneSettings(worldData: WorldAnalysisData): Promise<ToneAnalysisResult> {
-    const prompt = this.buildAnalysisPrompt(worldData);
-
-    try {
-      const response = await this.client.generateContent(prompt);
-
-      if (!response.content) {
-        throw new Error('AI service returned empty response');
-      }
-
-      return this.parseResponse(response.content);
-    } catch (error) {
-      if (error instanceof Error) {
-        logger.error('Failed to generate AI tone settings:', {
-          message: error.message,
-          worldData: { name: worldData.name, genre: worldData.genre }
-        });
-
-        // Provide more specific error messages based on error type
-        if (error.message.includes('rate limit') || error.message.includes('429')) {
-          throw new Error('AI service is currently busy. Please try again in a moment.');
-        } else if (error.message.includes('network') || error.message.includes('timeout')) {
-          throw new Error('Network error occurred. Please check your connection and try again.');
-        } else if (error.message.includes('No JSON found') || error.message.includes('Unable to parse')) {
-          throw new Error('AI response was invalid. Please try generating again.');
-        } else if (error.message.startsWith('Invalid ') || error.message.startsWith('Missing ') || error.message.includes('empty response')) {
-          // Re-throw validation errors and empty response errors as-is
-          throw error;
-        } else {
-          throw new Error('Unable to generate tone settings. Please try again or set them manually.');
-        }
-      } else {
-        logger.error('Unknown error generating AI tone settings:', error);
-        throw new Error('An unexpected error occurred. Please try again.');
-      }
-    }
-  }
-
-  /**
-   * Build the prompt for tone analysis
-   */
-  private buildAnalysisPrompt(worldData: WorldAnalysisData): string {
-    return `Analyze this fictional world and recommend appropriate tone settings for AI-generated narrative content.
+function buildAnalysisPrompt(worldData: WorldAnalysisData): string {
+  return `Analyze this fictional world and recommend appropriate tone settings for AI-generated narrative content.
 
 WORLD INFORMATION:
 Name: ${worldData.name}
@@ -122,88 +73,103 @@ Return your analysis in this exact JSON format:
 }
 
 Consider the world's genre conventions, target audience, thematic content, and the type of narrative experience that would best serve this setting. Your reasoning should be 2-3 sentences explaining why these specific settings match the world.`;
+}
+
+function validateParsedResponse(parsed: unknown): void {
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('Response must be an object');
   }
 
-  /**
-   * Parse AI response into structured tone settings
-   */
-  private parseResponse(content: string): ToneAnalysisResult {
-    try {
-      // Handle empty response
-      if (!content || content.trim() === '') {
-        throw new Error('AI service returned empty response');
-      }
+  const response = parsed as Record<string, unknown>;
 
-      // Extract JSON from response (handle cases where AI adds extra text)
-      const jsonMatch = content.match(/\{[\s\S]*\}/);
-      if (!jsonMatch) {
-        throw new Error('No JSON found in AI response');
-      }
+  if (!VALID_CONTENT_RATINGS.includes(response.contentRating as ContentRating)) {
+    throw new Error(`Invalid content rating: ${response.contentRating}`);
+  }
 
-      const parsed = JSON.parse(jsonMatch[0]);
+  if (!VALID_NARRATIVE_STYLES.includes(response.narrativeStyle as NarrativeStyle)) {
+    throw new Error(`Invalid narrative style: ${response.narrativeStyle}`);
+  }
 
-      // Validate the response structure
-      this.validateParsedResponse(parsed);
+  if (!VALID_LANGUAGE_COMPLEXITIES.includes(response.languageComplexity as LanguageComplexity)) {
+    throw new Error(`Invalid language complexity: ${response.languageComplexity}`);
+  }
 
-      return {
-        contentRating: parsed.contentRating as ContentRating,
-        narrativeStyle: parsed.narrativeStyle as NarrativeStyle,
-        languageComplexity: parsed.languageComplexity as LanguageComplexity,
-        reasoning: parsed.reasoning
-      };
-    } catch (error) {
-      // Re-throw validation errors and empty response errors as-is
-      if (error instanceof Error && (
-        error.message.startsWith('Invalid ') ||
-        error.message.startsWith('Missing ') ||
-        error.message.includes('empty response')
-      )) {
+  if (!response.reasoning || typeof response.reasoning !== 'string') {
+    throw new Error('Missing or invalid reasoning in response');
+  }
+}
+
+function parseResponse(content: string): ToneAnalysisResult {
+  try {
+    if (!content || content.trim() === '') {
+      throw new Error('AI service returned empty response');
+    }
+
+    const jsonMatch = content.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) {
+      throw new Error('No JSON found in AI response');
+    }
+
+    const parsed = JSON.parse(jsonMatch[0]);
+    validateParsedResponse(parsed);
+
+    return {
+      contentRating: parsed.contentRating as ContentRating,
+      narrativeStyle: parsed.narrativeStyle as NarrativeStyle,
+      languageComplexity: parsed.languageComplexity as LanguageComplexity,
+      reasoning: parsed.reasoning
+    };
+  } catch (error) {
+    if (error instanceof Error && (
+      error.message.startsWith('Invalid ') ||
+      error.message.startsWith('Missing ') ||
+      error.message.includes('empty response')
+    )) {
+      throw error;
+    }
+
+    logger.error('Failed to parse AI tone settings response:', error);
+    throw new Error('Unable to parse AI response. Please try again.');
+  }
+}
+
+export async function generateToneSettings(
+  client: AIClient,
+  worldData: WorldAnalysisData
+): Promise<ToneAnalysisResult> {
+  try {
+    const response = await client.generateContent(buildAnalysisPrompt(worldData));
+
+    if (!response.content) {
+      throw new Error('AI service returned empty response');
+    }
+
+    return parseResponse(response.content);
+  } catch (error) {
+    if (error instanceof Error) {
+      logger.error('Failed to generate AI tone settings:', {
+        message: error.message,
+        worldData: { name: worldData.name, genre: worldData.genre }
+      });
+
+      if (error.message.includes('rate limit') || error.message.includes('429')) {
+        throw new Error('AI service is currently busy. Please try again in a moment.');
+      } else if (error.message.includes('network') || error.message.includes('timeout')) {
+        throw new Error('Network error occurred. Please check your connection and try again.');
+      } else if (error.message.includes('No JSON found') || error.message.includes('Unable to parse')) {
+        throw new Error('AI response was invalid. Please try generating again.');
+      } else if (error.message.startsWith('Invalid ') || error.message.startsWith('Missing ') || error.message.includes('empty response')) {
         throw error;
+      } else {
+        throw new Error('Unable to generate tone settings. Please try again or set them manually.');
       }
-
-      logger.error('Failed to parse AI tone settings response:', error);
-      throw new Error('Unable to parse AI response. Please try again.');
-    }
-  }
-
-  /**
-   * Validate that parsed response contains valid values
-   */
-  private validateParsedResponse(parsed: unknown): void {
-    if (!parsed || typeof parsed !== 'object') {
-      throw new Error('Response must be an object');
-    }
-
-    const response = parsed as Record<string, unknown>;
-
-    const validContentRatings: ContentRating[] = ['G', 'PG', 'PG-13', 'R', 'NC-17'];
-    const validNarrativeStyles: NarrativeStyle[] = [
-      'serious', 'humorous', 'dramatic', 'lighthearted', 'mysterious',
-      'action-packed', 'contemplative', 'epic', 'balanced'
-    ];
-    const validLanguageComplexities: LanguageComplexity[] = ['simple', 'moderate', 'advanced', 'literary'];
-
-    if (!validContentRatings.includes(response.contentRating as ContentRating)) {
-      throw new Error(`Invalid content rating: ${response.contentRating}`);
-    }
-
-    if (!validNarrativeStyles.includes(response.narrativeStyle as NarrativeStyle)) {
-      throw new Error(`Invalid narrative style: ${response.narrativeStyle}`);
-    }
-
-    if (!validLanguageComplexities.includes(response.languageComplexity as LanguageComplexity)) {
-      throw new Error(`Invalid language complexity: ${response.languageComplexity}`);
-    }
-
-    if (!response.reasoning || typeof response.reasoning !== 'string') {
-      throw new Error('Missing or invalid reasoning in response');
+    } else {
+      logger.error('Unknown error generating AI tone settings:', error);
+      throw new Error('An unexpected error occurred. Please try again.');
     }
   }
 }
 
-/**
- * Extract world analysis data from a full World object
- */
 export function extractWorldAnalysisData(world: Partial<World>): WorldAnalysisData {
   if (!world.name || !world.description || !world.genre) {
     throw new Error('World must have name, description, and genre for tone analysis');

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -10,7 +10,7 @@ const isEnabled = (value: string | undefined): boolean => value === 'true';
 
 export const getFeatureFlags = (): Record<FeatureFlag, boolean> => ({
   BUFFERED_STREAMING: isEnabled(process.env.NEXT_PUBLIC_FEATURE_BUFFERED_STREAMING),
-  PROGRESSIVE_DISCLOSURE: process.env.NEXT_PUBLIC_FEATURE_PROGRESSIVE_DISCLOSURE === 'false' ? false : true,
+  PROGRESSIVE_DISCLOSURE: process.env.NEXT_PUBLIC_FEATURE_PROGRESSIVE_DISCLOSURE !== 'false',
   VIRTUALIZATION: isEnabled(process.env.NEXT_PUBLIC_FEATURE_VIRTUALIZATION),
 });
 

--- a/src/lib/services/__tests__/autoSaveService.test.ts
+++ b/src/lib/services/__tests__/autoSaveService.test.ts
@@ -1,9 +1,9 @@
 /**
- * Tests for AutoSaveService - TDD Implementation
+ * Tests for createAutoSave - TDD Implementation
  * Starting with basic functionality tests
  */
 
-import { AutoSaveService } from '../autoSaveService';
+import { createAutoSave, AutoSave } from '../autoSaveService';
 
 // Mock the persistence module
 jest.mock('@/state/persistence', () => ({
@@ -14,8 +14,8 @@ jest.mock('@/state/persistence', () => ({
   })
 }));
 
-describe('AutoSaveService', () => {
-  let service: AutoSaveService;
+describe('createAutoSave', () => {
+  let service: AutoSave;
   let mockStateProvider: jest.Mock;
 
   beforeEach(() => {
@@ -27,7 +27,7 @@ describe('AutoSaveService', () => {
       world: { id: 'world-1', name: 'Test World' },
     });
     
-    service = new AutoSaveService(mockStateProvider);
+    service = createAutoSave(mockStateProvider);
   });
 
   afterEach(() => {
@@ -52,7 +52,7 @@ describe('AutoSaveService', () => {
   describe('Event-Based Auto-Save', () => {
     it('should save immediately when triggered manually', async () => {
       const mockOnSave = jest.fn();
-      service = new AutoSaveService(mockStateProvider, { onSave: mockOnSave });
+      service = createAutoSave(mockStateProvider, { onSave: mockOnSave });
       
       service.start();
       await service.triggerSave('manual'); // Manual saves are immediate

--- a/src/lib/services/__tests__/worldCreationService.toneSettings.test.ts
+++ b/src/lib/services/__tests__/worldCreationService.toneSettings.test.ts
@@ -13,7 +13,7 @@ jest.mock('@/lib/utils/logger');
 import { useWorldStore } from '@/state/worldStore';
 import { generateUniqueId } from '@/lib/utils/generateId';
 import {
-  ToneSettingsGenerator,
+  generateToneSettings,
   extractWorldAnalysisData,
 } from '@/lib/ai/toneSettingsGenerator';
 import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
@@ -24,8 +24,8 @@ const mockUseWorldStore = useWorldStore as jest.MockedFunction<
 const mockGenerateUniqueId = generateUniqueId as jest.MockedFunction<
   typeof generateUniqueId
 >;
-const mockToneSettingsGenerator = ToneSettingsGenerator as jest.MockedClass<
-  typeof ToneSettingsGenerator
+const mockGenerateToneSettings = generateToneSettings as jest.MockedFunction<
+  typeof generateToneSettings
 >;
 const mockCreateDefaultGeminiClient =
   createDefaultGeminiClient as jest.MockedFunction<
@@ -43,7 +43,6 @@ describe('worldCreationService - AI Tone Settings Integration', () => {
     worlds: Record<string, unknown>;
   };
   let mockClient: ReturnType<typeof createDefaultGeminiClient>;
-  let mockGenerator: jest.Mocked<ToneSettingsGenerator>;
 
   beforeEach(() => {
     // Setup mock store
@@ -79,16 +78,11 @@ describe('worldCreationService - AI Tone Settings Integration', () => {
     mockUseWorldStore.mockReturnValue(mockStore);
     mockUseWorldStore.getState = jest.fn().mockReturnValue(mockStore);
 
-    // Setup mock AI client and generator
+    // Setup mock AI client
     mockClient = { generateContent: jest.fn() } as unknown as ReturnType<
       typeof createDefaultGeminiClient
     >;
     mockCreateDefaultGeminiClient.mockReturnValue(mockClient);
-
-    mockGenerator = {
-      generateToneSettings: jest.fn(),
-    } as unknown as jest.Mocked<ToneSettingsGenerator>;
-    mockToneSettingsGenerator.mockImplementation(() => mockGenerator);
 
     // Mock the extractWorldAnalysisData function
     mockExtractWorldAnalysisData.mockImplementation((worldData) => ({
@@ -155,7 +149,7 @@ describe('worldCreationService - AI Tone Settings Integration', () => {
           'Cyberpunk themes require mature content and dramatic storytelling',
       };
 
-      mockGenerator.generateToneSettings.mockResolvedValueOnce(
+      mockGenerateToneSettings.mockResolvedValueOnce(
         mockToneSettings
       );
 
@@ -164,8 +158,7 @@ describe('worldCreationService - AI Tone Settings Integration', () => {
       });
 
       // Verify AI tone generator was called with correct data
-      expect(mockToneSettingsGenerator).toHaveBeenCalledWith(mockClient);
-      expect(mockGenerator.generateToneSettings).toHaveBeenCalledWith({
+      expect(mockGenerateToneSettings).toHaveBeenCalledWith(mockClient, {
         name: 'Cyberpunk Metropolis',
         description: 'A dark future city where technology dominates human life',
         genre: 'sci-fi',
@@ -193,7 +186,7 @@ describe('worldCreationService - AI Tone Settings Integration', () => {
 
     it('should fall back to default tone settings if AI generation fails', async () => {
       // Mock AI tone generation failure
-      mockGenerator.generateToneSettings.mockRejectedValueOnce(
+      mockGenerateToneSettings.mockRejectedValueOnce(
         new Error('AI service unavailable')
       );
 
@@ -225,7 +218,7 @@ describe('worldCreationService - AI Tone Settings Integration', () => {
         reasoning: 'Dystopian themes with mystery elements',
       };
 
-      mockGenerator.generateToneSettings.mockResolvedValueOnce(
+      mockGenerateToneSettings.mockResolvedValueOnce(
         mockToneSettings
       );
 
@@ -235,7 +228,7 @@ describe('worldCreationService - AI Tone Settings Integration', () => {
       });
 
       // Verify AI was called with customized data
-      expect(mockGenerator.generateToneSettings).toHaveBeenCalledWith({
+      expect(mockGenerateToneSettings).toHaveBeenCalledWith(mockClient, {
         name: 'Custom Cyber City',
         description: 'My custom cyberpunk world',
         genre: 'cyberpunk',

--- a/src/lib/services/autoSaveService.ts
+++ b/src/lib/services/autoSaveService.ts
@@ -1,11 +1,10 @@
 /**
- * AutoSaveService - Manages automatic saving of game state
- * Integrates with IndexedDB for persistent storage
+ * Auto-save factory — manages periodic and event-based saving of game state to IndexedDB.
  */
 
 import { createIndexedDBStorage } from '@/state/persistence';
 import { getUserFriendlyError, isRetryableError } from '@/lib/utils/errorUtils';
-import { debounce, type DebouncedFunction } from '@/lib/utils/debounce';
+import { debounce } from '@/lib/utils/debounce';
 import Logger from '@/lib/utils/logger';
 
 export type GameState = {
@@ -42,132 +41,55 @@ export type AutoSaveOptions = {
   debounceMs?: number;
 };
 
-/**
- * AutoSaveService handles periodic and event-based auto-saving
- */
-export class AutoSaveService {
-  private stateProvider: StateProvider;
-  private intervalId: NodeJS.Timeout | null = null;
-  private isServiceRunning = false;
-  private readonly intervalMs = 5 * 60 * 1000; // 5 minutes
-  private options: AutoSaveOptions;
-  private storage = createIndexedDBStorage();
-  private debouncedSave: DebouncedFunction<(reason: SaveTriggerReason) => Promise<void>> | null = null;
-  private readonly debounceMs: number;
-  private logger: Logger;
-  private retryCount = new Map<string, number>();
-  private readonly maxRetries = 3;
+export interface AutoSave {
+  start(): void;
+  stop(): void;
+  isRunning(): boolean;
+  triggerSave(reason: SaveTriggerReason): Promise<void>;
+}
 
-  constructor(stateProvider: StateProvider, options: AutoSaveOptions = {}) {
-    this.stateProvider = stateProvider;
-    this.options = options;
-    this.debounceMs = options.debounceMs ?? 500; // Default 500ms debounce
-    this.logger = new Logger('AutoSaveService');
-    
-    // Create debounced save function
-    this.debouncedSave = debounce(this.performAutoSave.bind(this), this.debounceMs);
-  }
+const INTERVAL_MS = 5 * 60 * 1000;
+const MAX_RETRIES = 3;
+const DEFAULT_DEBOUNCE_MS = 500;
 
-  /**
-   * Start the auto-save service
-   */
-  start(): void {
-    if (this.isServiceRunning) {
-      this.logger.warn('Auto-save service is already running');
-      return;
-    }
+function nextRetryDelayMs(attempt: number): number {
+  return Math.pow(2, attempt) * 1000;
+}
 
-    this.isServiceRunning = true;
-    this.intervalId = setInterval(() => {
-      this.performAutoSave('periodic');
-    }, this.intervalMs);
+function shouldSkipForInactiveSession(state: GameState, reason: SaveTriggerReason): boolean {
+  return state.session.status !== 'active' && reason !== 'manual';
+}
 
-    // Run an immediate save so the first interval isn't delayed for users
-    this.performAutoSave('periodic').catch(error => {
-      this.logger.error('Initial auto-save failed:', error);
-    });
-  }
+function wrapErrorForCaller(error: Error) {
+  const userFriendlyError = getUserFriendlyError(error);
+  const enhanced = new Error(userFriendlyError.message) as Error & {
+    retryable: boolean;
+    userFriendlyError: typeof userFriendlyError;
+  };
+  enhanced.retryable = userFriendlyError.retryable;
+  enhanced.userFriendlyError = userFriendlyError;
+  return { enhanced, userFriendlyError };
+}
 
-  /**
-   * Stop the auto-save service
-   */
-  stop(): void {
-    
-    if (this.intervalId) {
-      clearInterval(this.intervalId);
-      this.intervalId = null;
-    }
-    
-    if (this.debouncedSave) {
-      this.debouncedSave.cancel();
-    }
-    
-    this.retryCount.clear();
-    this.isServiceRunning = false;
-  }
+export function createAutoSave(
+  stateProvider: StateProvider,
+  options: AutoSaveOptions = {}
+): AutoSave {
+  const debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+  const logger = new Logger('AutoSaveService');
+  const storage = createIndexedDBStorage();
+  const retryCount = new Map<string, number>();
 
-  /**
-   * Check if the service is currently running
-   */
-  isRunning(): boolean {
-    return this.isServiceRunning;
-  }
+  let intervalId: NodeJS.Timeout | null = null;
+  let running = false;
 
-  /**
-   * Trigger a save with debouncing for performance
-   */
-  async triggerSave(reason: SaveTriggerReason): Promise<void> {
-    // For manual saves, execute immediately
-    if (reason === 'manual') {
-      return this.performAutoSave(reason);
-    }
-
-    // For other triggers, use shared debouncing utility
-    if (this.debouncedSave) {
-      return this.debouncedSave(reason);
-    }
-    
-    // Fallback to immediate execution if debounce not available
-    return this.performAutoSave(reason);
-  }
-
-  /**
-   * Perform auto-save operation with retry logic
-   */
-  private async performAutoSave(reason: SaveTriggerReason): Promise<void> {
-    const operationId = `${reason}-${Date.now()}`;
-    const startTime = Date.now();
-    
-    try {
-      this.options.onSaveStart?.(reason);
-      const gameState = await this.stateProvider();
-      
-      // Only save if session is active (or if it's a manual save)
-      if (gameState.session.status === 'active' || reason === 'manual') {
-        await this.performSaveWithRetry(gameState, reason, startTime, operationId);
-      } else {
-        this.logger.debug('Skipping save - session not active:', gameState.session.status);
-        this.options.onSave?.({
-          success: false,
-          timestamp: new Date(),
-          reason,
-        });
-      }
-    } catch (error) {
-      await this.handleSaveError(error as Error, reason, operationId);
-    }
-  }
-
-  /**
-   * Perform save operation with automatic retry logic
-   */
-  private async performSaveWithRetry(
-    gameState: GameState, 
-    reason: SaveTriggerReason, 
+  async function performSaveWithRetry(
+    gameState: GameState,
+    reason: SaveTriggerReason,
     startTime: number,
     operationId: string
   ): Promise<void> {
-    const currentRetry = this.retryCount.get(operationId) ?? 0;
+    const currentRetry = retryCount.get(operationId) ?? 0;
 
     try {
       const endTime = Date.now();
@@ -175,78 +97,111 @@ export class AutoSaveService {
       const gameStateStr = JSON.stringify(gameState);
       const size = gameStateStr.length;
 
-
-      // Save game state to IndexedDB
       const saveKey = `auto-save-${gameState.session.id}-${Date.now()}`;
+      await storage.setItem(saveKey, { state: gameState, version: 1 });
 
-      await this.storage.setItem(saveKey, {
-        state: gameState,
-        version: 1,
-      });
-      
-      // Clear retry count on success
-      this.retryCount.delete(operationId);
-      
-      const result: SaveResult = {
+      retryCount.delete(operationId);
+      options.onSave?.({
         success: true,
         timestamp: new Date(endTime),
         reason,
         size,
-        duration
-      };
-      
-      
-      if (this.options.onSave) {
-        this.options.onSave(result);
-      }
+        duration,
+      });
     } catch (error) {
       const errorInstance = error as Error;
       const userFriendlyError = getUserFriendlyError(errorInstance);
-      
-      if (isRetryableError(errorInstance) && currentRetry < this.maxRetries) {
-        this.retryCount.set(operationId, currentRetry + 1);
-        this.logger.warn('Retrying save operation:', { 
-          attempt: currentRetry + 1, 
-          maxRetries: this.maxRetries,
-          error: errorInstance.message 
+
+      if (isRetryableError(errorInstance) && currentRetry < MAX_RETRIES) {
+        retryCount.set(operationId, currentRetry + 1);
+        logger.warn('Retrying save operation:', {
+          attempt: currentRetry + 1,
+          maxRetries: MAX_RETRIES,
+          error: errorInstance.message,
         });
-        
-        // Exponential backoff: 1s, 2s, 4s
-        const retryDelay = Math.pow(2, currentRetry) * 1000;
         setTimeout(() => {
-          this.performSaveWithRetry(gameState, reason, startTime, operationId);
-        }, retryDelay);
+          performSaveWithRetry(gameState, reason, startTime, operationId);
+        }, nextRetryDelayMs(currentRetry));
       } else {
-        // Max retries exceeded or non-retryable error
-        this.retryCount.delete(operationId);
+        retryCount.delete(operationId);
         throw new Error(`Save failed after ${currentRetry} retries: ${userFriendlyError.message}`);
       }
     }
   }
 
-  /**
-   * Handle save errors with user-friendly messaging
-   */
-  private async handleSaveError(error: Error, reason: SaveTriggerReason, operationId: string): Promise<void> {
-    const userFriendlyError = getUserFriendlyError(error);
-    
-    this.logger.error('Auto-save failed:', { 
-      reason, 
+  async function handleSaveError(error: Error, reason: SaveTriggerReason, operationId: string): Promise<void> {
+    const { enhanced, userFriendlyError } = wrapErrorForCaller(error);
+    logger.error('Auto-save failed:', {
+      reason,
       operationId,
       error: error.message,
-      userFriendlyMessage: userFriendlyError.message
+      userFriendlyMessage: userFriendlyError.message,
     });
-    
-    if (this.options.onError) {
-      // Enhance error with user-friendly information
-      const enhancedError = new Error(userFriendlyError.message) as Error & {
-        retryable: boolean;
-        userFriendlyError: typeof userFriendlyError;
-      };
-      enhancedError.retryable = userFriendlyError.retryable;
-      enhancedError.userFriendlyError = userFriendlyError;
-      
-      this.options.onError(enhancedError);
+    options.onError?.(enhanced);
+  }
+
+  async function performAutoSave(reason: SaveTriggerReason): Promise<void> {
+    const operationId = `${reason}-${Date.now()}`;
+    const startTime = Date.now();
+
+    try {
+      options.onSaveStart?.(reason);
+      const gameState = await stateProvider();
+
+      if (shouldSkipForInactiveSession(gameState, reason)) {
+        logger.debug('Skipping save - session not active:', gameState.session.status);
+        options.onSave?.({
+          success: false,
+          timestamp: new Date(),
+          reason,
+        });
+        return;
+      }
+
+      await performSaveWithRetry(gameState, reason, startTime, operationId);
+    } catch (error) {
+      await handleSaveError(error as Error, reason, operationId);
     }
   }
+
+  const debouncedSave = debounce(performAutoSave, debounceMs);
+
+  return {
+    start(): void {
+      if (running) {
+        logger.warn('Auto-save service is already running');
+        return;
+      }
+      running = true;
+      intervalId = setInterval(() => {
+        performAutoSave('periodic');
+      }, INTERVAL_MS);
+
+      // Run an immediate save so the first interval isn't delayed for users
+      performAutoSave('periodic').catch(error => {
+        logger.error('Initial auto-save failed:', error);
+      });
+    },
+
+    stop(): void {
+      if (intervalId) {
+        clearInterval(intervalId);
+        intervalId = null;
+      }
+      debouncedSave.cancel();
+      retryCount.clear();
+      running = false;
+    },
+
+    isRunning(): boolean {
+      return running;
+    },
+
+    async triggerSave(reason: SaveTriggerReason): Promise<void> {
+      if (reason === 'manual') {
+        return performAutoSave(reason);
+      }
+      return debouncedSave(reason);
+    },
+  };
 }

--- a/src/lib/services/worldCreationService.ts
+++ b/src/lib/services/worldCreationService.ts
@@ -6,7 +6,7 @@ import { GeneratedWorldData } from '@/lib/generators/worldGenerator';
 import { World, WorldAttribute, WorldSkill } from '@/types/world.types';
 import { DEFAULT_TONE_SETTINGS, ToneSettings } from '@/types/tone-settings.types';
 import { worldApi, WorldImageParams } from '@/lib/api/worldApi';
-import { ToneSettingsGenerator, extractWorldAnalysisData } from '@/lib/ai/toneSettingsGenerator';
+import { generateToneSettings, extractWorldAnalysisData } from '@/lib/ai/toneSettingsGenerator';
 import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
 import { logger } from '@/lib/utils/logger';
 import { npcPortraitService } from './npcPortraitService';
@@ -126,10 +126,9 @@ Every NPC must fit this world snugly. IDs must be unique, lowercase, kebab-case 
 async function generateAIToneSettings(worldData: Partial<World>): Promise<ToneSettings> {
   try {
     const client = createDefaultGeminiClient();
-    const generator = new ToneSettingsGenerator(client);
     const analysisData = extractWorldAnalysisData(worldData);
 
-    const result = await generator.generateToneSettings(analysisData);
+    const result = await generateToneSettings(client, analysisData);
 
     logger.info('AI tone settings generated:', {
       contentRating: result.contentRating,

--- a/src/lib/utils/__tests__/wizardValidation.test.ts
+++ b/src/lib/utils/__tests__/wizardValidation.test.ts
@@ -1,7 +1,8 @@
-import { 
-  WizardStepValidator, 
-  createValidationRules, 
-  createWizardValidator
+import {
+  validateFields,
+  combineValidators,
+  alwaysValid,
+  createValidationRules,
 } from '../wizardValidation';
 
 interface TestFormData {
@@ -12,262 +13,140 @@ interface TestFormData {
   isOptional?: boolean;
 }
 
-describe('WizardStepValidator', () => {
-  it('should validate required fields correctly', () => {
-    const validator = new WizardStepValidator<TestFormData>({
-      rules: {
-        name: [createValidationRules.required('Name is required')],
-        email: [createValidationRules.required('Email is required')],
-      },
+describe('validateFields', () => {
+  it('validates required fields', () => {
+    const validator = validateFields<TestFormData>({
+      name: [createValidationRules.required('Name is required')],
+      email: [createValidationRules.required('Email is required')],
     });
 
     const validData = { name: 'John', email: 'john@example.com', age: 30, skills: [] };
-    const result = validator.validate(validData);
+    const result = validator(validData);
     expect(result.valid).toBe(true);
     expect(result.errors).toEqual([]);
 
     const invalidData = { name: '', email: 'john@example.com', age: 30, skills: [] };
-    const invalidResult = validator.validate(invalidData);
+    const invalidResult = validator(invalidData);
     expect(invalidResult.valid).toBe(false);
     expect(invalidResult.errors).toContain('Name is required');
   });
 
-  it('should validate string length rules', () => {
-    const validator = new WizardStepValidator<TestFormData>({
-      rules: {
-        name: [
-          createValidationRules.minLength(2, 'Name must be at least 2 characters'),
-          createValidationRules.maxLength(50, 'Name must be at most 50 characters'),
-        ],
-      },
+  it('validates string length rules', () => {
+    const validator = validateFields<TestFormData>({
+      name: [
+        createValidationRules.minLength(2, 'Name must be at least 2 characters'),
+        createValidationRules.maxLength(50, 'Name must be at most 50 characters'),
+      ],
     });
 
-    const shortNameData = { name: 'J', email: '', age: 0, skills: [] };
-    const shortNameResult = validator.validate(shortNameData);
-    expect(shortNameResult.valid).toBe(false);
-    expect(shortNameResult.errors).toContain('Name must be at least 2 characters');
-
-    const longName = 'A'.repeat(51);
-    const longNameData = { name: longName, email: '', age: 0, skills: [] };
-    const longNameResult = validator.validate(longNameData);
-    expect(longNameResult.valid).toBe(false);
-    expect(longNameResult.errors).toContain('Name must be at most 50 characters');
-
-    const validData = { name: 'John', email: '', age: 0, skills: [] };
-    const validResult = validator.validate(validData);
-    expect(validResult.valid).toBe(true);
+    expect(validator({ name: 'J', email: '', age: 0, skills: [] }).errors)
+      .toContain('Name must be at least 2 characters');
+    expect(validator({ name: 'A'.repeat(51), email: '', age: 0, skills: [] }).errors)
+      .toContain('Name must be at most 50 characters');
+    expect(validator({ name: 'John', email: '', age: 0, skills: [] }).valid).toBe(true);
   });
 
-  it('should validate numeric range rules', () => {
-    const validator = new WizardStepValidator<TestFormData>({
-      rules: {
-        age: [
-          createValidationRules.minValue(18, 'Must be at least 18'),
-          createValidationRules.maxValue(100, 'Must be at most 100'),
-        ],
-      },
+  it('validates numeric range rules', () => {
+    const validator = validateFields<TestFormData>({
+      age: [
+        createValidationRules.minValue(18, 'Must be at least 18'),
+        createValidationRules.maxValue(100, 'Must be at most 100'),
+      ],
     });
 
-    const tooYoungData = { name: '', email: '', age: 16, skills: [] };
-    const tooYoungResult = validator.validate(tooYoungData);
-    expect(tooYoungResult.valid).toBe(false);
-    expect(tooYoungResult.errors).toContain('Must be at least 18');
-
-    const tooOldData = { name: '', email: '', age: 101, skills: [] };
-    const tooOldResult = validator.validate(tooOldData);
-    expect(tooOldResult.valid).toBe(false);
-    expect(tooOldResult.errors).toContain('Must be at most 100');
-
-    const validData = { name: '', email: '', age: 25, skills: [] };
-    const validResult = validator.validate(validData);
-    expect(validResult.valid).toBe(true);
+    expect(validator({ name: '', email: '', age: 16, skills: [] }).errors)
+      .toContain('Must be at least 18');
+    expect(validator({ name: '', email: '', age: 101, skills: [] }).errors)
+      .toContain('Must be at most 100');
+    expect(validator({ name: '', email: '', age: 25, skills: [] }).valid).toBe(true);
   });
 
-  it('should validate pattern rules', () => {
+  it('validates pattern rules', () => {
     const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    const validator = new WizardStepValidator<TestFormData>({
-      rules: {
-        email: [createValidationRules.pattern(emailPattern, 'Invalid email format')],
-      },
+    const validator = validateFields<TestFormData>({
+      email: [createValidationRules.pattern(emailPattern, 'Invalid email format')],
     });
 
-    const invalidEmailData = { name: '', email: 'notanemail', age: 0, skills: [] };
-    const invalidResult = validator.validate(invalidEmailData);
-    expect(invalidResult.valid).toBe(false);
-    expect(invalidResult.errors).toContain('Invalid email format');
-
-    const validEmailData = { name: '', email: 'test@example.com', age: 0, skills: [] };
-    const validResult = validator.validate(validEmailData);
-    expect(validResult.valid).toBe(true);
+    expect(validator({ name: '', email: 'notanemail', age: 0, skills: [] }).errors)
+      .toContain('Invalid email format');
+    expect(validator({ name: '', email: 'test@example.com', age: 0, skills: [] }).valid).toBe(true);
   });
 
-  it('should validate array length rules', () => {
-    const validator = new WizardStepValidator<TestFormData>({
-      rules: {
-        skills: [
-          createValidationRules.arrayMinLength(1, 'At least one skill required'),
-          createValidationRules.arrayMaxLength(5, 'Maximum 5 skills allowed'),
-        ],
-      },
+  it('validates array length rules', () => {
+    const validator = validateFields<TestFormData>({
+      skills: [
+        createValidationRules.arrayMinLength(1, 'At least one skill required'),
+        createValidationRules.arrayMaxLength(5, 'Maximum 5 skills allowed'),
+      ],
     });
 
-    const noSkillsData = { name: '', email: '', age: 0, skills: [] };
-    const noSkillsResult = validator.validate(noSkillsData);
-    expect(noSkillsResult.valid).toBe(false);
-    expect(noSkillsResult.errors).toContain('At least one skill required');
-
-    const tooManySkillsData = { 
-      name: '', 
-      email: '', 
-      age: 0, 
-      skills: ['skill1', 'skill2', 'skill3', 'skill4', 'skill5', 'skill6'] 
-    };
-    const tooManySkillsResult = validator.validate(tooManySkillsData);
-    expect(tooManySkillsResult.valid).toBe(false);
-    expect(tooManySkillsResult.errors).toContain('Maximum 5 skills allowed');
-
-    const validSkillsData = { name: '', email: '', age: 0, skills: ['skill1', 'skill2'] };
-    const validResult = validator.validate(validSkillsData);
-    expect(validResult.valid).toBe(true);
+    expect(validator({ name: '', email: '', age: 0, skills: [] }).errors)
+      .toContain('At least one skill required');
+    expect(validator({
+      name: '', email: '', age: 0,
+      skills: ['s1', 's2', 's3', 's4', 's5', 's6'],
+    }).errors).toContain('Maximum 5 skills allowed');
+    expect(validator({ name: '', email: '', age: 0, skills: ['s1', 's2'] }).valid).toBe(true);
   });
 
-  it('should handle custom validation rules', () => {
-    const validator = new WizardStepValidator<TestFormData>({
-      rules: {
-        name: [
-          createValidationRules.custom(
-            (name: string) => !name.includes('admin'),
-            'Name cannot contain "admin"'
-          ),
-        ],
-      },
+  it('handles custom rules', () => {
+    const validator = validateFields<TestFormData>({
+      name: [
+        createValidationRules.custom(
+          (name: string) => !name.includes('admin'),
+          'Name cannot contain "admin"'
+        ),
+      ],
     });
 
-    const invalidData = { name: 'admin-user', email: '', age: 0, skills: [] };
-    const invalidResult = validator.validate(invalidData);
-    expect(invalidResult.valid).toBe(false);
-    expect(invalidResult.errors).toContain('Name cannot contain "admin"');
-
-    const validData = { name: 'regular-user', email: '', age: 0, skills: [] };
-    const validResult = validator.validate(validData);
-    expect(validResult.valid).toBe(true);
+    expect(validator({ name: 'admin-user', email: '', age: 0, skills: [] }).errors)
+      .toContain('Name cannot contain "admin"');
+    expect(validator({ name: 'regular-user', email: '', age: 0, skills: [] }).valid).toBe(true);
   });
 
-  it('should handle custom validator functions', () => {
-    const validator = new WizardStepValidator<TestFormData>({
-      rules: {},
-      customValidator: (data) => {
-        if (data.age < 18 && data.skills.length > 0) {
-          return {
-            valid: false,
-            errors: ['Minors cannot have skills'],
-            touched: true,
-          };
-        }
-        return { valid: true, errors: [], touched: true };
-      },
+  it('skips empty non-required fields', () => {
+    const validator = validateFields<TestFormData>({
+      name: [createValidationRules.minLength(2, 'Name must be at least 2 characters')],
     });
 
-    const invalidData = { name: '', email: '', age: 16, skills: ['programming'] };
-    const invalidResult = validator.validate(invalidData);
-    expect(invalidResult.valid).toBe(false);
-    expect(invalidResult.errors).toContain('Minors cannot have skills');
-
-    const validData = { name: '', email: '', age: 20, skills: ['programming'] };
-    const validResult = validator.validate(validData);
-    expect(validResult.valid).toBe(true);
-  });
-
-  it('should validate individual fields', () => {
-    const validator = new WizardStepValidator<TestFormData>({
-      rules: {
-        name: [createValidationRules.required('Name is required')],
-        age: [createValidationRules.minValue(18, 'Must be at least 18')],
-      },
-    });
-
-    const nameResult = validator.validateField('name', '');
-    expect(nameResult.valid).toBe(false);
-    expect(nameResult.errors).toContain('Name is required');
-
-    const ageResult = validator.validateField('age', 16);
-    expect(ageResult.valid).toBe(false);
-    expect(ageResult.errors).toContain('Must be at least 18');
-
-    const validNameResult = validator.validateField('name', 'John');
-    expect(validNameResult.valid).toBe(true);
-  });
-
-  it('should skip validation for empty non-required fields', () => {
-    const validator = new WizardStepValidator<TestFormData>({
-      rules: {
-        name: [createValidationRules.minLength(2, 'Name must be at least 2 characters')],
-      },
-    });
-
-    // Empty non-required field should pass
-    const emptyData = { name: '', email: '', age: 0, skills: [] };
-    const result = validator.validate(emptyData);
-    expect(result.valid).toBe(true);
+    expect(validator({ name: '', email: '', age: 0, skills: [] }).valid).toBe(true);
   });
 });
 
-describe('createWizardValidator', () => {
-  it('should create validators using builder pattern', () => {
-    const validator = createWizardValidator<TestFormData>()
-      .field('name')
-        .required('Name is required')
-        .minLength(2, 'Name too short')
-      .field('email')
-        .required('Email is required')
-        .pattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, 'Invalid email')
-      .field('age')
-        .minValue(18, 'Must be 18 or older')
-      .customValidation((data) => ({
-        valid: data.skills.length > 0,
-        errors: data.skills.length === 0 ? ['At least one skill required'] : [],
-        touched: true,
-      }))
-      .build();
+describe('combineValidators', () => {
+  it('concatenates errors from multiple validators', () => {
+    const fieldValidator = validateFields<TestFormData>({
+      name: [createValidationRules.required('Name is required')],
+      email: [createValidationRules.pattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, 'Invalid email')],
+      age: [createValidationRules.minValue(18, 'Must be 18 or older')],
+    });
 
-    const invalidData = { 
-      name: '', 
-      email: 'invalid', 
-      age: 16, 
-      skills: [] 
-    };
-    
-    const result = validator.validate(invalidData);
+    const customValidator = (data: TestFormData) => ({
+      valid: data.skills.length > 0,
+      errors: data.skills.length === 0 ? ['At least one skill required'] : [],
+      touched: true,
+    });
+
+    const validator = combineValidators(fieldValidator, customValidator);
+
+    const result = validator({ name: '', email: 'invalid', age: 16, skills: [] });
     expect(result.valid).toBe(false);
     expect(result.errors).toContain('Name is required');
     expect(result.errors).toContain('Invalid email');
     expect(result.errors).toContain('Must be 18 or older');
     expect(result.errors).toContain('At least one skill required');
 
-    const validData = { 
-      name: 'John', 
-      email: 'john@example.com', 
-      age: 25, 
-      skills: ['programming'] 
-    };
-    
-    const validResult = validator.validate(validData);
+    const validResult = validator({
+      name: 'John', email: 'john@example.com', age: 25, skills: ['programming'],
+    });
     expect(validResult.valid).toBe(true);
     expect(validResult.errors).toEqual([]);
   });
+});
 
-  it('should allow chaining field validations', () => {
-    const validator = createWizardValidator<TestFormData>()
-      .field('name')
-        .required()
-        .minLength(2)
-        .maxLength(50)
-        .custom((name) => !name.includes('test'), 'Name cannot contain "test"')
-      .build();
-
-    const invalidData = { name: 'testuser', email: '', age: 0, skills: [] };
-    const result = validator.validate(invalidData);
-    expect(result.valid).toBe(false);
-    expect(result.errors).toContain('Name cannot contain "test"');
+describe('alwaysValid', () => {
+  it('always returns valid', () => {
+    expect(alwaysValid({}).valid).toBe(true);
+    expect(alwaysValid({ anything: 'goes' }).valid).toBe(true);
   });
 });

--- a/src/lib/utils/wizardValidation.ts
+++ b/src/lib/utils/wizardValidation.ts
@@ -10,96 +10,62 @@ export type FieldValidationRules<T = unknown> = {
   [K in keyof T]?: ValidationRule<T[K]>[];
 };
 
-export interface WizardStepValidatorConfig<T = unknown> {
-  rules: FieldValidationRules<T>;
-  customValidator?: (data: T) => WizardValidation;
+export type Validator<T> = (data: T) => WizardValidation;
+
+const isEmpty = (value: unknown): boolean =>
+  value === undefined || value === null || value === '';
+
+function applyRules<V>(value: V, rules: ValidationRule<V>[]): string[] {
+  const errors: string[] = [];
+  for (const rule of rules) {
+    if (rule.required && isEmpty(value)) {
+      errors.push(rule.message);
+      continue;
+    }
+    if (!rule.required && isEmpty(value)) continue;
+    if (!rule.validate(value)) errors.push(rule.message);
+  }
+  return errors;
 }
 
-export class WizardStepValidator<T = unknown> {
-  private rules: FieldValidationRules<T>;
-  private customValidator?: (data: T) => WizardValidation;
-
-  constructor(config: WizardStepValidatorConfig<T>) {
-    this.rules = config.rules;
-    this.customValidator = config.customValidator;
-  }
-
-  validate(data: T): WizardValidation {
+/**
+ * Build a validator from per-field rule arrays.
+ */
+export function validateFields<T>(rules: FieldValidationRules<T>): Validator<T> {
+  return (data: T): WizardValidation => {
     const errors: string[] = [];
-
-    // Run field-level validation rules
-    for (const [fieldName, fieldRules] of Object.entries(this.rules)) {
-      const fieldValue = data[fieldName as keyof T];
-      
-      if (fieldRules && Array.isArray(fieldRules)) {
-        for (const rule of fieldRules) {
-          // Check required fields
-          if (rule.required && (fieldValue === undefined || fieldValue === null || fieldValue === '')) {
-            errors.push(rule.message);
-            continue;
-          }
-
-          // Skip validation if field is empty and not required
-          if (!rule.required && (fieldValue === undefined || fieldValue === null || fieldValue === '')) {
-            continue;
-          }
-
-          // Run validation
-          if (!rule.validate(fieldValue)) {
-            errors.push(rule.message);
-          }
-        }
-      }
+    for (const [fieldName, fieldRules] of Object.entries(rules)) {
+      if (!Array.isArray(fieldRules)) continue;
+      const value = data[fieldName as keyof T];
+      errors.push(...applyRules(value, fieldRules as ValidationRule<unknown>[]));
     }
-
-    // Run custom validation if provided
-    if (this.customValidator) {
-      const customResult = this.customValidator(data);
-      if (!customResult.valid) {
-        errors.push(...customResult.errors);
-      }
-    }
-
-    return {
-      valid: errors.length === 0,
-      errors,
-      touched: true,
-    };
-  }
-
-  validateField<K extends keyof T>(fieldName: K, value: T[K]): WizardValidation {
-    const fieldRules = this.rules[fieldName];
-    const errors: string[] = [];
-
-    if (fieldRules && Array.isArray(fieldRules)) {
-      for (const rule of fieldRules) {
-        // Check required fields
-        if (rule.required && (value === undefined || value === null || value === '')) {
-          errors.push(rule.message);
-          continue;
-        }
-
-        // Skip validation if field is empty and not required
-        if (!rule.required && (value === undefined || value === null || value === '')) {
-          continue;
-        }
-
-        // Run validation
-        if (!rule.validate(value)) {
-          errors.push(rule.message);
-        }
-      }
-    }
-
-    return {
-      valid: errors.length === 0,
-      errors,
-      touched: true,
-    };
-  }
+    return { valid: errors.length === 0, errors, touched: true };
+  };
 }
 
-// Common validation rules factory
+/**
+ * Run multiple validators against the same data; concatenate their errors.
+ */
+export function combineValidators<T>(...validators: Validator<T>[]): Validator<T> {
+  return (data: T): WizardValidation => {
+    const errors: string[] = [];
+    for (const v of validators) {
+      const result = v(data);
+      if (!result.valid) errors.push(...result.errors);
+    }
+    return { valid: errors.length === 0, errors, touched: true };
+  };
+}
+
+/**
+ * A validator that always passes — useful for steps with no validation.
+ */
+export const alwaysValid: Validator<unknown> = () => ({
+  valid: true,
+  errors: [],
+  touched: true,
+});
+
 export const createValidationRules = {
   required: <T>(message: string = 'This field is required'): ValidationRule<T> => ({
     validate: (value: T) => value !== undefined && value !== null && value !== '',
@@ -150,101 +116,3 @@ export const createValidationRules = {
     message,
   }),
 };
-
-// Wizard step validator builder for common patterns
-export class WizardStepValidatorBuilder<T = unknown> {
-  private rules: FieldValidationRules<T> = {};
-  private customValidator?: (data: T) => WizardValidation;
-
-  field<K extends keyof T>(fieldName: K): FieldValidatorBuilder<T, K> {
-    return new FieldValidatorBuilder<T, K>(this, fieldName);
-  }
-
-  customValidation(validator: (data: T) => WizardValidation): this {
-    this.customValidator = validator;
-    return this;
-  }
-
-  build(): WizardStepValidator<T> {
-    return new WizardStepValidator<T>({
-      rules: this.rules,
-      customValidator: this.customValidator,
-    });
-  }
-
-  internal_addRule<K extends keyof T>(fieldName: K, rule: ValidationRule<T[K]>): void {
-    if (!this.rules[fieldName]) {
-      this.rules[fieldName] = [];
-    }
-    this.rules[fieldName]!.push(rule);
-  }
-}
-
-class FieldValidatorBuilder<T, K extends keyof T> {
-  constructor(
-    private parent: WizardStepValidatorBuilder<T>,
-    private fieldName: K
-  ) {}
-
-  required(message?: string): this {
-    this.parent.internal_addRule(this.fieldName, createValidationRules.required<T[K]>(message));
-    return this;
-  }
-
-  minLength(min: number, message?: string): this {
-    this.parent.internal_addRule(this.fieldName, createValidationRules.minLength(min, message) as ValidationRule<T[K]>);
-    return this;
-  }
-
-  maxLength(max: number, message?: string): this {
-    this.parent.internal_addRule(this.fieldName, createValidationRules.maxLength(max, message) as ValidationRule<T[K]>);
-    return this;
-  }
-
-  minValue(min: number, message?: string): this {
-    this.parent.internal_addRule(this.fieldName, createValidationRules.minValue(min, message) as ValidationRule<T[K]>);
-    return this;
-  }
-
-  maxValue(max: number, message?: string): this {
-    this.parent.internal_addRule(this.fieldName, createValidationRules.maxValue(max, message) as ValidationRule<T[K]>);
-    return this;
-  }
-
-  pattern(regex: RegExp, message: string): this {
-    this.parent.internal_addRule(this.fieldName, createValidationRules.pattern(regex, message) as ValidationRule<T[K]>);
-    return this;
-  }
-
-  arrayMinLength(min: number, message?: string): this {
-    this.parent.internal_addRule(this.fieldName, createValidationRules.arrayMinLength(min, message) as ValidationRule<T[K]>);
-    return this;
-  }
-
-  arrayMaxLength(max: number, message?: string): this {
-    this.parent.internal_addRule(this.fieldName, createValidationRules.arrayMaxLength(max, message) as ValidationRule<T[K]>);
-    return this;
-  }
-
-  custom(validate: (value: T[K]) => boolean, message: string): this {
-    this.parent.internal_addRule(this.fieldName, createValidationRules.custom(validate, message));
-    return this;
-  }
-
-  field<K2 extends keyof T>(fieldName: K2): FieldValidatorBuilder<T, K2> {
-    return this.parent.field(fieldName);
-  }
-
-  customValidation(validator: (data: T) => WizardValidation): WizardStepValidatorBuilder<T> {
-    return this.parent.customValidation(validator);
-  }
-
-  build(): WizardStepValidator<T> {
-    return this.parent.build();
-  }
-}
-
-// Factory function for creating validator builders
-export function createWizardValidator<T = unknown>(): WizardStepValidatorBuilder<T> {
-  return new WizardStepValidatorBuilder<T>();
-}


### PR DESCRIPTION
## Summary

Round 4 of the overengineering audit on top of develop. Six bounded picks from the runner-up list, net **−567 LOC** across 21 files.

1. **Generator class chain closed.** `ItemImageGenerator` and `ToneSettingsGenerator` → free functions. All 6 single-method generator classes are now free functions (Rounds 2-4 cumulatively).
2. **Wizard validator builder collapsed.** `WizardStepValidator` + `WizardStepValidatorBuilder` (250 LOC) → `Validator<T>` type + `validateFields` / `alwaysValid` / `combineValidators` helpers. Most call sites just wrap a function — the builder was bypassed in 11 of 14 cases. Browser verified: genre and description step gates fire correctly. **−267 LOC across 3 wizards.**
3. **featureFlags ternary cleanup.** `=== 'false' ? false : true` → `!== 'false'`.
4. **AutoSaveService factory.** 252-LOC class → `createAutoSave(stateProvider, options)` factory with the same `{ start, stop, isRunning, triggerSave }` shape. Three pure helpers extracted (`nextRetryDelayMs`, `shouldSkipForInactiveSession`, `wrapErrorForCaller`). **−45 LOC.**
5. **TutorialProvider retry polling extracted.** ~40-line `useEffect` polling for missing step targets → new `useTourTargetRetry` hook (alongside existing `useTutorialAutoScroll`). Pure structural extraction.
6. **TestDataGeneratorSection deduplication.** Devtools panel had two near-identical handlers sharing 4 copies of a hardcoded universe list, 2 copies of random-world-type selection, 2 copies of attribute/skill ID-stamping, and 2 copies of the image-generation fetch flow. Extracted 4 module helpers (`TV_MOVIE_UNIVERSES`, `pickRandomWorldType`, `buildWorldDataForStore`, `generateWorldImageAsync`). **−173 LOC** (1018 → 845).

No behavior changes intended. All affected tests pass unchanged where assertions weren't structural.

## Test plan

- [ ] CI runs (typecheck + unit + lint)
- [ ] Spot-check World Creation Wizard step gates (Genre required on step 1, description ≥50 chars on step 2) — verified locally during dev
- [ ] Spot-check Character Creation Wizard advances normally
- [ ] Spot-check Game Start Wizard (world → character → ready) advances normally
- [ ] If AutoSave instrumentation is hooked up locally, confirm a session save still fires and SaveIndicator updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)