### PR TITLE
feat: AI-inferred skill checks for custom actions (#918)

### DIFF
--- a/src/components/GameSession/ActiveGameSession.tsx
+++ b/src/components/GameSession/ActiveGameSession.tsx
@@ -81,6 +81,7 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
 
   // Track choice generation for UI state
   const [isGeneratingChoices, setIsGeneratingChoices] = React.useState(false);
+  const [isEvaluatingAction, setIsEvaluatingAction] = React.useState(false);
   const [isCharacterSummaryExpanded, setIsCharacterSummaryExpanded] = React.useState(false);
   const [activeDrawer, setActiveDrawer] = React.useState<DrawerType | null>(null);
   const [lastOpenedDrawer, setLastOpenedDrawer] = React.useState<DrawerType | null>(null);
@@ -255,6 +256,7 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
     setIsGenerating,
     setShouldTriggerGeneration,
     setIsGeneratingChoices,
+    setIsEvaluatingAction,
     setLocalSelectedChoiceId,
     choiceGenerationTimeoutRef,
     scheduleChoiceFallback,
@@ -464,6 +466,7 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
               status={status}
               isGenerating={isGenerating}
               isGeneratingChoices={isGeneratingChoices}
+              isEvaluatingAction={isEvaluatingAction}
               isSessionEnded={isSessionEnded(sessionId)}
               worldSkills={world?.skills || []}
               characterSkills={characterSkills}

--- a/src/components/GameSession/ActiveGameSessionChoicesColumn.tsx
+++ b/src/components/GameSession/ActiveGameSessionChoicesColumn.tsx
@@ -13,6 +13,7 @@ interface ActiveGameSessionChoicesColumnProps {
   status: 'active' | 'paused' | 'ended';
   isGenerating: boolean;
   isGeneratingChoices: boolean;
+  isEvaluatingAction?: boolean;
   isSessionEnded: boolean;
   worldSkills: WorldSkill[];
   characterSkills: CharacterSkill[];
@@ -42,6 +43,7 @@ const ActiveGameSessionChoicesColumn: React.FC<
   status,
   isGenerating,
   isGeneratingChoices,
+  isEvaluatingAction = false,
   isSessionEnded,
   worldSkills,
   characterSkills,
@@ -79,12 +81,19 @@ const ActiveGameSessionChoicesColumn: React.FC<
   );
 
   return (
-    <div className={className} aria-busy={isGeneratingChoices}>
-      {(isGenerating || isGeneratingChoices) && (
-        <div className="manuscript-streaming-indicator">
-          <span className="manuscript-streaming-dot" />
-          <span className="manuscript-streaming-label">Generating response...</span>
+    <div className={className} aria-busy={isGeneratingChoices || isEvaluatingAction}>
+      {isEvaluatingAction ? (
+        <div className="manuscript-evaluating-indicator" role="status">
+          <span className="manuscript-evaluating-die" aria-hidden="true" />
+          <span className="manuscript-evaluating-label">Evaluating action...</span>
         </div>
+      ) : (
+        (isGenerating || isGeneratingChoices) && (
+          <div className="manuscript-streaming-indicator">
+            <span className="manuscript-streaming-dot" />
+            <span className="manuscript-streaming-label">Generating response...</span>
+          </div>
+        )
       )}
       <div className="player-choices-container" data-tutorial={dataTutorial}>
         {/* Context summary shown above suggested actions toggle on mobile, and above selector on desktop */}

--- a/src/components/GameSession/hooks/__tests__/useActiveGameSessionActions.test.ts
+++ b/src/components/GameSession/hooks/__tests__/useActiveGameSessionActions.test.ts
@@ -34,6 +34,7 @@ const buildOptions = (overrides = {}) => ({
   setIsGenerating: jest.fn(),
   setShouldTriggerGeneration: jest.fn(),
   setIsGeneratingChoices: jest.fn(),
+  setIsEvaluatingAction: jest.fn(),
   setLocalSelectedChoiceId: jest.fn(),
   choiceGenerationTimeoutRef: { current: null },
   scheduleChoiceFallback: jest.fn(),

--- a/src/components/GameSession/hooks/useActiveGameSessionActions.ts
+++ b/src/components/GameSession/hooks/useActiveGameSessionActions.ts
@@ -2,9 +2,12 @@
 
 import { useCallback } from 'react';
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
-import type { Decision, NarrativeSegment } from '@/types/narrative.types';
+import type { Decision, DecisionRequirement, NarrativeSegment } from '@/types/narrative.types';
 import { useNarrativeStore } from '@/state/narrativeStore';
 import { useSessionStore } from '@/state/sessionStore';
+import { useCharacterStore } from '@/state/characterStore';
+import { useWorldStore } from '@/state/worldStore';
+import { inferCustomActionSkillChecks } from '@/lib/ai/customActionSkillInference';
 import { generateUniqueId } from '@/lib/utils';
 import type { UseAutoSaveReturn } from '@/hooks/useAutoSave';
 
@@ -16,6 +19,7 @@ interface UseActiveGameSessionActionsOptions {
   setIsGenerating: Dispatch<SetStateAction<boolean>>;
   setShouldTriggerGeneration: Dispatch<SetStateAction<boolean>>;
   setIsGeneratingChoices: Dispatch<SetStateAction<boolean>>;
+  setIsEvaluatingAction: Dispatch<SetStateAction<boolean>>;
   setLocalSelectedChoiceId: Dispatch<SetStateAction<string | undefined>>;
   choiceGenerationTimeoutRef: MutableRefObject<NodeJS.Timeout | null>;
   scheduleChoiceFallback: () => void;
@@ -37,6 +41,7 @@ export const useActiveGameSessionActions = ({
   setIsGenerating,
   setShouldTriggerGeneration,
   setIsGeneratingChoices,
+  setIsEvaluatingAction,
   setLocalSelectedChoiceId,
   choiceGenerationTimeoutRef,
   scheduleChoiceFallback,
@@ -103,7 +108,7 @@ export const useActiveGameSessionActions = ({
     void autoSave.triggerSave('player-choice');
   }, [autoSave, characterId, createDecisionJournalEntry, currentDecision, isSessionEnded, maybeCompleteFirstPlay, onChoiceSelected, sessionId, setCurrentDecision, setIsGenerating, setIsGeneratingChoices, setLocalSelectedChoiceId, setShouldTriggerGeneration]);
 
-  const handleCustomSubmit = useCallback((customText: string) => {
+  const handleCustomSubmit = useCallback(async (customText: string) => {
     // Check if session has ended - if so, prevent further generation
     if (isSessionEnded(sessionId)) {
       return;
@@ -117,6 +122,41 @@ export const useActiveGameSessionActions = ({
       createDecisionJournalEntry(currentDecision, customText, true);
     }
 
+    // Disable input immediately; the inference + roll happen before generation.
+    setIsGenerating(true);
+    setIsGeneratingChoices(true);
+    setLocalSelectedChoiceId(customChoiceId);
+
+    // Phase 1 (Issue #918): infer skill checks for the typed action so custom
+    // actions get the same d20 treatment as predefined choices. The resulting
+    // requirements are attached to the option below; NarrativeController then
+    // rolls them via its existing skill-check evaluation.
+    let inferredRequirements: DecisionRequirement[] = [];
+    if (currentDecision && characterId) {
+      const character = useCharacterStore.getState().characters[characterId];
+      const world = character
+        ? useWorldStore.getState().worlds[character.worldId]
+        : undefined;
+
+      if (character && world) {
+        setIsEvaluatingAction(true);
+        try {
+          const recentSegments = useNarrativeStore
+            .getState()
+            .getSessionSegments(sessionId)
+            .slice(-2);
+          inferredRequirements = await inferCustomActionSkillChecks({
+            actionText: customText,
+            character,
+            world,
+            recentSegments,
+          });
+        } finally {
+          setIsEvaluatingAction(false);
+        }
+      }
+    }
+
     // Create a custom decision option and add it to the current decision in the store
     if (currentDecision) {
       const customOption = {
@@ -124,6 +164,9 @@ export const useActiveGameSessionActions = ({
         text: customText,
         isCustomInput: true,
         customText: customText,
+        ...(inferredRequirements.length > 0
+          ? { requirements: inferredRequirements }
+          : {}),
       };
 
       // Update the decision in the store with the new custom option and select it
@@ -137,16 +180,13 @@ export const useActiveGameSessionActions = ({
     setCurrentDecision(null);
 
     // Trigger narrative generation with the custom choice
-    setIsGenerating(true);
-    setIsGeneratingChoices(true); // Start generating new choices
-    setLocalSelectedChoiceId(customChoiceId);
     setShouldTriggerGeneration(true);
 
     maybeCompleteFirstPlay();
     onChoiceSelected(customChoiceId);
 
     void autoSave.triggerSave('player-choice');
-  }, [autoSave, characterId, createDecisionJournalEntry, currentDecision, isSessionEnded, maybeCompleteFirstPlay, onChoiceSelected, sessionId, setCurrentDecision, setIsGenerating, setIsGeneratingChoices, setLocalSelectedChoiceId, setShouldTriggerGeneration]);
+  }, [autoSave, characterId, createDecisionJournalEntry, currentDecision, isSessionEnded, maybeCompleteFirstPlay, onChoiceSelected, sessionId, setCurrentDecision, setIsEvaluatingAction, setIsGenerating, setIsGeneratingChoices, setLocalSelectedChoiceId, setShouldTriggerGeneration]);
 
   const handleChoicesGenerated = useCallback((decision: Decision) => {
     if (!decision || !decision.options || (decision.options?.length || 0) === 0) {

--- a/src/lib/ai/__tests__/customActionSkillInference.test.ts
+++ b/src/lib/ai/__tests__/customActionSkillInference.test.ts
@@ -1,0 +1,179 @@
+// MVP tests for AI-inferred skill checks on custom actions (issue #918).
+// Validates parsing, world-skill validation, difficulty clamping, and graceful
+// fallback to no-check on bad/empty responses.
+
+import { inferCustomActionSkillChecks } from '../customActionSkillInference';
+import type { AIClient } from '../types';
+import type { World } from '@/types/world.types';
+import type { Character } from '@/state/characterStore';
+
+const makeWorld = (): World =>
+  ({
+    id: 'world-1',
+    name: 'Fantasy Realm',
+    description: 'A medieval fantasy world',
+    genre: 'fantasy',
+    skills: [
+      {
+        id: 'stealth',
+        name: 'Stealth',
+        description: 'Move unseen',
+        worldId: 'world-1',
+        difficulty: 'medium',
+        baseValue: 3,
+        minValue: 1,
+        maxValue: 5,
+      },
+      {
+        id: 'athletics',
+        name: 'Athletics',
+        description: 'Climb, jump, swim',
+        worldId: 'world-1',
+        difficulty: 'medium',
+        baseValue: 3,
+        minValue: 1,
+        maxValue: 5,
+      },
+    ],
+    attributes: [],
+    settings: {
+      maxAttributes: 6,
+      maxSkills: 12,
+      attributePointPool: 27,
+      skillPointPool: 40,
+    },
+    createdAt: '2023-01-01',
+    updatedAt: '2023-01-01',
+  }) as unknown as World;
+
+const makeCharacter = (): Character =>
+  ({
+    id: 'char-1',
+    name: 'Tess',
+    description: '',
+    worldId: 'world-1',
+    level: 1,
+    attributes: [],
+    skills: [
+      { id: 's1', characterId: 'char-1', worldSkillId: 'stealth', name: 'Stealth', level: 4 },
+    ],
+    derivedStats: [],
+    background: { history: '', personality: '', goals: [], fears: [] },
+    isPlayer: true,
+    status: { hp: 10, maxHp: 10, conditions: [] },
+    inventory: { characterId: 'char-1', items: [], capacity: 10, categories: [], itemOrder: [] },
+    createdAt: '2023-01-01',
+    updatedAt: '2023-01-01',
+  }) as unknown as Character;
+
+const mockClient = (content: string): AIClient =>
+  ({ generateContent: jest.fn().mockResolvedValue({ content }) }) as unknown as AIClient;
+
+const jsonBlock = (obj: unknown) => '```json\n' + JSON.stringify(obj) + '\n```';
+
+describe('inferCustomActionSkillChecks', () => {
+  it('returns one requirement for a single-skill action', async () => {
+    const client = mockClient(
+      jsonBlock({ skillCheckNeeded: true, checks: [{ skillId: 'stealth', difficulty: 3 }] })
+    );
+
+    const result = await inferCustomActionSkillChecks(
+      { actionText: 'sneak past the guard', character: makeCharacter(), world: makeWorld() },
+      client
+    );
+
+    expect(result).toEqual([
+      { type: 'skill', targetId: 'stealth', operator: 'gte', value: 3 },
+    ]);
+  });
+
+  it('returns multiple requirements for a multi-skill action', async () => {
+    const client = mockClient(
+      jsonBlock({
+        skillCheckNeeded: true,
+        checks: [
+          { skillId: 'stealth', difficulty: 2 },
+          { skillId: 'athletics', difficulty: 4 },
+        ],
+      })
+    );
+
+    const result = await inferCustomActionSkillChecks(
+      { actionText: 'climb the wall quietly', character: makeCharacter(), world: makeWorld() },
+      client
+    );
+
+    expect(result.map((r) => r.targetId)).toEqual(['stealth', 'athletics']);
+    expect(result.map((r) => r.value)).toEqual([2, 4]);
+  });
+
+  it('returns [] when no check is needed', async () => {
+    const client = mockClient(jsonBlock({ skillCheckNeeded: false, checks: [] }));
+
+    const result = await inferCustomActionSkillChecks(
+      { actionText: 'look around the room', character: makeCharacter(), world: makeWorld() },
+      client
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('drops skills that do not exist in the world', async () => {
+    const client = mockClient(
+      jsonBlock({
+        skillCheckNeeded: true,
+        checks: [
+          { skillId: 'telekinesis', difficulty: 3 },
+          { skillId: 'stealth', difficulty: 2 },
+        ],
+      })
+    );
+
+    const result = await inferCustomActionSkillChecks(
+      { actionText: 'do a thing', character: makeCharacter(), world: makeWorld() },
+      client
+    );
+
+    expect(result).toEqual([
+      { type: 'skill', targetId: 'stealth', operator: 'gte', value: 2 },
+    ]);
+  });
+
+  it('clamps difficulty to the skill range', async () => {
+    const client = mockClient(
+      jsonBlock({ skillCheckNeeded: true, checks: [{ skillId: 'stealth', difficulty: 99 }] })
+    );
+
+    const result = await inferCustomActionSkillChecks(
+      { actionText: 'attempt the impossible', character: makeCharacter(), world: makeWorld() },
+      client
+    );
+
+    expect(result[0].value).toBe(5); // maxValue of stealth
+  });
+
+  it('returns [] on a malformed AI response without throwing', async () => {
+    const client = mockClient('no json here, just prose');
+
+    const result = await inferCustomActionSkillChecks(
+      { actionText: 'sneak past the guard', character: makeCharacter(), world: makeWorld() },
+      client
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] without calling the AI when the world has no skills', async () => {
+    const world = makeWorld();
+    world.skills = [];
+    const client = mockClient(jsonBlock({ skillCheckNeeded: true, checks: [] }));
+
+    const result = await inferCustomActionSkillChecks(
+      { actionText: 'sneak past the guard', character: makeCharacter(), world },
+      client
+    );
+
+    expect(result).toEqual([]);
+    expect(client.generateContent).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/ai/customActionSkillInference.ts
+++ b/src/lib/ai/customActionSkillInference.ts
@@ -1,0 +1,160 @@
+// Infers d20 skill checks for free-text custom actions so typed actions get the
+// same mechanical depth as predefined choices (issue #918). Builds on PR #915:
+// the returned DecisionRequirement[] feeds the existing skill-check evaluation
+// in NarrativeController unchanged.
+
+import { AIClient } from './types';
+import { createDefaultGeminiClient } from './defaultGeminiClient';
+import type { World, WorldSkill } from '@/types/world.types';
+import type { Character } from '@/state/characterStore';
+import type { DecisionRequirement, NarrativeSegment } from '@/types/narrative.types';
+import { safeTrim } from '@/lib/utils';
+
+import Logger from '@/lib/utils/logger';
+const logger = new Logger('CustomActionSkillInference');
+
+export interface CustomActionSkillInferenceParams {
+  /** The free-text action the player typed. */
+  actionText: string;
+  character: Character;
+  world: World;
+  /** Recent narrative for situational fit; only the last couple are used. */
+  recentSegments?: NarrativeSegment[];
+}
+
+/**
+ * Ask the AI whether a typed action needs a skill check, which skill(s) apply,
+ * and at what difficulty. Returns skill-type DecisionRequirements ready for the
+ * existing evaluator. Returns [] when no check fits, or on any failure (graceful
+ * degradation - a typed action may legitimately need no roll).
+ */
+export async function inferCustomActionSkillChecks(
+  params: CustomActionSkillInferenceParams,
+  aiClient: AIClient = createDefaultGeminiClient()
+): Promise<DecisionRequirement[]> {
+  const { actionText, world } = params;
+  const worldSkills = world.skills ?? [];
+
+  if (!safeTrim(actionText) || worldSkills.length === 0) {
+    return [];
+  }
+
+  try {
+    const prompt = buildInferencePrompt(params, worldSkills);
+    const response = await aiClient.generateContent(prompt);
+
+    if (!response?.content) {
+      return [];
+    }
+
+    return parseInferenceResponse(response.content, worldSkills);
+  } catch (error) {
+    logger.warn('Skill inference failed - proceeding without a check', error);
+    return [];
+  }
+}
+
+function buildInferencePrompt(
+  params: CustomActionSkillInferenceParams,
+  worldSkills: WorldSkill[]
+): string {
+  const { actionText, character, recentSegments } = params;
+
+  const skillLines = worldSkills
+    .map((skill) => {
+      const characterSkill = character.skills.find(
+        (cs) => (cs.worldSkillId || cs.id) === skill.id
+      );
+      const level = characterSkill?.level ?? 0;
+      const description = skill.description ? ` | ${skill.description}` : '';
+      return `- id: "${skill.id}" | name: "${skill.name}" | difficulty range: ${skill.minValue}-${skill.maxValue} | character level: ${level}${description}`;
+    })
+    .join('\n');
+
+  const recent = (recentSegments ?? [])
+    .slice(-2)
+    .map((segment) => segment.content)
+    .filter(Boolean)
+    .join('\n\n');
+  const recentContext = recent ? `\n\nRECENT NARRATIVE:\n${recent}` : '';
+
+  return `You are a tabletop RPG game master deciding whether a player's freeform action requires a d20 skill check.
+
+PLAYER ACTION:
+"${actionText}"
+
+AVAILABLE SKILLS (use the exact id when referencing a skill):
+${skillLines}${recentContext}
+
+Decide:
+1. Does this action have a meaningful chance of failure that warrants a skill check? Routine or purely narrative actions (looking around, talking casually, walking somewhere safe) need NO check.
+2. If a check is warranted, which skill(s) apply? Usually exactly one; at most two when the action genuinely spans two skills.
+3. What difficulty fits? Pick an integer within the skill's listed difficulty range, higher for harder feats.
+
+Respond with ONLY a JSON block in this exact format:
+
+\`\`\`json
+{
+  "skillCheckNeeded": true,
+  "checks": [
+    { "skillId": "exact-skill-id-from-the-list", "difficulty": 3 }
+  ]
+}
+\`\`\`
+
+If no check is needed, return { "skillCheckNeeded": false, "checks": [] }.`;
+}
+
+function parseInferenceResponse(
+  content: string,
+  worldSkills: WorldSkill[]
+): DecisionRequirement[] {
+  const jsonMatch = content.match(/```json\s*([\s\S]*?)\s*```/);
+  if (!jsonMatch) {
+    return [];
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonMatch[1]);
+  } catch {
+    return [];
+  }
+
+  const result = parsed as { skillCheckNeeded?: unknown; checks?: unknown };
+  if (result.skillCheckNeeded === false || !Array.isArray(result.checks)) {
+    return [];
+  }
+
+  const requirements: DecisionRequirement[] = [];
+  for (const raw of result.checks as Array<Record<string, unknown>>) {
+    const skillId = typeof raw.skillId === 'string' ? raw.skillId : undefined;
+    if (!skillId) {
+      continue;
+    }
+
+    const worldSkill = worldSkills.find((ws) => ws.id === skillId);
+    if (!worldSkill) {
+      logger.warn(`Inferred skill "${skillId}" not found in world - dropping`);
+      continue;
+    }
+
+    requirements.push({
+      type: 'skill',
+      targetId: skillId,
+      operator: 'gte',
+      value: clampDifficulty(Number(raw.difficulty), worldSkill),
+    });
+  }
+
+  return requirements;
+}
+
+// Keep difficulty inside the skill's own range so DC (difficulty * 2) stays sane.
+function clampDifficulty(value: number, skill: WorldSkill): number {
+  const min = Number.isFinite(skill.minValue) ? skill.minValue : 1;
+  const max = Number.isFinite(skill.maxValue) ? skill.maxValue : 10;
+  const fallback = Number.isFinite(skill.baseValue) ? skill.baseValue : min;
+  const candidate = Number.isFinite(value) ? value : fallback;
+  return Math.max(min, Math.min(max, Math.round(candidate)));
+}

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -2751,6 +2751,43 @@ body.manuscript-overlay-open {
   letter-spacing: 0.04em;
 }
 
+/* Issue #918: evaluating-action state — a tumbling-die motif distinguishes a
+   skill-check evaluation phase from generic generation. Hidden by default,
+   themed per design system below. */
+.manuscript-evaluating-indicator {
+  display: none;
+}
+
+[data-theme="ds1"] .manuscript-evaluating-indicator {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1_5);
+  padding: var(--space-2_5) var(--space-2_5) var(--space-1_5);
+}
+
+[data-theme="ds1"] .manuscript-evaluating-die {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-sm);
+  background: var(--color-text-muted);
+  animation: manuscript-die-tumble 1s linear infinite;
+}
+
+[data-theme="ds1"] .manuscript-evaluating-label {
+  font-family: var(--font-system);
+  font-size: 0.625rem;
+  font-style: italic;
+  color: var(--color-text-muted);
+  letter-spacing: 0.04em;
+}
+
+/* Shared tumble keyframe — a die rotating as it is cast. */
+@keyframes manuscript-die-tumble {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
 /* DS1: always show expanded choices, hide mobile toggle */
 [data-theme="ds1"] .manuscript-mobile-rail-top-controls {
   display: none;
@@ -3801,6 +3838,32 @@ body.manuscript-overlay-open {
   50% { opacity: 1; }
 }
 
+/* DS2 evaluating-action — accent die, bolder to match the Bento accent language */
+[data-theme="ds2"] .manuscript-evaluating-indicator {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+
+[data-theme="ds2"] .manuscript-evaluating-die {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-sm);
+  background: var(--color-accent);
+  animation: manuscript-die-tumble 0.9s ease-in-out infinite;
+}
+
+[data-theme="ds2"] .manuscript-evaluating-label {
+  font-family: var(--font-system);
+  font-size: 0.625rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
 /* DS2 skeleton shimmer — warm gradient */
 [data-theme="ds2"] .manuscript-skeleton-pulse {
   background: linear-gradient(
@@ -4504,6 +4567,37 @@ body.manuscript-overlay-open {
 @keyframes ds3-streaming-pulse {
   0%, 100% { opacity: 0.4; }
   50% { opacity: 1; }
+}
+
+/* DS3 evaluating-action — cool muted die + bracketed console-style label */
+[data-theme="ds3"] .manuscript-evaluating-indicator {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1_5);
+}
+
+[data-theme="ds3"] .manuscript-evaluating-die {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-sm);
+  background: var(--color-text-muted);
+  animation: manuscript-die-tumble 1.3s linear infinite;
+}
+
+[data-theme="ds3"] .manuscript-evaluating-label {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--color-text-muted);
+  letter-spacing: 0.04em;
+}
+
+[data-theme="ds3"] .manuscript-evaluating-label::before {
+  content: "[ ";
+}
+
+[data-theme="ds3"] .manuscript-evaluating-label::after {
+  content: " ]";
 }
 
 /* DS3 skeleton shimmer — cool-toned gradient */

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -2761,17 +2761,19 @@ body.manuscript-overlay-open {
 [data-theme="ds1"] .manuscript-evaluating-indicator {
   display: flex;
   align-items: center;
-  gap: var(--space-1_5);
+  gap: var(--space-2);
   padding: var(--space-2_5) var(--space-2_5) var(--space-1_5);
 }
 
+/* DS1 — an outlined ink die tumbling end over end. */
 [data-theme="ds1"] .manuscript-evaluating-die {
   display: inline-block;
-  width: 8px;
-  height: 8px;
+  width: 10px;
+  height: 10px;
+  border: 1px solid var(--color-text-muted);
   border-radius: var(--radius-sm);
-  background: var(--color-text-muted);
-  animation: manuscript-die-tumble 1s linear infinite;
+  background: var(--color-surface);
+  animation: manuscript-die-tumble 1.1s ease-in-out infinite;
 }
 
 [data-theme="ds1"] .manuscript-evaluating-label {
@@ -2782,10 +2784,15 @@ body.manuscript-overlay-open {
   letter-spacing: 0.04em;
 }
 
-/* Shared tumble keyframe — a die rotating as it is cast. */
+/* Shared tumble — a die turning over as it is cast. Spinning while squashing
+   vertically to a thin edge twice per turn fakes a cube flipping over (the
+   manuscript stylelint allow-list permits rotate + scale, not 3D rotates). */
 @keyframes manuscript-die-tumble {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  0% { transform: rotate(0deg) scale(1, 1); }
+  25% { transform: rotate(90deg) scale(1, 0.18); }
+  50% { transform: rotate(180deg) scale(1, 1); }
+  75% { transform: rotate(270deg) scale(1, 0.18); }
+  100% { transform: rotate(360deg) scale(1, 1); }
 }
 
 /* DS1: always show expanded choices, hide mobile toggle */
@@ -3838,7 +3845,8 @@ body.manuscript-overlay-open {
   50% { opacity: 1; }
 }
 
-/* DS2 evaluating-action — accent die, bolder to match the Bento accent language */
+/* DS2 evaluating-action — a solid accent die, bolder to match the Bento accent
+   language; faster, springier tumble. */
 [data-theme="ds2"] .manuscript-evaluating-indicator {
   display: flex;
   align-items: center;
@@ -3848,11 +3856,12 @@ body.manuscript-overlay-open {
 
 [data-theme="ds2"] .manuscript-evaluating-die {
   display: inline-block;
-  width: 8px;
-  height: 8px;
+  width: 11px;
+  height: 11px;
   border-radius: var(--radius-sm);
   background: var(--color-accent);
-  animation: manuscript-die-tumble 0.9s ease-in-out infinite;
+  box-shadow: inset 0 0 0 1px var(--color-accent-hover);
+  animation: manuscript-die-tumble 0.85s ease-in-out infinite;
 }
 
 [data-theme="ds2"] .manuscript-evaluating-label {
@@ -4569,7 +4578,8 @@ body.manuscript-overlay-open {
   50% { opacity: 1; }
 }
 
-/* DS3 evaluating-action — cool muted die + bracketed console-style label */
+/* DS3 evaluating-action — an outlined cool die that ticks in mechanical
+   quarter-turns (console feel), plus a bracketed monospace label. */
 [data-theme="ds3"] .manuscript-evaluating-indicator {
   display: flex;
   align-items: center;
@@ -4578,11 +4588,21 @@ body.manuscript-overlay-open {
 
 [data-theme="ds3"] .manuscript-evaluating-die {
   display: inline-block;
-  width: 8px;
-  height: 8px;
+  width: 10px;
+  height: 10px;
+  border: 1px solid var(--color-text-muted);
   border-radius: var(--radius-sm);
-  background: var(--color-text-muted);
-  animation: manuscript-die-tumble 1.3s linear infinite;
+  background: transparent;
+  animation: manuscript-die-tick 1.4s ease-in-out infinite;
+}
+
+/* Quarter-turn ticks with brief holds — a clacking die, no steps() needed. */
+@keyframes manuscript-die-tick {
+  0%, 16% { transform: rotate(0deg); }
+  25%, 41% { transform: rotate(90deg); }
+  50%, 66% { transform: rotate(180deg); }
+  75%, 91% { transform: rotate(270deg); }
+  100% { transform: rotate(360deg); }
 }
 
 [data-theme="ds3"] .manuscript-evaluating-label {


### PR DESCRIPTION
## Summary

Builds on PR #915. Custom typed actions used to skip d20 skill checks entirely — only predefined choices got them — so freeform input felt mechanically thinner and quietly discouraged players from typing their own actions. This closes that gap.

When a player types an action, a new AI inference pass decides:
1. whether the action has a real chance of failure worth a check (routine stuff like "look around" gets none),
2. which skill(s) apply (usually one, up to two for genuinely dual-skill actions), and
3. what difficulty fits, clamped to the skill's own range.

Those become `skill` requirements attached to the custom option. The existing skill-check evaluation in `NarrativeController` then rolls them **unchanged** — so toasts, decision outcomes, the fatal-on-critical-decision path, and the narrative context all reuse PR #915's machinery. No duplicated roll logic.

Because the flow is now infer → roll → narrate, the action rail shows a short **"Evaluating action…"** state with a tumbling-die motif (distinct from the generic "Generating response…" dot), differentiated across DS1/DS2/DS3 and built entirely on design tokens.

## Key changes

- **New** `src/lib/ai/customActionSkillInference.ts` — modeled on `goalExtractor`/`structuredLoreExtractor`: prompt → `generateContent` → JSON-block parse → validate against world skills → `DecisionRequirement[]`. Drops hallucinated skills, clamps difficulty, returns `[]` gracefully on no-check / malformed / error.
- `useActiveGameSessionActions.handleCustomSubmit` is now async: runs inference, attaches requirements to the custom option, manages the evaluating flag in a `try/finally`.
- `ActiveGameSession` / `ActiveGameSessionChoicesColumn` thread an `isEvaluatingAction` state to render the new indicator.
- `manuscript-session.css` — per-theme evaluating-indicator + shared `manuscript-die-tumble` keyframe.

## Verification

- **Unit** — 7 new tests for the inference module (single/multi skill, no-check, hallucinated-skill drop, difficulty clamp, malformed response). Full `GameSession` + `lib/ai` suites green (508 tests, no regressions).
- **Types/lint** — `tsc --noEmit`, eslint, and stylelint all clean.
- **ds-guard** — no hardcoded colors, every `var()` resolves to an inventory token, no Tailwind, identifying classes present.
- **bdg** — verified the evaluating indicator's computed styles across DS1/DS2/DS3 on this worktree's dev server: `display:flex`, 8px die, token-resolved colors (DS1 muted ink, DS2 accent + uppercase, DS3 warm console), and distinct tumble timings (1s / 0.9s / 1.3s).

Note: the live end-to-end AI roll in-browser (typed action → real Gemini inference → roll toast) wasn't walked here — it needs a seeded session + API key — but it's covered by the unit tests and PR #915's existing integration test for the evaluation path.

## Test plan

- [ ] In a session, type an action that implies a skill (e.g. "sneak past the guard") → "Evaluating action…" shows, a roll toast appears, narrative reflects the result.
- [ ] Type a routine action (e.g. "look around") → no roll, straight to narrative.
- [ ] Confirm multi-skill actions roll each inferred skill.

Closes #918 (close manually on merge — `develop` isn't the default branch).