### PR TITLE
Give each git worktree its own dev-server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ npm run dev
 
 The app runs on `localhost:3000`. You'll see the world creation wizard first: either pick a template or build your own universe.
 
+> Running from a git worktree? `npm run dev` picks a stable per-worktree port automatically (the main checkout keeps 3000), so multiple worktrees can run side by side without fighting over the port. The chosen URL is printed on startup; set `PORT` to override.
+
 ## Development Setup
 
 I've been using a component-first approach with Storybook and TDD. Basically, build components in isolation first, then integrate them. It keeps things manageable.

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "bash scripts/kill-port.sh 3000 && next dev -p 3000",
-    "dev:turbo": "next dev --turbopack",
+    "dev": "bash scripts/dev.sh",
+    "dev:turbo": "bash scripts/dev.sh --turbopack",
     "kill": "pkill -f 'next dev' || true",
     "build": "next build && rm -rf public/storybook-static && npm run build-storybook && cp -r storybook-static public/",
     "build:app": "next build",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,35 @@
 import { defineConfig, devices } from '@playwright/test';
+import { execSync } from 'node:child_process';
+
+/**
+ * Resolve the base URL for local runs.
+ *
+ * CI always serves on 3000 (see the webServer block below) so visual baselines
+ * stay stable. Locally, follow this checkout's dev-server port so running tests
+ * from a git worktree targets that worktree's server, not a stray 3000.
+ * An explicit PLAYWRIGHT_BASE_URL always wins.
+ */
+function resolveBaseURL(): string {
+  if (process.env.PLAYWRIGHT_BASE_URL) {
+    return process.env.PLAYWRIGHT_BASE_URL;
+  }
+  if (process.env.CI) {
+    return 'http://localhost:3000';
+  }
+  try {
+    const port = execSync('node scripts/worktree-port.js', { encoding: 'utf8' }).trim();
+    if (port) {
+      return `http://localhost:${port}`;
+    }
+  } catch {
+    // Fall back to the canonical port below.
+  }
+  return 'http://localhost:3000';
+}
 
 /**
  * Playwright Configuration for Visual Regression Testing
- * 
+ *
  * Configures Playwright for consistent visual screenshot comparison
  * across multiple browsers and viewports. Optimized for CI/CD environments.
  */
