### PR TITLE
docs: align radius values in ui-ux-guidelines with actual DS tokens

### DIFF
--- a/public_docs/development/ui-ux-guidelines.md
+++ b/public_docs/development/ui-ux-guidelines.md
@@ -28,21 +28,21 @@ Three design systems ship with the app, each providing a complete set of CSS cus
 Sharp lines, archival ink, graph paper grid. Technical and precise.
 - **Fonts**: Lora (narrative), IBM Plex Mono (system), IBM Plex Sans (interface)
 - **Accent**: Archival Ink Blue `rgb(49 46 129)`
-- **Radius**: `0.5rem` — square and deliberate
+- **Radius**: `--radius-md: 4px` — square and deliberate (each theme picks its own radius scale on purpose; tighter corners read as more technical)
 - **Background**: Mechanical drafting grid (72x72px)
 
 ### DS2 — "Warm Earth"
 Organic earth tones, soft forms, breathing space. Welcoming and grounded.
 - **Fonts**: Crimson Pro (narrative), JetBrains Mono (system), Manrope (interface)
 - **Accent**: Sage Green `rgb(124 139 111)`
-- **Radius**: `0.75rem` — soft and rounded
+- **Radius**: `--radius-md: 12px` — soft and rounded
 - **Background**: Clean solid (no pattern)
 
 ### DS3 — "Mechanical Manuscript"
 Aged paper, drafting ink, dot grid aesthetic. Textured and literary.
 - **Fonts**: Newsreader (narrative), Fira Code (system), DM Sans (interface)
 - **Accent**: Steel Blue `rgb(91 122 140)`
-- **Radius**: `0.375rem` — tight and compact
+- **Radius**: `--radius-md: 6px` — tight and compact
 - **Background**: Dot grid (24x24px)
 
 ### Theme Implementation


### PR DESCRIPTION
## What's going on

Issue #1203 flagged that DS1's `--radius-md` token is `4px` but `ui-ux-guidelines.md` documented it as `0.5rem` (8px). Digging in, the doc and the tokens disagreed for DS1, and DS2/DS3 were technically right on size but written in rem while the token files use px.

The actual values are:
- DS1 `--radius-md: 4px`
- DS2 `--radius-md: 12px`
- DS3 `--radius-md: 6px`

## The call

These three radii aren't a bug — they're an intentional structural difference between the design systems (DS1/DS2/DS3 are meant to differ in shape and density, not just color and font). Forcing DS1 to 8px would homogenize the themes and could invalidate CI-adopted visual baselines.

So the fix is in the docs, not the CSS: the guidelines now reference the real per-theme `--radius-md` token values, so the doc and the token files actually agree. No CSS token changed.

## Changes
- Updated the DS1/DS2/DS3 Radius lines in `public_docs/development/ui-ux-guidelines.md` to cite the actual `--radius-md` token values, with a short note that the radius scale is intentionally per-theme.

## Testing
- `npm run lint` — passes (only pre-existing warnings in untouched files)
- `npm run type-check` — clean
- Doc-only change, so no visual baselines were regenerated.

Refs #1203 — base is `develop`, so this won't auto-close the issue. Please close #1203 manually after merge.