### PR TITLE
Inventory loop: starting equipment, equip/unequip, equipped indicator

### DIFF
--- a/src/app/characters/create/page.tsx
+++ b/src/app/characters/create/page.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import { ActionButtonGroup } from '@/components/shared/ActionButtonGroup';
 import { wizardStyles } from '@/components/shared/wizard';
 import { CharacterArchetype } from '@/types/world.types';
+import { applyStartingInventory } from '@/lib/inventory/startingInventory';
 import { useTutorial } from '@/components/TutorialProvider';
 
 import Logger from '@/lib/utils/logger';
@@ -182,6 +183,9 @@ export default function CharacterCreatePage() {
       // Create the character
       const characterId = createCharacter(characterData);
       setCurrentCharacter(characterId);
+
+      // Seed the character's archetype-appropriate starting inventory
+      applyStartingInventory(characterId, archetype.startingInventory);
 
       // Start a new game session
       await initializeSession(currentWorld.id, characterId, () => {

--- a/src/components/inventory/InventoryList.tsx
+++ b/src/components/inventory/InventoryList.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import React, { useState } from 'react';
+import { clsx } from 'clsx';
+import { Shield } from 'lucide-react';
 import { useInventoryStore } from '@/state/inventoryStore';
 import { useSessionStore } from '@/state/sessionStore';
 import { EntityID } from '@/types/common.types';
@@ -12,6 +14,7 @@ import {
   getCategoryMetadata,
   STANDARD_CATEGORIES,
 } from '@/lib/inventory/categories';
+import { isEquippableCategory } from '@/lib/inventory/equippable';
 import type { StandardInventoryCategory } from '@/types/inventory.types';
 import { processItemUsage } from '@/lib/inventory/itemUsageService';
 import { useItemDropConfirmation } from './hooks/useItemDropConfirmation';
@@ -63,8 +66,18 @@ export const InventoryList: React.FC<InventoryListProps> = ({
       .filter((item): item is InventoryItem => Boolean(item));
   }, [itemsObject, characterInventories, characterId]);
   const sessionId = useSessionStore((state) => state.id);
+  const toggleEquipItem = useInventoryStore((state) => state.toggleEquipItem);
   const [usingItemId, setUsingItemId] = useState<EntityID | null>(null);
   const [errorFeedback, setErrorFeedback] = useState<string | null>(null);
+
+  // Equip or unequip an item; surface the block message if the store rejects it
+  const handleToggleEquip = (item: InventoryItem) => {
+    setErrorFeedback(null);
+    const result = toggleEquipItem(characterId, item.id);
+    if (!result.success && result.error) {
+      setErrorFeedback(result.error.message);
+    }
+  };
 
   // Handle item usage
   const handleUseItem = async (itemId: EntityID) => {
@@ -111,7 +124,7 @@ export const InventoryList: React.FC<InventoryListProps> = ({
   // Empty state when no items
   if (items.length === 0) {
     return (
-      <div className={`${className}`}>
+      <div className={clsx('component-inventory-list', className)}>
         <EmptyState
           title="No items in inventory"
           description="Items will appear here as they are added"
@@ -123,7 +136,7 @@ export const InventoryList: React.FC<InventoryListProps> = ({
 
   return (
     <div
-      className={`${className}`}
+      className={clsx('component-inventory-list', className)}
       role="region"
       aria-label="Character inventory"
     >
@@ -155,13 +168,17 @@ export const InventoryList: React.FC<InventoryListProps> = ({
                 {categoryItems.map((item) => (
                   <article
                     key={item.id}
-                    className="manuscript-inventory-item"
+                    className={clsx(
+                      'manuscript-inventory-item',
+                      item.equipped && 'is-equipped'
+                    )}
+                    data-equipped={item.equipped ? 'true' : undefined}
                     role="listitem"
                   >
                     <div className="manuscript-inventory-item-header">
                       <h4 className="manuscript-inventory-item-name">{item.name}</h4>
                       {item.stackable && (
-                        <span 
+                        <span
                           className="manuscript-inventory-item-quantity"
                           aria-label={`Quantity: ${item.quantity}`}
                         >
@@ -169,6 +186,13 @@ export const InventoryList: React.FC<InventoryListProps> = ({
                         </span>
                       )}
                     </div>
+
+                    {item.equipped && (
+                      <span className="manuscript-inventory-item-equipped-badge">
+                        <Shield aria-hidden="true" />
+                        Equipped
+                      </span>
+                    )}
 
                     {item.description && (
                       <p className="manuscript-inventory-item-description">{item.description}</p>
@@ -180,6 +204,21 @@ export const InventoryList: React.FC<InventoryListProps> = ({
                       </span>
 
                       <div className="manuscript-inventory-actions">
+                        {isEquippableCategory(item.categoryId) && (
+                          <Button
+                            className="manuscript-inventory-action-button"
+                            variant={item.equipped ? 'secondary' : 'outline'}
+                            onClick={() => handleToggleEquip(item)}
+                            aria-pressed={item.equipped ?? false}
+                            aria-label={
+                              item.equipped
+                                ? `Unequip ${item.name}`
+                                : `Equip ${item.name}`
+                            }
+                          >
+                            {item.equipped ? 'UNEQUIP' : 'EQUIP'}
+                          </Button>
+                        )}
                         <Button
                           className="manuscript-inventory-action-button"
                           variant="outline"

--- a/src/components/inventory/__tests__/InventoryList.test.tsx
+++ b/src/components/inventory/__tests__/InventoryList.test.tsx
@@ -76,6 +76,7 @@ const createMockInventoryStore = (
     getCharacterItems,
     clearCharacterInventory: jest.fn(),
     useItem: jest.fn(),
+    toggleEquipItem: jest.fn(() => ({ success: true, equipped: true })),
     setGeneratingImage: jest.fn(),
     setImageGenerationError: jest.fn(),
     ...overrides,
@@ -113,6 +114,7 @@ const createItem = (overrides: Partial<InventoryItem>): InventoryItem => {
       },
     createdAt: overrides.createdAt ?? baseTimestamp,
     updatedAt: overrides.updatedAt ?? baseTimestamp,
+    equipped: overrides.equipped,
   };
 };
 
@@ -288,5 +290,107 @@ describe('InventoryList', () => {
     
     // Should call removeItem
     expect(mockRemoveItem).toHaveBeenCalledWith(characterId, 'item-1', 1);
+  });
+
+  test('shows the equipped indicator for equipped items', () => {
+    const equippedItem = createItem({
+      id: 'item-eq',
+      name: 'Steel Sword',
+      categoryId: 'equipment',
+      stackable: false,
+      equipped: true,
+    });
+
+    const mockStore = createMockInventoryStore({
+      items: { [equippedItem.id]: equippedItem },
+      characterInventories: { [characterId]: [equippedItem.id] },
+    });
+    mockUseInventoryStore.mockImplementation((selector) =>
+      selector ? selector(mockStore) : mockStore
+    );
+
+    const { container } = render(<InventoryList characterId={characterId} />);
+
+    expect(screen.getByText('Equipped')).toBeInTheDocument();
+    expect(container.querySelector('.manuscript-inventory-item.is-equipped')).toBeInTheDocument();
+  });
+
+  test('toggles equip state for equippable items', async () => {
+    const user = userEvent.setup();
+    const item = createItem({
+      id: 'item-eq',
+      name: 'Steel Sword',
+      categoryId: 'equipment',
+      stackable: false,
+      equipped: false,
+    });
+    const toggleEquipItem = jest.fn(() => ({ success: true, equipped: true }));
+
+    const mockStore = createMockInventoryStore({
+      items: { [item.id]: item },
+      characterInventories: { [characterId]: [item.id] },
+      toggleEquipItem,
+    });
+    mockUseInventoryStore.mockImplementation((selector) =>
+      selector ? selector(mockStore) : mockStore
+    );
+
+    render(<InventoryList characterId={characterId} />);
+
+    await user.click(screen.getByRole('button', { name: 'Equip Steel Sword' }));
+
+    expect(toggleEquipItem).toHaveBeenCalledWith(characterId, 'item-eq');
+  });
+
+  test('hides the equip control for non-equippable items', () => {
+    const potion = createItem({
+      id: 'item-potion',
+      name: 'Health Potion',
+      categoryId: 'consumables',
+      quantity: 3,
+    });
+
+    const mockStore = createMockInventoryStore({
+      items: { [potion.id]: potion },
+      characterInventories: { [characterId]: [potion.id] },
+    });
+    mockUseInventoryStore.mockImplementation((selector) =>
+      selector ? selector(mockStore) : mockStore
+    );
+
+    render(<InventoryList characterId={characterId} />);
+
+    expect(screen.queryByRole('button', { name: /Equip Health Potion/i })).not.toBeInTheDocument();
+  });
+
+  test('surfaces a block message when the store rejects an equip', async () => {
+    const user = userEvent.setup();
+    const item = createItem({
+      id: 'item-personal',
+      name: 'Lucky Charm',
+      categoryId: 'personal',
+      stackable: false,
+      equipped: false,
+    });
+    const toggleEquipItem = jest.fn(() => ({
+      success: false,
+      equipped: false,
+      error: { type: 'validation', title: 'Cannot Equip Item', message: 'That cannot be equipped.' },
+    }));
+
+    const mockStore = createMockInventoryStore({
+      items: { [item.id]: item },
+      characterInventories: { [characterId]: [item.id] },
+      toggleEquipItem,
+    });
+    mockUseInventoryStore.mockImplementation((selector) =>
+      selector ? selector(mockStore) : mockStore
+    );
+
+    render(<InventoryList characterId={characterId} />);
+
+    await user.click(screen.getByRole('button', { name: 'Equip Lucky Charm' }));
+
+    expect(await screen.findByText('That cannot be equipped.')).toBeInTheDocument();
   });
 });

--- a/src/lib/ai/narrativeGenerator.prompt.ts
+++ b/src/lib/ai/narrativeGenerator.prompt.ts
@@ -227,16 +227,11 @@ const getEquippedItemIds = (characterIds: string[] | undefined): string[] => {
   }
 
   try {
-    const { characters } = useCharacterStore.getState();
-    const playerCharacter = characters[characterIds[0]];
-    const inventoryItems =
-      (playerCharacter?.inventory?.items as Array<{
-        id: string;
-        equipped?: boolean;
-      }>) ?? [];
-
-    return inventoryItems
-      .filter((item) => item?.equipped)
+    // Read equipped state from the canonical inventory store — the same source
+    // the displayed items and buildInventoryContext() draw from.
+    const { getCharacterItems } = useInventoryStore.getState();
+    return getCharacterItems(characterIds[0])
+      .filter((item) => item.equipped)
       .map((item) => item.id);
   } catch {
     return [];

--- a/src/lib/constants/characterArchetypeTemplates.ts
+++ b/src/lib/constants/characterArchetypeTemplates.ts
@@ -9,6 +9,7 @@
  */
 
 import { GenreValue } from './genres';
+import type { InventoryItemInput } from '@/types/inventory.types';
 
 export interface ArchetypeTemplate {
   name: string;
@@ -20,6 +21,8 @@ export interface ArchetypeTemplate {
   motivations: string[];
   fears: string[][];
   nameTemplates: string[];
+  /** Archetype-appropriate equipment a character of this archetype starts with. */
+  startingInventory?: InventoryItemInput[];
 }
 
 const BASE_ARCHETYPE_TEMPLATES: Record<
@@ -48,7 +51,12 @@ const BASE_ARCHETYPE_TEMPLATES: Record<
         ['Dishonor', 'Cowardice'],
         ['Being forgotten', 'Letting down allies']
       ],
-      nameTemplates: ['Aelric', 'Bjorn', 'Gareth', 'Thora', 'Valdris', 'Kendra']
+      nameTemplates: ['Aelric', 'Bjorn', 'Gareth', 'Thora', 'Valdris', 'Kendra'],
+      startingInventory: [
+        { name: 'Steel Sword', description: 'A well-balanced blade, kept sharp.', categoryId: 'equipment', equipped: true },
+        { name: 'Wooden Shield', description: 'Battered but reliable.', categoryId: 'equipment' },
+        { name: 'Health Potion', description: 'Restores vitality when wounded.', categoryId: 'consumables', quantity: 3, stackable: true, maxStack: 10 }
+      ]
     },
     {
       name: 'Mage',
@@ -71,7 +79,12 @@ const BASE_ARCHETYPE_TEMPLATES: Record<
         ['Ignorance', 'Being intellectually surpassed'],
         ['Dark magic corruption', 'Forbidden knowledge']
       ],
-      nameTemplates: ['Lyra', 'Aldric', 'Seraphina', 'Mordecai', 'Celeste', 'Zephyr']
+      nameTemplates: ['Lyra', 'Aldric', 'Seraphina', 'Mordecai', 'Celeste', 'Zephyr'],
+      startingInventory: [
+        { name: 'Spellbook', description: 'Worn pages crowded with arcane notation.', categoryId: 'equipment', equipped: true },
+        { name: 'Traveler\'s Robes', description: 'Embroidered with protective sigils.', categoryId: 'personal', equipped: true },
+        { name: 'Mana Potion', description: 'Replenishes spent magical energy.', categoryId: 'consumables', quantity: 3, stackable: true, maxStack: 10 }
+      ]
     },
     {
       name: 'Scout',
@@ -94,7 +107,13 @@ const BASE_ARCHETYPE_TEMPLATES: Record<
         ['Civilization', 'Crowds'],
         ['Being detected', 'Failing a mission']
       ],
-      nameTemplates: ['Kael', 'Aria', 'Hunter', 'Sage', 'Raven', 'Swift']
+      nameTemplates: ['Kael', 'Aria', 'Hunter', 'Sage', 'Raven', 'Swift'],
+      startingInventory: [
+        { name: 'Hunting Bow', description: 'Strung and ready for the trail.', categoryId: 'equipment', equipped: true },
+        { name: 'Bundle of Arrows', description: 'Fletched for a clean flight.', categoryId: 'equipment', quantity: 20, stackable: true, maxStack: 50 },
+        { name: 'Lockpicks', description: 'A slim set for stubborn locks.', categoryId: 'equipment' },
+        { name: 'Leather Cloak', description: 'Muted greens for blending in.', categoryId: 'personal', equipped: true }
+      ]
     }
   ],
 
@@ -120,7 +139,12 @@ const BASE_ARCHETYPE_TEMPLATES: Record<
         ['Space madness', 'Isolation'],
         ['Losing their ship', 'Navigation errors']
       ],
-      nameTemplates: ['Nova', 'Ace', 'Vector', 'Cosmos', 'Stellar', 'Phoenix']
+      nameTemplates: ['Nova', 'Ace', 'Vector', 'Cosmos', 'Stellar', 'Phoenix'],
+      startingInventory: [
+        { name: 'Sidearm Blaster', description: 'Standard-issue, holstered at the hip.', categoryId: 'equipment', equipped: true },
+        { name: 'Flight Jacket', description: 'Insulated, patched at the elbows.', categoryId: 'personal', equipped: true },
+        { name: 'Ration Packs', description: 'Freeze-dried meals for long hauls.', categoryId: 'consumables', quantity: 3, stackable: true, maxStack: 10 }
+      ]
     },
     {
       name: 'Engineer',
@@ -143,7 +167,12 @@ const BASE_ARCHETYPE_TEMPLATES: Record<
         ['Obsolescence', 'Being replaced by AI'],
         ['Critical malfunction', 'Lives depending on their work']
       ],
-      nameTemplates: ['Circuit', 'Gears', 'Quantum', 'Binary', 'Flux', 'Tesla']
+      nameTemplates: ['Circuit', 'Gears', 'Quantum', 'Binary', 'Flux', 'Tesla'],
+      startingInventory: [
+        { name: 'Multi-Tool', description: 'A dozen instruments folded into one.', categoryId: 'equipment', equipped: true },
+        { name: 'Diagnostic Scanner', description: 'Reads faults the eye can\'t catch.', categoryId: 'equipment' },
+        { name: 'Spare Parts', description: 'Couplings, wiring, and seals.', categoryId: 'equipment', quantity: 5, stackable: true, maxStack: 20 }
+      ]
     },
     {
       name: 'Medic',
@@ -166,7 +195,12 @@ const BASE_ARCHETYPE_TEMPLATES: Record<
         ['Pandemic outbreaks', 'Incurable diseases'],
         ['Ethical dilemmas', 'Being unable to help']
       ],
-      nameTemplates: ['Haven', 'Grace', 'Mercy', 'Heal', 'Hope', 'Vita']
+      nameTemplates: ['Haven', 'Grace', 'Mercy', 'Heal', 'Hope', 'Vita'],
+      startingInventory: [
+        { name: 'Medkit', description: 'Field dressings, sealant, and tools.', categoryId: 'equipment', equipped: true },
+        { name: 'Med Scanner', description: 'Reads vitals through a sleeve.', categoryId: 'equipment' },
+        { name: 'Stim Injectors', description: 'Single-use shots that steady a patient.', categoryId: 'consumables', quantity: 3, stackable: true, maxStack: 10 }
+      ]
     }
   ],
 
@@ -192,7 +226,12 @@ const BASE_ARCHETYPE_TEMPLATES: Record<
         ['Corruption', 'System failures'],
         ['Wrong accusations', 'Innocent people suffering']
       ],
-      nameTemplates: ['Sam', 'Alex', 'Jordan', 'Casey', 'Morgan', 'Quinn']
+      nameTemplates: ['Sam', 'Alex', 'Jordan', 'Casey', 'Morgan', 'Quinn'],
+      startingInventory: [
+        { name: 'Service Pistol', description: 'Holstered, with the safety on.', categoryId: 'equipment', equipped: true },
+        { name: 'Magnifying Glass', description: 'For the details everyone else misses.', categoryId: 'equipment' },
+        { name: 'Case Notebook', description: 'Dog-eared and full of leads.', categoryId: 'documents' }
+      ]
     },
     {
       name: 'Athlete',
@@ -215,7 +254,12 @@ const BASE_ARCHETYPE_TEMPLATES: Record<
         ['Performance anxiety', 'Letting the team down'],
         ['Age and decline', 'Being surpassed']
       ],
-      nameTemplates: ['Max', 'Power', 'Swift', 'Strong', 'Ace', 'Champion']
+      nameTemplates: ['Max', 'Power', 'Swift', 'Strong', 'Ace', 'Champion'],
+      startingInventory: [
+        { name: 'Training Gear', description: 'Broken-in and built for movement.', categoryId: 'personal', equipped: true },
+        { name: 'Energy Bars', description: 'Quick fuel between efforts.', categoryId: 'consumables', quantity: 4, stackable: true, maxStack: 10 },
+        { name: 'Water Bottle', description: 'Insulated, always within reach.', categoryId: 'consumables' }
+      ]
     },
     {
       name: 'Scholar',
@@ -238,7 +282,12 @@ const BASE_ARCHETYPE_TEMPLATES: Record<
         ['Book burning', 'Lost knowledge'],
         ['Being wrong', 'Spreading false information']
       ],
-      nameTemplates: ['Professor', 'Doctor', 'Sage', 'Scholar', 'Librarian', 'Teacher']
+      nameTemplates: ['Professor', 'Doctor', 'Sage', 'Scholar', 'Librarian', 'Teacher'],
+      startingInventory: [
+        { name: 'Reference Tome', description: 'Annotated in three different hands.', categoryId: 'equipment', equipped: true },
+        { name: 'Reading Glasses', description: 'Smudged, but they do the job.', categoryId: 'personal', equipped: true },
+        { name: 'Field Notebook', description: 'Half notes, half questions.', categoryId: 'documents' }
+      ]
     }
   ],
 
@@ -264,7 +313,12 @@ const BASE_ARCHETYPE_TEMPLATES: Record<
         ['The law catching up', 'Their past being revealed'],
         ['Innocents getting hurt', 'Becoming the villain']
       ],
-      nameTemplates: ['Doc', 'Ace', 'Jesse', 'Belle', 'Kid', 'Slim']
+      nameTemplates: ['Doc', 'Ace', 'Jesse', 'Belle', 'Kid', 'Slim'],
+      startingInventory: [
+        { name: 'Six-Shooter Revolver', description: 'Worn grip, oiled action.', categoryId: 'equipment', equipped: true },
+        { name: 'Worn Duster', description: 'Trail dust ground into every seam.', categoryId: 'personal', equipped: true },
+        { name: 'Box of Ammunition', description: 'Enough rounds to settle most arguments.', categoryId: 'equipment', quantity: 24, stackable: true, maxStack: 50 }
+      ]
     },
     {
       name: 'Sheriff',
@@ -287,7 +341,12 @@ const BASE_ARCHETYPE_TEMPLATES: Record<
         ['Outlaws winning', 'Lawlessness spreading'],
         ['Innocent bloodshed', 'Becoming like the criminals']
       ],
-      nameTemplates: ['Marshal', 'Sheriff', 'Deputy', 'Wyatt', 'Justice', 'Badge']
+      nameTemplates: ['Marshal', 'Sheriff', 'Deputy', 'Wyatt', 'Justice', 'Badge'],
+      startingInventory: [
+        { name: 'Lawman\'s Revolver', description: 'Carried with the weight of the office.', categoryId: 'equipment', equipped: true },
+        { name: 'Sheriff\'s Badge', description: 'Tin star, polished by habit.', categoryId: 'personal', equipped: true },
+        { name: 'Set of Handcuffs', description: 'For the ones who come quietly.', categoryId: 'equipment' }
+      ]
     },
     {
       name: 'Cowboy',
@@ -310,7 +369,13 @@ const BASE_ARCHETYPE_TEMPLATES: Record<
         ['Drought', 'Losing the herd'],
         ['Settling down', 'Civilization encroaching']
       ],
-      nameTemplates: ['Buck', 'Dusty', 'Tex', 'Montana', 'Dakota', 'Ranger']
+      nameTemplates: ['Buck', 'Dusty', 'Tex', 'Montana', 'Dakota', 'Ranger'],
+      startingInventory: [
+        { name: 'Lasso', description: 'Coiled and ready at the saddle.', categoryId: 'equipment', equipped: true },
+        { name: 'Hunting Knife', description: 'Earns its keep on the range.', categoryId: 'equipment' },
+        { name: 'Canteen', description: 'Dented, never empty for long.', categoryId: 'consumables' },
+        { name: 'Bedroll', description: 'Home wherever the day ends.', categoryId: 'personal' }
+      ]
     }
   ],
 
@@ -336,7 +401,12 @@ const BASE_ARCHETYPE_TEMPLATES: Record<
         ['Failing their lord', 'Cowardice'],
         ['Being unworthy', 'Losing their status']
       ],
