### PR TITLE
fix: drop white placeholder on imageless world cards (#1113)

### DIFF
--- a/src/components/WorldCard/WorldCard.tsx
+++ b/src/components/WorldCard/WorldCard.tsx
@@ -11,7 +11,6 @@ import { ActiveStateCard, CardActionGroup } from '@/components/shared/cards';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
 import { formatDate } from '@/lib/utils';
-import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
 import { Hero } from '@/components/shared/Hero';
 import { CheckCircle, Play, Eye, Pencil, Trash } from 'lucide-react';
 
@@ -156,15 +155,13 @@ const WorldCard: React.FC<WorldCardProps> = ({
       <div>
         <Link href={`/worlds/${world.id}`}>
           {(() => {
-            // Use seeded placeholder image during Playwright tests if world has no image
-            const isPlaywright = isPlaywrightEnv();
-            const STABLE_PLACEHOLDER =
-              'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/awp2z0AAAAASUVORK5CYII=';
-            const heroImageUrl =
-              world.image?.url ||
-              (isPlaywright ? STABLE_PLACEHOLDER : undefined);
-            const heroImage = heroImageUrl
-              ? { url: heroImageUrl, alt: `${world.name} world` }
+            // When a world has no image, render no <img> at all and let Hero
+            // fall back to its tokenized themed background (see .component-hero
+            // in workshop.css). A previous white 1x1 placeholder rendered as a
+            // bright rectangle in dark mode (#1113). The themed empty-state is
+            // deterministic CSS, so it stays stable under visual tests too.
+            const heroImage = world.image?.url
+              ? { url: world.image.url, alt: `${world.name} world` }
               : undefined;
 
             return (

--- a/src/components/WorldCard/__tests__/WorldCard.test.tsx
+++ b/src/components/WorldCard/__tests__/WorldCard.test.tsx
@@ -4,6 +4,11 @@ import WorldCard from '../WorldCard';
 import { createMockWorld } from '@/lib/test-utils/testDataFactory';
 import { formatDate } from '@/lib/utils';
 
+// Regression: a world with no image previously rendered a white 1x1 data-URI
+// placeholder that showed as a bright rectangle in dark mode (#1113).
+const WHITE_PLACEHOLDER =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/awp2z0AAAAASUVORK5CYII=';
+
 describe('WorldCard', () => {
   const mockWorld = createMockWorld({
     name: 'Fantasy Realm',
@@ -132,6 +137,39 @@ describe('WorldCard', () => {
 
     const characterButton = screen.getByTitle('Play as Aragorn - Level 5');
     expect(characterButton).toHaveClass('world-card-character-pill');
+  });
+
+  // Regression test for #1113 - no white placeholder image in the no-image case
+  test('renders no placeholder image when the world has no image', () => {
+    const worldWithoutImage = createMockWorld({ image: undefined });
+
+    const { container } = render(
+      <WorldCard world={worldWithoutImage} onSelect={jest.fn()} onDelete={jest.fn()} />
+    );
+
+    // The themed empty-state hero renders (tokenized background via CSS), but
+    // there should be no hero <img> and no white data-URI placeholder.
+    expect(container.querySelector('.component-hero')).toBeInTheDocument();
+    expect(container.querySelector('.component-hero-image')).not.toBeInTheDocument();
+    expect(container.querySelector(`img[src="${WHITE_PLACEHOLDER}"]`)).not.toBeInTheDocument();
+  });
+
+  // Real (AI-generated) world images still render unchanged
+  test('renders the world image when one is provided', () => {
+    const worldWithImage = createMockWorld({
+      image: {
+        url: '/visual-assets/world-cyberpunk.png',
+        type: 'ai-generated',
+      },
+    });
+
+    const { container } = render(
+      <WorldCard world={worldWithImage} onSelect={jest.fn()} onDelete={jest.fn()} />
+    );
+
+    const heroImage = container.querySelector('.component-hero-image');
+    expect(heroImage).toBeInTheDocument();
+    expect(heroImage?.getAttribute('src')).not.toBe(WHITE_PLACEHOLDER);
   });
 
   // Test for Edit functionality


### PR DESCRIPTION
## What's going on

World cards on `/worlds` were injecting a white 1x1 PNG data URI as a placeholder whenever a world had no image (this only kicked in under Playwright, but it's the same code path the issue is about). Stretched across the hero, that white pixel showed up as a bright rectangle against the dark canvas in dark mode -- visually jarring, exactly what #1113 describes.

## The fix

When a world has no image, `WorldCard` now renders no `<img>` at all and lets `Hero` fall back to its existing tokenized themed background (`.component-hero` in `workshop.css`). That background is built from design tokens via `var()`, so it reads correctly across DS1/DS2/DS3 in both light and dark -- no more white rectangle.

Real AI-generated world images are untouched: if `world.image.url` is set, it renders exactly as before. And since the empty state is just deterministic CSS, visual tests stay stable -- nothing random sneaks in.

This also let me drop the now-unused `isPlaywrightEnv` import and the inline white-pixel data URI.

## Tests

Added two MVP tests to `WorldCard.test.tsx`:
- no-image world renders the themed hero but no `<img>` and no white data-URI placeholder
- a world with an image still renders the hero image (and it's not the white placeholder)

`npm run lint`, `npx tsc --noEmit`, and the WorldCard suite all pass. Didn't regenerate any visual-regression baselines.

## Browser check

Skipped the live check -- a dev server was already running on port 3000, but it's the main checkout, not this worktree, so it wouldn't reflect the change. Didn't want to kill it or fight setup with a competing server.

Refs #1113 (base is `develop`, so this won't auto-close -- close the issue manually after merge). Part of epic #1020.