### PR TITLE
test: strengthen tests that passed without verifying behavior

### DIFF
--- a/src/components/GameSession/__tests__/SessionBoundaryLogging.sessionStart.test.tsx
+++ b/src/components/GameSession/__tests__/SessionBoundaryLogging.sessionStart.test.tsx
@@ -58,14 +58,6 @@ describe('Session Boundary Logging - Session Start', () => {
     setupMockStores();
   });
 
-  it('verifies session initialization API exists', () => {
-    const sessionStore = useSessionStore();
-
-    expect(typeof sessionStore.initializeSession).toBe('function');
-    expect(typeof sessionStore.endSession).toBe('function');
-    expect(sessionStore).toBeDefined();
-  });
-
   it('handles session start callback and journal entry creation workflow', () => {
     const sessionStartTime = new Date('2024-01-15T10:30:00Z');
     const mockDate = jest.spyOn(global, 'Date').mockImplementation(() => sessionStartTime);

--- a/src/components/Narrative/__tests__/NarrativeDisplay.consequence.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeDisplay.consequence.test.tsx
@@ -200,7 +200,7 @@ describe('NarrativeDisplay - Choice Outcome Callout Integration (Issue #971)', (
     });
   });
 
-  it('should handle missing sessionId gracefully', () => {
+  it('renders despite a missing sessionId', () => {
     const segment = createMockNarrativeSegment({
       id: 'seg-1',
       // No sessionId
@@ -213,9 +213,9 @@ describe('NarrativeDisplay - Choice Outcome Callout Integration (Issue #971)', (
       }
     });
 
-    // Should not crash
-    expect(() => {
-      render(<NarrativeDisplay segment={segment} />);
-    }).not.toThrow();
+    render(<NarrativeDisplay segment={segment} />);
+
+    // A missing sessionId must not stop the narrative content from rendering.
+    expect(screen.getByText(/Something happens/)).toBeInTheDocument();
   });
 });

--- a/src/components/Narrative/__tests__/NarrativeDisplay.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeDisplay.test.tsx
@@ -43,7 +43,7 @@ describe('NarrativeDisplay', () => {
     expect(screen.getByText(/ancient forest whispered secrets/)).toBeInTheDocument();
   });
 
-  it('handles malformed NPC IDs without crashing', () => {
+  it('renders narrative content despite malformed NPC IDs', () => {
     const segment = createMockNarrativeSegment({
       id: 'seg-malformed',
       content: 'An unnamed figure watches from afar.',
@@ -54,9 +54,12 @@ describe('NarrativeDisplay', () => {
       },
     });
 
-    expect(() => {
-      render(<NarrativeDisplay segment={segment} />);
-    }).not.toThrow();
+    render(<NarrativeDisplay segment={segment} />);
+
+    // Empty/malformed NPC IDs must not stop the narrative content from rendering.
+    expect(
+      screen.getByText(/An unnamed figure watches from afar/)
+    ).toBeInTheDocument();
   });
 
   it('emphasizes participant names within the narrative text', () => {

--- a/src/components/devtools/DevToolsContext/__tests__/DevToolsContext.test.tsx
+++ b/src/components/devtools/DevToolsContext/__tests__/DevToolsContext.test.tsx
@@ -8,18 +8,7 @@ import React from 'react';
 import { DevToolsProvider, useDevTools } from '../DevToolsContext';
 
 describe('DevTools Section Visibility - MVP', () => {
-  test('provides section visibility functions', () => {
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <DevToolsProvider>{children}</DevToolsProvider>
-    );
-
-    const { result } = renderHook(() => useDevTools(), { wrapper });
-
-    expect(typeof result.current.isSectionVisible).toBe('function');
-    expect(typeof result.current.toggleSectionVisibility).toBe('function');
-  });
-
-  test('sections are by default', () => {
+  test('sections are visible by default', () => {
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <DevToolsProvider>{children}</DevToolsProvider>
     );

--- a/src/hooks/__tests__/useAutoSave.test.ts
+++ b/src/hooks/__tests__/useAutoSave.test.ts
@@ -207,11 +207,4 @@ describe('useAutoSave', () => {
     expect(mockSessionStore.setAutoSaveEnabled).toHaveBeenCalledWith(false);
   });
 
-  it('should clear toast mocks before each test', () => {
-    // This test ensures our toast mocking is working
-    renderHook(() => useAutoSave());
-
-    expect(mockToast.success).toHaveBeenCalledTimes(0);
-    expect(mockToast.error).toHaveBeenCalledTimes(0);
-  });
 });

--- a/src/lib/ai/__mocks__/__tests__/mockScenarios.test.ts
+++ b/src/lib/ai/__mocks__/__tests__/mockScenarios.test.ts
@@ -306,10 +306,11 @@ describe('Mock Scenarios System - API Contract Tests', () => {
       const wordCount = response.content.split(/\s+/).length;
       const expectedTokens = Math.ceil(wordCount * 1.3); // Rough tokens-to-words ratio
       
-      if (response.promptTokens && response.completionTokens) {
-        expect(response.completionTokens).toBeGreaterThan(0);
-        expect(response.completionTokens).toBeLessThan(expectedTokens * 3); // Allow generous range
-      }
+      // success-detailed must report realistic token counts. Asserting directly (rather
+      // than inside an `if`) guards against a vacuous pass when tokens are missing.
+      expect(response.promptTokens).toBeGreaterThan(0);
+      expect(response.completionTokens).toBeGreaterThan(0);
+      expect(response.completionTokens).toBeLessThan(expectedTokens * 3); // generous range
     });
   });
 

--- a/src/lib/ai/__tests__/clientFactory.mockIntegration.test.ts
+++ b/src/lib/ai/__tests__/clientFactory.mockIntegration.test.ts
@@ -57,14 +57,7 @@ describe('Client Factory Mock Integration', () => {
   });
 
   describe('Client Factory Behavior', () => {
-    test('creates a client successfully', () => {
-      const client = createAIClient();
-
-      expect(typeof client.generateContent).toBe('function');
-      expect(typeof client.generateImage).toBe('function');
-    });
-
-    test('client implements AIClient interface', async () => {
+    test('creates a client exposing the AIClient interface', () => {
       const client = createAIClient();
 
       expect(typeof client.generateContent).toBe('function');

--- a/src/lib/lore/__tests__/fuzzyMatcher.test.ts
+++ b/src/lib/lore/__tests__/fuzzyMatcher.test.ts
@@ -144,7 +144,9 @@ describe('findPotentialDuplicates', () => {
         worldId: locationsWorld,
         category: 'locations',
         key: 'location_inn',
-        value: 'Prancing Pony Inn',
+        // Drop-the-article duplicate of "The Prancing Pony" (~0.76 similarity, above
+        // the default 0.60 threshold) so the category-filter test has a real match.
+        value: 'Prancing Pony',
         aliases: [],
         source: 'narrative',
       visibility: 'world-shared',
@@ -167,7 +169,9 @@ describe('findPotentialDuplicates', () => {
 
     const locationDuplicates = findPotentialDuplicates(mixedFacts, locationsWorld, { category: 'locations' });
 
-    // Should only find location duplicates, not characters
+    // The two similar locations must be detected (guards against a vacuous pass on []).
+    expect(locationDuplicates.length).toBeGreaterThan(0);
+    // ...and only locations are returned, never the similarly-named character.
     locationDuplicates.forEach(dup => {
       expect(dup.fact1.category).toBe('locations');
       expect(dup.fact2.category).toBe('locations');
@@ -175,10 +179,16 @@ describe('findPotentialDuplicates', () => {
   });
 
   it('respects minimum confidence threshold', () => {
-    const duplicates = findPotentialDuplicates(testFacts, worldId, { minConfidence: 0.95 });
+    const strict = findPotentialDuplicates(testFacts, worldId, { minConfidence: 0.95 });
+    const lenient = findPotentialDuplicates(testFacts, worldId, { minConfidence: 0.8 });
 
-    // High threshold should filter out medium-confidence matches
-    duplicates.forEach(dup => {
+    // A higher threshold must actually filter out the medium-confidence Gandalf/Gandolf
+    // match (guards against a vacuous pass when the result is empty).
+    expect(lenient.length).toBeGreaterThan(0);
+    expect(strict.length).toBeLessThan(lenient.length);
+
+    // Anything that does pass must meet the threshold.
+    strict.forEach(dup => {
       expect(dup.confidence).toBeGreaterThanOrEqual(0.95);
     });
   });

--- a/src/state/__tests__/goalStore.test.ts
+++ b/src/state/__tests__/goalStore.test.ts
@@ -217,18 +217,16 @@ describe('goalStore', () => {
 
       const goalId = useGoalStore.getState().createGoal(goalData);
 
-      // Valid transition: active -> completed
-      expect(() => {
-        useGoalStore.getState().updateGoal(goalId, { status: 'completed' });
-      }).not.toThrow();
+      // Valid transition: active -> completed (assert it actually took effect).
+      useGoalStore.getState().updateGoal(goalId, { status: 'completed' });
+      expect(useGoalStore.getState().goals[goalId].status).toBe('completed');
 
-      // Reset for next test
+      // Reset, then transition active -> abandoned.
       useGoalStore.getState().updateGoal(goalId, { status: 'active' });
+      expect(useGoalStore.getState().goals[goalId].status).toBe('active');
 
-      // Valid transition: active -> abandoned
-      expect(() => {
-        useGoalStore.getState().updateGoal(goalId, { status: 'abandoned' });
-      }).not.toThrow();
+      useGoalStore.getState().updateGoal(goalId, { status: 'abandoned' });
+      expect(useGoalStore.getState().goals[goalId].status).toBe('abandoned');
     });
 
     test('should track goal progress with notes', () => {

--- a/src/state/__tests__/loreStore.aliases.test.ts
+++ b/src/state/__tests__/loreStore.aliases.test.ts
@@ -130,6 +130,9 @@ describe('LoreStore - Alias Management', () => {
           result.current.addAlias('non-existent-id', 'Alias');
         });
       }).not.toThrow();
+
+      // "Do nothing" must mean no fact is created under the missing id.
+      expect(result.current.getById('non-existent-id')).toBeUndefined();
     });
   });
 
@@ -188,6 +191,9 @@ describe('LoreStore - Alias Management', () => {
           result.current.removeAlias('non-existent-id', 'Alias');
         });
       }).not.toThrow();
+
+      // "Do nothing" must mean no fact is created under the missing id.
+      expect(result.current.getById('non-existent-id')).toBeUndefined();
     });
   });
 
@@ -334,6 +340,9 @@ describe('LoreStore - Alias Management', () => {
           result.current.setAliases('non-existent-id', ['Alias']);
         });
       }).not.toThrow();
+
+      // "Do nothing" must mean no fact is created under the missing id.
+      expect(result.current.getById('non-existent-id')).toBeUndefined();
     });
   });
 

--- a/src/state/__tests__/loreStore.deduplication.test.ts
+++ b/src/state/__tests__/loreStore.deduplication.test.ts
@@ -273,6 +273,12 @@ describe('mergeFactsImpl', () => {
     expect(() => {
       mergeFactsImpl(primaryFact.id, secondaryFact.id, mockContext);
     }).not.toThrow();
+
+    // The merge should still proceed and update the primary despite missing metadata.
+    expect(mockContext.updateFact).toHaveBeenCalledWith(
+      primaryFact.id,
+      expect.any(Object)
+    );
   });
 
   it('determines primary based on importance when swapped', () => {

--- a/src/state/__tests__/persistence/worldStore.persistence.test.ts
+++ b/src/state/__tests__/persistence/worldStore.persistence.test.ts
@@ -241,22 +241,9 @@ describe('worldStore persistence', () => {
     });
   });
 
-  describe('fallback behavior', () => {
-    test('should log appropriate errors on persistence failure', async () => {
-      // Mock console.error
-      const consoleError = jest.spyOn(console, 'error').mockImplementation();
-      
-      // Make getItem call to trigger onRehydrateStorage error handler
-      mockGetItem('narraitor-world-store');
-      
-      // Allow async operations to complete
-      await new Promise(resolve => setTimeout(resolve, 10));
-      
-      // Verify getItem was called
-      expect(mockGetItem).toHaveBeenCalled();
-
-      // Restore console.error
-      consoleError.mockRestore();
-    });
-  });
+  // NOTE: a "fallback behavior / logs errors on persistence failure" test was removed
+  // here. It was self-fulfilling (it called the mock itself, then asserted the mock was
+  // called) and could not be salvaged in place: this file mocks out zustand's `persist`
+  // middleware, so `onRehydrateStorage`'s error handler never runs. Real persistence-error
+  // logging coverage needs a separate test that exercises the un-mocked persist path.
 });

--- a/src/utils/__tests__/storageHelpers.test.ts
+++ b/src/utils/__tests__/storageHelpers.test.ts
@@ -186,38 +186,29 @@ describe('storageHelpers', () => {
       expect(mockIndexedDB.deleteDatabase).toHaveBeenCalledTimes(1);
     });
 
-    test('should handle partial clearing on error', async () => {
+    test('swallows non-security deletion errors (logs, does not reject)', async () => {
       const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
-      
-      // Mock first deletion success, second failure
-      let callCount = 0;
+
+      // Fire the async onerror path with a generic (non-SecurityError) error.
       mockIndexedDB.deleteDatabase.mockImplementation(() => {
         const request = {
           onsuccess: null as ((ev: Event) => void) | null,
           onerror: null as ((ev: Event) => void) | null
         };
-        
+
         setTimeout(() => {
-          if (callCount === 0 && request.onsuccess) {
-            request.onsuccess({} as Event);
-          } else if (callCount === 1 && request.onerror) {
-            request.onerror({ target: { error: new Error('Delete failed') } } as unknown as Event);
-          }
-          callCount++;
+          request.onerror?.({ target: { error: new Error('Delete failed') } } as unknown as Event);
         }, 0);
-        
+
         return request;
       });
 
-      try {
-        await clearAllStoredData();
-      } catch {
-        // Expected to throw
-      }
+      // Non-security errors are logged and swallowed so the rest of the cleanup
+      // can proceed — the call must resolve, not reject.
+      await expect(clearAllStoredData()).resolves.toBeUndefined();
+      expect(mockIndexedDB.deleteDatabase).toHaveBeenCalledWith('narraitor-state');
+      expect(consoleError).toHaveBeenCalled();
 
-      // First database should be cleared
-      expect(mockIndexedDB.deleteDatabase).toHaveBeenCalled();
-      
       consoleError.mockRestore();
     });
 


### PR DESCRIPTION
## Summary

Several unit tests passed without actually asserting the behavior they claimed to cover. They were found via a manual review pass plus a one-off mutation-testing pass (Stryker, throwaway scaffolding — not added to the repo). This PR fixes them in-place; no source code changes, tests only.

- **fuzzyMatcher** — the "filters by category" and "respects minimum confidence" tests iterated over the result with no length guard, so an empty result passed vacuously. Added guards; this surfaced a fixture pair ("The Prancing Pony" / "Prancing Pony Inn") sitting at ~0.59, just under the 0.60 match threshold, so it never actually matched — fixed the fixture to a real duplicate. The threshold test now compares strict (0.95) vs lenient (0.8) to prove filtering.
- **storageHelpers** — replaced an empty-`catch` self-passing test with one that fires the real non-security `onerror` path and asserts the call resolves (error swallowed) and logs.
- **loreStore aliases/dedup, goalStore transitions, mockScenarios tokens** — now assert the actual effect (fact stays absent / status changed / tokens present) instead of only "did not throw".
- **NarrativeDisplay** — two render-not-throw tests now assert the narrative content actually renders.
- **Removed** tests that only checked a mock's own shape (SessionBoundaryLogging, DevToolsContext, a useAutoSave meta-test) or were self-fulfilling (worldStore.persistence "logs errors" — the file mocks out `persist`, so the path is untestable there); collapsed a duplicate clientFactory test.

## Test plan

- [x] `jest` on all 13 modified suites — 124 passing
- [x] `eslint` on all 13 files — 0 errors
- [x] Rebased on latest `develop`
- [ ] CI green