### PR TITLE
Fix DS1 wizard template-grid overflow in the 1025-1080px band

### DIFF
--- a/src/app/wizard.css
+++ b/src/app/wizard.css
@@ -700,6 +700,15 @@
   align-items: stretch;
 }
 
+/* Let the choice panels shrink below their content's min-content size so the
+   three-column grid never spills past its track. Without this, the default
+   min-width:auto keeps the panels wider than the DS1 content column in the
+   ~1025–1080px band (sidebar + manuscript rail present), pushing the tab
+   navigation past the viewport. Wrapping content absorbs the squeeze instead. */
+.wizard-template-mode-grid > * {
+  min-width: 0;
+}
+
 .wizard-template-mode-divider {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

The world/character creation wizard's template-mode choice grid (`.wizard-template-mode-grid`, the three-column "Start from Scratch / or / Use a Template" panel) causes horizontal page overflow in **DS1** between **1025px and ~1080px**, pushing the template tab navigation past the viewport.

This is the residual of the same overflow fixed for the 768–1024px band in `4959f180`. That commit raised the grid-collapse breakpoint to `<= 1024px`, but at 1025px the three-column grid resumes while the DS1 manuscript rail (~448px) and the app sidebar (~288px) are both still present. The `1fr` panels default to `min-width: auto`, so they refuse to shrink below their content's min-content width and spill out of the `minmax(0, 1fr)` content column.

PR #1275 (rail-width sync) did not address this — the overflow still reproduces on current `develop`.

## Fix

One rule on the base, theme-independent selector in `src/app/wizard.css`:

```css
.wizard-template-mode-grid > * {
  min-width: 0;
}
```

This lets the choice panels shrink and wrap instead of overflowing. It's the root cause (grid items unable to shrink), not another breakpoint patch.

## Verification

Measured directly against the live `develop`/#1275 codebase by toggling the rule on/off (CDP viewport emulation):

| Width | DS1 overflow (no fix) | DS1 overflow (fix) |
|-------|----------------------|--------------------|
| 1025px | 39px | 0 |
| 1040px | 24px | 0 |
| 1060px | 4px  | 0 |
| 1080px | 0 | 0 |
| 1280px | 0 | 0 |

- Zero horizontal overflow across **DS1/DS2/DS3** from 768px through 1280px.
- **1280px grid columns are byte-identical** with and without the fix (`270.859px 81.2812px 270.859px`) — desktop layout and existing visual baselines are unchanged, because the tracks already sit above min-content there.
- ds-guard clean (`min-width: 0` is token-exempt; no hardcoded colors/spacing, no off-system tokens, no Tailwind, no inline styles).
- stylelint passes.

## Test plan

- [ ] Visual-regression suite stays green (1280px baselines should not move)
- [ ] Manual check: `/worlds/create?step=1` at ~1025–1080px in DS1 shows no horizontal scrollbar