-      nameTemplates: ['Sir Galahad', 'Sir Lancelot', 'Lady Joan', 'Sir Richard', 'Dame Eleanor', 'Sir William']
+      nameTemplates: ['Sir Galahad', 'Sir Lancelot', 'Lady Joan', 'Sir Richard', 'Dame Eleanor', 'Sir William'],
+      startingInventory: [
+        { name: 'Steel Longsword', description: 'Crest etched near the hilt.', categoryId: 'equipment', equipped: true },
+        { name: 'Kite Shield', description: 'Bears the marks of past tourneys.', categoryId: 'equipment', equipped: true },
+        { name: 'Health Tonic', description: 'A field remedy for grievous wounds.', categoryId: 'consumables', quantity: 3, stackable: true, maxStack: 10 }
+      ]
     },
     {
       name: 'Merchant',
@@ -359,7 +429,12 @@ const BASE_ARCHETYPE_TEMPLATES: Record<
         ['Pirates', 'Thieves'],
         ['Market collapse', 'Losing reputation']
       ],
-      nameTemplates: ['Giovanni', 'Marco', 'Isabella', 'Lorenzo', 'Catalina', 'Antonio']
+      nameTemplates: ['Giovanni', 'Marco', 'Isabella', 'Lorenzo', 'Catalina', 'Antonio'],
+      startingInventory: [
+        { name: 'Fine Cloak', description: 'Cut to signal means and taste.', categoryId: 'personal', equipped: true },
+        { name: 'Coin Purse', description: 'Heavy enough to open doors.', categoryId: 'valuables', quantity: 50, stackable: true, maxStack: 999 },
+        { name: 'Ledger', description: 'Every debt and favor, accounted for.', categoryId: 'documents' }
+      ]
     },
     {
       name: 'Blacksmith',
@@ -382,7 +457,12 @@ const BASE_ARCHETYPE_TEMPLATES: Record<
         ['Poor materials', 'Substandard work'],
         ['Being forgotten', 'Craft dying out']
       ],
