### PR TITLE
ci: gate circular-dep count via skott (#979 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,32 @@ jobs:
       - name: Run Knip
         run: npm run knip
 
+  skott-cycles:
+    name: Skott circular-dep budget
+    runs-on: ubuntu-latest
+    needs: [setup]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Restore node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-modules-
+
+      # Blocking: fails when the count of circular dependencies reachable from
+      # the app entrypoint exceeds the baseline in `.skott-baseline.json`.
+      # Intentional new cycles bump the baseline; accidental new cycles get
+      # fixed (run `npm run skott:circular` locally to inspect which loop is new).
+      - name: Run skott:check
+        run: npm run skott:check
+
   audit-css:
     name: CSS audit (unused selectors)
     runs-on: ubuntu-latest

--- a/.skott-baseline.json
+++ b/.skott-baseline.json
@@ -1,0 +1,3 @@
+{
+  "maxCircularDependencies": 17
+}

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "skott:analyze": "skott --displayMode=webapp --tsconfig=./tsconfig.json --ignorePattern=**/*.test.* --ignorePattern=**/*.stories.* --ignorePattern=**/__tests__/** --exitCodeOnCircularDependencies=0 src/app/layout.tsx",
     "skott:circular": "skott --showCircularDependencies --displayMode=file-tree --tsconfig=./tsconfig.json --ignorePattern=**/*.test.* --ignorePattern=**/*.stories.* --ignorePattern=**/__tests__/** --exitCodeOnCircularDependencies=0 src/app/layout.tsx",
     "skott:graph": "skott --displayMode=graph --tsconfig=./tsconfig.json --ignorePattern=**/*.test.* --ignorePattern=**/*.stories.* --ignorePattern=**/__tests__/** --exitCodeOnCircularDependencies=0 src/app/layout.tsx",
-    "skott:watch": "skott --displayMode=webapp --watch --tsconfig=./tsconfig.json --ignorePattern=**/*.test.* --ignorePattern=**/*.stories.* --ignorePattern=**/__tests__/** --exitCodeOnCircularDependencies=0 src/app/layout.tsx"
+    "skott:watch": "skott --displayMode=webapp --watch --tsconfig=./tsconfig.json --ignorePattern=**/*.test.* --ignorePattern=**/*.stories.* --ignorePattern=**/__tests__/** --exitCodeOnCircularDependencies=0 src/app/layout.tsx",
+    "skott:check": "node scripts/check-circular-count.mjs"
   },
   "dependencies": {
     "@google/genai": "^0.13.0",

--- a/public_docs/architecture/dependency-analysis.md
+++ b/public_docs/architecture/dependency-analysis.md
@@ -23,6 +23,8 @@ npm run deps:validate
 
 > **Note:** Dependency-cruiser v13+ auto-finds `.dependency-cruiser.cjs` - no `--config` flag needed!
 
+> **Looking for a live, click-through graph?** dependency-cruiser is great for validation and static diagrams; for interactive exploration ("what imports `characterStore`?", "how does this cycle actually loop?"), use [skott](using-skott.md) (`npm run skott:analyze` / `skott:circular`). Run `skott:circular` before cross-domain refactors and during code-health audits to catch new cycles early.
+
 ## Generated Diagrams
 
 Diagrams are generated at **multiple zoom levels** for optimal viewing:

--- a/public_docs/architecture/dependency-analysis.md
+++ b/public_docs/architecture/dependency-analysis.md
@@ -23,7 +23,7 @@ npm run deps:validate
 
 > **Note:** Dependency-cruiser v13+ auto-finds `.dependency-cruiser.cjs` - no `--config` flag needed!
 
-> **Looking for a live, click-through graph?** dependency-cruiser is great for validation and static diagrams; for interactive exploration ("what imports `characterStore`?", "how does this cycle actually loop?"), use [skott](using-skott.md) (`npm run skott:analyze` / `skott:circular`). Run `skott:circular` before cross-domain refactors and during code-health audits to catch new cycles early.
+> **Looking for a live, click-through graph?** dependency-cruiser produces the static diagrams here; for interactive exploration ("what imports `characterStore`?", "how does this cycle actually loop?"), use [skott](using-skott.md). New circular dependencies are blocked at CI by the `skott:check` budget — `using-skott.md` covers what to do when that fails.
 
 ## Generated Diagrams
 

--- a/public_docs/architecture/using-skott.md
+++ b/public_docs/architecture/using-skott.md
@@ -5,6 +5,15 @@
 - **dependency-cruiser** — PR-blocking validation, static diagrams in `public_docs/architecture/`, architecture rules. See [dependency-analysis.md](dependency-analysis.md).
 - **skott** — daily debugging: "what depends on `characterStore`?", "how does this circular dep actually loop?", "show me everything in the narrative domain."
 
+## When to reach for it
+
+Two concrete triggers, plus opportunistic use:
+
+1. **Before opening a refactor PR that moves files between domains, or when adding a new store** — run `npm run skott:circular`. If the count of circular dependencies goes up vs. develop, that's a new cycle to deal with before review. dependency-cruiser will eventually flag it in CI, but skott's file-tree view tells you *which loop* you introduced, faster.
+2. **As part of the recurring code-health audit** (`workflow-skills:code-health-audit`) — run `npm run skott:circular` once per pass to see whether the circular-dep count has crept up since the last sweep. New cycles are usually a cleanup candidate.
+
+Outside those, reach for it whenever a question like *"what imports `characterStore`?"* or *"how does this cycle actually loop?"* would otherwise turn into a grep session.
+
 ## Quick start
 
 Open the interactive webapp (default — opens a browser):

--- a/public_docs/architecture/using-skott.md
+++ b/public_docs/architecture/using-skott.md
@@ -5,14 +5,17 @@
 - **dependency-cruiser** — PR-blocking validation, static diagrams in `public_docs/architecture/`, architecture rules. See [dependency-analysis.md](dependency-analysis.md).
 - **skott** — daily debugging: "what depends on `characterStore`?", "how does this circular dep actually loop?", "show me everything in the narrative domain."
 
-## When to reach for it
+## How it's integrated
 
-Two concrete triggers, plus opportunistic use:
+CI runs `npm run skott:check` (the `Skott circular-dep budget` job in `ci.yml`). That script invokes skott and fails the build if the count of circular dependencies reachable from `src/app/layout.tsx` is higher than the baseline in `.skott-baseline.json`. So new cycles can't sneak in without you noticing.
 
-1. **Before opening a refactor PR that moves files between domains, or when adding a new store** — run `npm run skott:circular`. If the count of circular dependencies goes up vs. develop, that's a new cycle to deal with before review. dependency-cruiser will eventually flag it in CI, but skott's file-tree view tells you *which loop* you introduced, faster.
-2. **As part of the recurring code-health audit** (`workflow-skills:code-health-audit`) — run `npm run skott:circular` once per pass to see whether the circular-dep count has crept up since the last sweep. New cycles are usually a cleanup candidate.
+When CI fails:
 
-Outside those, reach for it whenever a question like *"what imports `characterStore`?"* or *"how does this cycle actually loop?"* would otherwise turn into a grep session.
+1. Run `npm run skott:circular` locally — you get the file-tree view of every cycle, top-down.
+2. Diff against what was there before to find the new one. The list is small enough (currently 17) to eyeball.
+3. Either fix the cycle, or — if it's deliberate, like the `StoreEventBus` pattern — bump the integer in `.skott-baseline.json` and note the reason in the commit message.
+
+If a refactor *removes* cycles, `skott:check` prints a "consider lowering the baseline" notice but still passes. Tightening is on the next refactor.
 
 ## Quick start
 

--- a/scripts/check-circular-count.mjs
+++ b/scripts/check-circular-count.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// Runs skott against the app entrypoint and fails if the circular-dependency
+// count exceeds the checked-in baseline in `.skott-baseline.json`. Used by
+// the `skott:check` npm script and the `skott` CI job (see `.github/workflows/ci.yml`).
+//
+// If you intentionally accept a new cycle (e.g. the StoreEventBus pattern),
+// re-run this script and copy the reported count into `.skott-baseline.json`.
+
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..');
+const baselinePath = resolve(repoRoot, '.skott-baseline.json');
+
+const baseline = JSON.parse(readFileSync(baselinePath, 'utf8'));
+const limit = baseline.maxCircularDependencies;
+
+if (typeof limit !== 'number' || !Number.isFinite(limit) || limit < 0) {
+  console.error(`Invalid baseline in ${baselinePath}: expected { maxCircularDependencies: <number> }`);
+  process.exit(2);
+}
+
+const args = [
+  'skott',
+  '--showCircularDependencies',
+  '--displayMode=raw',
+  '--tsconfig=./tsconfig.json',
+  '--ignorePattern=**/*.test.*',
+  '--ignorePattern=**/*.stories.*',
+  '--ignorePattern=**/__tests__/**',
+  '--exitCodeOnCircularDependencies=0',
+  'src/app/layout.tsx',
+];
+
+const child = spawn('npx', args, { cwd: repoRoot, stdio: ['ignore', 'pipe', 'inherit'] });
+
+let stdout = '';
+child.stdout.on('data', (chunk) => {
+  stdout += chunk.toString('utf8');
+});
+
+child.on('error', (err) => {
+  console.error('Failed to spawn skott:', err.message);
+  process.exit(2);
+});
+
+child.on('close', (code) => {
+  if (code !== 0) {
+    console.error(`skott exited with code ${code}`);
+    process.stdout.write(stdout);
+    process.exit(2);
+  }
+
+  // skott prints e.g. `✖ (17) circular dependencies found` on the final line
+  // when cycles exist; absence of the line means zero cycles.
+  const match = stdout.match(/\((\d+)\)\s+circular dependencies found/);
+  const count = match ? Number.parseInt(match[1], 10) : 0;
+
+  if (count > limit) {
+    console.error(
+      `Cycle count regressed: ${count} circular dependencies (baseline ${limit}).\n` +
+        `Run \`npm run skott:circular\` to inspect which loop is new, then either fix it\n` +
+        `or, if it's a deliberate addition like StoreEventBus, bump\n` +
+        `\`.skott-baseline.json\` to ${count} and leave a note in the commit message.`
+    );
+    process.stdout.write(stdout);
+    process.exit(1);
+  }
+
+  if (count < limit) {
+    // Lowering happens organically — not an error, just a heads-up that the
+    // baseline is now loose. Bumping is optional; tightening is on the
+    // next person who runs `skott:check` after a refactor that drops cycles.
+    console.log(
+      `Cycle count is ${count} (baseline ${limit}). Consider lowering the baseline.`
+    );
+    process.exit(0);
+  }
+
+  console.log(`Cycle count holds at ${count} (baseline ${limit}).`);
+  process.exit(0);
+});


### PR DESCRIPTION
## Summary

PR #1307 shipped skott + a docs page, but the docs only described it — they didn't *integrate* anything. With one dev on this project, "remember to run this manually" is just hope dressed up as a workflow. So this PR makes skott CI-enforced instead.

### Integration
- **`scripts/check-circular-count.mjs`** — runs skott from `src/app/layout.tsx`, parses the `✖ (N) circular dependencies found` summary line, fails if N exceeds the baseline. Prints a "consider lowering the baseline" notice when N is lower so it can be tightened later.
- **`.skott-baseline.json`** — single integer (`maxCircularDependencies`), checked in. Currently 17 — the count today from `layout.tsx`.
- **`skott:check` npm script** — wraps the above. Run locally before pushing, or just let CI run it.
- **`Skott circular-dep budget` CI job** in `ci.yml` — mirrors the Knip job pattern, blocks merges when the baseline is exceeded.

### Workflow when CI fails
1. `npm run skott:circular` → file-tree view of every cycle.
2. Diff against develop's list to find the new one.
3. Either fix it, or — if it's intentional like `StoreEventBus` — bump `.skott-baseline.json` and note the reason in the commit message.

### Codex review address
The earlier doc claimed "dependency-cruiser will eventually flag it in CI" — [Codex correctly caught](https://github.com/jerseycheese/Narraitor/pull/1308#discussion_r3310926425) that `deps:validate` isn't actually wired into any workflow. Rolled back that line. The cross-link from `dependency-analysis.md` now points at the skott budget as the actual gate, which is what's true.

### Test plan
- [x] `npm run skott:check` locally — "Cycle count holds at 17 (baseline 17)."
- [x] `npm run lint` clean (pre-existing warnings only)
- [x] `npm run knip` clean
- [x] CI run will validate the new `skott-cycles` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)