### PR TITLE
Add narrative text size control (#985)

### DIFF
--- a/src/components/Narrative/NarrativeHistory.tsx
+++ b/src/components/Narrative/NarrativeHistory.tsx
@@ -4,6 +4,8 @@ import { NarrativeDisplay } from './NarrativeDisplay';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useBufferedNarrativeSegments } from './hooks/useBufferedNarrativeSegments';
 import { useTheme } from '@/lib/theme/ThemeProvider';
+import { NarrativeTextSizeControl } from './NarrativeTextSizeControl';
+import { useUIPreferencesStore } from '@/state/uiPreferencesStore';
 
 interface NarrativeHistoryProps {
   segments: NarrativeSegment[];
@@ -31,6 +33,9 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
 
   const { theme } = useTheme();
   const { renderedSegments } = useBufferedNarrativeSegments(segments);
+  const narrativeTextSize = useUIPreferencesStore(
+    (state) => state.narrativeTextSize
+  );
 
   // Check if the viewport is near the bottom
   const getIsNearBottom = useCallback(() => {
@@ -287,7 +292,9 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
       className={['narrative-history-container', className].filter(Boolean).join(' ')}
       onKeyDown={handleKeyDown}
       tabIndex={0}
+      data-narrative-text-size={narrativeTextSize}
     >
+      <NarrativeTextSizeControl className="narrative-history-text-size-control" />
       <ScrollArea
         ref={scrollAreaRef}
         className="mobile-scroll"

--- a/src/components/Narrative/NarrativeTextSizeControl.tsx
+++ b/src/components/Narrative/NarrativeTextSizeControl.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import React from 'react';
+import {
+  useUIPreferencesStore,
+  type NarrativeTextSize,
+} from '@/state/uiPreferencesStore';
+
+const TEXT_SIZE_OPTIONS: { value: NarrativeTextSize; label: string }[] = [
+  { value: 'small', label: 'Small' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'large', label: 'Large' },
+];
+
+interface NarrativeTextSizeControlProps {
+  className?: string;
+}
+
+/**
+ * Lets the reader pick the narrative text size (Small / Medium / Large).
+ * Medium matches the per-theme default. The selection is persisted via
+ * uiPreferencesStore and drives `data-narrative-text-size` on the history
+ * container, which scales `.text-narrative` through CSS.
+ */
+export const NarrativeTextSizeControl: React.FC<NarrativeTextSizeControlProps> = ({
+  className,
+}) => {
+  const narrativeTextSize = useUIPreferencesStore(
+    (state) => state.narrativeTextSize
+  );
+  const setNarrativeTextSize = useUIPreferencesStore(
+    (state) => state.setNarrativeTextSize
+  );
+
+  return (
+    <div
+      className={['narrative-text-size-control', className]
+        .filter(Boolean)
+        .join(' ')}
+      role="group"
+      aria-label="Narrative text size"
+    >
+      <span className="narrative-text-size-control-label">Text size</span>
+      <div className="narrative-text-size-control-options">
+        {TEXT_SIZE_OPTIONS.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            className="narrative-text-size-control-button"
+            aria-pressed={narrativeTextSize === option.value}
+            onClick={() => setNarrativeTextSize(option.value)}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/Narrative/__tests__/NarrativeTextSizeControl.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeTextSizeControl.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { NarrativeTextSizeControl } from '../NarrativeTextSizeControl';
+import {
+  useUIPreferencesStore,
+  DEFAULT_NARRATIVE_TEXT_SIZE,
+} from '@/state/uiPreferencesStore';
+
+describe('NarrativeTextSizeControl', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useUIPreferencesStore.setState({
+      narrativeTextSize: DEFAULT_NARRATIVE_TEXT_SIZE,
+    });
+  });
+
+  it('renders Small, Medium, and Large options', () => {
+    render(<NarrativeTextSizeControl />);
+    expect(screen.getByRole('button', { name: 'Small' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Medium' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Large' })).toBeInTheDocument();
+  });
+
+  it('marks the active size with aria-pressed', () => {
+    render(<NarrativeTextSizeControl />);
+    expect(screen.getByRole('button', { name: 'Medium' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(screen.getByRole('button', { name: 'Large' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  });
+
+  it('updates the store when a different size is selected', () => {
+    render(<NarrativeTextSizeControl />);
+    fireEvent.click(screen.getByRole('button', { name: 'Large' }));
+    expect(useUIPreferencesStore.getState().narrativeTextSize).toBe('large');
+    expect(screen.getByRole('button', { name: 'Large' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+  });
+});

--- a/src/state/__tests__/uiPreferencesStore.test.ts
+++ b/src/state/__tests__/uiPreferencesStore.test.ts
@@ -1,0 +1,28 @@
+import {
+  useUIPreferencesStore,
+  DEFAULT_NARRATIVE_TEXT_SIZE,
+} from '../uiPreferencesStore';
+
+describe('uiPreferencesStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useUIPreferencesStore.setState({
+      narrativeTextSize: DEFAULT_NARRATIVE_TEXT_SIZE,
+    });
+  });
+
+  it('defaults narrative text size to medium', () => {
+    expect(useUIPreferencesStore.getState().narrativeTextSize).toBe('medium');
+  });
+
+  it('updates the narrative text size', () => {
+    useUIPreferencesStore.getState().setNarrativeTextSize('large');
+    expect(useUIPreferencesStore.getState().narrativeTextSize).toBe('large');
+  });
+
+  it('persists the narrative text size to localStorage', () => {
+    useUIPreferencesStore.getState().setNarrativeTextSize('small');
+    const persisted = localStorage.getItem('narraitor-ui-preferences-store');
+    expect(persisted).toContain('small');
+  });
+});

--- a/src/state/uiPreferencesStore.ts
+++ b/src/state/uiPreferencesStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+/**
+ * User-selectable narrative text sizes. "medium" matches the per-theme default.
+ */
+export type NarrativeTextSize = 'small' | 'medium' | 'large';
+
+export const DEFAULT_NARRATIVE_TEXT_SIZE: NarrativeTextSize = 'medium';
+
+export interface UIPreferencesState {
+  narrativeTextSize: NarrativeTextSize;
+  setNarrativeTextSize: (size: NarrativeTextSize) => void;
+}
+
+/**
+ * Persisted display preferences that aren't tied to a single session, world, or
+ * character (e.g. narrative text size). Kept separate from navigation/session
+ * state so reading-comfort settings survive across sessions.
+ */
+export const useUIPreferencesStore = create<UIPreferencesState>()(
+  persist(
+    (set) => ({
+      narrativeTextSize: DEFAULT_NARRATIVE_TEXT_SIZE,
+      setNarrativeTextSize: (size) => set({ narrativeTextSize: size }),
+    }),
+    {
+      name: 'narraitor-ui-preferences-store',
+      version: 1,
+      partialize: (state) => ({
+        narrativeTextSize: state.narrativeTextSize,
+      }),
+    }
+  )
+);

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -106,10 +106,82 @@ body.manuscript-overlay-open {
 /* Fix 25a-c: NarrativeHistory inline style replacements */
 .narrative-history-container {
   height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .mobile-scroll {
-  height: 100%;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* Narrative text size control (Issue 985) — sits above the scroll viewport */
+.narrative-text-size-control {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex: 0 0 auto;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-1);
+  margin-bottom: var(--space-2);
+  border-bottom: 1px solid var(--color-border);
+  font-family: var(--font-interface);
+}
+
+.narrative-text-size-control-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.narrative-text-size-control-options {
+  display: inline-flex;
+  gap: var(--space-1);
+  padding: var(--space-1);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.narrative-text-size-control-button {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font: inherit;
+  font-size: 0.8125rem;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.narrative-text-size-control-button:hover {
+  background: var(--color-surface-hover);
+  color: var(--color-text-primary);
+}
+
+.narrative-text-size-control-button[aria-pressed='true'] {
+  background: var(--color-accent);
+  color: var(--color-text-inverse);
+}
+
+.narrative-text-size-control-button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+/* Narrative text size scale (Issue 985) — multiplies the per-theme
+   `.text-narrative` font-size below. Medium matches the existing default. */
+[data-narrative-text-size='small'] {
+  --narrative-text-scale: 0.875;
+}
+
+[data-narrative-text-size='medium'] {
+  --narrative-text-scale: 1;
+}
+
+[data-narrative-text-size='large'] {
+  --narrative-text-scale: 1.25;
 }
 
 .scroll-smooth {
@@ -3210,7 +3282,7 @@ body.manuscript-overlay-open {
 
 /* Fix 87: DS1 narrative text — compact typography matching demo reference */
 [data-theme="ds1"] .text-narrative {
-  font-size: 0.8125rem;
+  font-size: calc(0.8125rem * var(--narrative-text-scale, 1));
   line-height: 1.65;
 }
 
@@ -3613,7 +3685,7 @@ body.manuscript-overlay-open {
 
 /* DS2 narrative typography — warm journal reading style */
 [data-theme="ds2"] .text-narrative {
-  font-size: 1.1875rem;
+  font-size: calc(1.1875rem * var(--narrative-text-scale, 1));
   line-height: 1.82;
   margin-bottom: 1.25rem;
 }
@@ -4381,7 +4453,7 @@ body.manuscript-overlay-open {
 
 /* DS3 narrative text — 18px with generous line-height */
 [data-theme="ds3"] .text-narrative {
-  font-size: 1.125rem;
+  font-size: calc(1.125rem * var(--narrative-text-scale, 1));
   line-height: 1.75;
 }
 


### PR DESCRIPTION
## What this does

Lets readers change the narrative text size from the story view. There's a small Small / Medium / Large control in the narrative history header, and the pick sticks across sessions.

Medium maps to the existing per-theme size, so the default look is unchanged — you only see a difference if you opt into Small or Large.

Closes #985.

## How it works

- **`uiPreferencesStore`** — a small persisted Zustand store holding `narrativeTextSize`. Kept separate from session/navigation state so a reading-comfort setting survives across sessions and worlds.
- **`NarrativeTextSizeControl`** — segmented control wired to the store, with `role="group"` + `aria-pressed` on the active size.
- **CSS** — the per-theme `.text-narrative` font-size now multiplies by `--narrative-text-scale` (small 0.875, medium 1, large 1.25). The scale comes from `data-narrative-text-size` on the history container, which inherits down to every `.text-narrative` (history + live segment), so changes apply immediately. The history container became a flex column so the control header doesn't fight the scroll area.

## Acceptance criteria

- [x] UI control to switch text size (Small / Medium / Large)
- [x] Medium matches the current default (verified: ds1 base 13px at Medium)
- [x] Selection persisted (survives reload)
- [x] Narrative updates immediately on change (no reload)

## Testing

- Unit: store (default / set / persist) and control (renders options, reflects state, dispatches change) — Jest + RTL.
- Browser: drove the real game session on the dev route — Medium 13px, Large 16.25px, Small 11.375px, selection survived reload.
- Full Narrative + GameSession suites green (213 tests).

## Note on visual baselines

This adds a visible header to the narrative panel, so the game-session (and likely a few manuscript) visual baselines will diff by design. I'll adopt the regenerated baselines from the CI run rather than guess them locally.