### PR TITLE
test: cover devtools section-visibility persistence + route through browserStorage

### DIFF
--- a/src/lib/devtools/__tests__/sectionVisibilityStorage.test.ts
+++ b/src/lib/devtools/__tests__/sectionVisibilityStorage.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Issue #646: behavioral coverage for DevTools section-visibility persistence.
+ * Persistence was extracted from the provider into these pure functions, which
+ * dissolves the original mock-isolation problem — real jsdom localStorage,
+ * cleared between tests, replaces the stateful mock.
+ */
+import {
+  loadSectionVisibility,
+  loadSectionVisibilityWithDefaults,
+  saveSectionVisibility,
+  toggleSectionVisibility,
+  setSectionVisibility,
+  isSectionVisible,
+  DEFAULT_SECTION_VISIBILITY,
+  DevToolsSection,
+} from '../sectionVisibilityStorage';
+
+const STORAGE_KEY = 'narraitor-devtools-section-visibility';
+
+describe('sectionVisibilityStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('loadSectionVisibility', () => {
+    it('returns defaults when storage is empty', () => {
+      expect(loadSectionVisibility()).toEqual(DEFAULT_SECTION_VISIBILITY);
+    });
+
+    it('falls back to defaults when stored value is corrupt JSON', () => {
+      localStorage.setItem(STORAGE_KEY, 'invalid json');
+      expect(loadSectionVisibility()).toEqual(DEFAULT_SECTION_VISIBILITY);
+    });
+  });
+
+  describe('loadSectionVisibilityWithDefaults', () => {
+    it('merges stored values over the provided defaults', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ [DevToolsSection.STATE_SECTION]: false })
+      );
+
+      const result = loadSectionVisibilityWithDefaults(DEFAULT_SECTION_VISIBILITY);
+
+      expect(result[DevToolsSection.STATE_SECTION]).toBe(false);
+      expect(result[DevToolsSection.AI_TESTING]).toBe(true);
+    });
+  });
+
+  describe('saveSectionVisibility', () => {
+    it('persists state that survives a reload', () => {
+      const visibility = {
+        ...DEFAULT_SECTION_VISIBILITY,
+        [DevToolsSection.ERROR_SECTION]: false,
+      };
+
+      saveSectionVisibility(visibility);
+
+      expect(loadSectionVisibility()).toEqual(visibility);
+    });
+  });
+
+  describe('toggleSectionVisibility', () => {
+    it('flips a section and persists the change', () => {
+      const next = toggleSectionVisibility(
+        DevToolsSection.STATE_SECTION,
+        DEFAULT_SECTION_VISIBILITY
+      );
+
+      expect(next[DevToolsSection.STATE_SECTION]).toBe(false);
+      expect(loadSectionVisibility()[DevToolsSection.STATE_SECTION]).toBe(false);
+    });
+  });
+
+  describe('setSectionVisibility', () => {
+    it('merges partial input with defaults and persists', () => {
+      const result = setSectionVisibility({ [DevToolsSection.LORE_MANAGEMENT]: false });
+
+      expect(result[DevToolsSection.LORE_MANAGEMENT]).toBe(false);
+      expect(result[DevToolsSection.STATE_SECTION]).toBe(true);
+      expect(loadSectionVisibility()[DevToolsSection.LORE_MANAGEMENT]).toBe(false);
+    });
+  });
+
+  describe('isSectionVisible', () => {
+    it('defaults to visible for an unknown section id', () => {
+      expect(isSectionVisible('nonexistentSection', DEFAULT_SECTION_VISIBILITY)).toBe(true);
+    });
+  });
+});

--- a/src/lib/devtools/sectionVisibilityStorage.ts
+++ b/src/lib/devtools/sectionVisibilityStorage.ts
@@ -1,9 +1,12 @@
 /**
  * DevTools Section Visibility Storage
- * 
+ *
  * Manages localStorage persistence for DevTools section visibility preferences.
- * Provides error handling and fallback behavior for storage operations.
+ * Storage access goes through the SSR-safe browserStorage wrapper, which no-ops
+ * on the server and treats missing/corrupt values as "no value".
  */
