### PR TITLE
feat: extract token usage from GeminiClient SDK responses

### DIFF
--- a/src/lib/ai/__tests__/geminiClient.test.ts
+++ b/src/lib/ai/__tests__/geminiClient.test.ts
@@ -61,6 +61,10 @@ describe('GeminiClient', () => {
         text: 'Generated test content',
         result: {
           finishReason: 'STOP'
+        },
+        usageMetadata: {
+          promptTokenCount: 12,
+          candidatesTokenCount: 34
         }
       };
       mockGenerateContent.mockResolvedValueOnce(mockSDKResponse);
@@ -79,9 +83,46 @@ describe('GeminiClient', () => {
       expect(result).toEqual({
         content: 'Generated test content',
         finishReason: 'STOP',
-        promptTokens: undefined,
-        completionTokens: undefined
+        promptTokens: 12,
+        completionTokens: 34
       });
+    });
+
+    test('should extract token usage from SDK usageMetadata', async () => {
+      const mockSDKResponse = {
+        text: 'Token tracked content',
+        result: {
+          finishReason: 'STOP'
+        },
+        usageMetadata: {
+          promptTokenCount: 150,
+          candidatesTokenCount: 275,
+          totalTokenCount: 425
+        }
+      };
+      mockGenerateContent.mockResolvedValueOnce(mockSDKResponse);
+
+      client = new GeminiClient(config);
+      const result = await client.generateContent('Test prompt');
+
+      expect(result.promptTokens).toBe(150);
+      expect(result.completionTokens).toBe(275);
+    });
+
+    test('should return undefined token counts when usageMetadata is absent', async () => {
+      const mockSDKResponse = {
+        text: 'No usage metadata',
+        result: {
+          finishReason: 'STOP'
+        }
+      };
+      mockGenerateContent.mockResolvedValueOnce(mockSDKResponse);
+
+      client = new GeminiClient(config);
+      const result = await client.generateContent('Test prompt');
+
+      expect(result.promptTokens).toBeUndefined();
+      expect(result.completionTokens).toBeUndefined();
     });
 
     test('should retry on transient errors', async () => {

--- a/src/lib/ai/geminiClient.ts
+++ b/src/lib/ai/geminiClient.ts
@@ -77,8 +77,8 @@ export class GeminiClient implements AIClient {
       return {
         content: response.text || '',
         finishReason: response.result?.finishReason || 'STOP',
-        promptTokens: undefined,
-        completionTokens: undefined
+        promptTokens: response.usageMetadata?.promptTokenCount || undefined,
+        completionTokens: response.usageMetadata?.candidatesTokenCount || undefined
       };
     } catch (error) {
       logger.error('GEMINI API: Request failed:', error);

--- a/src/types/@google/genai.d.ts
+++ b/src/types/@google/genai.d.ts
@@ -13,11 +13,18 @@ declare module '@google/genai' {
     threshold: string;
   }
 
+  export interface GenerateContentResponseUsageMetadata {
+    promptTokenCount?: number;
+    candidatesTokenCount?: number;
+    totalTokenCount?: number;
+  }
+
   export interface GenerateContentResponse {
     text: string;
     result?: {
       finishReason: string;
     };
+    usageMetadata?: GenerateContentResponseUsageMetadata;
   }
 
   export interface GenerateContentConfig {


### PR DESCRIPTION
## Summary

Closes #326.

`GeminiClient.makeRequest` was hardcoding `promptTokens`/`completionTokens` to `undefined`. The `@google/genai` SDK already returns `usageMetadata` on each response, so this reads `promptTokenCount` and `candidatesTokenCount` from it — the same fields the REST path in `src/utils/apiHelpers.ts` already extracts. Now the SDK client path reports real token counts for cost/usage tracking.

## Changes

- `src/lib/ai/geminiClient.ts` — read token counts from `response.usageMetadata` instead of returning `undefined`.
- `src/types/@google/genai.d.ts` — the project's local ambient declaration shadows the real SDK types, so it needed `usageMetadata` added for the extraction to typecheck.
- `src/lib/ai/__tests__/geminiClient.test.ts` — assert tokens are extracted from `usageMetadata`, plus a case where it's absent (falls back to `undefined`).

Kept it minimal — no separate usage-tracking/aggregation service (that was a "consider" in the issue, not required for MVP).

## Test plan

- [x] `npx jest src/lib/ai/__tests__/geminiClient.test.ts` — 10 passing
- [x] `npx jest src/lib/ai src/utils/apiHelpers` — 369 passing, no regressions
- [x] `npx tsc --noEmit` — clean
- [x] eslint on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)