-      nameTemplates: ['John', 'Thomas', 'Mary', 'William', 'Agnes', 'Robert']
+      nameTemplates: ['John', 'Thomas', 'Mary', 'William', 'Agnes', 'Robert'],
+      startingInventory: [
+        { name: 'Smithing Hammer', description: 'Balanced from years at the anvil.', categoryId: 'equipment', equipped: true },
+        { name: 'Leather Apron', description: 'Scorched, scarred, and trusted.', categoryId: 'personal', equipped: true },
+        { name: 'Iron Ingots', description: 'Raw stock waiting for the forge.', categoryId: 'equipment', quantity: 5, stackable: true, maxStack: 20 }
+      ]
     }
   ],
 
@@ -408,7 +488,12 @@ const BASE_ARCHETYPE_TEMPLATES: Record<
         ['Being consumed by darkness', 'Becoming a monster'],
         ['Forbidden knowledge', 'Things beyond comprehension']
       ],
-      nameTemplates: ['Arkham', 'Lovecraft', 'Poe', 'Raven', 'Shadow', 'Grimm']
+      nameTemplates: ['Arkham', 'Lovecraft', 'Poe', 'Raven', 'Shadow', 'Grimm'],
+      startingInventory: [
+        { name: 'Revolver', description: 'Six rounds against the dark.', categoryId: 'equipment', equipped: true },
+        { name: 'Electric Torch', description: 'The beam flickers when it shouldn\'t.', categoryId: 'equipment', equipped: true },
+        { name: 'Field Journal', description: 'Notes that read worse by lamplight.', categoryId: 'documents' }
+      ]
     },
     {
       name: 'Survivor',
@@ -431,7 +516,12 @@ const BASE_ARCHETYPE_TEMPLATES: Record<
         ['No one believing them', 'Being alone'],
         ['Losing their mind', 'Becoming what they fear']
       ],
