### PR TITLE
Add accessible names to edit-form range sliders and image-prompt textarea

### DIFF
--- a/src/components/CharacterEditor/components/AttributesForm.tsx
+++ b/src/components/CharacterEditor/components/AttributesForm.tsx
@@ -94,6 +94,7 @@ export const AttributesForm: React.FC<AttributesFormProps> = ({
                 onChange={newValue => handleValueChange(attr.id, newValue)}
                 disabled={false}
                 showLabel={false}
+                ariaLabel={`${worldAttr?.name || `Attribute ${index + 1}`} value`}
                 testId={`attribute-${attr.id}`}
               />
               <div className="attributes-form-meta">

--- a/src/components/CharacterEditor/components/SkillsForm.tsx
+++ b/src/components/CharacterEditor/components/SkillsForm.tsx
@@ -106,6 +106,7 @@ export const SkillsForm: React.FC<SkillsFormProps> = ({
                 onChange={newValue => handleValueChange(skill.id, newValue)}
                 disabled={false}
                 showLabel={false}
+                ariaLabel={`${worldSkill?.name || `Skill ${index + 1}`} skill level`}
                 testId={`skill-${skill.id}`}
               />
               <div className="skills-form-meta">

--- a/src/components/forms/AttributeRangeEditor.tsx
+++ b/src/components/forms/AttributeRangeEditor.tsx
@@ -28,6 +28,7 @@ const AttributeRangeEditor: React.FC<AttributeRangeEditorProps> = ({
       disabled={disabled}
       showLabel={showLabels}
       labelText="Default Value"
+      ariaLabel={`${attribute.name} value`}
       testId="attribute-range-editor"
     />
   );

--- a/src/components/forms/SkillRangeEditor.tsx
+++ b/src/components/forms/SkillRangeEditor.tsx
@@ -53,6 +53,7 @@ const SkillRangeEditor: React.FC<SkillRangeEditorProps> = ({
       disabled={disabled}
       showLabel={showLabels}
       labelText="Default Value"
+      ariaLabel={`${skill.name} skill level`}
       levelDescriptions={levelDescriptions}
       showLevelDescription={showLevelDescriptions}
       testId="skill-range-editor"

--- a/src/components/forms/__tests__/AttributeRangeEditor.test.tsx
+++ b/src/components/forms/__tests__/AttributeRangeEditor.test.tsx
@@ -52,6 +52,14 @@ describe('AttributeRangeEditor', () => {
     expect(screen.getByTestId('current-value')).toHaveTextContent('Current: 5');
   });
 
+  test('exposes an accessible name naming the attribute', () => {
+    render(<TestWrapper initialAttribute={mockAttribute} />);
+
+    expect(
+      screen.getByRole('slider', { name: 'Strength value' })
+    ).toBeInTheDocument();
+  });
+
   test('allows user to change value within valid range', () => {
     render(<TestWrapper initialAttribute={mockAttribute} />);
 

--- a/src/components/forms/__tests__/SkillRangeEditor.test.tsx
+++ b/src/components/forms/__tests__/SkillRangeEditor.test.tsx
@@ -38,6 +38,19 @@ describe('SkillRangeEditor', () => {
     expect(slider).toHaveValue('3');
   });
 
+  it('exposes an accessible name naming the skill', () => {
+    render(
+      <SkillRangeEditor
+        skill={mockSkill}
+        onChange={mockOnChange}
+      />
+    );
+
+    expect(
+      screen.getByRole('slider', { name: 'Test Skill skill level' })
+    ).toBeInTheDocument();
+  });
+
   it('passes min and max values to the RangeSlider component', () => {
     // This test verifies the component is receiving the correct min/max props
     // We can't directly test the min/max DOM attributes due to how the component is rendered

--- a/src/components/shared/ImageGenerationSection.tsx
+++ b/src/components/shared/ImageGenerationSection.tsx
@@ -121,7 +121,7 @@ export const ImageGenerationSection: React.FC<ImageGenerationSectionProps> = ({
                 onChange={(e) => handleCustomPromptChange(e.target.value)}
                 placeholder={customPromptPlaceholder}
                 rows={3}
-                
+                aria-label={customPromptLabel}
               />
               <p>
                 {customPromptHelpText}

--- a/src/components/shared/__tests__/ImageGenerationSection.test.tsx
+++ b/src/components/shared/__tests__/ImageGenerationSection.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ImageGenerationSection } from '../ImageGenerationSection';
+
+describe('ImageGenerationSection accessibility', () => {
+  const baseProps = {
+    title: 'Character Portrait',
+    description: 'AI-generated portrait.',
+    isGenerating: false,
+    onGenerate: jest.fn(),
+    onRemove: jest.fn(),
+    customPromptLabel: 'Customize physical description for portrait generation',
+    imageComponent: <div>portrait</div>,
+  };
+
+  it('labels the custom-prompt checkbox', () => {
+    render(<ImageGenerationSection {...baseProps} />);
+
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'Customize physical description for portrait generation',
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('gives the custom-prompt textarea an accessible name when shown', () => {
+    render(<ImageGenerationSection {...baseProps} defaultCustomPromptChecked />);
+
+    expect(
+      screen.getByRole('textbox', {
+        name: 'Customize physical description for portrait generation',
+      })
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Range sliders on the character and world edit forms had no accessible name. A screen reader announced a bare "slider" with no way to tell which attribute or skill it controlled — the visible "Default Value" header and the field labels weren't programmatically tied to the input, so they didn't carry over.

This passes an `aria-label` derived from the attribute/skill name through `RangeSlider` (which already supported the prop):

- Character edit attribute sliders → `"Strength value"`
- Character edit skill sliders → `"Stealth skill level"`
- World edit skill sliders (`SkillRangeEditor`) → `"{name} skill level"`
- World attribute editor (`AttributeRangeEditor`) → `"{name} value"`

It also gives the image-generation custom-prompt `<textarea>` an `aria-label` matching its toggle checkbox — it had no associated label before. This covers both the character portrait and the world image sections (shared `ImageGenerationSection`).

## On the checkboxes

The original audit flagged several checkboxes ("Customize physical description", the world skills' "Linked Attributes"). Those already get an accessible name from the `Checkbox` component's wrapping `<label>`, so they needed no code change — looks like that part of the audit predates the `Checkbox` label support. Added a test to lock the behavior in so it can't silently regress.

## Verification

Accessible names are asserted via `getByRole('slider' | 'checkbox' | 'textbox', { name })`, which runs the real W3C accessible-name computation (the same algorithm a screen reader uses) against the rendered DOM — so this is verified at the name-resolution level, not just by attribute presence.

- `AttributeRangeEditor` / `SkillRangeEditor` tests: assert the slider's accessible name
- New `ImageGenerationSection` test: asserts both the checkbox and the textarea names
- Full affected suites green (56 tests), `eslint` clean, `tsc --noEmit` clean

Closes #1118 (will close manually after merge, since the merge target is `develop`)