### PR TITLE
Offer retry with feedback and a fallback on recoverable errors (#302)

### DIFF
--- a/src/components/ui/ErrorDisplay/ErrorDisplay.test.tsx
+++ b/src/components/ui/ErrorDisplay/ErrorDisplay.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import { ErrorDisplay } from './ErrorDisplay';
 
 describe('ErrorDisplay', () => {
@@ -39,5 +39,102 @@ describe('ErrorDisplay', () => {
     );
 
     expect(container.querySelector('.error-display-suggestion')).toBeNull();
+  });
+
+  // Recoverable errors offer retry; non-recoverable ones do not.
+  it('shows a retry button only when retry is enabled and a callback is given', () => {
+    const { rerender } = render(
+      <ErrorDisplay variant="section" message="Non-recoverable." />
+    );
+    expect(screen.queryByRole('button', { name: /try again/i })).toBeNull();
+
+    rerender(
+      <ErrorDisplay variant="section" message="Recoverable." showRetry onRetry={jest.fn()} />
+    );
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it('invokes the retry callback when the retry button is clicked', async () => {
+    const onRetry = jest.fn();
+    render(
+      <ErrorDisplay variant="section" message="Recoverable." showRetry onRetry={onRetry} />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+    });
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows in-progress feedback while an async retry is pending', async () => {
+    let resolveRetry: () => void = () => {};
+    const onRetry = jest.fn(
+      () => new Promise<void>((resolve) => { resolveRetry = resolve; })
+    );
+
+    render(
+      <ErrorDisplay variant="section" message="Recoverable." showRetry onRetry={onRetry} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+
+    const retrying = await screen.findByRole('button', { name: /retrying/i });
+    expect(retrying).toBeDisabled();
+    expect(retrying).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('status')).toHaveTextContent(/retrying/i);
+
+    await act(async () => {
+      resolveRetry();
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /try again/i })).toBeEnabled()
+    );
+  });
+
+  it('supports multiple retry attempts when no limit is set', async () => {
+    const onRetry = jest.fn();
+    render(
+      <ErrorDisplay variant="section" message="Recoverable." showRetry onRetry={onRetry} />
+    );
+
+    const button = screen.getByRole('button', { name: /try again/i });
+    await act(async () => { fireEvent.click(button); });
+    await act(async () => { fireEvent.click(button); });
+
+    expect(onRetry).toHaveBeenCalledTimes(2);
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it('degrades to a fallback action once retries are exhausted', async () => {
+    const onRetry = jest.fn();
+    const onFallback = jest.fn();
+
+    render(
+      <ErrorDisplay
+        variant="section"
+        message="Persistent failure."
+        showRetry
+        onRetry={onRetry}
+        maxRetries={1}
+        fallbackMessage="Still stuck. Head back to your worlds."
+        fallbackLabel="Back to Worlds"
+        onFallback={onFallback}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /try again/i })).toBeNull()
+    );
+    expect(screen.getByText('Still stuck. Head back to your worlds.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /back to worlds/i }));
+    expect(onFallback).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/ui/ErrorDisplay/ErrorDisplay.test.tsx
+++ b/src/components/ui/ErrorDisplay/ErrorDisplay.test.tsx
@@ -137,4 +137,35 @@ describe('ErrorDisplay', () => {
     expect(onFallback).toHaveBeenCalledTimes(1);
     expect(onRetry).toHaveBeenCalledTimes(1);
   });
+
+  // A failed retry is the case this feature targets — the rejection must not
+  // escape the click handler, and the flow must still degrade to the fallback.
+  it('absorbs a rejected retry and still degrades to the fallback', async () => {
+    const onRetry = jest.fn().mockRejectedValue(new Error('still failing'));
+    const onFallback = jest.fn();
+
+    render(
+      <ErrorDisplay
+        variant="section"
+        message="Persistent failure."
+        showRetry
+        onRetry={onRetry}
+        maxRetries={1}
+        fallbackMessage="Still stuck. Head back to your worlds."
+        fallbackLabel="Back to Worlds"
+        onFallback={onFallback}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /try again/i })).toBeNull()
+    );
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Still stuck. Head back to your worlds.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /back to worlds/i })).toBeInTheDocument();
+  });
 });