-      nameTemplates: ['Ash', 'Ripley', 'Laurie', 'Final', 'Last', 'Sole']
+      nameTemplates: ['Ash', 'Ripley', 'Laurie', 'Final', 'Last', 'Sole'],
+      startingInventory: [
+        { name: 'Crowbar', description: 'Pries, pries open, and pries off.', categoryId: 'equipment', equipped: true },
+        { name: 'Bandages', description: 'Clean enough, mostly.', categoryId: 'consumables', quantity: 3, stackable: true, maxStack: 10 },
+        { name: 'Canned Food', description: 'Dented tins, labels long gone.', categoryId: 'consumables', quantity: 2, stackable: true, maxStack: 10 }
+      ]
     },
     {
       name: 'Occultist',
@@ -454,7 +544,12 @@ const BASE_ARCHETYPE_TEMPLATES: Record<
         ['Dark entities', 'Demons and spirits'],
         ['Corruption', 'Becoming evil']
       ],
-      nameTemplates: ['Crowley', 'Salem', 'Hex', 'Rune', 'Tarot', 'Witch']
+      nameTemplates: ['Crowley', 'Salem', 'Hex', 'Rune', 'Tarot', 'Witch'],
+      startingInventory: [
+        { name: 'Ritual Dagger', description: 'Cold to the touch, always.', categoryId: 'equipment', equipped: true },
+        { name: 'Tome of Rites', description: 'Bound in something best not named.', categoryId: 'documents' },
+        { name: 'Bundle of Candles', description: 'Black wax for the longer workings.', categoryId: 'consumables', quantity: 5, stackable: true, maxStack: 20 }
+      ]
     }
   ]
 };

