### PR TITLE
chore: enable JSX markup-hygiene lint rules (#1088)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,6 +35,10 @@ const eslintConfig = [
       // need a deliberate suppression with a reason. Dev tools, tests, and
       // stories are overridden below.
       "@typescript-eslint/no-explicit-any": "error",
+      // Structural markup hygiene (#1088): both auto-fixable. warn keeps them
+      // out of the blocking CI gate as a first-pass introduction.
+      "react/jsx-no-useless-fragment": ["warn", { "allowExpressions": true }],
+      "react/self-closing-comp": "warn",
     },
   },
   {

--- a/src/app/dev/choice-alignment/page.tsx
+++ b/src/app/dev/choice-alignment/page.tsx
@@ -214,15 +214,15 @@ export default function ChoiceAlignmentTestPage() {
                 <h3>Alignment Legend:</h3>
                 <div>
                   <div>
-                    <div></div>
+                    <div />
                     <span><strong>Lawful:</strong> Follows rules, respects authority</span>
                   </div>
                   <div>
-                    <div></div>
+                    <div />
                     <span><strong>Neutral:</strong> Balanced, practical approach</span>
                   </div>
                   <div>
-                    <div></div>
+                    <div />
                     <span><strong>Chaos:</strong> Unexpected, disruptive action</span>
                   </div>
                 </div>

--- a/src/app/dev/ending-system/page.tsx
+++ b/src/app/dev/ending-system/page.tsx
@@ -188,9 +188,9 @@ The world had been saved, and all knew that heroes like this one would always ri
                 <p>Please wait while we create your story ending...</p>
                 <div>
                   <div>
-                    <div></div>
-                    <div></div>
-                    <div></div>
+                    <div />
+                    <div />
+                    <div />
                   </div>
                 </div>
               </div>

--- a/src/app/worlds/page.tsx
+++ b/src/app/worlds/page.tsx
@@ -232,7 +232,7 @@ export default function WorldsPage() {
 
           {isGenerating && (
             <p>
-              <span></span>
+              <span />
               {generatingStatus}
             </p>
           )}

--- a/src/components/CharacterCard/CharacterCard.tsx
+++ b/src/components/CharacterCard/CharacterCard.tsx
@@ -178,7 +178,7 @@ export function CharacterCard({
               <p>{context.recentEvent}</p>
             </div>
           )}
-          <div></div>
+          <div />
         </div>
 
         {/* Footer with buttons - always at bottom */}

--- a/src/components/GenerateCharacterDialog/GenerateCharacterDialog.tsx
+++ b/src/components/GenerateCharacterDialog/GenerateCharacterDialog.tsx
@@ -104,7 +104,7 @@ export const GenerateCharacterDialog: React.FC<
 
       {isGenerating && (
         <div>
-          <span></span>
+          <span />
           {generatingStatus}
         </div>
       )}

--- a/src/components/Journal/JournalEntryList.tsx
+++ b/src/components/Journal/JournalEntryList.tsx
@@ -73,7 +73,7 @@ export const JournalEntryList: React.FC<JournalEntryListProps> = ({
                 )}
                 {entry.title || titleCase(entry.type.replace('_', ' '))}
               </h4>
-              {!entry.isRead && <div></div>}
+              {!entry.isRead && <div />}
             </div>
 
             <p>

--- a/src/components/shared/ImageGenerationSection.tsx
+++ b/src/components/shared/ImageGenerationSection.tsx
@@ -135,7 +135,7 @@ export const ImageGenerationSection: React.FC<ImageGenerationSectionProps> = ({
             >
               {isGenerating ? (
                 <>
-                  <div></div>
+                  <div />
                   Generating...
                 </>
               ) : (


### PR DESCRIPTION
## Summary

Closes out #1088, the last piece of the dead-code-tooling arc. The headline recommendations from the issue already shipped on `develop`:

- Knip adopted and made a blocking CI gate (#1231/#1256)
- depcheck removed from devDependencies (#1256)
- CSS audit tooling added (#1087/#1257)

This PR adds the two remaining auto-fixable ESLint rules:

- `react/jsx-no-useless-fragment` (`allowExpressions: true`)
- `react/self-closing-comp`

Both are set to `warn` — a KISS first-pass introduction that keeps them out of the blocking lint gate while still surfacing regressions. The auto-fix converted 7 empty elements (`<div></div>` -> `<div />`) across dev pages and a few components. No useless fragments were found (all existing `<>...</>` usage is legitimate and spared by `allowExpressions`).

The new rules are documented inline in `eslint.config.mjs` next to the existing `no-console` / `no-explicit-any` conventions.

## Deferred (with rationale)

The issue's "establish baseline DOM node count" AC is intentionally deferred. No static tool pinpoints *unnecessary markup* — Knip handles dead exports/files, ESLint handles fragments/self-closing, but wrapper-div necessity depends on CSS layout context and stays a manual-review concern (the issue itself states this). A one-off `querySelectorAll('*').length` snapshot would be a frozen number with no enforcement hook, so it's not worth carrying.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (warnings only, all pre-existing)
- [x] `npm run lint:css` — clean
- [x] `npm test` — 298 suites / 2123 tests pass
- [x] `npm run knip` — clean (blocking gate)