### PR TITLE
refactor: clean up audit quick wins (mock spam, DS hooks, stale types)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
-        "@types/react-joyride": "^2.0.2",
         "@typescript-eslint/eslint-plugin": "^8.41.0",
         "@typescript-eslint/parser": "^8.41.0",
         "autoprefixer": "^10.4.21",
@@ -6704,16 +6703,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
-      }
-    },
-    "node_modules/@types/react-joyride": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/react-joyride/-/react-joyride-2.0.2.tgz",
-      "integrity": "sha512-RbixI8KE4K4B4bVzigT765oiQMCbWqlb9vj5qz1pFvkOvynkiAGurGVVf+nGszGGa89WrQhUnAwd0t1tqxeoDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "*"
       }
     },
     "node_modules/@types/resolve": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@types/react-joyride": "^2.0.2",
     "@typescript-eslint/eslint-plugin": "^8.41.0",
     "@typescript-eslint/parser": "^8.41.0",
     "autoprefixer": "^10.4.21",

--- a/src/app/dev/design-system-2/DS2Page.tsx
+++ b/src/app/dev/design-system-2/DS2Page.tsx
@@ -1,77 +1,10 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import { useScrollReveal } from '@/hooks/useScrollReveal';
+import { useActiveSection } from '@/hooks/useActiveSection';
 import SessionDemo from './SessionDemo';
 import './design-system-2.css';
-
-// ─────────────────────────────────────────────────────────────────
-// Scroll Reveal Hook
-// ─────────────────────────────────────────────────────────────────
-function useScrollReveal() {
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-
-    const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    if (prefersReduced) {
-      el.querySelectorAll('.ds2-reveal').forEach((child) => {
-        child.classList.add('ds2-visible');
-      });
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            entry.target.classList.add('ds2-visible');
-          }
-        });
-      },
-      { threshold: 0.12, rootMargin: '0px 0px -60px 0px' }
-    );
-
-    el.querySelectorAll('.ds2-reveal').forEach((child) => {
-      observer.observe(child);
-    });
-
-    return () => observer.disconnect();
-  }, []);
-
-  return ref;
-}
-
-// ─────────────────────────────────────────────────────────────────
-// Active Section Tracking Hook
-// ─────────────────────────────────────────────────────────────────
-function useActiveSection(sectionIds: string[]) {
-  const [active, setActive] = useState(sectionIds[0]);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const visible = entries.filter((e) => e.isIntersecting);
-        if (visible.length > 0) {
-          // Pick the one closest to the top
-          visible.sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
-          setActive(visible[0].target.id);
-        }
-      },
-      { threshold: 0.15, rootMargin: '-10% 0px -60% 0px' }
-    );
-
-    sectionIds.forEach((id) => {
-      const el = document.getElementById(id);
-      if (el) observer.observe(el);
-    });
-
-    return () => observer.disconnect();
-  }, [sectionIds]);
-
-  return active;
-}
 
 // ─────────────────────────────────────────────────────────────────
 // Navigation Sections