--- a/src/lib/inventory/__tests__/startingInventory.test.ts
+++ b/src/lib/inventory/__tests__/startingInventory.test.ts
@@ -1,0 +1,57 @@
+// src/lib/inventory/__tests__/startingInventory.test.ts
+
+import { useInventoryStore } from '@/state/inventoryStore';
+import { applyStartingInventory } from '../startingInventory';
+import { ARCHETYPE_TEMPLATES } from '@/lib/constants/characterArchetypeTemplates';
+import { setupTestTimers, cleanupTestTimers } from '@/lib/test-utils/testTimers';
+
+const warriorInventory = () =>
+  ARCHETYPE_TEMPLATES.fantasy.find((template) => template.name === 'Warrior')
+    ?.startingInventory;
+
+describe('applyStartingInventory', () => {
+  const characterId = 'char-start';
+
+  beforeEach(() => {
+    setupTestTimers();
+    useInventoryStore.getState().reset();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    cleanupTestTimers();
+  });
+
+  test('does nothing when there is no starting inventory', () => {
+    applyStartingInventory(characterId, undefined);
+    applyStartingInventory(characterId, []);
+
+    expect(
+      useInventoryStore.getState().getCharacterItems(characterId)
+    ).toHaveLength(0);
+  });
+
+  test("seeds the character with the archetype's items tagged as starting equipment", () => {
+    applyStartingInventory(characterId, warriorInventory());
+
+    const items = useInventoryStore.getState().getCharacterItems(characterId);
+    const names = items.map((item) => item.name);
+
+    expect(names).toContain('Steel Sword');
+    expect(names).toContain('Health Potion');
+    items.forEach((item) => {
+      expect(item.acquisitionHistory[0].method).toBe('starting-equipment');
+    });
+  });
+
+  test('equips items flagged as equipped in the starting inventory', () => {
+    applyStartingInventory(characterId, warriorInventory());
+
+    const items = useInventoryStore.getState().getCharacterItems(characterId);
+    const sword = items.find((item) => item.name === 'Steel Sword');
+    const potion = items.find((item) => item.name === 'Health Potion');
+
+    expect(sword?.equipped).toBe(true);
+    expect(potion?.equipped).toBeFalsy();
+  });
+});

--- a/src/lib/inventory/equippable.ts
+++ b/src/lib/inventory/equippable.ts
@@ -8,7 +8,7 @@ import { getCategoryMetadata } from './categories';
  * Everything else (consumables, valuables, documents, quest-items, etc.)
  * is carried but not "equipped" in a loadout sense.
  */
