### PR TITLE
feat: immersive error messages maintaining story context (#201)

### DIFF
--- a/src/components/GameSession/GameSessionError.tsx
+++ b/src/components/GameSession/GameSessionError.tsx
@@ -18,11 +18,12 @@ const GameSessionError: React.FC<GameSessionErrorProps> = ({
     <div data-testid="game-session-error">
       <ErrorDisplay
         variant="section"
-        title="Game Session Error"
+        title="The story paused"
         message={error}
         severity="error"
         showRetry
         onRetry={onRetry}
+        retryLabel="Continue the story"
         showDismiss={!!onDismiss}
         onDismiss={onDismiss}
       />

--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/types/narrative.types';
 import { truncate } from '@/lib/utils';
 import { isSessionEndingSegment } from '@/lib/narrative/isSessionEndingSegment';
+import { getNarrativeError } from '@/lib/narrative/narrativeErrors';
 import { logger } from '@/lib/utils/logger';
 import { AI_GENERATION_TIMEOUT_MS } from '@/lib/constants/timeouts';
 import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
@@ -415,11 +416,9 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
           }
         }
       }
-    } catch {
+    } catch (error) {
       // Unhandled error in generatePlayerChoices
-      setError(
-        'Unable to generate choices. Please check your connection and try again.'
-      );
+      setError(getNarrativeError(error as Error).message);
 
       // Even if we get an unhandled error, try to provide fallback choices
 
@@ -774,11 +773,9 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
             generatePlayerChoices();
           }, 500);
         }
