### PR TITLE
docs: add skott circular-dep budget to roadmap tooling roster

### DIFF
--- a/public_docs/development/mvp-roadmap.md
+++ b/public_docs/development/mvp-roadmap.md
@@ -129,7 +129,7 @@ Valuable but can launch with Gemini-only:
 
 ## Technical Debt & Infrastructure
 - Playwright visual regression testing — done (`tests/visual/`, runs in CI)
-- Dead-code and architecture tooling — done (knip, CSS audit, dependency-cruiser, mutation testing)
+- Dead-code and architecture tooling — done (knip, CSS audit, dependency-cruiser, mutation testing, skott circular-dep budget)
 - Optimize bundle size and performance
 - Enhance error boundaries and recovery
 - Improve TypeScript strictness


### PR DESCRIPTION
## Summary

One-line housekeeping. The "Dead-code and architecture tooling" line in the roadmap listed knip, CSS audit, dependency-cruiser, and mutation testing but not the skott circular-dependency budget that shipped in #1308. This keeps that roster current so it stays the canonical "what's already covered" reference.

## Test plan
- [x] Doc-only, single-line change. No build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)