### PR TITLE
fix: demote self-healed language-complexity logs to debug (#916)

### DIFF
--- a/src/lib/ai/__tests__/narrativeGenerator.languageComplexity.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.languageComplexity.test.ts
@@ -1,0 +1,70 @@
+import { enforceLanguageComplexity } from '../narrativeGenerator.languageComplexity';
+import { MockAIClient } from '../../__mocks__/mockAiClient';
+import { logger } from '@/lib/utils/logger';
+import type { NarrativeGenerationResult } from '@/types/narrative.types';
+import type { ToneSettings } from '@/types/tone-settings.types';
+
+const COMPLEXITY_WARNINGS = [
+  'Language complexity rewrite did not pass thresholds',
+  'Generated narrative exceeds language complexity guidelines',
+];
+
+const denseProse =
+  'Calibrated luminescence surges through the labyrinthine conduits, illuminating iridescent glyphs with inexorable precision and unfathomable consequence.';
+
+const baseResult = (content: string): NarrativeGenerationResult => ({
+  content,
+  segmentType: 'scene',
+  metadata: {
+    characterIds: ['character-1'],
+    tags: [],
+  },
+});
+
+describe('enforceLanguageComplexity logging', () => {
+  let mockAiClient: MockAIClient;
+  let debugSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockAiClient = new MockAIClient();
+    debugSpy = jest.spyOn(logger, 'debug').mockImplementation(() => {});
+    warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('logs at debug (not warn) and still self-heals when content and rewrite both exceed thresholds', async () => {
+    // Rewrite attempt also returns dense prose, so both evaluations fail.
+    mockAiClient.setMockResponses([{ content: denseProse }]);
+
+    const toneSettings: ToneSettings = {
+      contentRating: 'PG',
+      narrativeStyle: 'dramatic',
+      languageComplexity: 'simple',
+    };
+
+    const result = await enforceLanguageComplexity(
+      baseResult(denseProse),
+      toneSettings,
+      mockAiClient
+    );
+
+    const warnMessages = warnSpy.mock.calls.map((call) => call[0]);
+    COMPLEXITY_WARNINGS.forEach((message) => {
+      expect(warnMessages).not.toContain(message);
+    });
+
+    const debugMessages = debugSpy.mock.calls.map((call) => call[0]);
+    COMPLEXITY_WARNINGS.forEach((message) => {
+      expect(debugMessages).toContain(message);
+    });
+
+    // Self-heal behavior is unchanged: original content kept, diagnostic tags added.
+    expect(result.content).toBe(denseProse);
+    expect(result.metadata.tags).toContain('language-complexity-review');
+    expect(result.metadata.tags).toContain('language-complexity-simple');
+  });
+});

--- a/src/lib/ai/narrativeGenerator.languageComplexity.ts
+++ b/src/lib/ai/narrativeGenerator.languageComplexity.ts
@@ -92,7 +92,7 @@ export const enforceLanguageComplexity = async (
         };
       }
 
-      logger.warn('Language complexity rewrite did not pass thresholds', {
+      logger.debug('Language complexity rewrite did not pass thresholds', {
         level,
         reasons: secondEval.reasons,
         metrics: secondEval.metrics,
@@ -100,7 +100,7 @@ export const enforceLanguageComplexity = async (
     }
   }
 
-  logger.warn('Generated narrative exceeds language complexity guidelines', {
+  logger.debug('Generated narrative exceeds language complexity guidelines', {
     reasons: evaluation.reasons,
     metrics: evaluation.metrics,
     level,


### PR DESCRIPTION
## Summary

Fixes the console noise from #916. During normal gameplay the console fills with two repeating WARN logs:

- `Language complexity rewrite did not pass thresholds`
- `Generated narrative exceeds language complexity guidelines`

Root cause: the default tone is `moderate` (avg sentence <=20 words, <=10% long words). Normal AI narrative routinely trips those heuristic thresholds, and the rewrite pass often doesn't hit them either. When that happens, `enforceLanguageComplexity` already self-heals -- it keeps the original content and adds two metadata tags (`language-complexity-review`, `language-complexity-{level}`) that nothing in production consumes. So nothing is broken for the player; the two `logger.warn` calls are firing at WARN for an expected, non-actionable, self-handled condition.

This is the path the issue itself suggested (investigation item 4: "Consider if these warnings should be debug-level").

## Changes

- Demote both diagnostic messages from `logger.warn` to `logger.debug` in `src/lib/ai/narrativeGenerator.languageComplexity.ts`. `logger.debug` is suppressed by default in dev (min level WARN), so the console stays clean, but the diagnostics remain reachable via `NEXT_PUBLIC_LOG_LEVEL=debug`.
- The genuine rewrite-exception path (`Failed to rewrite narrative for language complexity`, inside the catch block) stays at `warn` -- that's an actual AI/network failure, the kind of "genuine issue" the issue says warnings should be reserved for.
- New focused test `src/lib/ai/__tests__/narrativeGenerator.languageComplexity.test.ts` asserting the debug-level logging and that the self-heal behavior (original content + tags) is preserved.

Scope is intentionally minimal (log-level only) -- no threshold or prompt changes, so generation/rewrite behavior is unchanged.

## Test plan

- [x] `npx jest narrativeGenerator.languageComplexity` -- new test passes
- [x] `npx jest narrativeGenerator.toneSettings languageComplexity` -- existing suites stay green (13 tests)
- [x] `npx eslint` on touched files -- clean
- [ ] Manual: play a turn at default (moderate) tone, confirm the two messages no longer appear at WARN; set `NEXT_PUBLIC_LOG_LEVEL=debug` and confirm they reappear as DEBUG

Refs #916