@@ -150,8 +83,8 @@ const SPACING_SCALE = [8, 16, 24, 32, 40, 48, 64, 96];
 export default function DesignSystem2Page() {
   const [isDark, setIsDark] = useState(false);
   const [showGrid, setShowGrid] = useState(false);
-  const revealRef = useScrollReveal();
-  const activeSection = useActiveSection(NAV_SECTIONS.map((s) => s.id));
+  const revealRef = useScrollReveal({ revealClass: 'ds2-reveal', visibleClass: 'ds2-visible', threshold: 0.12, rootMargin: '0px 0px -60px 0px' });
+  const activeSection = useActiveSection(NAV_SECTIONS.map((s) => s.id), { threshold: 0.15, rootMargin: '-10% 0px -60% 0px' });
 
   useEffect(() => {
     setIsDark(document.documentElement.classList.contains('dark'));

--- a/src/app/dev/design-system-3/DS3Page.tsx
+++ b/src/app/dev/design-system-3/DS3Page.tsx
@@ -1,44 +1,11 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import './design-system-3.css';
 import * as Icons from './icons';
 import SessionDemo from './SessionDemo';
-
-// ── Hooks ──────────────────────────────────────────────────────
-function useScrollReveal() {
-  const ref = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      el.querySelectorAll('.ds3-reveal').forEach(c => c.classList.add('ds3-visible'));
-      return;
-    }
-    const obs = new IntersectionObserver(entries => {
-      entries.forEach(e => { if (e.isIntersecting) e.target.classList.add('ds3-visible'); });
-    }, { threshold: 0.1, rootMargin: '0px 0px -40px 0px' });
-    el.querySelectorAll('.ds3-reveal').forEach(c => obs.observe(c));
-    return () => obs.disconnect();
-  }, []);
-  return ref;
-}
-
-function useActiveSection(ids: string[]) {
-  const [active, setActive] = useState(ids[0]);
-  useEffect(() => {
-    const obs = new IntersectionObserver(entries => {
-      const vis = entries.filter(e => e.isIntersecting);
-      if (vis.length) {
-        vis.sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
-        setActive(vis[0].target.id);
-      }
-    }, { threshold: 0.15, rootMargin: '-10% 0px -60% 0px' });
-    ids.forEach(id => { const el = document.getElementById(id); if (el) obs.observe(el); });
-    return () => obs.disconnect();
-  }, [ids]);
-  return active;
-}
+import { useScrollReveal } from '@/hooks/useScrollReveal';
+import { useActiveSection } from '@/hooks/useActiveSection';
 
 // ── Data ───────────────────────────────────────────────────────
 const NAV = [
@@ -102,8 +69,8 @@ const ICON_LIST: [string, React.FC<{ size?: number; className?: string }>][] = [
 // ── Page ───────────────────────────────────────────────────────
 export default function DesignSystem3Page() {
   const [isDark, setIsDark] = useState(false);
-  const revealRef = useScrollReveal();
-  const active = useActiveSection(NAV.map(s => s.id));
+  const revealRef = useScrollReveal({ revealClass: 'ds3-reveal', visibleClass: 'ds3-visible', threshold: 0.1, rootMargin: '0px 0px -40px 0px' });
+  const active = useActiveSection(NAV.map(s => s.id), { threshold: 0.15, rootMargin: '-10% 0px -60% 0px' });
 
   useEffect(() => {
     setIsDark(document.documentElement.classList.contains('dark'));

--- a/src/app/dev/design-system/DS1Page.tsx
+++ b/src/app/dev/design-system/DS1Page.tsx
@@ -1,53 +1,14 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import type { LucideIcon } from 'lucide-react';
 import { Globe, Users, Play, Sparkles } from 'lucide-react';
 import { primitiveColors } from '@/lib/design-tokens';
+import { useScrollReveal } from '@/hooks/useScrollReveal';
+import { useActiveSection } from '@/hooks/useActiveSection';
 import ManuscriptDemo from './ManuscriptDemo';
 import './design-system.css';
 
-// ---------------------------------------------------------------------------
-// Scroll Reveal Hook
-// ---------------------------------------------------------------------------
-function useScrollReveal() {
-  const ref = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    if (prefersReduced) {
-      el.querySelectorAll('.ds1-reveal').forEach(c => c.classList.add('ds1-visible'));
-      return;
-    }
-    const observer = new IntersectionObserver(
-      (entries) => entries.forEach(e => { if (e.isIntersecting) e.target.classList.add('ds1-visible'); }),
-      { threshold: 0.12, rootMargin: '0px 0px -60px 0px' }
-    );
-    el.querySelectorAll('.ds1-reveal').forEach(c => observer.observe(c));
-    return () => observer.disconnect();
-  }, []);
-  return ref;
-}
-
-// ---------------------------------------------------------------------------
-// Active Section Tracking Hook
-// ---------------------------------------------------------------------------
-function useActiveSection(ids: string[]) {
-  const [active, setActive] = useState(ids[0]);
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const visible = entries.filter(e => e.isIntersecting).sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
-        if (visible.length > 0) setActive(visible[0].target.id);
-      },
-      { rootMargin: '-20% 0px -60% 0px' }
-    );
-    ids.forEach(id => { const el = document.getElementById(id); if (el) observer.observe(el); });
-    return () => observer.disconnect();
-  }, [ids]);
-  return active;
-}
 // ---------------------------------------------------------------------------
 // Helper: Color Swatch
 // ---------------------------------------------------------------------------
