### PR TITLE
feat: exit confirmation for active sessions (#268)

### DIFF
--- a/src/app/worlds/[id]/play/__tests__/page.exitConfirmation.test.tsx
+++ b/src/app/worlds/[id]/play/__tests__/page.exitConfirmation.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import PlayPage from '../page';
+
+const pushMock = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: (...args: unknown[]) => pushMock(...args) }),
+  useParams: () => ({ id: 'world-1' }),
+  useSearchParams: () => new URLSearchParams(),
+  notFound: jest.fn(),
+}));
+
+jest.mock('@/components/GameSession/GameSession', () => {
+  return function DummyGameSession({
+    worldId,
+    onBack,
+    onStartNew,
+  }: {
+    worldId: string;
+    onBack?: () => void;
+    onStartNew?: () => void;
+  }) {
+    return (
+      <div>
+        <div data-testid="mock-game-session">Game Session for {worldId}</div>
+        <button type="button" data-testid="mock-back-btn" onClick={onBack}>
+          Mock Back
+        </button>
+        <button type="button" data-testid="mock-start-new-btn" onClick={onStartNew}>
+          Mock Start New
+        </button>
+      </div>
+    );
+  };
+});
+
+const sessionState = { id: 'session-1' };
+const segmentsBySession: Record<string, string[]> = {};
+
+jest.mock('@/state/sessionStore', () => ({
+  useSessionStore: (selector: (state: typeof sessionState) => unknown) => selector(sessionState),
+}));
+
+jest.mock('@/state/narrativeStore', () => ({
+  useNarrativeStore: () => ({
+    getSessionSegments: (sessionId: string) => segmentsBySession[sessionId] ?? [],
+  }),
+}));
+
+describe('PlayPage exit confirmation (#268)', () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+    sessionState.id = 'session-1';
+    for (const key of Object.keys(segmentsBySession)) delete segmentsBySession[key];
+  });
+
+  test('routes directly back when there is no narrative progress to abandon', () => {
+    render(<PlayPage />);
+
+    fireEvent.click(screen.getByTestId('mock-back-btn'));
+
+    expect(pushMock).toHaveBeenCalledWith('/worlds/world-1');
+    expect(screen.queryByText('Leave the Story?')).not.toBeInTheDocument();
+  });
+
+  test('prompts for confirmation when there is narrative progress', () => {
+    segmentsBySession['session-1'] = ['seg-a', 'seg-b'];
+    render(<PlayPage />);
+
+    fireEvent.click(screen.getByTestId('mock-back-btn'));
+
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(screen.getByText('Leave the Story?')).toBeInTheDocument();
+  });
+
+  test('confirming the exit dialog navigates back to the world page', () => {
+    segmentsBySession['session-1'] = ['seg-a'];
+    render(<PlayPage />);
+
+    fireEvent.click(screen.getByTestId('mock-back-btn'));
+    fireEvent.click(screen.getByRole('button', { name: /leave story/i }));
+
+    expect(pushMock).toHaveBeenCalledWith('/worlds/world-1');
+  });
+
+  test('cancelling the exit dialog keeps the player on the page', () => {
+    segmentsBySession['session-1'] = ['seg-a'];
+    render(<PlayPage />);
+
+    fireEvent.click(screen.getByTestId('mock-back-btn'));
+    fireEvent.click(screen.getByRole('button', { name: /keep playing/i }));
+
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(screen.queryByText('Leave the Story?')).not.toBeInTheDocument();
+  });
+});

