### PR TITLE
feat(lore): loosen name filter, cache alias index, balance categories (#1301)

### DIFF
--- a/src/state/__tests__/loreStore.aliases.test.ts
+++ b/src/state/__tests__/loreStore.aliases.test.ts
@@ -459,6 +459,47 @@ describe('LoreStore - Alias Management', () => {
       expect(found2?.value).toBe('Lady Victoria');
     });
 
+    it('should stay correct after aliases are added, removed, and replaced (index invalidation)', () => {
+      const { result } = renderHook(() => useLoreStore());
+
+      let factId!: string;
+      act(() => {
+        factId = result.current.addFact(
+          'world-1:character_lady_seraphina',
+          'Lady Seraphina',
+          'characters',
+          'manual',
+          'world-1'
+        );
+        result.current.setAliases(factId, ['Seraphina', 'Lady Sera']);
+      });
+
+      // Index built from the post-setAliases facts record.
+      expect(result.current.findEntityByAnyName('Lady Sera', 'world-1')?.id).toBe(factId);
+
+      act(() => {
+        result.current.removeAlias(factId, 'Lady Sera');
+      });
+
+      // After mutation, the cached index for the old facts object is stale, but
+      // findEntityByAnyName looks up against the new facts record so it must miss.
+      expect(result.current.findEntityByAnyName('Lady Sera', 'world-1')).toBeNull();
+
+      act(() => {
+        result.current.addAlias(factId, 'Lady Sera');
+      });
+
+      // Re-adding should make it findable again.
+      expect(result.current.findEntityByAnyName('Lady Sera', 'world-1')?.id).toBe(factId);
+
+      act(() => {
+        result.current.deleteFact(factId);
+      });
+
+      // Deletion invalidates the index too.
+      expect(result.current.findEntityByAnyName('Lady Seraphina', 'world-1')).toBeNull();
+    });
+
     it('should handle special characters in names', () => {
       const { result } = renderHook(() => useLoreStore());
 

--- a/src/state/__tests__/loreStore.categoryBalance.test.ts
+++ b/src/state/__tests__/loreStore.categoryBalance.test.ts
@@ -1,0 +1,114 @@
+import { renderHook, act } from '@testing-library/react';
+import { useLoreStore } from '../loreStore';
+import { setupLoreStore } from './loreStore.testHelpers';
+import type { LoreCategory } from '@/types/lore.types';
+
+describe('LoreStore - Category-Balanced getLoreContext', () => {
+  beforeEach(() => {
+    setupLoreStore();
+  });
+
+  function seedFacts(
+    add: ReturnType<typeof useLoreStore.getState>['addFact'],
+    counts: Partial<Record<LoreCategory, number>>
+  ) {
+    for (const [category, count] of Object.entries(counts) as [LoreCategory, number][]) {
+      for (let i = 0; i < count; i++) {
+        add(
+          `world-1:${category}_${i}`,
+          `${category} ${i}`,
+          category,
+          'manual',
+          'world-1',
+          undefined,
+          { importance: i === 0 ? 'high' : 'medium' }
+        );
+      }
+    }
+  }
+
+  it('does not guarantee per-category representation by default', () => {
+    const { result } = renderHook(() => useLoreStore());
+
+    act(() => {
+      // All characters at medium importance, only one fact for other categories at low importance.
+      const add = result.current.addFact;
+      for (let i = 0; i < 10; i++) {
+        add(`world-1:characters_${i}`, `Character ${i}`, 'characters', 'manual', 'world-1', undefined, { importance: 'medium' });
+      }
+      add('world-1:locations_0', 'Location 0', 'locations', 'manual', 'world-1', undefined, { importance: 'low' });
+      add('world-1:rules_0', 'Rule 0', 'rules', 'manual', 'world-1', undefined, { importance: 'low' });
+    });
+
+    const context = result.current.getLoreContext('world-1', undefined, 5);
+    const categories = context.facts.map((s) => s.split(':')[0]);
+
+    // Default sort: medium-importance characters crowd out low-importance locations/rules.
+    expect(categories.filter((c) => c === 'characters').length).toBe(5);
+    expect(categories).not.toContain('locations');
+    expect(categories).not.toContain('rules');
+  });
+
+  it('guarantees per-category representation when categoryBalanced is true', () => {
+    const { result } = renderHook(() => useLoreStore());
+
+    act(() => {
+      seedFacts(result.current.addFact, {
+        characters: 10,
+        locations: 2,
+        rules: 1,
+        events: 1,
+      });
+    });
+
+    const context = result.current.getLoreContext('world-1', undefined, 6, {
+      categoryBalanced: true,
+    });
+    const categories = context.facts.map((s) => s.split(':')[0]);
+
+    expect(categories).toContain('characters');
+    expect(categories).toContain('locations');
+    expect(categories).toContain('rules');
+    expect(categories).toContain('events');
+    expect(context.factCount).toBe(6);
+  });
+
+  it('falls back gracefully when categories are missing', () => {
+    const { result } = renderHook(() => useLoreStore());
+
+    act(() => {
+      seedFacts(result.current.addFact, { characters: 3, locations: 1 });
+    });
+
+    const context = result.current.getLoreContext('world-1', undefined, 10, {
+      categoryBalanced: true,
+    });
+
+    // Should pull everything available without throwing or padding.
+    expect(context.factCount).toBe(4);
+  });
+
+  it('prefers high-importance facts within each category', () => {
+    const { result } = renderHook(() => useLoreStore());
+
+    act(() => {
+      // First addFact for each category gets 'high', rest get 'medium'.
+      seedFacts(result.current.addFact, {
+        characters: 3,
+        locations: 3,
+        rules: 3,
+        events: 3,
+      });
+    });
+
+    const context = result.current.getLoreContext('world-1', undefined, 4, {
+      categoryBalanced: true,
+    });
+
+    // Each category's "0" entry (high-importance) should land before lower-importance siblings.
+    for (const category of ['characters', 'locations', 'rules', 'events']) {
+      const firstFromCategory = context.facts.find((s) => s.startsWith(`${category}:`));
+      expect(firstFromCategory).toMatch(new RegExp(`${category}_0`));
+    }
+  });
+});

--- a/src/state/__tests__/loreStore.hardening.test.ts
+++ b/src/state/__tests__/loreStore.hardening.test.ts
@@ -72,9 +72,14 @@ describe('Lore Extraction Hardening Logic', () => {
       expect(shouldStoreExtractedCharacterName('Woman with hood')).toBe(false);
     });
 
-    it('should reject plural groups (short names ending in s without apostrophe)', () => {
+    it('should reject names made entirely of generic NPC words (denylist)', () => {
       expect(shouldStoreExtractedCharacterName('guards')).toBe(false);
       expect(shouldStoreExtractedCharacterName('villagers')).toBe(false);
+      expect(shouldStoreExtractedCharacterName('the villagers')).toBe(false);
+    });
+
+    it('should reject plural-group structures like "Dothraki warriors"', () => {
+      expect(shouldStoreExtractedCharacterName('Dothraki warriors')).toBe(false);
       expect(shouldStoreExtractedCharacterName('town guards')).toBe(false);
     });
 
@@ -82,11 +87,17 @@ describe('Lore Extraction Hardening Logic', () => {
       expect(shouldStoreExtractedCharacterName('The tall mysterious figure wearing a dark hooded cloak')).toBe(false);
     });
 
-    // Edge Cases explicitly mentioned in plan
-    it('should reject short names ending in s without apostrophe (heuristic)', () => {
-      expect(shouldStoreExtractedCharacterName('James')).toBe(false);
-      expect(shouldStoreExtractedCharacterName('Artemis')).toBe(false);
-      expect(shouldStoreExtractedCharacterName('Charles')).toBe(false);
+    // Single-token proper names ending in 's' shouldn't be rejected as plural
+    // groups — that was the structural false-positive #1301 calls out.
+    it('should accept single-token proper names that end in s', () => {
+      expect(shouldStoreExtractedCharacterName('James')).toBe(true);
+      expect(shouldStoreExtractedCharacterName('Artemis')).toBe(true);
+      expect(shouldStoreExtractedCharacterName('Charles')).toBe(true);
+    });
+
+    it('should accept faction-style names with "of" or a possessive', () => {
+      expect(shouldStoreExtractedCharacterName('Brothers of Steel')).toBe(true);
+      expect(shouldStoreExtractedCharacterName("King's Guard")).toBe(true);
     });
   });
 

--- a/src/state/loreStore.actions.ts
+++ b/src/state/loreStore.actions.ts
@@ -296,7 +296,8 @@ export const createLoreFactActions = (set: SetState, get: GetState) => ({
   getLoreContext: (
     worldId: EntityID,
     sessionId?: EntityID,
-    limit = 20
+    limit = 20,
+    options?: { categoryBalanced?: boolean }
   ): LoreContext => {
     const worldFacts = get().getFacts({ worldId });
 
@@ -307,18 +308,46 @@ export const createLoreFactActions = (set: SetState, get: GetState) => ({
       );
     });
 
-    const sortedFacts = visibleFacts.sort((a, b) => {
+    const byImportance = (a: LoreFact, b: LoreFact) => {
       const rankA = importanceRank(a.metadata?.importance);
       const rankB = importanceRank(b.metadata?.importance);
-
-      if (rankA !== rankB) {
-        return rankB - rankA;
-      }
-
+      if (rankA !== rankB) return rankB - rankA;
       return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-    });
+    };
 
-    const selectedFacts = sortedFacts.slice(0, limit);
+    let selectedFacts: LoreFact[];
+
+    if (options?.categoryBalanced) {
+      // Round-robin across categories so character-heavy worlds don't crowd out
+      // locations / rules / events. Within each category we still prefer higher
+      // importance, falling back to recency.
+      const buckets: Record<LoreCategory, LoreFact[]> = {
+        characters: [],
+        locations: [],
+        events: [],
+        rules: [],
+      };
+      for (const fact of visibleFacts) {
+        buckets[fact.category]?.push(fact);
+      }
+      for (const category of Object.keys(buckets) as LoreCategory[]) {
+        buckets[category].sort(byImportance);
+      }
+      selectedFacts = [];
+      const order: LoreCategory[] = ['characters', 'locations', 'rules', 'events'];
+      while (selectedFacts.length < limit) {
+        const before = selectedFacts.length;
+        for (const category of order) {
+          if (selectedFacts.length >= limit) break;
+          const next = buckets[category].shift();
+          if (next) selectedFacts.push(next);
+        }
+        if (selectedFacts.length === before) break; // no more facts to draw
+      }
+    } else {
+      selectedFacts = [...visibleFacts].sort(byImportance).slice(0, limit);
+    }
+
     const factStrings = selectedFacts.map(
       (fact) => `${fact.category}: ${fact.key} = ${fact.value}`
     );
@@ -503,6 +532,7 @@ export const createLoreAliasActions = (_set: SetState, get: GetState) => {
     getFact: get().getById,
     updateFact: get().update,
     getFacts: get().getFacts,
+    getAllFacts: () => get().facts,
   });
 
   return {

--- a/src/state/loreStore.aliases.ts
+++ b/src/state/loreStore.aliases.ts
@@ -4,6 +4,35 @@ import { normalizeText, NORM_NAME } from '../lib/utils/textNormalization';
 import { logger } from '@/lib/utils/logger';
 
 /**
+ * Cache of (worldId, normalized name|alias) → factId, keyed by the facts record
+ * reference. The Zustand store creates a new facts object on every mutation, so
+ * the WeakMap entry auto-invalidates after writes and is rebuilt lazily on the
+ * next lookup. Drops findEntityByAnyName from O(n) per call to O(1) on cache hits.
+ */
+const aliasIndexCache = new WeakMap<object, Map<string, EntityID>>();
+
+function buildAliasIndex(allFacts: Record<EntityID, LoreFact>): Map<string, EntityID> {
+  const index = new Map<string, EntityID>();
+  for (const fact of Object.values(allFacts)) {
+    const valueKey = `${fact.worldId}::${normalizeText(fact.value, NORM_NAME).toLowerCase()}`;
+    index.set(valueKey, fact.id);
+    for (const alias of fact.aliases ?? []) {
+      const aliasKey = `${fact.worldId}::${normalizeText(alias, NORM_NAME).toLowerCase()}`;
+      index.set(aliasKey, fact.id);
+    }
+  }
+  return index;
+}
+
+function getAliasIndex(allFacts: Record<EntityID, LoreFact>): Map<string, EntityID> {
+  const cached = aliasIndexCache.get(allFacts);
+  if (cached) return cached;
+  const index = buildAliasIndex(allFacts);
+  aliasIndexCache.set(allFacts, index);
+  return index;
+}
+
+/**
  * Alias management functions for the lore store
  * Handles adding, removing, and searching by aliases
  */
@@ -12,6 +41,12 @@ export interface AliasManagementContext {
   getFact: (id: EntityID) => LoreFact | undefined;
   updateFact: (id: EntityID, updates: Partial<LoreFact>) => void;
   getFacts: (options?: { worldId?: EntityID }) => LoreFact[];
+  /**
+   * Returns the raw facts record from the store. Required for index-based
+   * lookups in findEntityByAnyNameImpl; pass `() => useLoreStore.getState().facts`
+   * (or the equivalent) from the action layer.
+   */
+  getAllFacts?: () => Record<EntityID, LoreFact>;
 }
 
 /**
@@ -115,14 +150,23 @@ export function findEntityByAnyNameImpl(
   worldId: EntityID,
   context: AliasManagementContext
 ): LoreFact | null {
-  const facts = context.getFacts({ worldId });
   const normalizedName = normalizeText(name, NORM_NAME).toLowerCase();
 
+  // Fast path: cached alias index over the entire facts record. Falls back to
+  // a per-world linear scan only when the action layer didn't wire getAllFacts.
+  if (context.getAllFacts) {
+    const allFacts = context.getAllFacts();
+    const index = getAliasIndex(allFacts);
+    const factId = index.get(`${worldId}::${normalizedName}`);
+    if (!factId) return null;
+    return allFacts[factId] ?? null;
+  }
+
+  const facts = context.getFacts({ worldId });
   return (
     facts.find((fact) => {
       const normalizedValue = normalizeText(fact.value, NORM_NAME).toLowerCase();
       const normalizedAliases = fact.aliases?.map((a) => normalizeText(a, NORM_NAME).toLowerCase()) || [];
-
       return normalizedValue === normalizedName || normalizedAliases.includes(normalizedName);
     }) || null
   );

--- a/src/state/loreStore.helpers.ts
+++ b/src/state/loreStore.helpers.ts
@@ -33,14 +33,47 @@ export function generateLoreKey(worldId: string, category: string, name: string,
 }
 
 /**
+ * Generic NPC words that, when they make up the entire name, mark it as a
+ * non-specific group rather than a stored entity. Pair with the structural
+ * "plural" check below for harder cases like "Dothraki warriors".
+ */
+const GENERIC_NPC_DENYLIST = new Set([
+  'guards', 'guard',
+  'villagers',
+  'soldiers',
+  'warriors',
+  'townsfolk', 'townspeople',
+  'citizens',
+  'peasants',
+  'merchants',
+  'travelers',
+  'workers',
+  'farmers',
+  'bandits',
+  'thieves',
+  'mages',
+  'knights',
+  'crowd', 'mob', 'group', 'party',
+  'people', 'men', 'women', 'children',
+  'man', 'woman', 'child', 'boy', 'girl',
+  'figure', 'figures',
+  'stranger', 'strangers',
+  'person', 'persons',
+]);
+
+/**
  * Filters out generic/unnamed characters that shouldn't be stored as named entities,
  * which avoids cluttering the lore store with placeholders or vague groups.
  *
  * Rejects:
  * - Unnamed placeholders (e.g., "Unnamed warrior", "Unknown person")
  * - Descriptive phrases (e.g., "Man with sword")
- * - Plural/group entities (e.g., "guards", "villagers")
+ * - Plural/group entities (e.g., "guards", "Dothraki warriors") via a denylist
+ *   plus a structural plural heuristic
  * - Sentence-like names (too many words)
+ *
+ * Accepts faction-style names that include "of" ("Brothers of Steel") or a
+ * possessive ("King's Guard") even when they trip the plural heuristic.
  *
  * @param name - The character name to validate.
  * @returns True if the name should be stored, false otherwise.
@@ -56,16 +89,37 @@ export function shouldStoreExtractedCharacterName(name: string): boolean {
   if (normalized.startsWith('unnamed ') || normalized.startsWith('unknown ')) return false;
   if (normalized.includes(' with ')) return false;
 
-  // Reject obvious group/plural entities (usually not a stable, named character).
   const tokens = normalized.split(/\s+/).filter(Boolean);
-  const isPluralGroup =
-    tokens.length <= 3 &&
-    tokens.some((token) => token.endsWith('s')) &&
-    !canonicalName.includes("'"); // allow possessives/aliases like "King's Guard"
-  if (isPluralGroup) return false;
 
   // Avoid sentence-like "names".
   if (tokens.length > 6) return false;
+
+  const stopWords = new Set(['the', 'a', 'an']);
+  const meaningfulTokens = tokens.filter((token) => !stopWords.has(token));
+
+  // Every meaningful token is a generic NPC word → reject ("guards", "the villagers").
+  if (
+    meaningfulTokens.length > 0 &&
+    meaningfulTokens.every((token) => GENERIC_NPC_DENYLIST.has(token))
+  ) {
+    return false;
+  }
+
+  // Faction-style names with "of" or a possessive are explicit signals — accept
+  // even when the plural heuristic would otherwise reject ("Brothers of Steel",
+  // "King's Guard").
+  if (/\bof\b/i.test(canonicalName) || canonicalName.includes("'")) {
+    return true;
+  }
+
+  // Structural plural heuristic: short multi-word names whose tokens end in 's'
+  // are usually generic groups ("Dothraki warriors", "town guards"). Allow
+  // single-token proper nouns ending in 's' through ("James", "Artemis").
+  const isPluralGroup =
+    tokens.length >= 2 &&
+    tokens.length <= 3 &&
+    tokens.some((token) => token.endsWith('s'));
+  if (isPluralGroup) return false;
 
   return true;
 }

--- a/src/state/loreStore.ts
+++ b/src/state/loreStore.ts
@@ -61,7 +61,12 @@ export interface LoreStore extends CrudStore<LoreFact> {
   getFactHistory: (id: EntityID) => LoreFact[];
   validateFact: (fact: Partial<{ key: string; value: string; category: LoreCategory; worldId: EntityID }>) => boolean;
   validateKey: (key: string) => boolean;
-  getLoreContext: (worldId: EntityID, sessionId?: EntityID, limit?: number) => LoreContext;
+  getLoreContext: (
+    worldId: EntityID,
+    sessionId?: EntityID,
+    limit?: number,
+    options?: { categoryBalanced?: boolean }
+  ) => LoreContext;
   addStructuredLore: (extraction: StructuredLoreExtraction, worldId: EntityID, sessionId?: EntityID) => void;
   addAlias: (id: EntityID, alias: string) => void;
   removeAlias: (id: EntityID, alias: string) => void;


### PR DESCRIPTION
## Summary

Bundles three small lore-extraction quality items from #1301. They all
touch the same code path, so this is one regression-test pass instead of
three.

## What changed

**Name filter** (#943 → bundled)
`shouldStoreExtractedCharacterName` used to reject single tokens that
end in "s" without an apostrophe, which caught "James" / "Artemis" /
"Charles" as false positives, and rejected faction-style names like
"Brothers of Steel". This swaps the structural rule for a generic-NPC
denylist plus a tightened plural heuristic that still rejects "Dothraki
warriors" and "town guards". Adds an "of"-or-possessive carve-out so
"Brothers of Steel" and "King's Guard" pass.

**Alias index** (#945 → bundled)
`findEntityByAnyName` now goes through a `WeakMap`-cached
`(worldId, normalized name|alias) → factId` index keyed by the facts
record reference. Zustand creates a fresh facts object on every
mutation, so the cache auto-invalidates and rebuilds lazily on the next
lookup. O(n) on the first call after a write, O(1) afterward, no
mutation-path instrumentation to keep in sync.

**Category balance** (#955 → bundled)
Adds an opt-in `categoryBalanced` option to `getLoreContext` that
round-robins across characters/locations/rules/events instead of pure
importance-then-recency sort. Useful for character-heavy worlds where
world rules and locations currently get squeezed out. Default behavior
is unchanged.

## Test plan

- [x] `npx jest src/state/` — 357 tests, all passing
- [x] New: `loreStore.categoryBalance.test.ts` covers the new option
- [x] New: `loreStore.aliases.test.ts` "index invalidation" case
- [x] Updated: hardening tests reflect new name-filter behavior
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (only pre-existing warnings)

Closes #1301.
Bundles and closes #943, #945, #955.