+
+import { readJSON, writeJSON } from '@/lib/utils/browserStorage';
 
 const STORAGE_KEY = 'narraitor-devtools-section-visibility';
 
@@ -45,24 +48,6 @@ export const DEFAULT_SECTION_VISIBILITY: SectionVisibility = {
 };
 
 /**
- * Check if localStorage is available and working
- */
-function isStorageAvailable(): boolean {
-  if (typeof window === 'undefined') {
-    return false;
-  }
-
-  try {
-    const testKey = '__storage_test__';
-    localStorage.setItem(testKey, 'test');
-    localStorage.removeItem(testKey);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
  * Load section visibility state from localStorage
  */
 export function loadSectionVisibility(): SectionVisibility {
@@ -73,43 +58,20 @@ export function loadSectionVisibility(): SectionVisibility {
  * Load section visibility state from localStorage with custom defaults
  */
 export function loadSectionVisibilityWithDefaults(defaultVisibility: SectionVisibility): SectionVisibility {
-  if (!isStorageAvailable()) {
-    return { ...defaultVisibility };
+  const stored = readJSON<SectionVisibility | null>('local', STORAGE_KEY, null);
+
+  if (stored && typeof stored === 'object') {
+    return { ...defaultVisibility, ...stored };
   }
 
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (!stored) {
-      return { ...defaultVisibility };
-    }
-
-    const parsed = JSON.parse(stored);
-    
-    // Ensure parsed data is valid and merge with defaults
-    if (typeof parsed === 'object' && parsed !== null) {
-      return { ...defaultVisibility, ...parsed };
-    }
-    
-    return { ...defaultVisibility };
-  } catch (error) {
-    console.warn('Failed to load DevTools section visibility from localStorage:', error);
-    return { ...defaultVisibility };
-  }
+  return { ...defaultVisibility };
 }
 
 /**
  * Save section visibility state to localStorage
  */
 export function saveSectionVisibility(visibility: SectionVisibility): void {
-  if (!isStorageAvailable()) {
-    return;
-  }
-
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(visibility));
-  } catch (error) {
-    console.warn('Failed to save DevTools section visibility to localStorage:', error);
-  }
+  writeJSON('local', STORAGE_KEY, visibility);
 }
 
 /**


### PR DESCRIPTION
## Summary

Resolves #646. The issue asked to re-enable 3 skipped localStorage tests for DevTools section visibility, but those tests (and `sectionVisibilityPersistence.test.tsx`) were removed when persistence was extracted from the React provider into the pure-function module `src/lib/devtools/sectionVisibilityStorage.ts`. That refactor dissolved the original mock-isolation problem — but left the module with zero test coverage.

This PR closes that gap and consolidates the module onto the shared storage wrapper:

- **Adds** `src/lib/devtools/__tests__/sectionVisibilityStorage.test.ts` — 7 behavioral unit tests covering the originally-skipped cases (defaults, defaults-override, save/reload round-trip, corrupt-data fallback) plus toggle/set/unknown-id. Uses real jsdom localStorage cleared between tests, so there's no mock contamination to fight.
- **Refactors** `sectionVisibilityStorage.ts` to route load/save through the SSR-safe `browserStorage` wrapper (`readJSON`/`writeJSON`) from #1248, dropping its bespoke `isStorageAvailable()` and manual try/catch JSON handling (net -38 lines in the module).

Observable behavior is unchanged: missing/corrupt/non-object stored values all collapse to defaults exactly as before. The only difference is the two failure-path `console.warn` calls go away (the wrapper swallows silently by design); the unknown-section-id warning in `isSectionVisible` is unchanged. Exported signatures are identical, so the three importers need no edits.

## Test plan

- [x] `npx tsc --noEmit` clean (pre-existing stale `.next` design-system cache entries aside)
- [x] `npx jest src/lib/devtools/__tests__/sectionVisibilityStorage.test.ts` — 7/7 pass
- [x] `npx jest src/components/devtools` — 38/38 pass, no regressions
- [x] `npx eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)