--- a/src/app/worlds/[id]/play/page.tsx
+++ b/src/app/worlds/[id]/play/page.tsx
@@ -17,6 +17,7 @@ export default function PlayPage() {
   const worldId = params?.id as string;
   const [isClient, setIsClient] = useState(false);
   const [showStartNewConfirmation, setShowStartNewConfirmation] = useState(false);
+  const [showExitConfirmation, setShowExitConfirmation] = useState(false);
 
   // Check for test data to support visual regression tests (guarded for SSR)
   // Always call hooks and use persisted store data
@@ -49,6 +50,22 @@ export default function PlayPage() {
     setShowStartNewConfirmation(false);
     router.push(`/worlds/${worldId}/play?fresh=true`);
   };
+
+  // Exit prompts confirmation only when there's narrative progress to abandon.
+  // Auto-save means data isn't lost either way; the prompt just guards against
+  // accidental clicks mid-story (issue #268).
+  const handleBackClick = () => {
+    if (currentProgress > 0) {
+      setShowExitConfirmation(true);
+    } else {
+      router.push(`/worlds/${worldId}`);
+    }
+  };
+
+  const handleConfirmedExit = () => {
+    setShowExitConfirmation(false);
+    router.push(`/worlds/${worldId}`);
+  };
   
   // For server rendering, show a simple placeholder
   if (!isClient) {
@@ -66,11 +83,11 @@ export default function PlayPage() {
 
   return (
     <div className="manuscript-play-page">
-      <GameSession 
-        worldId={worldId} 
+      <GameSession
+        worldId={worldId}
         disableAutoResume={disableAutoResume}
         onStartNew={handleStartNewClick}
-        onBack={() => router.push(`/worlds/${worldId}`)}
+        onBack={handleBackClick}
       />
 
       {/* Confirmation dialog for starting new session */}
@@ -79,6 +96,15 @@ export default function PlayPage() {
         onClose={() => setShowStartNewConfirmation(false)}
         onConfirm={handleConfirmedStartNew}
         type="start-new"
+        currentProgress={currentProgress}
+      />
+
+      {/* Confirmation dialog for exiting the session mid-story */}
+      <GameSessionConfirmationDialog
+        isOpen={showExitConfirmation}
+        onClose={() => setShowExitConfirmation(false)}
+        onConfirm={handleConfirmedExit}
+        type="exit"
         currentProgress={currentProgress}
       />
     </div>

--- a/src/components/GameSession/GameSessionConfirmationDialog.tsx
+++ b/src/components/GameSession/GameSessionConfirmationDialog.tsx
@@ -6,7 +6,7 @@ interface GameSessionConfirmationDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onConfirm: () => void;
-  type: 'start-new' | 'character-switch';
+  type: 'start-new' | 'character-switch' | 'exit';
   characterName?: string;
   currentProgress?: number;
 }
@@ -30,6 +30,13 @@ const copyConfig: Record<GameSessionConfirmationDialogProps['type'], {
       'Switching characters ends the current session and starts a new one with the selected hero. Your existing progress is saved so you can return later.',
     confirmText: 'Switch Characters',
     cancelText: 'Stay with Current Character',
+  },
+  'exit': {
+    title: 'Leave the Story?',
+    description:
+      'Your progress is saved automatically, so you can resume from this exact spot any time. Are you sure you want to step away now?',
+    confirmText: 'Leave Story',
+    cancelText: 'Keep Playing',
   },
 };
 


### PR DESCRIPTION
## Summary

Close on the play page used to navigate straight back to the world. Auto-save already protects the session, so no data was being lost — but a single mis-click could yank the player out of a long story they were absorbed in.

This mirrors the existing `start-new` confirmation pattern: prompt only when there's narrative progress (>0 segments), route directly otherwise so the exit stays "responsive and quick" per the issue's last acceptance criterion. Adds an `'exit'` type to `GameSessionConfirmationDialog` with copy that calls out auto-save so the prompt informs without scaring.

### What changed
- `GameSessionConfirmationDialog`: new `'exit'` type with "Leave the Story?" copy
- `src/app/worlds/[id]/play/page.tsx`: gate `onBack` through `handleBackClick` → confirmation dialog when `currentProgress > 0`
- `__tests__/page.exitConfirmation.test.tsx`: 4 tests covering both no-progress and with-progress flows + confirm/cancel paths

### Acceptance criteria status
- [x] Exit button is clearly accessible — already present (HUD Close button)
- [x] Exiting prompts for confirmation before leaving — new in this PR
- [x] Game state is saved before exiting — already covered by auto-save
- [x] Exit process is responsive and quick — direct route when no progress; minimal dialog otherwise
- [x] Exiting returns to an appropriate menu or screen — back to `/worlds/[id]`

Closes #268

## Test plan
- [x] `npx jest --testPathPattern="src/app/worlds/\[id\]/play/__tests__/page"` — 10/10 pass
- [x] `npm run lint` — clean (pre-existing warnings only)
- [x] `npx tsc --noEmit` — clean
- [x] `npx knip` — clean
- [x] `npx stylelint '**/*.css'` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)