--- a/src/components/ui/ErrorDisplay/ErrorDisplay.tsx
+++ b/src/components/ui/ErrorDisplay/ErrorDisplay.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+'use client';
+
+import React, { useCallback, useState } from 'react';
 import { cssClasses } from '@/lib/utils';
 import type { ErrorSeverity } from '@/lib/utils/errorUtils';
 
@@ -15,10 +17,26 @@ interface ErrorDisplayProps {
   message: string;
   /** Plain-language suggested next step shown below the message */
   suggestion?: string;
-  /** Show retry button */
+  /** Show retry button. Only present a retry option for recoverable errors. */
   showRetry?: boolean;
-  /** Retry button callback */
-  onRetry?: () => void;
+  /**
+   * Retry button callback. May be async — while the returned promise is
+   * pending the button shows an in-progress state and is disabled.
+   */
+  onRetry?: () => void | Promise<void>;
+  /** Label for the retry button (defaults to "Try Again"). */
+  retryLabel?: string;
+  /**
+   * Maximum retry attempts before the retry button is replaced by the fallback
+   * action. Omit for unlimited retries (no fallback).
+   */
+  maxRetries?: number;
+  /** Message shown once retries are exhausted, pointing the user to an alternative. */
+  fallbackMessage?: string;
+  /** Label for the fallback action shown once retries are exhausted. */
+  fallbackLabel?: string;
+  /** Callback for the fallback action shown once retries are exhausted. */
+  onFallback?: () => void;
   /** Show dismiss button */
   showDismiss?: boolean;
   /** Dismiss button callback */
@@ -29,6 +47,35 @@ interface ErrorDisplayProps {
   fieldName?: string;
 }
 
+/**
+ * Shared retry/fallback behavior for the variants that expose action buttons.
+ * Tracks attempt count and in-progress state so a recoverable error can be
+ * retried multiple times before degrading to a fallback action.
+ */
+function useRetryState(
+  onRetry: ErrorDisplayProps['onRetry'],
+  maxRetries: number | undefined
+) {
+  const [attempts, setAttempts] = useState(0);
+  const [isRetrying, setIsRetrying] = useState(false);
+
+  const retriesExhausted =
+    maxRetries !== undefined && attempts >= maxRetries;
+
+  const handleRetry = useCallback(async () => {
+    if (!onRetry || isRetrying) return;
+    setAttempts((count) => count + 1);
+    setIsRetrying(true);
+    try {
+      await onRetry();
+    } finally {
+      setIsRetrying(false);
+    }
+  }, [onRetry, isRetrying]);
+
+  return { isRetrying, retriesExhausted, handleRetry };
+}
+
 export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
   variant = 'section',
   severity = 'error',
@@ -37,12 +84,28 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
   suggestion,
   showRetry = false,
   onRetry,
+  retryLabel = 'Try Again',
+  maxRetries,
+  fallbackMessage,
+  fallbackLabel = 'Get help',
+  onFallback,
   showDismiss = false,
   onDismiss,
   className,
   fieldName,
 }) => {
   const severityClass = `error-display-${severity}`;
+  const { isRetrying, retriesExhausted, handleRetry } = useRetryState(
+    onRetry,
+    maxRetries
+  );
+
+  // Keep the retry button visible while the final allowed attempt is still in
+  // flight, then swap it for the fallback once that attempt settles.
+  const canRetry = showRetry && !!onRetry && (!retriesExhausted || isRetrying);
+  const showFallback = retriesExhausted && !isRetrying;
+  const hasActions =
+    canRetry || (showFallback && !!onFallback) || (showDismiss && !!onDismiss);
 
   if (variant === 'inline') {
     return (
@@ -57,6 +120,40 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
     );
   }
 
+  // Visually-hidden live region announcing retry progress and exhaustion to
+  // assistive tech without competing with the alert region's static content.
+  const retryStatus = (
+    <span className="sr-only" role="status" aria-live="polite">
+      {isRetrying
+        ? 'Retrying, please wait.'
+        : showFallback
+          ? 'Automatic retry is unavailable. Choose an alternative.'
+          : ''}
+    </span>
+  );
+
+  const retryButton = canRetry && (
+    <button
+      type="button"
+      className="error-display-retry"
+      onClick={handleRetry}
+      disabled={isRetrying}
+      aria-busy={isRetrying}
+    >
+      {isRetrying ? 'Retrying…' : retryLabel}
+    </button>
+  );
+
+  const fallbackButton = showFallback && onFallback && (
+    <button
+      type="button"
+      className="error-display-fallback-action"
+      onClick={onFallback}
+    >
+      {fallbackLabel}
+    </button>
+  );
+
   if (variant === 'page') {
     return (
       <div
@@ -67,17 +164,16 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
         {title && <h1>{title}</h1>}
         <p>{message}</p>
         {suggestion && <p className="error-display-suggestion">{suggestion}</p>}
-        {(showRetry || showDismiss) && (
-          <div>
-            {showRetry && onRetry && (
-              <button
-                onClick={onRetry}
-              >
-                Try Again
-              </button>
-            )}
+        {showFallback && fallbackMessage && (
+          <p className="error-display-fallback">{fallbackMessage}</p>
+        )}
+        {retryStatus}
+        {hasActions && (
+          <div className="error-display-actions">
+            {retryButton}
+            {fallbackButton}
             {showDismiss && onDismiss && (
-              <button onClick={onDismiss}>Dismiss</button>
+              <button type="button" onClick={onDismiss}>Dismiss</button>
             )}
           </div>
         )}
@@ -100,6 +196,7 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
           </div>
           {showDismiss && onDismiss && (
             <button
+              type="button"
               onClick={onDismiss}
               aria-label="Dismiss"
               className="error-display-dismiss"
@@ -122,15 +219,16 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
       {title && <h2 className="error-display-title">{title}</h2>}
       <p className="error-display-message">{message}</p>
       {suggestion && <p className="error-display-suggestion">{suggestion}</p>}
-      {(showRetry || showDismiss) && (
+      {showFallback && fallbackMessage && (
+        <p className="error-display-fallback">{fallbackMessage}</p>
+      )}
+      {retryStatus}
+      {hasActions && (
         <div className="error-display-actions">
-          {showRetry && onRetry && (
-            <button className="error-display-retry" onClick={onRetry}>
-              Try Again
-            </button>
-          )}
+          {retryButton}
+          {fallbackButton}
           {showDismiss && onDismiss && (
-            <button className="error-display-dismiss" onClick={onDismiss}>Dismiss</button>
+            <button type="button" className="error-display-dismiss" onClick={onDismiss}>Dismiss</button>
           )}
         </div>
       )}

--- a/src/components/ui/ErrorDisplay/ErrorDisplay.tsx
+++ b/src/components/ui/ErrorDisplay/ErrorDisplay.tsx
@@ -68,6 +68,11 @@ function useRetryState(
     setIsRetrying(true);
     try {
       await onRetry();
+    } catch {
+      // A failed retry is the case this feature exists for: the caller keeps
+      // the error surfaced and the fallback appears once attempts run out. We
+      // absorb the rejection here so it doesn't escape the click handler as an
+      // unhandled promise rejection.
     } finally {
       setIsRetrying(false);
     }

--- a/src/stories/01-atoms/feedback/ErrorDisplay.stories.tsx
+++ b/src/stories/01-atoms/feedback/ErrorDisplay.stories.tsx
@@ -39,7 +39,19 @@ const meta: Meta<typeof ErrorDisplay> = {
     },
     showRetry: {
       control: 'boolean',
-      description: 'Show retry button',
+      description: 'Show retry button (only for recoverable errors)',
+    },
+    maxRetries: {
+      control: 'number',
+      description: 'Attempts allowed before the retry button degrades to a fallback action',
+    },
+    fallbackMessage: {
+      control: 'text',
+      description: 'Message shown once retries are exhausted',
+    },
+    fallbackLabel: {
+      control: 'text',
+      description: 'Label for the fallback action shown once retries are exhausted',
     },
     showDismiss: {
       control: 'boolean',
@@ -49,6 +61,7 @@ const meta: Meta<typeof ErrorDisplay> = {
   args: {
     onRetry: fn(),
     onDismiss: fn(),
+    onFallback: fn(),
   },
 };
 
@@ -216,6 +229,32 @@ export const FormValidation: Story = {
   ),
 };
 
+
+// Recoverable error: retry shows in-progress feedback, then degrades to a
+// fallback action after the configured number of attempts. Click "Try Again"
+// twice (each attempt simulates a ~1.2s failed call) to see the fallback appear.
+export const RetryWithFallback: Story = {
+  render: () => {
+    const failingRetry = () =>
+      new Promise<void>((resolve) => setTimeout(resolve, 1200));
+
+    return (
+      <ErrorDisplay
+        variant="section"
+        severity="error"
+        title="Couldn't Generate the Next Scene"
+        message="The AI service didn't respond in time."
+        suggestion="This is usually temporary — try again."
+        showRetry
+        onRetry={failingRetry}
+        maxRetries={2}
+        fallbackMessage="Still stuck after a couple of tries. You can head back to your worlds and pick up later."
+        fallbackLabel="Back to Worlds"
+        onFallback={fn()}
+      />
+    );
+  },
+};
 
 // Interactive playground
 export const Playground: Story = {

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -2990,6 +2990,39 @@ body.manuscript-overlay-open {
   background: hsl(var(--destructive) / 6%);
 }
 
+/* Issue #302 — retry in-progress + fallback after persistent failures.
+   Token-driven so each theme's --destructive / surface tokens carry through. */
+.error-display-actions .error-display-retry:disabled,
+.error-display-actions .error-display-retry[aria-busy="true"] {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+/* Alternative path offered once retries are exhausted — secondary styling so it
+   reads as a different action from the destructive retry. */
+.error-display-fallback {
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+  margin: 0 0 var(--space-2_5);
+}
+
+.error-display-actions .error-display-fallback-action {
+  padding: var(--space-1_5) var(--space-3);
+  font-size: 0.875rem;
+  font-weight: 500;
+  background: var(--color-surface);
+  color: hsl(var(--destructive));
+  border: 1px solid hsl(var(--destructive) / 30%);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.error-display-actions .error-display-fallback-action:hover {
+  background: hsl(var(--destructive) / 6%);
+}
+
 /* Fix 56: DS1 error container */
 [data-theme="ds1"] .error-display-section {
   margin: var(--space-4) 0;


### PR DESCRIPTION
## Summary

Closes #302.

`ErrorDisplay` already had `showRetry`/`onRetry`, but retrying was fire-and-forget — no sign anything was happening, no attempt limit, and no way out when it kept failing. This fills in the rest of the issue.

- **In-progress feedback.** `onRetry` can now be async. While the returned promise is pending, the button reads "Retrying…", goes `disabled` with `aria-busy="true"`, and an `sr-only` `role="status"` live region announces progress to screen readers.
- **Multiple attempts, then a fallback.** `maxRetries` caps how many times the user can retry. Once exhausted, the retry button steps aside for a `fallbackMessage` + an alternative action (`fallbackLabel` / `onFallback`, e.g. "Back to Worlds") — so a persistent failure isn't a dead end.
- **Recoverable vs non-recoverable** stays the caller's decision via `showRetry`, fed by the existing `UserFriendlyError.retryable` / `isRetryableError()` classification in `errorUtils.ts`. No new classifier invented.

New states are token-driven (`--destructive`, `--color-surface`, `--color-text-secondary`, `--space-*`, `--radius-sm`), so DS1/DS2/DS3 all pick them up. Section + page variants share the retry/fallback logic; toast and inline are untouched. The widened `onRetry` signature and new props are all optional — existing call sites are unaffected.

## Acceptance criteria

- [x] Retry options presented for recoverable errors
- [x] Retry button clearly visible and accessible (`type=button`, `aria-busy`, focusable)
- [x] Multiple retry attempts supported when appropriate (`maxRetries`)
- [x] Feedback during retry attempts (button label + `aria-busy` + live region)
- [x] Persistent failures offer alternative solutions (fallback message + action)

## Test plan

- [x] `npx jest src/components/ui/ErrorDisplay` — 9 tests (retry callback, in-progress feedback, multiple attempts, fallback exhaustion, recoverable gating)
- [x] Consumer suites green: `GameSession`, `SaveIndicator`, `Narrative` (222 tests)
- [x] `npm run type-check`, eslint, and `stylelint` all clean
- [x] Verified live in Storybook (`RetryWithFallback` story) with bdg: retry → "Retrying…"/disabled/`aria-busy` → returns → after 2 attempts the fallback message + "Back to Worlds" action appear; computed styles confirm `--color-surface` background and `--destructive` text/border