### PR TITLE
Give user-facing errors a severity and a suggested next step (#222)

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ActionButtonGroup } from '@/components/shared/ActionButtonGroup';
+import { getUserFriendlyError } from '@/lib/utils/errorUtils';
 
 export default function Error({
   error,
@@ -9,17 +10,23 @@ export default function Error({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  // Translate the raw error into plain language rather than leaking the
+  // technical message (and any stack detail) straight to the player.
+  const friendly = getUserFriendlyError(error);
+
   return (
-    <div>
-      <h2>Something went wrong!</h2>
-      <p>{error.message || 'An unexpected error occurred'}</p>
+    <div className="app-error">
+      <h2 className="error-display-title">{friendly.title}</h2>
+      <p className="error-display-message">{friendly.message}</p>
+      {friendly.suggestion && (
+        <p className="error-display-suggestion">{friendly.suggestion}</p>
+      )}
       <ActionButtonGroup
         actions={[{
-          label: 'Try again',
+          label: friendly.actionLabel ?? 'Try again',
           onClick: reset,
           variant: 'primary'
         }]}
-        
       />
     </div>
   );

--- a/src/components/Journal/__tests__/JournalPage.test.tsx
+++ b/src/components/Journal/__tests__/JournalPage.test.tsx
@@ -180,6 +180,7 @@ describe('JournalPage', () => {
         message: 'Unable to load journal',
         retryable: false,
         type: ErrorType.UNKNOWN,
+        severity: 'error',
       },
     });
     mockUseJournalStore.mockImplementation(mockJournalSelector(journalStore));

--- a/src/components/WorldListScreen/WorldListScreen.tsx
+++ b/src/components/WorldListScreen/WorldListScreen.tsx
@@ -88,6 +88,7 @@ const WorldListScreen: React.FC<WorldListScreenProps> = ({
               message: 'An unexpected error occurred while loading worlds.',
               retryable: false,
               type: ErrorType.UNKNOWN,
+              severity: 'error',
             } satisfies UserFriendlyError);
       setError(friendlyError);
       setLoading(false);

--- a/src/components/ui/ErrorDisplay/ErrorDisplay.test.tsx
+++ b/src/components/ui/ErrorDisplay/ErrorDisplay.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ErrorDisplay } from './ErrorDisplay';
+
+describe('ErrorDisplay', () => {
+  it('applies a severity class so styling can reflect severity', () => {
+    const { container } = render(
+      <ErrorDisplay variant="section" message="Some features are limited." severity="warning" />
+    );
+
+    const root = container.querySelector('.error-display');
+    expect(root).toHaveClass('error-display-warning');
+  });
+
+  it('defaults to error severity when none is given', () => {
+    const { container } = render(<ErrorDisplay variant="section" message="It broke." />);
+
+    expect(container.querySelector('.error-display')).toHaveClass('error-display-error');
+  });
+
+  it('renders a suggested next step when provided', () => {
+    render(
+      <ErrorDisplay
+        variant="section"
+        title="Connection Problem"
+        message="Unable to connect."
+        suggestion="Make sure you are online, then try again."
+      />
+    );
+
+    expect(
+      screen.getByText('Make sure you are online, then try again.')
+    ).toBeInTheDocument();
+  });
+
+  it('omits the suggestion element when no suggestion is given', () => {
+    const { container } = render(
+      <ErrorDisplay variant="section" message="Unable to connect." />
+    );
+
+    expect(container.querySelector('.error-display-suggestion')).toBeNull();
+  });
+});

--- a/src/components/ui/ErrorDisplay/ErrorDisplay.tsx
+++ b/src/components/ui/ErrorDisplay/ErrorDisplay.tsx
@@ -1,18 +1,20 @@
 import React from 'react';
 import { cssClasses } from '@/lib/utils';
+import type { ErrorSeverity } from '@/lib/utils/errorUtils';
 
 type ErrorVariant = 'inline' | 'section' | 'page' | 'toast';
-type ErrorSeverity = 'error' | 'warning' | 'info';
 
 interface ErrorDisplayProps {
   /** The variant of error display */
   variant?: ErrorVariant;
-  /** Severity level of the error */
+  /** Severity level of the error — drives accent color and prominence */
   severity?: ErrorSeverity;
   /** Error title (for section and page variants) */
   title?: string;
   /** Error message */
   message: string;
+  /** Plain-language suggested next step shown below the message */
+  suggestion?: string;
   /** Show retry button */
   showRetry?: boolean;
   /** Retry button callback */
@@ -32,6 +34,7 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
   severity = 'error',
   title,
   message,
+  suggestion,
   showRetry = false,
   onRetry,
   showDismiss = false,
@@ -39,10 +42,12 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
   className,
   fieldName,
 }) => {
+  const severityClass = `error-display-${severity}`;
+
   if (variant === 'inline') {
     return (
       <p
-        className={className}
+        className={cssClasses('error-display', 'error-display-inline', severityClass, className)}
         role="alert"
         aria-live="polite"
         {...(fieldName && { id: `${fieldName}-error` })}
@@ -55,12 +60,13 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
   if (variant === 'page') {
     return (
       <div
-        className={className}
+        className={cssClasses('error-display', 'error-display-page', severityClass, className)}
         role="alert"
         aria-live="polite"
       >
         {title && <h1>{title}</h1>}
         <p>{message}</p>
+        {suggestion && <p className="error-display-suggestion">{suggestion}</p>}
         {(showRetry || showDismiss) && (
           <div>
             {showRetry && onRetry && (
@@ -82,7 +88,7 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
   if (variant === 'toast') {
     return (
       <div
-        className={className}
+        className={cssClasses('error-display', 'error-display-toast', severityClass, className)}
         role="alert"
         aria-live="assertive"
       >
@@ -90,10 +96,11 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
           <div>
             {title && <h3>{title}</h3>}
             <p>{message}</p>
+            {suggestion && <p className="error-display-suggestion">{suggestion}</p>}
           </div>
           {showDismiss && onDismiss && (
-            <button 
-              onClick={onDismiss} 
+            <button
+              onClick={onDismiss}
               aria-label="Dismiss"
               className="error-display-dismiss"
             >
@@ -108,12 +115,13 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
   // Default: section variant
   return (
     <div
-      className={cssClasses('error-display', 'error-display-section', className)}
+      className={cssClasses('error-display', 'error-display-section', severityClass, className)}
       role="alert"
       aria-live="polite"
     >
       {title && <h2 className="error-display-title">{title}</h2>}
       <p className="error-display-message">{message}</p>
+      {suggestion && <p className="error-display-suggestion">{suggestion}</p>}
       {(showRetry || showDismiss) && (
         <div className="error-display-actions">
           {showRetry && onRetry && (

--- a/src/lib/utils/__tests__/errorUtils.test.ts
+++ b/src/lib/utils/__tests__/errorUtils.test.ts
@@ -180,6 +180,46 @@ describe('errorUtils', () => {
     });
   });
 
+  describe('getUserFriendlyError severity and suggestions', () => {
+    it('should classify auth failures as critical', () => {
+      const result = getUserFriendlyError(new Error('401 unauthorized'));
+      expect(result.severity).toBe('critical');
+      expect(result.suggestion).toBeTruthy();
+    });
+
+    it('should classify network errors as error severity', () => {
+      const result = getUserFriendlyError(new Error('network connection failed'));
+      expect(result.severity).toBe('error');
+    });
+
+    it('should classify timeout, rate-limit and validation as warning', () => {
+      expect(getUserFriendlyError(new Error('request timeout')).severity).toBe('warning');
+      expect(getUserFriendlyError(new Error('429 rate limit')).severity).toBe('warning');
+      expect(getUserFriendlyError(new Error('invalid input')).severity).toBe('warning');
+    });
+
+    it('should default unknown errors to error severity', () => {
+      expect(getUserFriendlyError(new Error('boom')).severity).toBe('error');
+    });
+
+    it('should include a plain-language suggestion for every mapped type', () => {
+      const cases = [
+        'network down',
+        'request timeout',
+        '429 rate limit',
+        '401 unauthorized',
+        'invalid input',
+        'totally unexpected',
+      ];
+
+      for (const message of cases) {
+        const result = getUserFriendlyError(new Error(message));
+        expect(typeof result.suggestion).toBe('string');
+        expect(result.suggestion!.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
   describe('createStoreError', () => {
     it('should create error with default values', () => {
       const error = createStoreError('Not Found', 'The item could not be found');
@@ -188,6 +228,20 @@ describe('errorUtils', () => {
       expect(error.message).toBe('The item could not be found');
       expect(error.type).toBe(ErrorType.VALIDATION);
       expect(error.retryable).toBe(false);
+      expect(error.severity).toBe('error');
+    });
+
+    it('should accept custom severity and suggestion', () => {
+      const error = createStoreError(
+        'Heads Up',
+        'A minor issue occurred',
+        ErrorType.VALIDATION,
+        false,
+        { severity: 'warning', suggestion: 'Double-check your input.' }
+      );
+
+      expect(error.severity).toBe('warning');
+      expect(error.suggestion).toBe('Double-check your input.');
     });
 
     it('should create error with custom type', () => {

--- a/src/lib/utils/errorUtils.ts
+++ b/src/lib/utils/errorUtils.ts
@@ -8,18 +8,28 @@
  */
 export enum ErrorType {
   NETWORK = 'network',
-  SERVICE = 'service', 
+  SERVICE = 'service',
   VALIDATION = 'validation',
   AUTH = 'auth',
   UNKNOWN = 'unknown'
 }
 
+/**
+ * User-facing severity, ordered from most to least prominent.
+ * Drives how prominently an error is displayed (see ErrorDisplay):
+ * critical is the most attention-grabbing, info the least intrusive.
+ */
+export type ErrorSeverity = 'critical' | 'error' | 'warning' | 'info';
+
 export interface UserFriendlyError {
   title: string;
   message: string;
+  /** Plain-language next step the user can take to resolve the issue. */
+  suggestion?: string;
   actionLabel?: string;
   retryable: boolean;
   type: ErrorType;
+  severity: ErrorSeverity;
 }
 
 /**
@@ -60,9 +70,11 @@ export function getUserFriendlyError(error: Error): UserFriendlyError {
     return {
       title: 'Connection Problem',
       message: 'Unable to connect. Please check your internet connection.',
+      suggestion: 'Make sure you are online, then try again.',
       actionLabel: 'Try Again',
       retryable: true,
-      type: ErrorType.NETWORK
+      type: ErrorType.NETWORK,
+      severity: 'error'
     };
   }
 
@@ -71,9 +83,11 @@ export function getUserFriendlyError(error: Error): UserFriendlyError {
     return {
       title: 'Request Timed Out',
       message: 'The request is taking too long. Please try again.',
+      suggestion: 'This is usually temporary — wait a moment and try again.',
       actionLabel: 'Try Again',
       retryable: true,
-      type: ErrorType.NETWORK
+      type: ErrorType.NETWORK,
+      severity: 'warning'
     };
   }
 
@@ -82,9 +96,11 @@ export function getUserFriendlyError(error: Error): UserFriendlyError {
     return {
       title: 'Too Many Requests',
       message: 'Too many requests. Please wait a moment before trying again.',
+      suggestion: 'Wait a minute or so before trying again.',
       actionLabel: 'Try Again Later',
       retryable: true,
-      type: ErrorType.SERVICE
+      type: ErrorType.SERVICE,
+      severity: 'warning'
     };
   }
 
@@ -93,8 +109,10 @@ export function getUserFriendlyError(error: Error): UserFriendlyError {
     return {
       title: 'Authentication Error',
       message: 'Authentication failed. Please check your credentials.',
+      suggestion: 'Check that your API key is set correctly in Settings.',
       retryable: false,
-      type: ErrorType.AUTH
+      type: ErrorType.AUTH,
+      severity: 'critical'
     };
   }
 
@@ -105,8 +123,10 @@ export function getUserFriendlyError(error: Error): UserFriendlyError {
     return {
       title: 'Validation Error',
       message: 'The provided data is invalid. Please check your input and try again.',
+      suggestion: 'Review the highlighted fields and correct any invalid entries.',
       retryable: false,
-      type: ErrorType.VALIDATION
+      type: ErrorType.VALIDATION,
+      severity: 'warning'
     };
   }
 
@@ -114,9 +134,11 @@ export function getUserFriendlyError(error: Error): UserFriendlyError {
   return {
     title: 'Something Went Wrong',
     message: 'An unexpected error occurred. Please try again.',
+    suggestion: 'If this keeps happening, try reloading the page.',
     actionLabel: 'Try Again',
     retryable: isRetryableError(error),
-    type: ErrorType.UNKNOWN
+    type: ErrorType.UNKNOWN,
+    severity: 'error'
   };
 }
 
@@ -130,6 +152,7 @@ export function getUserFriendlyError(error: Error): UserFriendlyError {
  * @param message - Detailed error message for user
  * @param type - Error type category (defaults to VALIDATION)
  * @param retryable - Whether the operation can be retried (defaults to false)
+ * @param options - Optional severity and suggested next step
  * @returns UserFriendlyError object
  *
  * @example
@@ -145,13 +168,16 @@ export function createStoreError(
   title: string,
   message: string,
   type: ErrorType = ErrorType.VALIDATION,
-  retryable = false
+  retryable = false,
+  options: { severity?: ErrorSeverity; suggestion?: string } = {}
 ): UserFriendlyError {
   return {
     title,
     message,
     retryable,
     type,
+    severity: options.severity ?? 'error',
+    ...(options.suggestion && { suggestion: options.suggestion }),
   };
 }
 
@@ -201,7 +227,9 @@ export function createAPIErrorResponse(
       error: friendlyError.message,
       title: friendlyError.title,
       type: friendlyError.type,
+      severity: friendlyError.severity,
       retryable: friendlyError.retryable,
+      ...(friendlyError.suggestion && { suggestion: friendlyError.suggestion }),
       ...(friendlyError.actionLabel && { actionLabel: friendlyError.actionLabel }),
       ...(details && { details })
     },

--- a/src/state/__mocks__/worldStore.ts
+++ b/src/state/__mocks__/worldStore.ts
@@ -39,6 +39,7 @@ const createError = (
   message,
   retryable,
   type,
+  severity: 'error',
 });
 
 const syncWorldToEntities = (worldId: string) => {

--- a/src/state/__tests__/characterStore.state.test.ts
+++ b/src/state/__tests__/characterStore.state.test.ts
@@ -26,6 +26,7 @@ describe('useCharacterStore - State Management', () => {
         message: 'Something went wrong',
         type: ErrorType.VALIDATION,
         retryable: false,
+        severity: 'error' as const,
       };
 
       useCharacterStore.getState().setError(error);
@@ -51,6 +52,7 @@ describe('useCharacterStore - State Management', () => {
         message: 'State corrupted',
         type: ErrorType.UNKNOWN,
         retryable: false,
+        severity: 'error',
       });
 
       useCharacterStore.getState().setLoading(true);

--- a/src/state/__tests__/npcStore.validation.test.ts
+++ b/src/state/__tests__/npcStore.validation.test.ts
@@ -100,6 +100,7 @@ describe('npcStore - Validation and Error Handling', () => {
         message: 'Persistence failed',
         retryable: false,
         type: ErrorType.UNKNOWN,
+        severity: 'error',
       });
       expect(useNPCStore.getState().error?.title).toBe('Persistence failed');
 

--- a/src/state/loreStore.deduplication.ts
+++ b/src/state/loreStore.deduplication.ts
@@ -65,6 +65,7 @@ export async function scanForDuplicatesImpl(
       message: 'Failed to scan for duplicates',
       retryable: true,
       type: ErrorType.SERVICE,
+      severity: 'error',
     });
     return [];
   }
@@ -194,6 +195,7 @@ export function mergeFactsImpl(
       message: 'Failed to merge facts',
       retryable: false,
       type: ErrorType.SERVICE,
+      severity: 'error',
     });
     throw error;
   }

--- a/src/state/worldStore.ts
+++ b/src/state/worldStore.ts
@@ -534,6 +534,7 @@ export const useWorldStore = create<WorldStore>()(
               message: error instanceof Error ? error.message : 'Failed to fetch worlds',
               retryable: true,
               type: ErrorType.SERVICE,
+              severity: 'error',
             });
           }
         },

--- a/src/stories/01-atoms/feedback/ErrorDisplay.stories.tsx
+++ b/src/stories/01-atoms/feedback/ErrorDisplay.stories.tsx
@@ -22,8 +22,8 @@ const meta: Meta<typeof ErrorDisplay> = {
     },
     severity: {
       control: 'select',
-      options: ['error', 'warning', 'info'],
-      description: 'Severity level affecting colors and styling',
+      options: ['critical', 'error', 'warning', 'info'],
+      description: 'Severity level affecting colors and prominence',
     },
     title: {
       control: 'text',
@@ -32,6 +32,10 @@ const meta: Meta<typeof ErrorDisplay> = {
     message: {
       control: 'text',
       description: 'The error message to display',
+    },
+    suggestion: {
+      control: 'text',
+      description: 'Plain-language suggested next step shown below the message',
     },
     showRetry: {
       control: 'boolean',
@@ -125,6 +129,51 @@ export const AllVariants: Story = {
   ),
 };
 
+// Severity ordering: critical is the most prominent, info the least intrusive.
+// Each shows a plain-language suggested next step under the message.
+export const SeverityLevels: Story = {
+  render: (args) => (
+    <div>
+      <ErrorDisplay
+        variant="section"
+        severity="critical"
+        title="Authentication Error"
+        message="We couldn't verify your AI service credentials."
+        suggestion="Check that your API key is set correctly in Settings."
+        showDismiss
+        onDismiss={args.onDismiss}
+      />
+      <ErrorDisplay
+        variant="section"
+        severity="error"
+        title="Connection Problem"
+        message="Unable to connect. Please check your internet connection."
+        suggestion="Make sure you are online, then try again."
+        showRetry
+        onRetry={args.onRetry}
+      />
+      <ErrorDisplay
+        variant="section"
+        severity="warning"
+        title="Request Timed Out"
+        message="The request is taking too long."
+        suggestion="This is usually temporary — wait a moment and try again."
+        showRetry
+        onRetry={args.onRetry}
+      />
+      <ErrorDisplay
+        variant="section"
+        severity="info"
+        title="Heads Up"
+        message="Some features are unavailable in offline mode."
+        suggestion="Reconnect to use AI-assisted tools."
+        showDismiss
+        onDismiss={args.onDismiss}
+      />
+    </div>
+  ),
+};
+
 // Form validation example
 export const FormValidation: Story = {
   render: () => (
@@ -175,6 +224,7 @@ export const Playground: Story = {
     severity: 'error',
     title: 'Operation Failed',
     message: 'Something went wrong while processing your request.',
+    suggestion: 'Try again. If the problem continues, reload the page.',
     showRetry: true,
     showDismiss: true,
   },

--- a/src/stories/04-templates/layouts/WorldListScreen.stories.tsx
+++ b/src/stories/04-templates/layouts/WorldListScreen.stories.tsx
@@ -140,7 +140,8 @@ export const WithError: Story = {
           title: 'Failed to load worlds',
           message: 'Failed to load worlds',
           retryable: false,
-          type: ErrorType.SERVICE
+          type: ErrorType.SERVICE,
+          severity: 'error'
         }
       });
       return <Story />;

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -3123,6 +3123,114 @@ body.manuscript-overlay-open {
   background: hsl(var(--destructive) / 6%);
 }
 
+/* ===========================================================================
+   Issue #222 — severity-aware error display.
+   Default ("error") rendering is intentionally left untouched above; the rules
+   below only re-color the WARNING / INFO severities and add prominence to
+   CRITICAL. Selector lists cover DS3 (base), DS1 and DS2 so the accent wins
+   over each theme's destructive-coloured section rule.
+   =========================================================================== */
+
+/* Suggested next step — secondary to the message, same in every variant. */
+.error-display-suggestion {
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+  margin: 0 0 var(--space-2_5);
+}
+
+/* Inline errors previously had no colour; give them a severity accent. */
+.error-display-inline {
+  font-size: 0.875rem;
+  line-height: 1.4;
+  margin: var(--space-1) 0 0;
+}
+
+.error-display-inline.error-display-error,
+.error-display-inline.error-display-critical {
+  color: hsl(var(--destructive));
+}
+
+.error-display-inline.error-display-warning {
+  color: hsl(var(--warning));
+}
+
+.error-display-inline.error-display-info {
+  color: hsl(var(--info));
+}
+
+/* --- WARNING (amber): less alarming than an error --- */
+.error-display-warning.error-display-section,
+[data-theme="ds1"] .error-display-warning.error-display-section,
+[data-theme="ds2"] .error-display-warning.error-display-section {
+  background: hsl(var(--warning) / 8%);
+  border-color: hsl(var(--warning) / 30%);
+}
+
+.error-display-warning .error-display-title,
+.error-display-warning .error-display-message,
+[data-theme="ds1"] .error-display-warning .error-display-title,
+[data-theme="ds1"] .error-display-warning .error-display-message,
+[data-theme="ds2"] .error-display-warning .error-display-title,
+[data-theme="ds2"] .error-display-warning .error-display-message {
+  color: hsl(var(--warning));
+}
+
+.error-display-warning .error-display-actions .error-display-retry,
+[data-theme="ds1"] .error-display-warning .error-display-actions .error-display-retry,
+[data-theme="ds2"] .error-display-warning .error-display-actions .error-display-retry {
+  background: hsl(var(--warning));
+  color: hsl(var(--warning-foreground));
+}
+
+.error-display-warning .error-display-actions .error-display-dismiss,
+[data-theme="ds1"] .error-display-warning .error-display-actions .error-display-dismiss,
+[data-theme="ds2"] .error-display-warning .error-display-actions .error-display-dismiss {
+  color: hsl(var(--warning));
+  border-color: hsl(var(--warning) / 30%);
+}
+
+/* --- INFO (blue): least intrusive --- */
+.error-display-info.error-display-section,
+[data-theme="ds1"] .error-display-info.error-display-section,
+[data-theme="ds2"] .error-display-info.error-display-section {
+  background: hsl(var(--info) / 7%);
+  border-color: hsl(var(--info) / 20%);
+}
+
+.error-display-info .error-display-title,
+.error-display-info .error-display-message,
+[data-theme="ds1"] .error-display-info .error-display-title,
+[data-theme="ds1"] .error-display-info .error-display-message,
+[data-theme="ds2"] .error-display-info .error-display-title,
+[data-theme="ds2"] .error-display-info .error-display-message {
+  color: hsl(var(--info));
+}
+
+.error-display-info .error-display-actions .error-display-retry,
+[data-theme="ds1"] .error-display-info .error-display-actions .error-display-retry,
+[data-theme="ds2"] .error-display-info .error-display-actions .error-display-retry {
+  background: hsl(var(--info));
+  color: hsl(var(--info-foreground));
+}
+
+.error-display-info .error-display-actions .error-display-dismiss,
+[data-theme="ds1"] .error-display-info .error-display-actions .error-display-dismiss,
+[data-theme="ds2"] .error-display-info .error-display-actions .error-display-dismiss {
+  color: hsl(var(--info));
+  border-color: hsl(var(--info) / 20%);
+}
+
+/* --- CRITICAL: same danger colour as an error, but more prominent --- */
+.error-display-critical.error-display-section,
+[data-theme="ds1"] .error-display-critical.error-display-section,
+[data-theme="ds2"] .error-display-critical.error-display-section {
+  border-width: 1px;
+  border-left-width: var(--space-1);
+  border-left-color: hsl(var(--destructive));
+  background: hsl(var(--destructive) / 12%);
+}
+
 /* Fix 69: DS1 tools menu items — compact, transparent background */
 [data-theme="ds1"] .manuscript-tools-menu-item {
   padding: var(--space-2) var(--space-2_5);


### PR DESCRIPTION
## What & why

Closes #222.

The friendly-error plumbing already gave us clear titles and plain text, but the `severity` prop on `ErrorDisplay` did nothing — every error rendered in the destructive red, so a "warning" or even a success message looked just as alarming as a hard failure. And nothing actually told the player what to *do* about the problem.

This wires severity through end to end, and adds a plain-language "suggested next step" to each error.

## Changes

- **`getUserFriendlyError`** now tags every mapped error with a `severity` (`critical` / `error` / `warning` / `info`) and a `suggestion`. Auth failures are `critical`, network/unknown are `error`, timeout / rate-limit / validation are `warning`. `createStoreError` takes optional `severity`/`suggestion`, and `createAPIErrorResponse` passes both through.
- **`ErrorDisplay`** applies an `error-display-{severity}` class on every variant and renders the suggestion below the message. The severity union is now the canonical `ErrorSeverity` type from `errorUtils`.
- **CSS** re-colours `warning` (amber) and `info` (blue, lightest treatment) and gives `critical` a prominent left accent bar. The default `error` rendering is left **byte-identical** across DS1/DS2/DS3, so existing red errors don't shift (verified by computed-style check).
- **App-level error boundary** (`app/error.tsx`) now runs the raw error through `getUserFriendlyError` instead of leaking `error.message` (and any technical detail) straight to the player.
- A handful of direct `UserFriendlyError` literals (stores, mocks, tests) get an explicit `severity` now that the field is required.

## Acceptance criteria

- [x] Error messages use non-technical language
- [x] Messages explain what went wrong in clear terms
- [x] Error messages include suggested actions when applicable
- [x] Styled appropriately to indicate severity
- [x] Critical errors prominently displayed, minor issues less intrusive

## Testing

- `tsc --noEmit`, `next lint`, `stylelint **/*.css` — all clean
- Full unit suite: 2168 passing (added `ErrorDisplay.test.tsx` + severity/suggestion cases in `errorUtils.test.ts`)
- Verified rendered output in Storybook under DS1 (the default theme) via computed styles: critical = crimson + 3px left accent bar, error = unchanged crimson, warning = amber, info = blue, all four rendering their suggestion. New `SeverityLevels` story added.

Note: "Closes #222" won't auto-close on merge to `develop` — I'll close it manually after merge.