@@ -196,8 +157,8 @@ const NAV_SECTIONS = [
 // ---------------------------------------------------------------------------
 export default function DesignSystemPage() {
   const [isDark, setIsDark] = useState(false);
-  const revealRef = useScrollReveal();
-  const activeSection = useActiveSection(NAV_SECTIONS.map(s => s.id));
+  const revealRef = useScrollReveal({ revealClass: 'ds1-reveal', visibleClass: 'ds1-visible', threshold: 0.12, rootMargin: '0px 0px -60px 0px' });
+  const activeSection = useActiveSection(NAV_SECTIONS.map(s => s.id), { rootMargin: '-20% 0px -60% 0px' });
 
   useEffect(() => {
     setIsDark(document.documentElement.classList.contains('dark'));

--- a/src/hooks/useActiveSection.ts
+++ b/src/hooks/useActiveSection.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface ActiveSectionOptions {
+  threshold?: number;
+  rootMargin?: string;
+}
+
+/**
+ * Tracks which section is currently active based on scroll position, returning the
+ * id of the topmost visible section. Used to highlight in-page navigation.
+ */
+export function useActiveSection(
+  ids: string[],
+  { threshold, rootMargin = '-20% 0px -60% 0px' }: ActiveSectionOptions = {}
+) {
+  const [active, setActive] = useState(ids[0]);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible.length > 0) setActive(visible[0].target.id);
+      },
+      { threshold, rootMargin }
+    );
+
+    ids.forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    });
+
+    return () => observer.disconnect();
+  }, [ids, threshold, rootMargin]);
+
+  return active;
+}

--- a/src/hooks/useScrollReveal.ts
+++ b/src/hooks/useScrollReveal.ts
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+interface ScrollRevealOptions {
+  revealClass: string;
+  visibleClass: string;
+  threshold?: number;
+  rootMargin?: string;
+}
+
+/**
+ * Reveals elements matching `revealClass` by adding `visibleClass` as they scroll
+ * into view. Respects prefers-reduced-motion by revealing everything immediately.
+ * Returns a ref to attach to the container whose descendants should be observed.
+ */
+export function useScrollReveal({
+  revealClass,
+  visibleClass,
+  threshold = 0.12,
+  rootMargin = '0px 0px -60px 0px',
+}: ScrollRevealOptions) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (prefersReduced) {
+      el.querySelectorAll(`.${revealClass}`).forEach((child) => child.classList.add(visibleClass));
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) =>
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) entry.target.classList.add(visibleClass);
+        }),
+      { threshold, rootMargin }
+    );
+
+    el.querySelectorAll(`.${revealClass}`).forEach((child) => observer.observe(child));
+    return () => observer.disconnect();
+  }, [revealClass, visibleClass, threshold, rootMargin]);
+
+  return ref;
+}

--- a/src/state/__mocks__/worldStore.ts
+++ b/src/state/__mocks__/worldStore.ts
@@ -1,8 +1,7 @@
 // Mock for the worldStore module
-console.log('[__mocks__/worldStore.ts] Mock module loading');
 
 import { World, WorldAttribute, WorldSkill, WorldSettings } from '@/types/world.types';
-import { formatForDebug, getTimestamp } from '@/lib/utils';
+import { getTimestamp } from '@/lib/utils';
 import { UserFriendlyError, ErrorType } from '@/lib/utils/errorUtils';
 import { WorldState, WorldStateUpdate, createEmptyWorldState } from '@/types/world-state.types';
 import { applyWorldStateUpdate, getActiveWorldState, mergeState } from '@/lib/world';