-export const EQUIPPABLE_CATEGORIES: StandardInventoryCategory[] = [
+const EQUIPPABLE_CATEGORIES: StandardInventoryCategory[] = [
   'equipment',
   'personal',
 ];

--- a/src/lib/inventory/equippable.ts
+++ b/src/lib/inventory/equippable.ts
@@ -1,0 +1,41 @@
+// src/lib/inventory/equippable.ts
+
+import type { InventoryItem, StandardInventoryCategory } from '@/types/inventory.types';
+import { getCategoryMetadata } from './categories';
+
+/**
+ * Categories whose items can be worn, wielded, or otherwise equipped.
+ * Everything else (consumables, valuables, documents, quest-items, etc.)
+ * is carried but not "equipped" in a loadout sense.
+ */
+export const EQUIPPABLE_CATEGORIES: StandardInventoryCategory[] = [
+  'equipment',
+  'personal',
+];
+
+export function isEquippableCategory(
+  categoryId: StandardInventoryCategory
+): boolean {
+  return EQUIPPABLE_CATEGORIES.includes(categoryId);
+}
+
+export interface EquipEligibility {
+  allowed: boolean;
+  reason?: string;
+}
+
+/**
+ * Decides whether an item can be equipped and, if not, gives a player-facing
+ * reason. Only equipment and personal items are equippable for now.
+ */
+export function canEquipItem(item: InventoryItem): EquipEligibility {
+  if (isEquippableCategory(item.categoryId)) {
+    return { allowed: true };
+  }
+
+  const label = getCategoryMetadata(item.categoryId)?.name ?? item.categoryId;
+  return {
+    allowed: false,
+    reason: `${item.name} can't be equipped — ${label} items are carried, not worn or wielded.`,
+  };
+}

--- a/src/lib/inventory/startingInventory.ts
+++ b/src/lib/inventory/startingInventory.ts
@@ -1,0 +1,51 @@
+// src/lib/inventory/startingInventory.ts
+
+import type { EntityID } from '@/types/common.types';
+import type { InventoryItemInput } from '@/types/inventory.types';
+import { useInventoryStore } from '@/state/inventoryStore';
+import { getTimestamp } from '@/lib/utils';
+
+/**
+ * Seeds a freshly created character's inventory with their archetype's
+ * starting equipment. Items are tagged with the `starting-equipment`
+ * acquisition method so journal/timeline views can distinguish them from
+ * items earned in play. Items flagged `equipped` are equipped immediately.
+ */
+export function applyStartingInventory(
+  characterId: EntityID,
+  startingInventory: InventoryItemInput[] | undefined
+): void {
+  if (!startingInventory || startingInventory.length === 0) {
+    return;
+  }
+
+  const store = useInventoryStore.getState();
+  const acquiredAt = getTimestamp();
+
+  startingInventory.forEach((input) => {
+    const stackable = input.stackable ?? false;
+    const quantity = input.quantity ?? 1;
+
+    const itemId = store.addItem(characterId, {
+      name: input.name,
+      description: input.description,
+      quantity,
+      stackable,
+      maxStack: input.maxStack,
+      categorization: {
+        categoryId: input.categoryId,
+        source: 'system',
+        classifiedAt: acquiredAt,
+      },
+      acquisition: {
+        acquiredAt,
+        method: 'starting-equipment',
+        quantity,
+      },
+    });
+
+    if (itemId && input.equipped) {
+      store.updateItem(itemId, { equipped: true });
+    }
+  });
+}

--- a/src/lib/test-utils/mockStoreFactories/inventory.ts
+++ b/src/lib/test-utils/mockStoreFactories/inventory.ts
@@ -29,6 +29,7 @@ export function createMockInventoryStore(
     getCharacterItems: jest.fn(() => []),
     clearCharacterInventory: jest.fn(),
     useItem: jest.fn(() => ({ success: true, message: 'Item used' })),
+    toggleEquipItem: jest.fn(() => ({ success: true, equipped: true })),
     ...overrides,
   } as InventoryStore;
 }

--- a/src/lib/utils/__tests__/characterFinalization.test.ts
+++ b/src/lib/utils/__tests__/characterFinalization.test.ts
@@ -1,6 +1,7 @@
 import { finalizeCharacterCreation } from '../characterFinalization';
 import { useCharacterStore } from '@/state/characterStore';
 import { useSessionStore } from '@/state/sessionStore';
+import { useInventoryStore } from '@/state/inventoryStore';
 import { createMockWorld, createMockWorldAttribute, createMockWorldSkill } from '@/lib/test-utils';
 
 jest.mock('@/state/characterStore');
@@ -87,5 +88,73 @@ describe('finalizeCharacterCreation', () => {
       completed: true,
       skipped: false,
     });
+  });
+
+  it('seeds the inventory from the selected quick-start template', () => {
+    const characterId = 'char-inv';
+    useInventoryStore.getState().reset();
+
+    mockCharacterStore.getState.mockReturnValue({
+      createCharacter: jest.fn(() => characterId),
+      recalculateDerivedStats: jest.fn(),
+      setCurrentCharacter: jest.fn(),
+      currentCharacterId: characterId,
+    });
+
+    (useSessionStore as unknown as { getState: jest.Mock }).getState = jest.fn(() => ({
+      updateTutorialProgress: jest.fn(),
+    }));
+
+    const world = createMockWorld({
+      id: 'world-2',
+      name: 'Inventory World',
+      genre: 'fantasy',
+      attributes: [
+        createMockWorldAttribute({ id: 'attr-1', name: 'Strength', minValue: 1, maxValue: 5, worldId: 'world-2' }),
+      ],
+      skills: [
+        createMockWorldSkill({ id: 'skill-1', name: 'Combat', minValue: 1, maxValue: 5, worldId: 'world-2' }),
+      ],
+      settings: { maxAttributes: 6, maxSkills: 8, attributePointPool: 10, skillPointPool: 10 },
+      characterTemplates: [
+        {
+          id: 'tmpl-1',
+          name: 'Warrior',
+          description: 'A fighter',
+          level: 1,
+          attributes: [{ id: 'attr-1', name: 'Strength', value: 3 }],
+          skills: [{ id: 'skill-1', name: 'Combat', level: 2 }],
+          background: { description: '', personality: '', motivation: '', fears: [] },
+          startingInventory: [
+            { name: 'Steel Sword', categoryId: 'equipment', equipped: true },
+            { name: 'Health Potion', categoryId: 'consumables', quantity: 3, stackable: true, maxStack: 10 },
+          ],
+        },
+      ],
+    });
+
+    finalizeCharacterCreation(
+      {
+        name: 'Hero',
+        worldId: 'world-2',
+        description: '',
+        portraitPlaceholder: '',
+        selectedTemplateId: 'tmpl-1',
+        background: { history: '', personality: '', motivation: '', goals: [], physicalDescription: '' },
+        attributes: [
+          { attributeId: 'attr-1', name: 'Strength', description: '', value: 3, minValue: 1, maxValue: 5 },
+        ],
+        skills: [
+          { skillId: 'skill-1', name: 'Combat', description: '', level: 2, minLevel: 1, maxLevel: 5, isSelected: true },
+        ],
+      },
+      world
+    );
+
+    const items = useInventoryStore.getState().getCharacterItems(characterId);
+    const names = items.map((item) => item.name);
+    expect(names).toContain('Steel Sword');
+    expect(names).toContain('Health Potion');
+    expect(items.find((item) => item.name === 'Steel Sword')?.equipped).toBe(true);
   });
 });

--- a/src/lib/utils/characterArchetypes.ts
+++ b/src/lib/utils/characterArchetypes.ts
@@ -85,7 +85,8 @@ export async function generateCharacterArchetypes(
           motivation,
           fears,
           physicalDescription: generatePhysicalDescription(template, world.genre, world.name)
-        }
+        },
+        startingInventory: template.startingInventory
       };
       
       archetypes.push(archetype);

--- a/src/lib/utils/characterFinalization.ts
+++ b/src/lib/utils/characterFinalization.ts
@@ -3,6 +3,7 @@ import { World } from '@/types/world.types';
 import { useCharacterStore } from '@/state/characterStore';
 import { useSessionStore } from '@/state/sessionStore';
 import { generateUniqueId } from '@/lib/utils/generateId';