-      } catch {
+      } catch (error) {
         // Surface the original error if fallback insert also fails
-        setError(
-          'Unable to generate narrative. Please check your connection and try again.'
-        );
+        setError(getNarrativeError(error as Error).message);
       }
     } finally {
       initialGenerationLocksRef.current.delete(lockKey);

--- a/src/components/Narrative/NarrativeDisplay.tsx
+++ b/src/components/Narrative/NarrativeDisplay.tsx
@@ -116,10 +116,11 @@ export const NarrativeDisplay: React.FC<NarrativeDisplayProps> = ({
         <ErrorDisplay
           variant="section"
           severity="error"
-          title="Unable to Generate Narrative"
+          title="The story paused"
           message={error}
           showRetry={!!onRetry}
           onRetry={onRetry}
+          retryLabel="Continue the story"
         />
       </div>
     );

--- a/src/components/Narrative/__tests__/NarrativeDisplay.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeDisplay.test.tsx
@@ -156,9 +156,9 @@ describe('NarrativeDisplay', () => {
     render(<NarrativeDisplay segment={null} error={errorMessage} onRetry={mockRetry} />);
 
     expect(screen.getByText(errorMessage)).toBeInTheDocument();
-    expect(screen.getByText('Try Again')).toBeInTheDocument();
+    expect(screen.getByText('Continue the story')).toBeInTheDocument();
 
-    await user.click(screen.getByText('Try Again'));
+    await user.click(screen.getByText('Continue the story'));
     expect(mockRetry).toHaveBeenCalledTimes(1);
   });
 

--- a/src/lib/ai/__tests__/aiErrorFlow.integration.test.tsx
+++ b/src/lib/ai/__tests__/aiErrorFlow.integration.test.tsx
@@ -270,10 +270,10 @@ describe('AI error flow → ErrorDisplay/GameSessionError integration', () => {
 
       const wrapper = await screen.findByTestId('game-session-error');
       expect(wrapper).toBeInTheDocument();
-      expect(screen.getByText('Game Session Error')).toBeInTheDocument();
+      expect(screen.getByText('The story paused')).toBeInTheDocument();
 
       // Retry then dismiss both work through the GameSessionError surface.
-      fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+      fireEvent.click(screen.getByRole('button', { name: /continue the story/i }));
       await waitFor(() => {
         expect(screen.queryByTestId('game-session-error')).not.toBeInTheDocument();
       });

--- a/src/lib/narrative/__tests__/narrativeErrors.test.ts
+++ b/src/lib/narrative/__tests__/narrativeErrors.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for narrative-styled error copy (Issue #201)
+ */
+
+import { getNarrativeError } from '../narrativeErrors';
+
+// Jargon that must never reach the player in narrative copy.
+const JARGON = [/\bAI\b/, /network/i, /\b429\b/, /timeout/i, /\bAPI\b/, /unauthorized/i, /HTTP/i];
+
+function assertNoJargon(text: string) {
+  for (const pattern of JARGON) {
+    expect(text).not.toMatch(pattern);
+  }
+}
+
+describe('getNarrativeError', () => {
+  it('frames network errors as a story pause and offers a narrative recovery', () => {
+    const result = getNarrativeError(new Error('network connection failed'));
+    expect(result.title).toBe('The story paused');
+    expect(result.retryLabel).toBe('Continue the story');
+    expect(result.retryable).toBe(true);
+    assertNoJargon(result.title);
+    assertNoJargon(result.message);
+    assertNoJargon(result.suggestion ?? '');
+  });
+
+  it('frames rate-limit/service errors as the story needing a moment', () => {
+    const result = getNarrativeError(new Error('429 too many requests'));
+    expect(result.title).toBe('The story needs a moment');
+    expect(result.retryable).toBe(true);
+    assertNoJargon(result.message);
+    assertNoJargon(result.suggestion ?? '');
+  });
+
+  it('treats auth errors as non-retryable, critical, and points to settings without jargon', () => {
+    const result = getNarrativeError(new Error('401 unauthorized'));
+    expect(result.retryable).toBe(false);
+    expect(result.severity).toBe('critical');
+    expect(result.suggestion).toMatch(/Settings/);
+    assertNoJargon(result.message);
+    assertNoJargon(result.suggestion ?? '');
+  });
+
+  it('frames validation errors as something that did not fit the story', () => {
+    const result = getNarrativeError(new Error('invalid input data'));
+    expect(result.title).toBe('That didn\'t fit the story');
+    expect(result.retryable).toBe(false);
+    assertNoJargon(result.message);
+  });
+
+  it('gives unknown errors a gentle narrative fallback', () => {
+    const result = getNarrativeError(new Error('something exploded internally'));
+    expect(result.title).toBe('The story stumbled');
+    expect(result.retryLabel).toBe('Continue the story');
+    assertNoJargon(result.message);
+    assertNoJargon(result.suggestion ?? '');
+  });
+
+  it('accepts a raw string and still returns clean narrative copy', () => {
+    const result = getNarrativeError('network unreachable');
+    expect(result.title).toBe('The story paused');
+    assertNoJargon(result.message);
+  });
+});

--- a/src/lib/narrative/narrativeErrors.ts
+++ b/src/lib/narrative/narrativeErrors.ts
@@ -1,0 +1,80 @@
+/**
+ * Narrative-styled error copy for the game-session play loop (Issue #201).
+ *
+ * Errors that surface while a story is being generated should read as part of
+ * the story, not as technical faults. This maps an error to genre-neutral,
+ * jargon-free copy and frames the recovery action as a narrative choice.
+ *
+ * Scoped to the play surfaces on purpose — the global getUserFriendlyError copy
+ * stays generic because it is also used in non-narrative contexts (forms, etc.).
+ */
+
+import {
+  getUserFriendlyError,
+  ErrorType,
+  type ErrorSeverity,
+} from '@/lib/utils/errorUtils';
+
+export interface NarrativeError {
+  title: string;
+  message: string;
+  /** Narrative-appropriate next step the player can take. */
+  suggestion?: string;
+  retryable: boolean;
+  /** Recovery action framed as a narrative choice. */
+  retryLabel: string;
+  severity: ErrorSeverity;
+}
+
+const RETRY_LABEL = 'Continue the story';
+
+const NARRATIVE_COPY: Record<
+  ErrorType,
+  { title: string; message: string; suggestion: string }
+> = {
+  [ErrorType.NETWORK]: {
+    title: 'The story paused',
+    message: 'We lost the connection needed to continue your story.',
+    suggestion: 'Check that you\'re online, then pick up where you left off.',
+  },
+  [ErrorType.SERVICE]: {
+    title: 'The story needs a moment',
+    message: 'The story is moving faster than it can keep up.',
+    suggestion: 'Wait a few moments, then continue.',
+  },
+  [ErrorType.AUTH]: {
+    title: 'The story can\'t continue',
+    message: 'Your story can\'t continue until your account settings are sorted out.',
+    suggestion: 'Open Settings to check your access, then return to your story.',
+  },
+  [ErrorType.VALIDATION]: {
+    title: 'That didn\'t fit the story',
+    message: 'Part of what happened didn\'t come together as expected.',
+    suggestion: 'Try a different choice to continue.',
+  },
+  [ErrorType.UNKNOWN]: {
+    title: 'The story stumbled',
+    message: 'Something interrupted your story unexpectedly.',
+    suggestion: 'Try to continue — if it keeps happening, refresh and resume.',
+  },
+};
+
+/**
+ * Maps an error (or raw error string) to narrative-styled copy. Reuses the
+ * shared categorization in errorUtils so retryability and severity stay
+ * consistent with the rest of the app.
+ */
+export function getNarrativeError(error: Error | string): NarrativeError {
+  const errorObj = typeof error === 'string' ? new Error(error) : error;
+  const { type, retryable, severity } = getUserFriendlyError(errorObj);
+  const copy = NARRATIVE_COPY[type];
+
+  return {
+    title: copy.title,
+    message: copy.message,
+    suggestion: copy.suggestion,
+    retryable,
+    retryLabel: RETRY_LABEL,
+    severity,
+  };
+}


### PR DESCRIPTION
## Summary

Closes #201 (manual close needed — "Closes" doesn't auto-fire on merge to `develop`).

In-game generation failures used to surface as technical faults — "Unable to generate narrative. Please check your connection and try again.", a "Game Session Error" heading, and a bare "Try Again" button. That breaks immersion, which is the whole point of the issue.

The error *infrastructure* was already solid: `ErrorDisplay` handles severity, retry-with-exhaustion, suggestions, and is themed across DS1/DS2/DS3 (that's why the "styled to match the narrative aesthetic" criterion was already ticked). What was missing was the copy and the framing.

So this is deliberately a small, copy-and-framing change rather than new infrastructure:

- New `src/lib/narrative/narrativeErrors.ts` — `getNarrativeError()` maps an error to genre-neutral, jargon-free copy ("The story paused", "The story needs a moment") and frames recovery as a narrative choice ("Continue the story"). It reuses the shared `errorUtils` categorization so retryability and severity stay consistent with the rest of the app.
- `NarrativeController` sets the narrative message at the source (where the real error is in hand), so the stored message is type-accurate and clean.
- `NarrativeDisplay` and `GameSessionError` get narrative titles and a "Continue the story" recovery label.

The global `getUserFriendlyError` copy is intentionally left generic — it's also used in non-narrative contexts (form validation, etc.) where a story tone would be wrong.

Worth noting: copy is genre-neutral on purpose (Narraitor worlds span fantasy, sci-fi, modern), and it keeps "AI" out of the user-facing strings per the standing copy rule.

## Acceptance criteria

- [x] Error messages are styled to match the narrative aesthetic (already met by `ErrorDisplay` theming)
- [x] Messages explain issues in narrative-appropriate language
- [x] Errors avoid technical jargon and maintain story context
- [x] Recovery options are presented as narrative choices when possible ("Continue the story")
- [x] Critical errors are handled with minimal disruption — `NarrativeController` already inserts fallback choices/narrative so play continues; the narrative copy completes the intent

## Test plan

- [x] New unit test for `getNarrativeError` — per-category copy, asserts no jargon ("AI", "network", "429", "timeout", "API") leaks, retryability/severity carried from categorization
- [x] Updated `NarrativeDisplay` test — in-play error surface shows the narrative title + "Continue the story"
- [x] Updated `aiErrorFlow` integration test — drives a real failing client through `GameSessionError` and confirms the narrative copy renders
- [x] `npm run type-check` clean, eslint clean (0 errors on touched files)

## Out of scope (follow-ups)

- The "AI service ..." wording in `src/lib/ai/userFriendlyErrors.ts` also trips the no-AI-copy rule, but it surfaces outside the core play loop — not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)