### PR TITLE
fix(storybook): wrap stories in TutorialProvider (#1130)

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -13,6 +13,7 @@ import {
 } from 'next/font/google';
 import { ThemeProvider, useTheme } from '../src/lib/theme/ThemeProvider';
 import type { DesignSystem, ColorScheme } from '../src/lib/theme';
+import { TutorialProvider } from '../src/components/TutorialProvider/TutorialProvider';
 
 import '../src/app/globals.css';
 import '../src/app/workshop.css';
@@ -70,7 +71,9 @@ const withTheme = (Story: React.FC, context: { globals: Record<string, string> }
     <ThemeProvider>
       <FontInjector />
       <ThemeSyncer sbTheme={theme} sbColorScheme={colorScheme} />
-      <Story />
+      <TutorialProvider>
+        <Story />
+      </TutorialProvider>
     </ThemeProvider>
   );
 };

--- a/src/stories/02-molecules/ui-components/layout/CollapsibleSection.stories.tsx
+++ b/src/stories/02-molecules/ui-components/layout/CollapsibleSection.stories.tsx
@@ -1,9 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
 import { CollapsibleSection } from '@/components/ui/CollapsibleSection';
 
 const meta: Meta<typeof CollapsibleSection> = {
   title: '02-Molecules/ui-components/layout/CollapsibleSection',
   component: CollapsibleSection,
+  args: {
+    // Explicit spy so Storybook's implicit-action regex doesn't throw when the
+    // component fires onToggle from its mount effect (Storybook 8 deprecation).
+    onToggle: fn(),
+  },
   parameters: {
     layout: 'centered',
     docs: {


### PR DESCRIPTION
## Summary

Fixes #1130. Three Storybook story groups rendered an error screen instead of their component:

- **Navigation** and **MobileNavigationMenu** crashed with `useTutorial must be used within TutorialProvider` because `.storybook/preview.tsx` never wrapped stories in `TutorialProvider`. Added it to the global `withTheme` decorator, so every story (and any future component using `useTutorial()`) gets the context.
- **CollapsibleSection** turned out to crash for a *different* reason — not a provider gap. It fires `onToggle` from a mount `useEffect`, and the global `argTypesRegex: '^on[A-Z].*'` auto-spied that as an *implicit* action, which Storybook 8 throws on when invoked during render. Fixed with an explicit `fn()` spy (`args: { onToggle: fn() }`), the pattern Storybook itself recommends and already used across the repo. The issue lumped this story in with the `useTutorial` crash; the symptom (red error screen) was the same, the cause wasn't.

Both fixes are theme-independent.

## Changes

- `.storybook/preview.tsx` — import `TutorialProvider`, wrap `<Story />` inside it in `withTheme`.
- `src/stories/.../CollapsibleSection.stories.tsx` — add `onToggle: fn()` to meta args.

`TutorialProgressWidget` renders `null` and `Joyride` only mounts during an active tour, so the global wrap adds nothing visible to other stories — no snapshot pollution.

## Verification

- `npm run type-check`, `npm run lint`, `npm run build-storybook` — clean.
- Ran Storybook and confirmed in a browser that **Navigation**, **MobileNavigationMenu**, and **CollapsibleSection** render their components (no error screen) across **DS1, DS2, and DS3**.
- Spot-checked an unrelated atom story (Button) — renders normally, no stray tutorial widget, no regression.

## Test plan

- [ ] CI green (type-check, lint, knip, build, storybook build, e2e)
- [ ] Reviewer loads the three story groups in Storybook and confirms they render

🤖 Generated with [Claude Code](https://claude.com/claude-code)