### PR TITLE
Add per-entry image generation to the journal (#975)

### DIFF
--- a/src/app/api/generate-journal-image/__tests__/route.test.ts
+++ b/src/app/api/generate-journal-image/__tests__/route.test.ts
@@ -1,0 +1,141 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('@/lib/ai/geminiImageGenerator', () => ({
+  generateAndSaveImageWithGemini: jest.fn(),
+}));
+jest.mock('@/lib/utils/logger', () => {
+  return jest.fn().mockImplementation(() => ({
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  }));
+});
+jest.mock('@/lib/utils/genrePromptGuide', () => ({
+  getGenreStyleGuidance: jest.fn((genre: string, context: string) => `style for ${genre} ${context}`),
+  getGenreFallbackImage: jest.fn((genre: string, seed: string) => `https://picsum.photos/seed/${seed}/800/600`),
+}));
+
+import { NextRequest } from 'next/server';
+import { POST } from '../route';
+import { generateAndSaveImageWithGemini } from '@/lib/ai/geminiImageGenerator';
+import type { JournalEntry } from '@/types/journal.types';
+import type { World } from '@/types/world.types';
+
+const mockGenerateAndSave = generateAndSaveImageWithGemini as jest.MockedFunction<
+  typeof generateAndSaveImageWithGemini
+>;
+
+const mockEntry: JournalEntry = {
+  id: 'entry-1',
+  sessionId: 'session-1',
+  worldId: 'world-1',
+  characterId: 'char-1',
+  type: 'character_event',
+  title: 'A Turning Point',
+  content: 'Short summary.',
+  detailedContent: 'The hero crossed the burning bridge as the city fell behind them.',
+  significance: 'major',
+  isRead: false,
+  relatedEntities: [],
+  metadata: { tags: [], automaticEntry: false },
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+};
+
+const mockWorld: World = {
+  id: 'world-1',
+  name: 'Test Realm',
+  description: 'A fantasy realm',
+  genre: 'fantasy',
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+  attributes: [],
+  skills: [],
+  settings: { maxAttributes: 10, maxSkills: 20, attributePointPool: 25, skillPointPool: 30 },
+};
+
+const makeRequest = (body: unknown) =>
+  new NextRequest('http://localhost:3000/api/generate-journal-image', {
+    method: 'POST',
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+
+describe('/api/generate-journal-image', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.GEMINI_API_KEY = 'test-api-key';
+  });
+
+  afterEach(() => {
+    delete process.env.GEMINI_API_KEY;
+  });
+
+  it('returns 400 when no entry is provided', async () => {
+    const response = await POST(makeRequest({ world: mockWorld }));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Journal entry data is required');
+  });
+
+  it('builds a prompt from the entry content and saves the image', async () => {
+    mockGenerateAndSave.mockResolvedValue({ url: '/uploads/journals/entry-1.png', fileSize: 2048 });
+
+    const response = await POST(makeRequest({ entry: mockEntry, world: mockWorld }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.aiGenerated).toBe(true);
+    expect(data.placeholder).toBe(false);
+    expect(data.imageUrl).toBe('/uploads/journals/entry-1.png');
+
+    const [prompt, , entityId, category] = mockGenerateAndSave.mock.calls[0];
+    expect(prompt).toContain('burning bridge');
+    expect(prompt).toContain('A Turning Point');
+    expect(entityId).toBe('entry-1');
+    expect(category).toBe('journals');
+  });
+
+  it('uses the custom prompt verbatim when provided', async () => {
+    mockGenerateAndSave.mockResolvedValue({ url: '/uploads/journals/entry-1.png', fileSize: 2048 });
+
+    await POST(makeRequest({ entry: mockEntry, world: mockWorld, customPrompt: 'A lone lighthouse' }));
+
+    expect(mockGenerateAndSave.mock.calls[0][0]).toBe('A lone lighthouse');
+  });
+
+  it('falls back to a placeholder when the API key is missing', async () => {
+    delete process.env.GEMINI_API_KEY;
+
+    const response = await POST(makeRequest({ entry: mockEntry, world: mockWorld }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.aiGenerated).toBe(false);
+    expect(data.placeholder).toBe(true);
+    expect(data.imageUrl).toContain('picsum.photos');
+    expect(mockGenerateAndSave).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a placeholder when generation returns null', async () => {
+    mockGenerateAndSave.mockResolvedValue(null);
+
+    const response = await POST(makeRequest({ entry: mockEntry, world: mockWorld }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.aiGenerated).toBe(false);
+    expect(data.placeholder).toBe(true);
+    expect(data.imageUrl).toContain('picsum.photos');
+  });
+
+  it('returns 500 when request parsing fails', async () => {
+    const response = await POST(makeRequest('invalid json'));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe('Failed to generate journal image. Please try again.');
+  });
+});

--- a/src/app/api/generate-journal-image/__tests__/route.test.ts
+++ b/src/app/api/generate-journal-image/__tests__/route.test.ts
@@ -3,7 +3,7 @@
  */
 
 jest.mock('@/lib/ai/geminiImageGenerator', () => ({
-  generateAndSaveImageWithGemini: jest.fn(),
+  generateImageWithGemini: jest.fn(),
 }));
 jest.mock('@/lib/utils/logger', () => {
   return jest.fn().mockImplementation(() => ({
@@ -19,13 +19,11 @@ jest.mock('@/lib/utils/genrePromptGuide', () => ({
 
 import { NextRequest } from 'next/server';
 import { POST } from '../route';
-import { generateAndSaveImageWithGemini } from '@/lib/ai/geminiImageGenerator';
+import { generateImageWithGemini } from '@/lib/ai/geminiImageGenerator';
 import type { JournalEntry } from '@/types/journal.types';
 import type { World } from '@/types/world.types';
 
-const mockGenerateAndSave = generateAndSaveImageWithGemini as jest.MockedFunction<
-  typeof generateAndSaveImageWithGemini
->;
+const mockGenerate = generateImageWithGemini as jest.MockedFunction<typeof generateImageWithGemini>;
 
 const mockEntry: JournalEntry = {
   id: 'entry-1',
@@ -80,19 +78,12 @@ describe('/api/generate-journal-image', () => {
     expect(data.error).toBe('Journal entry data is required');
   });
 
-  it('rejects an entry id with unsafe path characters', async () => {
-    const response = await POST(
-      makeRequest({ entry: { ...mockEntry, id: '../../etc/passwd' }, world: mockWorld })
-    );
-    const data = await response.json();
-
-    expect(response.status).toBe(400);
-    expect(data.error).toBe('Invalid journal entry id');
-    expect(mockGenerateAndSave).not.toHaveBeenCalled();
-  });
-
-  it('builds a prompt from the entry content and saves the image', async () => {
-    mockGenerateAndSave.mockResolvedValue({ url: '/uploads/journals/entry-1.png', fileSize: 2048 });
+  it('builds a prompt from the entry content and returns the generated image', async () => {
+    mockGenerate.mockResolvedValue({
+      url: 'data:image/png;base64,abc123',
+      mimeType: 'image/png',
+      base64Data: 'abc123',
+    });
 
     const response = await POST(makeRequest({ entry: mockEntry, world: mockWorld }));
     const data = await response.json();
@@ -100,21 +91,23 @@ describe('/api/generate-journal-image', () => {
     expect(response.status).toBe(200);
     expect(data.aiGenerated).toBe(true);
     expect(data.placeholder).toBe(false);
-    expect(data.imageUrl).toBe('/uploads/journals/entry-1.png');
+    expect(data.imageUrl).toBe('data:image/png;base64,abc123');
 
-    const [prompt, , entityId, category] = mockGenerateAndSave.mock.calls[0];
+    const prompt = mockGenerate.mock.calls[0][0];
     expect(prompt).toContain('burning bridge');
     expect(prompt).toContain('A Turning Point');
-    expect(entityId).toBe('entry-1');
-    expect(category).toBe('journals');
   });
 
   it('uses the custom prompt verbatim when provided', async () => {
-    mockGenerateAndSave.mockResolvedValue({ url: '/uploads/journals/entry-1.png', fileSize: 2048 });
+    mockGenerate.mockResolvedValue({
+      url: 'data:image/png;base64,abc123',
+      mimeType: 'image/png',
+      base64Data: 'abc123',
+    });
 
     await POST(makeRequest({ entry: mockEntry, world: mockWorld, customPrompt: 'A lone lighthouse' }));
 
-    expect(mockGenerateAndSave.mock.calls[0][0]).toBe('A lone lighthouse');
+    expect(mockGenerate.mock.calls[0][0]).toBe('A lone lighthouse');
   });
 
   it('falls back to a placeholder when the API key is missing', async () => {
@@ -127,11 +120,11 @@ describe('/api/generate-journal-image', () => {
     expect(data.aiGenerated).toBe(false);
     expect(data.placeholder).toBe(true);
     expect(data.imageUrl).toContain('picsum.photos');
-    expect(mockGenerateAndSave).not.toHaveBeenCalled();
+    expect(mockGenerate).not.toHaveBeenCalled();
   });
 
   it('falls back to a placeholder when generation returns null', async () => {
-    mockGenerateAndSave.mockResolvedValue(null);
+    mockGenerate.mockResolvedValue(null);
 
     const response = await POST(makeRequest({ entry: mockEntry, world: mockWorld }));
     const data = await response.json();

--- a/src/app/api/generate-journal-image/__tests__/route.test.ts
+++ b/src/app/api/generate-journal-image/__tests__/route.test.ts
@@ -80,6 +80,17 @@ describe('/api/generate-journal-image', () => {
     expect(data.error).toBe('Journal entry data is required');
   });
 
+  it('rejects an entry id with unsafe path characters', async () => {
+    const response = await POST(
+      makeRequest({ entry: { ...mockEntry, id: '../../etc/passwd' }, world: mockWorld })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Invalid journal entry id');
+    expect(mockGenerateAndSave).not.toHaveBeenCalled();
+  });
+
   it('builds a prompt from the entry content and saves the image', async () => {
     mockGenerateAndSave.mockResolvedValue({ url: '/uploads/journals/entry-1.png', fileSize: 2048 });
 

--- a/src/app/api/generate-journal-image/route.ts
+++ b/src/app/api/generate-journal-image/route.ts
@@ -57,7 +57,20 @@ export async function POST(request: NextRequest) {
     }
 
     const { entry, world, customPrompt } = body;
-    logger.debug('generate-journal-image', 'Starting image generation for entry:', entry.id);
+
+    // The entry id becomes part of a saved file path (and a log line), so
+    // constrain it to a safe allowlist at the boundary. This rejects path
+    // separators / control characters outright, on top of the sanitizing
+    // saveBase64Image already does.
+    if (typeof entry.id !== 'string' || !/^[a-zA-Z0-9_-]+$/.test(entry.id)) {
+      return NextResponse.json(
+        { error: 'Invalid journal entry id' },
+        { status: 400 }
+      );
+    }
+    const entryId = entry.id;
+
+    logger.debug('generate-journal-image', 'Starting image generation for entry:', entryId);
 
     const imagePrompt = customPrompt || generateImagePrompt(entry, world);
     const apiKey = process.env.GEMINI_API_KEY;
@@ -76,14 +89,14 @@ export async function POST(request: NextRequest) {
       const savedImage = await generateAndSaveImageWithGemini(
         imagePrompt,
         apiKey,
-        entry.id,
+        entryId,
         'journals'
       );
 
       if (savedImage) {
         logger.debug(
           'generate-journal-image',
-          `Gemini image saved successfully: ${savedImage.url} (${savedImage.fileSize} bytes)`
+          `Gemini image saved successfully (${savedImage.fileSize} bytes)`
         );
         return NextResponse.json({
           imageUrl: savedImage.url,

--- a/src/app/api/generate-journal-image/route.ts
+++ b/src/app/api/generate-journal-image/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import type { JournalEntry } from '@/types/journal.types';
 import type { World } from '@/types/world.types';
 import Logger from '@/lib/utils/logger';
-import { generateAndSaveImageWithGemini } from '@/lib/ai/geminiImageGenerator';
+import { generateImageWithGemini } from '@/lib/ai/geminiImageGenerator';
 import { getGenreStyleGuidance, getGenreFallbackImage } from '@/lib/utils/genrePromptGuide';
 
 const logger = new Logger('JournalImageAPI');
@@ -57,21 +57,7 @@ export async function POST(request: NextRequest) {
     }
 
     const { entry, world, customPrompt } = body;
-
-    // The entry id becomes part of a saved file path (and a log line), so
-    // constrain it to a safe allowlist at the boundary. Capture it into a
-    // single variable first, then guard *that* variable, so the validated
-    // value is the one that flows onward (rejects path separators / control
-    // characters outright, on top of saveBase64Image's own sanitizing).
-    const entryId = entry.id;
-    if (typeof entryId !== 'string' || !/^[a-zA-Z0-9_-]+$/.test(entryId)) {
-      return NextResponse.json(
-        { error: 'Invalid journal entry id' },
-        { status: 400 }
-      );
-    }
-
-    logger.debug('generate-journal-image', 'Starting image generation for entry:', entryId);
+    logger.debug('generate-journal-image', 'Starting image generation');
 
     const imagePrompt = customPrompt || generateImagePrompt(entry, world);
     const apiKey = process.env.GEMINI_API_KEY;
@@ -87,20 +73,12 @@ export async function POST(request: NextRequest) {
     }
 
     try {
-      const savedImage = await generateAndSaveImageWithGemini(
-        imagePrompt,
-        apiKey,
-        entryId,
-        'journals'
-      );
+      const generatedImage = await generateImageWithGemini(imagePrompt, apiKey);
 
-      if (savedImage) {
-        logger.debug(
-          'generate-journal-image',
-          `Gemini image saved successfully (${savedImage.fileSize} bytes)`
-        );
+      if (generatedImage) {
+        logger.debug('generate-journal-image', 'Gemini image generated successfully');
         return NextResponse.json({
-          imageUrl: savedImage.url,
+          imageUrl: generatedImage.url,
           prompt: imagePrompt,
           placeholder: false,
           aiGenerated: true,

--- a/src/app/api/generate-journal-image/route.ts
+++ b/src/app/api/generate-journal-image/route.ts
@@ -59,16 +59,17 @@ export async function POST(request: NextRequest) {
     const { entry, world, customPrompt } = body;
 
     // The entry id becomes part of a saved file path (and a log line), so
-    // constrain it to a safe allowlist at the boundary. This rejects path
-    // separators / control characters outright, on top of the sanitizing
-    // saveBase64Image already does.
-    if (typeof entry.id !== 'string' || !/^[a-zA-Z0-9_-]+$/.test(entry.id)) {
+    // constrain it to a safe allowlist at the boundary. Capture it into a
+    // single variable first, then guard *that* variable, so the validated
+    // value is the one that flows onward (rejects path separators / control
+    // characters outright, on top of saveBase64Image's own sanitizing).
+    const entryId = entry.id;
+    if (typeof entryId !== 'string' || !/^[a-zA-Z0-9_-]+$/.test(entryId)) {
       return NextResponse.json(
         { error: 'Invalid journal entry id' },
         { status: 400 }
       );
     }
-    const entryId = entry.id;
 
     logger.debug('generate-journal-image', 'Starting image generation for entry:', entryId);
 

--- a/src/app/api/generate-journal-image/route.ts
+++ b/src/app/api/generate-journal-image/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from 'next/server';
+import type { JournalEntry } from '@/types/journal.types';
+import type { World } from '@/types/world.types';
+import Logger from '@/lib/utils/logger';
+import { generateAndSaveImageWithGemini } from '@/lib/ai/geminiImageGenerator';
+import { getGenreStyleGuidance, getGenreFallbackImage } from '@/lib/utils/genrePromptGuide';
+
+const logger = new Logger('JournalImageAPI');
+
+// Cap how much entry text we feed into the prompt to keep generation focused.
+const MAX_CONTENT_CHARS = 600;
+
+interface GenerateJournalImageRequest {
+  entry: JournalEntry;
+  world?: World;
+  customPrompt?: string;
+}
+
+// Build a scene prompt from the entry's narrative content.
+function generateImagePrompt(entry: JournalEntry, world?: World): string {
+  const genre = world?.genre?.toLowerCase() || 'fantasy';
+  const sceneText = (entry.detailedContent || entry.content || '').slice(0, MAX_CONTENT_CHARS);
+  const styleGuidance = getGenreStyleGuidance(genre, 'landscape');
+
+  return `Create a highly detailed, cinematic illustration capturing this moment from a story journal${
+    world ? ` set in the world "${world.name}"` : ''
+  }. Genre: ${genre}.
+
+Scene: ${entry.title ? `${entry.title}. ` : ''}${sceneText}
+
+${styleGuidance}
+
+Requirements:
+- Ultra-high quality concept art illustrating the described moment
+- Cinematic composition with dramatic, atmospheric lighting
+- Rich detail and environmental storytelling
+- Professional game/film concept art style
+- Landscape orientation (16:9 or similar)
+- No text, logos, or watermarks
+- Colors and mood appropriate to the scene and ${genre} genre`;
+}
+
+function generateFallbackImage(entry: JournalEntry, world?: World): string {
+  const genre = world?.genre || 'fantasy';
+  return getGenreFallbackImage(genre, `journal-${entry.id}`);
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as GenerateJournalImageRequest;
+
+    if (!body.entry) {
+      return NextResponse.json(
+        { error: 'Journal entry data is required' },
+        { status: 400 }
+      );
+    }
+
+    const { entry, world, customPrompt } = body;
+    logger.debug('generate-journal-image', 'Starting image generation for entry:', entry.id);
+
+    const imagePrompt = customPrompt || generateImagePrompt(entry, world);
+    const apiKey = process.env.GEMINI_API_KEY;
+
+    if (!apiKey || apiKey === 'MOCK_API_KEY') {
+      logger.debug('generate-journal-image', 'No Gemini API key configured, using fallback');
+      return NextResponse.json({
+        imageUrl: generateFallbackImage(entry, world),
+        prompt: imagePrompt,
+        placeholder: true,
+        aiGenerated: false,
+      });
+    }
+
+    try {
+      const savedImage = await generateAndSaveImageWithGemini(
+        imagePrompt,
+        apiKey,
+        entry.id,
+        'journals'
+      );
+
+      if (savedImage) {
+        logger.debug(
+          'generate-journal-image',
+          `Gemini image saved successfully: ${savedImage.url} (${savedImage.fileSize} bytes)`
+        );
+        return NextResponse.json({
+          imageUrl: savedImage.url,
+          prompt: imagePrompt,
+          placeholder: false,
+          aiGenerated: true,
+        });
+      }
+
+      logger.warn('generate-journal-image', 'Image generation failed, using fallback');
+    } catch (imageGenError) {
+      logger.error('generate-journal-image', 'Gemini image generation failed, using fallback:', imageGenError);
+    }
+
+    return NextResponse.json({
+      imageUrl: generateFallbackImage(entry, world),
+      prompt: imagePrompt,
+      placeholder: true,
+      aiGenerated: false,
+    });
+  } catch (error) {
+    logger.error('generate-journal-image', 'Journal image generation failed:', error);
+    return NextResponse.json(
+      { error: 'Failed to generate journal image. Please try again.' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/workshop.css
+++ b/src/app/workshop.css
@@ -3559,6 +3559,29 @@
   gap: var(--space-4);
 }
 
+/* Per-entry AI image generation (#975).
+   The "Entry Image" heading renders as an h4 and inherits the shared
+   .journal-entry-detail h4 label styling. */
+.journal-entry-image-preview {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  aspect-ratio: 16 / 9;
+  width: 100%;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--color-surface-recessed);
+  color: var(--color-text-muted);
+}
+
+.journal-entry-image-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
 .journal-empty-state {
   padding: var(--space-8) var(--space-4);
   text-align: center;

--- a/src/components/Journal/JournalEntryDetail.tsx
+++ b/src/components/Journal/JournalEntryDetail.tsx
@@ -13,6 +13,7 @@ import {
 import { formatSessionDuration } from '@/lib/utils/sessionUtils';
 import { Play, Square, Settings } from 'lucide-react';
 import { getSignificanceBadgeVariant } from './journalUtils';
+import { JournalEntryImage } from './JournalEntryImage';
 
 interface JournalEntryDetailProps {
   entry: JournalEntry;
@@ -87,6 +88,8 @@ export const JournalEntryDetail: React.FC<JournalEntryDetailProps> = ({
               : entry.detailedContent || entry.content}
           </p>
         </div>
+
+        {!isSystemEvent && <JournalEntryImage entry={entry} />}
 
         {entry.relatedEntities && entry.relatedEntities.length > 0 && (
           <div>

--- a/src/components/Journal/JournalEntryImage.tsx
+++ b/src/components/Journal/JournalEntryImage.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import React, { useState } from 'react';
+import Image from 'next/image';
+import { ImageOff, AlertCircle } from 'lucide-react';
+import { JournalEntry } from '@/types/journal.types';
+import { GeneratedImage } from '@/types/common.types';
+import { ImageGenerationSection } from '@/components/shared';
+import { generateJournalImage } from '@/lib/ai/journalImageGenerator';
+import { useJournalStore } from '@/state/journalStore';
+import { useWorldStore } from '@/state/worldStore';
+import { getTimestamp } from '@/lib/utils';
+
+interface JournalEntryImageProps {
+  entry: JournalEntry;
+}
+
+const EntryImagePreview: React.FC<{
+  image?: GeneratedImage;
+  title: string;
+  error?: string | null;
+}> = ({ image, title, error }) => {
+  const [loadFailed, setLoadFailed] = useState(false);
+
+  if (error || loadFailed) {
+    return (
+      <div className="journal-entry-image-preview" data-state="error">
+        <AlertCircle aria-hidden="true" />
+        <p>Error loading image</p>
+      </div>
+    );
+  }
+
+  if (!image || image.type === 'placeholder' || !image.url) {
+    return (
+      <div className="journal-entry-image-preview" data-state="empty">
+        <ImageOff aria-hidden="true" />
+        <p>No image</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="journal-entry-image-preview" data-state="ready">
+      <Image
+        src={image.url}
+        alt={`Illustration for ${title}`}
+        width={640}
+        height={360}
+        onError={() => setLoadFailed(true)}
+      />
+    </div>
+  );
+};
+
+export const JournalEntryImage: React.FC<JournalEntryImageProps> = ({ entry }) => {
+  const world = useWorldStore((state) => state.worlds[entry.worldId]);
+  const updateEntry = useJournalStore((state) => state.updateEntry);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const image = entry.metadata.image;
+  const entryTitle = entry.title || 'this entry';
+
+  const persistImage = (next: GeneratedImage) => {
+    updateEntry(entry.id, {
+      metadata: { ...entry.metadata, image: next },
+    });
+  };
+
+  const handleGenerate = async (customPrompt?: string) => {
+    setIsGenerating(true);
+    setError(null);
+
+    try {
+      const generated = await generateJournalImage(entry, world, customPrompt);
+      persistImage(generated);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to generate image');
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  const handleRemove = () => {
+    persistImage({ type: 'placeholder', url: null, generatedAt: getTimestamp() });
+  };
+
+  return (
+    <ImageGenerationSection
+      className="journal-entry-image"
+      headingLevel="h4"
+      title="Entry Image"
+      description="AI-generated illustration capturing this moment from your story."
+      currentImageUrl={image?.url}
+      currentImageType={image?.type}
+      generatedAt={image?.generatedAt}
+      currentPrompt={image?.prompt}
+      isGenerating={isGenerating}
+      onGenerate={handleGenerate}
+      onRemove={handleRemove}
+      error={error}
+      customPromptLabel="Customize description for this image"
+      customPromptPlaceholder="Describe the specific visual details you want in the image..."
+      customPromptHelpText="This will override the auto-generated prompt based on the entry content for this generation only"
+      generateButtonText="Generate Image"
+      regenerateButtonText="Regenerate Image"
+      removeButtonText="Remove Image"
+      imageComponent={
+        <EntryImagePreview image={image} title={entryTitle} error={error} />
+      }
+    />
+  );
+};

--- a/src/components/Journal/JournalEntryImage.tsx
+++ b/src/components/Journal/JournalEntryImage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { ImageOff, AlertCircle } from 'lucide-react';
 import { JournalEntry } from '@/types/journal.types';
@@ -21,6 +21,12 @@ const EntryImagePreview: React.FC<{
   error?: string | null;
 }> = ({ image, title, error }) => {
   const [loadFailed, setLoadFailed] = useState(false);
+
+  // Clear a stale load failure when a new image is generated, otherwise the
+  // component stays stuck on "Error loading image" until a full remount.
+  useEffect(() => {
+    setLoadFailed(false);
+  }, [image?.url]);
 
   if (error || loadFailed) {
     return (

--- a/src/components/Journal/__tests__/JournalEntryImage.test.tsx
+++ b/src/components/Journal/__tests__/JournalEntryImage.test.tsx
@@ -69,6 +69,31 @@ describe('JournalEntryImage', () => {
     });
   });
 
+  it('clears a stale load error when a new image url arrives', () => {
+    const withImage = (url: string): JournalEntry => ({
+      ...entry,
+      metadata: {
+        ...entry.metadata,
+        image: { type: 'ai-generated', url, generatedAt: '2024-01-02T00:00:00.000Z', prompt: 'p' },
+      },
+    });
+
+    useJournalStore.setState({
+      entries: { [entry.id]: withImage('/a.png') },
+      sessionEntries: { [entry.sessionId]: [entry.id] },
+    });
+
+    const { rerender } = render(<JournalEntryImage entry={withImage('/a.png')} />);
+
+    fireEvent.error(screen.getByAltText(/illustration for/i));
+    expect(screen.getByText(/error loading image/i)).toBeInTheDocument();
+
+    rerender(<JournalEntryImage entry={withImage('/b.png')} />);
+
+    expect(screen.getByAltText(/illustration for/i)).toBeInTheDocument();
+    expect(screen.queryByText(/error loading image/i)).not.toBeInTheDocument();
+  });
+
   it('surfaces an error message when generation fails', async () => {
     mockGenerate.mockRejectedValue(new Error('generation failed'));
 

--- a/src/components/Journal/__tests__/JournalEntryImage.test.tsx
+++ b/src/components/Journal/__tests__/JournalEntryImage.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { JournalEntryImage } from '../JournalEntryImage';
+import { useJournalStore } from '@/state/journalStore';
+import { JournalEntry } from '@/types/journal.types';
+import { generateJournalImage } from '@/lib/ai/journalImageGenerator';
+
+jest.mock('@/lib/ai/journalImageGenerator', () => ({
+  generateJournalImage: jest.fn(),
+}));
+
+const mockGenerate = generateJournalImage as jest.MockedFunction<typeof generateJournalImage>;
+
+const entry: JournalEntry = {
+  id: 'entry-1',
+  sessionId: 'session-1',
+  worldId: 'world-1',
+  characterId: 'char-1',
+  type: 'character_event',
+  title: 'A Turning Point',
+  content: 'Short summary.',
+  detailedContent: 'Full details.',
+  significance: 'major',
+  isRead: false,
+  relatedEntities: [],
+  metadata: { tags: [], automaticEntry: false },
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+};
+
+describe('JournalEntryImage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useJournalStore.setState({
+      entries: { [entry.id]: entry },
+      sessionEntries: { [entry.sessionId]: [entry.id] },
+    });
+  });
+
+  it('shows the generate control and an empty placeholder when no image exists', () => {
+    render(<JournalEntryImage entry={entry} />);
+
+    expect(screen.getByRole('button', { name: /generate image/i })).toBeInTheDocument();
+    expect(screen.getByText(/no image/i)).toBeInTheDocument();
+  });
+
+  it('renders the section heading as h4 to fit the detail panel heading order', () => {
+    render(<JournalEntryImage entry={entry} />);
+
+    expect(screen.getByRole('heading', { level: 4, name: 'Entry Image' })).toBeInTheDocument();
+  });
+
+  it('persists the generated image to the journal store', async () => {
+    mockGenerate.mockResolvedValue({
+      type: 'ai-generated',
+      url: '/uploads/journals/entry-1.png',
+      generatedAt: '2024-01-02T00:00:00.000Z',
+      prompt: 'a prompt',
+    });
+
+    render(<JournalEntryImage entry={entry} />);
+    fireEvent.click(screen.getByRole('button', { name: /generate image/i }));
+
+    await waitFor(() => {
+      expect(useJournalStore.getState().entries[entry.id].metadata.image?.url).toBe(
+        '/uploads/journals/entry-1.png'
+      );
+    });
+  });
+
+  it('surfaces an error message when generation fails', async () => {
+    mockGenerate.mockRejectedValue(new Error('generation failed'));
+
+    render(<JournalEntryImage entry={entry} />);
+    fireEvent.click(screen.getByRole('button', { name: /generate image/i }));
+
+    expect(await screen.findByText('generation failed')).toBeInTheDocument();
+  });
+});

--- a/src/components/shared/ImageGenerationSection.tsx
+++ b/src/components/shared/ImageGenerationSection.tsx
@@ -25,6 +25,7 @@ interface ImageGenerationSectionProps {
   className?: string;
   defaultCustomPromptChecked?: boolean; // Whether the custom prompt checkbox should be checked by default
   error?: string | null; // Inline error message for generation failures
+  headingLevel?: 'h2' | 'h3' | 'h4'; // Heading element for the title, to fit the surrounding heading order
 }
 
 export const ImageGenerationSection: React.FC<ImageGenerationSectionProps> = ({
@@ -46,7 +47,8 @@ export const ImageGenerationSection: React.FC<ImageGenerationSectionProps> = ({
   imageComponent,
   className = "",
   defaultCustomPromptChecked = !!currentPrompt,
-  error = null
+  error = null,
+  headingLevel: HeadingTag = 'h2'
 }) => {
   // Separate user input from API-returned prompts
   const [showCustomPrompt, setShowCustomPrompt] = useState(defaultCustomPromptChecked);
@@ -79,7 +81,7 @@ export const ImageGenerationSection: React.FC<ImageGenerationSectionProps> = ({
 
   return (
     <div className={`${className}`}>
-      <h2>{title}</h2>
+      <HeadingTag>{title}</HeadingTag>
       <div>
         <div>
           {imageComponent}

--- a/src/lib/ai/__tests__/journalImageGenerator.test.ts
+++ b/src/lib/ai/__tests__/journalImageGenerator.test.ts
@@ -1,0 +1,69 @@
+import { generateJournalImage } from '../journalImageGenerator';
+import type { JournalEntry } from '@/types/journal.types';
+
+const entry: JournalEntry = {
+  id: 'entry-1',
+  sessionId: 'session-1',
+  worldId: 'world-1',
+  characterId: 'char-1',
+  type: 'character_event',
+  title: 'A Turning Point',
+  content: 'Short summary.',
+  significance: 'major',
+  isRead: false,
+  relatedEntities: [],
+  metadata: { tags: [], automaticEntry: false },
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+};
+
+describe('generateJournalImage', () => {
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  it('posts the entry to the journal image endpoint and maps the response', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        imageUrl: '/uploads/journals/entry-1.png',
+        prompt: 'a generated prompt',
+        aiGenerated: true,
+      }),
+    } as Response);
+
+    const result = await generateJournalImage(entry);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/generate-journal-image',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(result.type).toBe('ai-generated');
+    expect(result.url).toBe('/uploads/journals/entry-1.png');
+    expect(result.prompt).toBe('a generated prompt');
+    expect(result.generatedAt).toBeTruthy();
+  });
+
+  it('marks placeholder results as placeholder type', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ imageUrl: 'https://picsum.photos/seed/x/800/600', aiGenerated: false }),
+    } as Response);
+
+    const result = await generateJournalImage(entry);
+
+    expect(result.type).toBe('placeholder');
+  });
+
+  it('throws when the request fails', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: 'boom' }),
+    } as Response);
+
+    await expect(generateJournalImage(entry)).rejects.toThrow('boom');
+  });
+});

--- a/src/lib/ai/journalImageGenerator.ts
+++ b/src/lib/ai/journalImageGenerator.ts
@@ -1,0 +1,44 @@
+// src/lib/ai/journalImageGenerator.ts
+
+import { JournalEntry } from '@/types/journal.types';
+import { World } from '@/types/world.types';
+import { GeneratedImage } from '@/types/common.types';
+import { getTimestamp } from '@/lib/utils';
+import Logger from '@/lib/utils/logger';
+
+const logger = new Logger('JournalImageGenerator');
+
+/**
+ * Request an AI-generated image for a journal entry and return it as a
+ * GeneratedImage ready to store on the entry's metadata.
+ */
+export async function generateJournalImage(
+  entry: JournalEntry,
+  world?: World,
+  customPrompt?: string
+): Promise<GeneratedImage> {
+  try {
+    const response = await fetch('/api/generate-journal-image', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ entry, world, customPrompt }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.error || 'Failed to generate journal image');
+    }
+
+    const data = await response.json();
+
+    return {
+      type: data.aiGenerated ? 'ai-generated' : 'placeholder',
+      url: data.imageUrl,
+      generatedAt: getTimestamp(),
+      prompt: data.prompt,
+    };
+  } catch (error) {
+    logger.error('Journal image generation error:', error);
+    throw error;
+  }
+}

--- a/src/lib/utils/fileStorage.ts
+++ b/src/lib/utils/fileStorage.ts
@@ -16,7 +16,7 @@ export interface SaveImageOptions {
   /**
    * Category/type of image (e.g., 'worlds', 'characters', 'portraits')
    */
-  category: 'worlds' | 'characters' | 'portraits' | 'items' | 'endings' | 'journals';
+  category: 'worlds' | 'characters' | 'portraits' | 'items' | 'endings';
 
   /**
    * Unique identifier for the entity (e.g., world ID, character ID)
@@ -71,7 +71,7 @@ function sanitizeEntityId(entityId: string): string {
  * Validate category is one of the allowed values
  */
 function validateCategory(category: string): asserts category is SaveImageOptions['category'] {
-  const validCategories: Array<SaveImageOptions['category']> = ['worlds', 'characters', 'portraits', 'items', 'endings', 'journals'];
+  const validCategories: Array<SaveImageOptions['category']> = ['worlds', 'characters', 'portraits', 'items', 'endings'];
 
   if (!validCategories.includes(category as SaveImageOptions['category'])) {
     throw new Error(`Invalid category: must be one of ${validCategories.join(', ')}`);

--- a/src/lib/utils/fileStorage.ts
+++ b/src/lib/utils/fileStorage.ts
@@ -16,7 +16,7 @@ export interface SaveImageOptions {
   /**
    * Category/type of image (e.g., 'worlds', 'characters', 'portraits')
    */
-  category: 'worlds' | 'characters' | 'portraits' | 'items' | 'endings';
+  category: 'worlds' | 'characters' | 'portraits' | 'items' | 'endings' | 'journals';
 
   /**
    * Unique identifier for the entity (e.g., world ID, character ID)
@@ -71,7 +71,7 @@ function sanitizeEntityId(entityId: string): string {
  * Validate category is one of the allowed values
  */
 function validateCategory(category: string): asserts category is SaveImageOptions['category'] {
-  const validCategories: Array<SaveImageOptions['category']> = ['worlds', 'characters', 'portraits', 'items', 'endings'];
+  const validCategories: Array<SaveImageOptions['category']> = ['worlds', 'characters', 'portraits', 'items', 'endings', 'journals'];
 
   if (!validCategories.includes(category as SaveImageOptions['category'])) {
     throw new Error(`Invalid category: must be one of ${validCategories.join(', ')}`);

--- a/src/types/journal.types.ts
+++ b/src/types/journal.types.ts
@@ -1,6 +1,6 @@
 // src/types/journal.types.ts
 
-import { EntityID, TimestampedEntity } from './common.types';
+import { EntityID, TimestampedEntity, GeneratedImage } from './common.types';
 
 /**
  * Represents a journal entry in the game
@@ -71,4 +71,6 @@ interface JournalMetadata {
     characterName?: string;
     sessionNumber?: number;
   };
+  // AI-generated visual for the entry (issue #975)
+  image?: GeneratedImage;
 }


### PR DESCRIPTION
## What & why

Journal entries are text-only today, which makes scanning back through a long session a slog. This adds a **Generate Image** action to the entry detail panel so each memorable beat can get a quick visual anchor that sticks around. Addresses #975.

## How it works

- **New route** `POST /api/generate-journal-image` builds a scene prompt from the entry's `detailedContent`/`content` + title + genre style guidance, then saves through the same Gemini path used for world images. Added a `'journals'` storage category so images land under `public/uploads/journals/`. No API key (or `MOCK_API_KEY`) falls back to a genre placeholder, same as worlds.
- **Client wrapper** `generateJournalImage()` mirrors `worldImageGenerator` and returns a `GeneratedImage`.
- **Storage**: the result is saved to `entry.metadata.image` (optional, so older entries stay valid) with its URL, timestamp, and prompt — so it persists across sessions and doesn't regenerate on every view.
- **UI**: a new `JournalEntryImage` component reuses the shared `ImageGenerationSection` (Generate / Regenerate / Remove). The action row is non-blocking — the entry stays readable while a generation is in flight, the button disables mid-generation, and errors show inline. It's hidden for system events (session start/end).
- **A11y**: made `ImageGenerationSection`'s heading level configurable (defaults to `h2`, so existing consumers are unchanged) and pass `h4` in the journal so the section heading fits the detail panel's `h3` title / `h4` label order instead of jumping back to `h2`.

## Tests

- API route: validation, prompt building, custom-prompt passthrough, missing-key and null-result fallbacks, parse error (6 tests).
- Client wrapper: endpoint call + response mapping, placeholder typing, error throw (3 tests).
- `JournalEntryImage`: renders the control + empty state, heading-level, persists to the store on generate, surfaces errors (4 tests).
- Full suite green locally: 2150 passing. ESLint + Stylelint clean.

## Verification note

I couldn't do a live browser pass from this worktree: the only running dev server on :3000 belongs to a *different* worktree (I won't disrupt it), and this worktree's `next` binary isn't installed, so I can't launch an isolated server without a full reinstall. Coverage here is the automated suite above. The UI reuses the production-proven `ImageGenerationSection` and tokenized journal styles, so visual risk is low — but a manual look at the detail panel before merge wouldn't hurt.

## Notes

- "Closes #975" is intentionally not used — auto-close doesn't fire on merge to `develop`, so the issue should be closed manually after merge.