@@ -49,7 +76,7 @@ export default defineConfig({
   // Global test setup
   use: {
     // Base URL for all tests
-    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000',
+    baseURL: resolveBaseURL(),
     
     // Reduced timeouts for faster execution
     actionTimeout: 10 * 1000,

--- a/scripts/__tests__/worktree-port.test.js
+++ b/scripts/__tests__/worktree-port.test.js
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment node
+ *
+ * Tests the pure port-derivation logic in scripts/worktree-port.js.
+ */
+
+import { derivePort } from '../worktree-port.js';
+
+describe('derivePort', () => {
+  it('keeps the main checkout on 3000 (git-dir == git-common-dir)', () => {
+    expect(
+      derivePort({ gitDir: '/repo/.git', commonDir: '/repo/.git', cwd: '/repo' })
+    ).toBe(3000);
+  });
+
+  it('derives a stable, in-range port for a linked worktree', () => {
+    const port = derivePort({
+      gitDir: '/repo/.git/worktrees/feature-a',
+      commonDir: '/repo/.git',
+      cwd: '/repo/worktrees/feature-a',
+    });
+    expect(port).toBeGreaterThanOrEqual(3001);
+    expect(port).toBeLessThanOrEqual(3899);
+  });
+
+  it('is deterministic for a given worktree path', () => {
+    const args = {
+      gitDir: '/repo/.git/worktrees/feature-a',
+      commonDir: '/repo/.git',
+      cwd: '/repo/worktrees/feature-a',
+    };
+    expect(derivePort(args)).toBe(derivePort(args));
+  });
+
+  it('gives two different worktree paths different ports', () => {
+    const a = derivePort({
+      gitDir: '/repo/.git/worktrees/feature-a',
+      commonDir: '/repo/.git',
+      cwd: '/repo/worktrees/feature-a',
+    });
+    const b = derivePort({
+      gitDir: '/repo/.git/worktrees/feature-b',
+      commonDir: '/repo/.git',
+      cwd: '/repo/worktrees/feature-b',
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it('honors an explicit PORT override even in a worktree', () => {
+    expect(
+      derivePort({
+        gitDir: '/repo/.git/worktrees/feature-a',
+        commonDir: '/repo/.git',
+        cwd: '/repo/worktrees/feature-a',
+        portEnv: '4500',
+      })
+    ).toBe(4500);
+  });
+
+  it('ignores a non-numeric PORT and falls back to derivation', () => {
+    expect(
+      derivePort({ gitDir: '/repo/.git', commonDir: '/repo/.git', cwd: '/repo', portEnv: 'nope' })
+    ).toBe(3000);
+  });
+});

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Start the Next.js dev server on this checkout's own port.
+#
+# The main checkout uses 3000; each git worktree gets its own stable port
+# (see scripts/worktree-port.js), so multiple worktrees can run dev servers
+# at once without fighting over 3000. We only free the port we're about to
+# use, never a hard-coded 3000 that might belong to another worktree.
+#
+# Override with PORT=xxxx npm run dev.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+port="$(node scripts/worktree-port.js)"
+
+bash scripts/kill-port.sh "$port"
+
+echo ""
+echo "Narraitor dev server -> http://localhost:$port"
+echo ""
+
+exec next dev -p "$port" "$@"

--- a/scripts/worktree-port.js
+++ b/scripts/worktree-port.js
@@ -1,0 +1,76 @@
+/**
+ * Picks the dev-server port for the current git checkout.
+ *
+ * The main checkout keeps the canonical port 3000. Each linked git worktree
+ * gets its own stable port derived from its path, so concurrent worktrees
+ * never collide on 3000 (and `npm run dev` no longer has to kill whatever is
+ * already serving the main tree). An explicit PORT env var always wins.
+ *
+ * Used by scripts/dev.sh (CLI) and playwright.config.ts (local baseURL).
+ */
+
+import { execSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const MIN_WORKTREE_PORT = 3001;
+const PORT_RANGE = 899; // 3001..3899
+
+/**
+ * Pure port derivation, separated from git/process lookups so it can be tested.
+ *
+ * @param {object} args
+ * @param {string} [args.gitDir] - `git rev-parse --git-dir`
+ * @param {string} [args.commonDir] - `git rev-parse --git-common-dir`
+ * @param {string} [args.cwd] - current working directory
+ * @param {string} [args.portEnv] - value of process.env.PORT, if any
+ * @returns {number}
+ */
+export function derivePort({ gitDir, commonDir, cwd, portEnv } = {}) {
+  if (portEnv) {
+    const explicit = parseInt(portEnv, 10);
+    if (Number.isInteger(explicit) && explicit > 0) {
+      return explicit;
+    }
+  }
+
+  // In the main checkout, --git-dir and --git-common-dir resolve to the same
+  // path. In a linked worktree they differ.
+  if (gitDir && commonDir && resolve(gitDir) === resolve(commonDir)) {
+    return 3000;
+  }
+
+  // Stable hash of the worktree path -> a deterministic port in range.
+  const key = cwd || '';
+  let hash = 0;
+  for (let i = 0; i < key.length; i++) {
+    hash = (hash * 31 + key.charCodeAt(i)) >>> 0;
+  }
+  return MIN_WORKTREE_PORT + (hash % PORT_RANGE);
+}
+
+function gitRevParse(flag) {
+  try {
+    return execSync(`git rev-parse ${flag}`, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+/** Resolve the port for the current process's checkout. */
+export function getWorktreePort() {
+  return derivePort({
+    gitDir: gitRevParse('--git-dir'),
+    commonDir: gitRevParse('--git-common-dir'),
+    cwd: process.cwd(),
+    portEnv: process.env.PORT,
+  });
+}
+
+// CLI entry: `node scripts/worktree-port.js` prints the port (no newline).
+// Avoids import.meta so the module also loads cleanly under ts-jest (CJS).
+if (process.argv[1] && process.argv[1].endsWith('worktree-port.js')) {
+  process.stdout.write(String(getWorktreePort()));
+}


### PR DESCRIPTION
## What & why

Running a dev server from a git worktree has been a footgun. `"dev"` was:

```
"dev": "bash scripts/kill-port.sh 3000 && next dev -p 3000"
```

So every `npm run dev` hard-killed whatever was on **3000** — often another worktree's server — and then pinned itself there. Two worktrees couldn't run at once, and you'd silently clobber a server you were relying on.

This makes the dev port **per checkout**: the main tree keeps 3000, and each linked worktree gets its own stable port derived from its path. We only free the port we're about to use, never a blanket 3000.

## How it works

- **`scripts/worktree-port.js`** — single source of truth. Main checkout (where `git --git-dir` == `--git-common-dir`) returns 3000; a linked worktree hashes its path into a stable port in 3001–3899. An explicit `PORT` always wins. Runnable as a CLI (`node scripts/worktree-port.js` prints the port) and importable. The pure derivation is split out so it's unit-tested.
- **`scripts/dev.sh`** — computes the port, frees only that port, starts `next dev -p <port>`, prints the URL, and forwards extra args (so `dev:turbo` still works).
- **`package.json`** — `dev` and `dev:turbo` route through `dev.sh`.
- **`playwright.config.ts`** — local `baseURL` follows the same port so `test:visual` from a worktree targets that worktree's server. **CI is untouched**: it sets `PORT=3000` and the config short-circuits to `http://localhost:3000` under `CI`, so visual baselines don't move.

## Backwards compatibility

- **Main checkout:** identical behavior — 3000, kill-port 3000, `next dev -p 3000`.
- **CI:** `webServer` runs `npm run dev` with `env.PORT=3000`; the explicit `PORT` wins in `derivePort`, so it still serves on 3000.
- **Override:** `PORT=4500 npm run dev` works everywhere.

## Verification

- `derivePort` unit tests (6) — main=3000, worktree in-range, deterministic, distinct paths differ, `PORT` override, non-numeric `PORT` ignored.
- Real runs: main checkout -> `3000`, this worktree -> `3186` (stable).
- `tsc --noEmit` clean, ESLint clean on changed files.
- `playwright test --list` loads the config cleanly (106 tests) and resolves local baseURL to the worktree port.

Could not run a live `next dev` here (worktrees start without `node_modules`; I installed deps to run the gate above, but didn't boot a long-running server). The startup path is `bash -n`-clean and the port resolution is verified end to end.