+import { applyStartingInventory } from '@/lib/inventory/startingInventory';
 import { CharacterCreationData } from '@/hooks/useCharacterCreationWizard';
 
 /**
@@ -77,6 +78,13 @@ export function finalizeCharacterCreation(
 
   // Calculate derived stats from world formulas
   useCharacterStore.getState().recalculateDerivedStats(characterId);
+
+  // Seed archetype-appropriate starting inventory when a quick-start template
+  // was used as the basis for this character.
+  const selectedTemplate = world?.characterTemplates?.find(
+    (template) => template.id === data.selectedTemplateId
+  );
+  applyStartingInventory(characterId, selectedTemplate?.startingInventory);
 
   // Set as current character
   useCharacterStore.getState().setCurrentCharacter(characterId);

--- a/src/state/__tests__/inventoryStore.equip.test.ts
+++ b/src/state/__tests__/inventoryStore.equip.test.ts
@@ -1,0 +1,107 @@
+// src/state/__tests__/inventoryStore.equip.test.ts
+
+import { useInventoryStore } from '../inventoryStore';
+import type { InventoryItemAddPayload } from '../inventoryStore';
+import type {
+  InventoryItemCategorization,
+  InventoryAcquisitionRecord,
+  StandardInventoryCategory,
+} from '@/types/inventory.types';
+import { setupTestTimers, cleanupTestTimers } from '@/lib/test-utils/testTimers';
+
+const buildCategorization = (
+  categoryId: StandardInventoryCategory
+): InventoryItemCategorization => ({
+  categoryId,
+  source: 'manual',
+  classifiedAt: '2025-01-15T12:00:00Z',
+});
+
+const buildAcquisition = (quantity = 1): InventoryAcquisitionRecord => ({
+  acquiredAt: '2025-01-15T12:00:00Z',
+  method: 'manual',
+  quantity,
+});
+
+const equipmentPayload = (
+  overrides: Partial<InventoryItemAddPayload> = {}
+): InventoryItemAddPayload => ({
+  name: 'Steel Sword',
+  description: 'A reliable blade',
+  stackable: false,
+  quantity: 1,
+  categorization: buildCategorization('equipment'),
+  acquisition: buildAcquisition(1),
+  ...overrides,
+});
+
+describe('useInventoryStore toggleEquipItem', () => {
+  const characterId = 'char-equip';
+
+  beforeEach(() => {
+    setupTestTimers();
+    useInventoryStore.getState().reset();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    cleanupTestTimers();
+  });
+
+  test('equips an equippable item and sets the equipped flag', () => {
+    const store = useInventoryStore.getState();
+    const itemId = store.addItem(characterId, equipmentPayload());
+
+    const result = store.toggleEquipItem(characterId, itemId);
+
+    expect(result.success).toBe(true);
+    expect(result.equipped).toBe(true);
+    expect(useInventoryStore.getState().items[itemId].equipped).toBe(true);
+  });
+
+  test('unequips an equipped item when toggled again', () => {
+    const store = useInventoryStore.getState();
+    const itemId = store.addItem(characterId, equipmentPayload());
+
+    store.toggleEquipItem(characterId, itemId);
+    const result = useInventoryStore
+      .getState()
+      .toggleEquipItem(characterId, itemId);
+
+    expect(result.success).toBe(true);
+    expect(result.equipped).toBe(false);
+    expect(useInventoryStore.getState().items[itemId].equipped).toBe(false);
+  });
+
+  test('blocks equipping an incompatible item with a clear message', () => {
+    const store = useInventoryStore.getState();
+    const itemId = store.addItem(
+      characterId,
+      equipmentPayload({
+        name: 'Health Potion',
+        stackable: true,
+        maxStack: 10,
+        quantity: 3,
+        categorization: buildCategorization('consumables'),
+        acquisition: buildAcquisition(3),
+      })
+    );
+
+    const result = store.toggleEquipItem(characterId, itemId);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.title).toBe('Cannot Equip Item');
+    expect(result.error?.message).toMatch(/can't be equipped/i);
+    expect(useInventoryStore.getState().items[itemId].equipped).toBeFalsy();
+  });
+
+  test('returns an error when the item is not in the character inventory', () => {
+    const store = useInventoryStore.getState();
+    const itemId = store.addItem(characterId, equipmentPayload());
+
+    const result = store.toggleEquipItem('someone-else', itemId);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.title).toBe('Item Not In Inventory');
+  });
+});

--- a/src/state/inventoryStore.ts
+++ b/src/state/inventoryStore.ts
@@ -12,7 +12,9 @@ import {
   InventoryItemCategorization,
   InventoryAcquisitionRecord,
   ItemUsageResult,
+  ItemEquipResult,
 } from '@/types/inventory.types';
+import { canEquipItem } from '@/lib/inventory/equippable';
 import { EntityID, GeneratedImage } from '../types/common.types';
 import { generateUniqueId } from '../lib/utils/generateId';
 import { createIndexedDBStorage } from './persistence';
@@ -55,6 +57,10 @@ export interface InventoryStore extends CrudStore<InventoryItem> {
   getCharacterItems: (characterId: EntityID) => InventoryItem[];
   clearCharacterInventory: (characterId: EntityID) => void;
   useItem: (characterId: EntityID, itemId: EntityID) => ItemUsageResult;
+  toggleEquipItem: (
+    characterId: EntityID,
+    itemId: EntityID
+  ) => ItemEquipResult;
 
   // Image generation tracking
   setGeneratingImage: (itemId: EntityID, isGenerating: boolean) => void;
@@ -418,6 +424,10 @@ export const useInventoryStore = create<InventoryStore>()(
 
           if ('image' in updates) {
             normalizedUpdates.image = updates.image;
+          }
+
+          if ('equipped' in updates) {
+            normalizedUpdates.equipped = updates.equipped;
           }
 
           const now = getTimestamp();
@@ -972,6 +982,76 @@ export const useInventoryStore = create<InventoryStore>()(
             wasConsumed,
             remainingQuantity,
             previousQuantity,
+          };
+        },
+
+        toggleEquipItem: (characterId, itemId) => {
+          const state = get();
+          const item = state.items[itemId];
+
+          if (!item) {
+            const error = createStoreError(
+              'Item Not Found',
+              'The specified item could not be found.',
+              ErrorType.VALIDATION
+            );
+            set({ error });
+            return {
+              success: false,
+              error: {
+                type: error.type,
+                title: error.title,
+                message: error.message,
+              },
+            };
+          }
+
+          const characterItems = ensureCharacterInventory(characterId, state);
+          if (!characterItems.includes(itemId)) {
+            const error = createStoreError(
+              'Item Not In Inventory',
+              "The specified item is not in this character's inventory.",
+              ErrorType.VALIDATION
+            );
+            set({ error });
+            return {
+              success: false,
+              error: {
+                type: error.type,
+                title: error.title,
+                message: error.message,
+              },
+            };
+          }
+
+          // Unequipping is always allowed; equipping is gated by compatibility.
+          const nextEquipped = !item.equipped;
+          if (nextEquipped) {
+            const eligibility = canEquipItem(item);
+            if (!eligibility.allowed) {
+              const error = createStoreError(
+                'Cannot Equip Item',
+                eligibility.reason ?? 'This item cannot be equipped.',
+                ErrorType.VALIDATION
+              );
+              set({ error });
+              return {
+                success: false,
+                equipped: item.equipped ?? false,
+                error: {
+                  type: error.type,
+                  title: error.title,
+                  message: error.message,
+                },
+              };
+            }
+          }
+
+          get().update(itemId, { equipped: nextEquipped });
+
+          return {
+            success: true,
+            equipped: nextEquipped,
           };
         },
       };

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -1710,6 +1710,37 @@ body.manuscript-overlay-open {
   border-color: var(--color-border-strong);
 }
 
+/* Equipped items get a distinct accent border + tinted surface so the state
+   reads instantly without relying on color alone (paired with the badge below). */
+.manuscript-inventory-item.is-equipped {
+  border-color: var(--color-accent);
+  border-left-width: 3px;
+  background: var(--color-accent-soft);
+}
+
+.manuscript-inventory-item-equipped-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  align-self: flex-start;
+  margin-bottom: var(--space-2);
+  padding: var(--space-0_5) var(--space-2);
+  font-family: var(--font-system);
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-sm);
+}
+
+.manuscript-inventory-item-equipped-badge svg {
+  width: 1em;
+  height: 1em;
+}
+
 .manuscript-inventory-item-header {
   display: flex;
   justify-content: space-between;

--- a/src/types/archetype.types.ts
+++ b/src/types/archetype.types.ts
@@ -1,5 +1,7 @@
 // src/types/archetype.types.ts
 
+import type { InventoryItemInput } from './inventory.types';
+
 /**
  * Interface representing a character archetype.
  * Used for quick-start character generation and templates.
@@ -26,4 +28,6 @@ export interface CharacterArchetype {
     fears: string[];
     physicalDescription?: string;
   };
+  /** Archetype-appropriate equipment the character starts with. */
+  startingInventory?: InventoryItemInput[];
 }