@@ -59,24 +58,20 @@ const ensureWorldState = (worldId: string): WorldState => {
 };
 
 const mockInitializeWorldState = jest.fn((worldId: string) => {
-  console.log('[__mocks__/worldStore.ts] initializeWorldState called:', worldId);
   ensureWorldState(worldId);
 });
 
 const mockUpdateWorldState = jest.fn((worldId: string, update: WorldStateUpdate, sessionId: string) => {
-  console.log('[__mocks__/worldStore.ts] updateWorldState called:', { worldId, sessionId, update });
   const current = ensureWorldState(worldId);
   mockState.worldStates[worldId] = applyWorldStateUpdate(worldId, current, update, sessionId);
 });
 
 const mockMergeWorldState = jest.fn((incomingState: WorldState) => {
-  console.log('[__mocks__/worldStore.ts] mergeWorldState called:', incomingState.worldId);
   const current = mockState.worldStates[incomingState.worldId];
   mockState.worldStates[incomingState.worldId] = current ? mergeState(current, incomingState) : incomingState;
 });
 
 const mockGetWorldState = jest.fn((worldId: string, options?: { includeEndedSessions?: boolean }) => {
-  console.log('[__mocks__/worldStore.ts] getWorldState called:', worldId, options);
   const current = ensureWorldState(worldId);
   if (options?.includeEndedSessions) {
     return current;
@@ -85,21 +80,15 @@ const mockGetWorldState = jest.fn((worldId: string, options?: { includeEndedSess
 });
 
 const mockGetRawWorldState = jest.fn((worldId: string) => {
-  console.log('[__mocks__/worldStore.ts] getRawWorldState called:', worldId);
   return mockState.worldStates[worldId];
 });
 
 const mockCreateWorld = jest.fn((worldData: Partial<World>): string => {
-  console.log('[__mocks__/worldStore.ts] mockCreateWorld called with:', formatForDebug(worldData, { indent: 2 }));
-  console.log('[__mocks__/worldStore.ts] Checking validation - name is:', worldData.name ? `"${worldData.name}"` : 'empty/null');
-  
   // Validate required fields - THROW on validation failure
   if (!worldData.name || worldData.name.trim() === '') {
-    console.log('[__mocks__/worldStore.ts] VALIDATION FAILURE: World name is required!');
-    console.log('[__mocks__/worldStore.ts] Throwing exception...');
     throw new Error('World name is required');
   }
-  
+
   // Actually create the world in our mock state
   const worldId = 'mock-world-id';
   const newWorld: World = {
@@ -119,11 +108,10 @@ const mockCreateWorld = jest.fn((worldData: Partial<World>): string => {
     createdAt: getTimestamp(),
     updatedAt: getTimestamp()
   };
-  
+
   mockState.worlds[worldId] = newWorld;
   syncWorldToEntities(worldId);
   ensureWorldState(worldId);
-  console.log('[__mocks__/worldStore.ts] Created world in mock state:', mockState.worlds[worldId]);
   return worldId;
 });
 
@@ -165,7 +153,6 @@ type WorldStore = MockWorldState & WorldStoreActions;
 
 // Create mock actions that mutate the shared state
 const mockUpdateWorld = jest.fn((worldId: string, updates: Partial<World>) => {
-  console.log('[__mocks__/worldStore.ts] updateWorld called:', worldId, updates);
   if (!mockState.worlds[worldId]) {
     mockState.error = createError('World not found', { type: ErrorType.VALIDATION });
     return;
@@ -179,7 +166,6 @@ const mockUpdateWorld = jest.fn((worldId: string, updates: Partial<World>) => {
 });
 
 const mockDeleteWorld = jest.fn((worldId: string) => {
-  console.log('[__mocks__/worldStore.ts] deleteWorld called:', worldId);
   if (mockState.currentWorldId === worldId) {
     mockState.currentWorldId = null;
     mockState.currentEntityId = null;
@@ -189,7 +175,6 @@ const mockDeleteWorld = jest.fn((worldId: string) => {
 });
 
 const mockSetCurrentWorld = jest.fn((worldId: string | null) => {
-  console.log('[__mocks__/worldStore.ts] setCurrentWorld called:', worldId);
   if (worldId && !mockState.worlds[worldId]) {
     mockState.error = createError('World not found', { type: ErrorType.VALIDATION });
     return;
@@ -200,14 +185,12 @@ const mockSetCurrentWorld = jest.fn((worldId: string | null) => {
 });
 
 const mockAddAttribute = jest.fn((worldId: string, attribute: Partial<WorldAttribute>) => {
-  console.log('[__mocks__/worldStore.ts] addAttribute called:', worldId, attribute);
   if (!mockState.worlds[worldId]) {
     mockState.error = createError('World not found', { type: ErrorType.VALIDATION });
     return;
   }
   const world = mockState.worlds[worldId];
   if (world.attributes.length >= (world.settings?.maxAttributes || 10)) {
-    console.log('[__mocks__/worldStore.ts] LIMIT REACHED - setting error "Maximum attributes limit reached"');
     mockState.error = createError('Maximum attributes limit reached', { type: ErrorType.VALIDATION });
     return;
   }
@@ -225,7 +208,6 @@ const mockAddAttribute = jest.fn((worldId: string, attribute: Partial<WorldAttri
 });
 
 const mockUpdateAttribute = jest.fn((worldId: string, attributeId: string, updates: Partial<WorldAttribute>) => {
-  console.log('[__mocks__/worldStore.ts] updateAttribute called:', worldId, attributeId, updates);
   if (!mockState.worlds[worldId]) {
     mockState.error = createError('World not found', { type: ErrorType.VALIDATION });
     return;
@@ -239,7 +221,6 @@ const mockUpdateAttribute = jest.fn((worldId: string, attributeId: string, updat
 });
 
 const mockRemoveAttribute = jest.fn((worldId: string, attributeId: string) => {
-  console.log('[__mocks__/worldStore.ts] removeAttribute called:', worldId, attributeId);
   if (!mockState.worlds[worldId]) {
     mockState.error = createError('World not found', { type: ErrorType.VALIDATION });
     return;
@@ -250,14 +231,12 @@ const mockRemoveAttribute = jest.fn((worldId: string, attributeId: string) => {
 });
 
 const mockAddSkill = jest.fn((worldId: string, skill: Partial<WorldSkill>) => {
-  console.log('[__mocks__/worldStore.ts] addSkill called:', worldId, skill);
   if (!mockState.worlds[worldId]) {
     mockState.error = createError('World not found', { type: ErrorType.VALIDATION });
     return;
   }
   const world = mockState.worlds[worldId];
   if (world.skills.length >= (world.settings?.maxSkills || 10)) {
-    console.log('[__mocks__/worldStore.ts] LIMIT REACHED - setting error "Maximum skills limit reached"');
     mockState.error = createError('Maximum skills limit reached', { type: ErrorType.VALIDATION });
     return;
   }
@@ -277,7 +256,6 @@ const mockAddSkill = jest.fn((worldId: string, skill: Partial<WorldSkill>) => {
 });
 
 const mockUpdateSkill = jest.fn((worldId: string, skillId: string, updates: Partial<WorldSkill>) => {
-  console.log('[__mocks__/worldStore.ts] updateSkill called:', worldId, skillId, updates);
   if (!mockState.worlds[worldId]) {
     mockState.error = createError('World not found', { type: ErrorType.VALIDATION });
     return;
@@ -291,7 +269,6 @@ const mockUpdateSkill = jest.fn((worldId: string, skillId: string, updates: Part
 });
 
 const mockRemoveSkill = jest.fn((worldId: string, skillId: string) => {
-  console.log('[__mocks__/worldStore.ts] removeSkill called:', worldId, skillId);
   if (!mockState.worlds[worldId]) {
     mockState.error = createError('World not found', { type: ErrorType.VALIDATION });
     return;
@@ -302,7 +279,6 @@ const mockRemoveSkill = jest.fn((worldId: string, skillId: string) => {
 });
 
 const mockUpdateSettings = jest.fn((worldId: string, settings: Partial<WorldSettings>) => {
-  console.log('[__mocks__/worldStore.ts] updateSettings called:', worldId, settings);
   if (!mockState.worlds[worldId]) {
     mockState.error = createError('World not found', { type: ErrorType.VALIDATION });
     return;
@@ -315,7 +291,6 @@ const mockUpdateSettings = jest.fn((worldId: string, settings: Partial<WorldSett
 });
 
 const mockUpdateToneSettings = jest.fn((worldId: string, toneSettings: Partial<import('@/types/tone-settings.types').ToneSettings>) => {
-  console.log('[__mocks__/worldStore.ts] updateToneSettings called:', worldId, toneSettings);
   if (!mockState.worlds[worldId]) {
     mockState.error = createError('World not found', { type: ErrorType.VALIDATION });
     return;
@@ -337,7 +312,6 @@ const mockUpdateToneSettings = jest.fn((worldId: string, toneSettings: Partial<i
 });
 
 const mockGetWorldById = jest.fn((worldId: string) => {
-  console.log('[__mocks__/worldStore.ts] getWorldById called:', worldId);
   return mockState.worlds[worldId] || null;
 });
 
@@ -349,7 +323,6 @@ const mockGetById = jest.fn((id: string) => mockGetWorldById(id));
 const mockGetAll = jest.fn(() => Object.values(mockState.worlds));
 
 const mockReset = jest.fn(() => {
-  console.log('[__mocks__/worldStore.ts] reset called');
   mockState = {
     worlds: {},
     entities: {},
@@ -362,7 +335,6 @@ const mockReset = jest.fn(() => {
 });
 
 const mockSetError = jest.fn((error: UserFriendlyError | string | null) => {
-  console.log('[__mocks__/worldStore.ts] setError called:', error);
   if (typeof error === 'string') {
     mockState.error = createError(error);
   } else {
@@ -371,12 +343,10 @@ const mockSetError = jest.fn((error: UserFriendlyError | string | null) => {
 });
 
 const mockClearError = jest.fn(() => {
-  console.log('[__mocks__/worldStore.ts] clearError called');
   mockState.error = null;
 });
 
 const mockSetLoading = jest.fn((loading: boolean) => {
-  console.log('[__mocks__/worldStore.ts] setLoading called:', loading);
   mockState.loading = loading;
 });
 
@@ -384,8 +354,6 @@ const mockFetchWorlds = jest.fn(() => Promise.resolve());
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockWorldStore = jest.fn((selector?: (state: WorldStore) => any) => {
-  console.log('[__mocks__/worldStore.ts] worldStore mock called with selector type:', typeof selector);
-  
   const state: WorldStore = {
     ...mockState,
     worldStates: mockState.worldStates,
@@ -419,22 +387,17 @@ const mockWorldStore = jest.fn((selector?: (state: WorldStore) => any) => {
     getById: mockGetById,
     getAll: mockGetAll,
   };
-  
+
   // If no selector is provided, return the entire state (like useStore() with no selector)
   if (!selector || typeof selector !== 'function') {
-    console.log('[__mocks__/worldStore.ts] No selector provided, returning full state');
     return state;
   }
-  
-  const result = selector(state);
-  console.log('[__mocks__/worldStore.ts] Selector returned:', result);
-  return result;
+
+  return selector(state);
 });
 
 // Add mock for static methods
 const mockGetState = jest.fn((): WorldStore => {
-  console.log('[__mocks__/worldStore.ts] getState called');
-  
   const state: WorldStore = {
     ...mockState,
     worldStates: mockState.worldStates,
@@ -468,7 +431,7 @@ const mockGetState = jest.fn((): WorldStore => {
     getById: mockGetById,
     getAll: mockGetAll,
   };
-  
+
   return state;
 });
 
@@ -515,6 +478,3 @@ export const worldStore = Object.assign(mockWorldStore, {
 });
 
 export const useWorldStore = worldStore;
-
-console.log('[__mocks__/worldStore.ts] Mock module exported');
-console.log('[__mocks__/worldStore.ts] worldStore has getState:', typeof worldStore.getState);


### PR DESCRIPTION
## Summary

Quick-win cleanup from a fresh "embarrassing code" audit (16 candidates surfaced; the structural refactors stay as a report for later). All behavior-preserving.

- **Mock console spam** — removed 35 `console.log` narration lines from `src/state/__mocks__/worldStore.ts` (each mock method was logging itself + a module-load log at import). No test depended on them; mock logic untouched.
- **DS scroll-hook dedup** — `useScrollReveal` and `useActiveSection` were copy-pasted into DS1/DS2/DS3. Extracted to `src/hooks/useScrollReveal.ts` and `src/hooks/useActiveSection.ts`, parametrized by `revealClass`/`visibleClass`/`threshold`/`rootMargin` so each page keeps its **exact** observer tuning (no visual change).
- **Stale react-joyride types** — dropped `@types/react-joyride@^2.0.2`. The pinned runtime `react-joyride@3.0.0-7` bundles its own v3 types (`dist/index.d.ts`); the v2 `@types` described a different API. Runtime pin unchanged.

## Deliberately not included

- **knip `|| true` in CI** — left as-is. knip is not currently clean (unused exports, 4 unused enum members in `promptTemplates/types.ts`, a duplicate `aiContextStore` export, a config hint), so flipping the gate would turn CI red. That's the #1231 ignore-rule work, out of scope here.

## Test plan

- [x] `npx tsc --noEmit` clean (confirms bundled v3 types cover all used symbols after dropping `@types`)
- [x] `npm run lint` clean (only pre-existing warnings)
- [x] worldStore-mock consumer tests green (26 across 5 suites); no mock narration in output
- [x] Browser: `/dev/design-system`, `/dev/design-system/2`, `/dev/design-system/3` all render and scroll-reveal fires (41 / 98 / 91 elements), no runtime errors

Generated with [Claude Code](https://claude.com/claude-code)