--- a/src/types/inventory.types.ts
+++ b/src/types/inventory.types.ts
@@ -46,6 +46,7 @@ export type InventoryAcquisitionMethod =
   | 'reward'
   | 'gift'
   | 'manual'
+  | 'starting-equipment'
   | 'unknown';
 
 export interface InventoryAcquisitionRecord {
@@ -82,6 +83,35 @@ export interface InventoryItem extends NamedEntity, TimestampedEntity {
   acquisitionHistory: InventoryAcquisitionRecord[];
   categorization: InventoryItemCategorization;
   image?: GeneratedImage; // AI-generated visual asset for the item
+  equipped?: boolean; // Whether the item is currently equipped (undefined === not equipped)
+}
+
+/**
+ * Lightweight declaration of a starting inventory item, used by character
+ * archetypes/templates to seed a freshly created character's inventory.
+ * Timestamps, IDs, and acquisition metadata are filled in when the item is added.
+ */
+export interface InventoryItemInput {
+  name: string;
+  description?: string;
+  categoryId: StandardInventoryCategory;
+  quantity?: number;
+  stackable?: boolean;
+  maxStack?: number;
+  equipped?: boolean;
+}
+
+/**
+ * Result of attempting to equip or unequip an item.
+ */
+export interface ItemEquipResult {
+  success: boolean;
+  equipped?: boolean;
+  error?: {
+    type: string;
+    title: string;
+    message: string;
+  };
 }
 
 /**


### PR DESCRIPTION
## Description
Closes the inventory loop from #1298: characters start outfitted, players can equip and unequip gear, and equipped items carry an indicator you can read at a glance. Bundles the old equip/unequip/indicator trio (#242/#243/#244) and starting inventory (#999) — they all touch the same store and share an `equipped` flag.

## Related Issue
Closes #1298 (bundles #242 / #243 / #244 / #999). Merges to `develop`, so `Closes` won't auto-close — close manually after merge.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
As a player, I want my character to start with appropriate equipment and to be able to equip and unequip items with a clear visual indicator, so I can begin outfitted, change loadout mid-game, and see what's active without digging through menus. (#1298)

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

## Implementation Notes
**Starting inventory**
- Each archetype template carries a `startingInventory` (Warrior gets a Steel Sword + Health Potions, Mage a Spellbook + Mana Potion, and so on across every genre). The field rides along on the generated `CharacterArchetype`, so it's stable per world.
- Both creation paths seed it: the wizard's `finalizeCharacterCreation` (looking up the selected quick-start template) and the quick-start selection on the create page. Items get a new `starting-equipment` acquisition method so journal/timeline views can tell them apart from loot.
- A small `applyStartingInventory` helper does the seeding and equips anything flagged `equipped`.

**Equip / unequip / indicator**
- Inventory items gain an optional `equipped` flag and a `toggleEquipItem` store action. Equipping is gated by category — only equipment and personal items are equippable, anything else is blocked with a clear message (rule lives in `lib/inventory/equippable.ts`). State persists through the store's existing partialize, so it survives a reload.
- `InventoryList` renders an Equip/Unequip control on equippable items and an equipped badge. The indicator isn't color alone: accent left-border + tinted surface on the card, plus a badge with an "Equipped" label and a shield icon. All on design tokens — verified in a live browser that the computed styles resolve to the active theme's accent.
- The narrative engine now reads equipped state from the canonical inventory store (it was reading a character snapshot that never got populated), so what's equipped actually reaches the AI context — which already knew how to render `[Equipped]`.

## Testing Instructions
1. Create a character via the wizard or a quick-start archetype → confirm it starts with that archetype's items, tagged as starting equipment.
2. In the inventory, equip an equippable item → the Equip control flips to Unequip and the equipped badge (accent border + tinted surface + shield) appears; reload and confirm it persists.
3. Try equipping a non-equippable item → blocked with a clear message; confirm the control is hidden for items outside the equippable categories.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed
- [ ] No console.log statements in production code
- [ ] No unhandled promises

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
