### PR TITLE
Restore a game session after an unexpected browser closure (#221)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,9 @@
 /* Character development suggestions panel (character creation wizard) */
 @import url('../styles/character-suggestions.css');
 
+/* Crash-recovery prompt (restore a session after an unexpected closure) */
+@import url('../styles/session-recovery.css');
+
 /* Skip link - visually hidden until focused (accessibility) */
 a[href="#main-content"] {
   position: absolute;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,6 +23,7 @@ import '@/lib/theme/themes/ds3.css';
 import { DevToolsProvider } from '@/components/devtools';
 import { ClientOnlyDevTools } from '@/components/ClientOnlyDevTools';
 import { AppSurfaceShell } from '@/components/layout/AppSurfaceShell';
+import { SessionRecoveryManager } from '@/components/GameSession/SessionRecoveryManager';
 import { NavigationLoadingProvider } from '@/components/shared/NavigationLoadingProvider';
 import { SkipLinks } from '@/components/shared/SkipLinks';
 import { ToastProvider, Toaster } from '@/components/ui/toast';
@@ -139,6 +140,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
                   <AppSurfaceShell>
                     {children}
                   </AppSurfaceShell>
+                  <SessionRecoveryManager />
                   <ClientOnlyDevTools />
                   <Toaster />
                 </TutorialProvider>

--- a/src/components/GameSession/GameSessionRecoveryPrompt.tsx
+++ b/src/components/GameSession/GameSessionRecoveryPrompt.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+import { RotateCcw } from 'lucide-react';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { formatRelativeTime } from '@/lib/utils';
+
+interface GameSessionRecoveryPromptProps {
+  isOpen: boolean;
+  worldName: string;
+  characterName: string;
+  /** ISO timestamp of the last activity before the session ended abnormally. */
+  lastActivity: string;
+  narrativeCount: number;
+  onRestore: () => void;
+  onDismiss: () => void;
+}
+
+/**
+ * Recovery prompt shown when a previous game session ended unexpectedly
+ * (browser crash, tab killed). Offers to restore the auto-saved session or to
+ * step away and start fresh (issue #221).
+ *
+ * Built on the Radix dialog primitives directly — with its own scoped overlay
+ * and surface classes — so it presents as a centered modal with its own focus
+ * trap and scrim, rather than inheriting the shared modal's in-flow rendering.
+ */
+export function GameSessionRecoveryPrompt({
+  isOpen,
+  worldName,
+  characterName,
+  lastActivity,
+  narrativeCount,
+  onRestore,
+  onDismiss,
+}: GameSessionRecoveryPromptProps) {
+  const relativeTime = formatRelativeTime(lastActivity);
+  const continueButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Lead with the primary action for keyboard users.
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const timer = setTimeout(() => continueButtonRef.current?.focus(), 80);
+    return () => clearTimeout(timer);
+  }, [isOpen]);
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onDismiss();
+        }
+      }}
+    >
+      <DialogContent
+        className="game-session-recovery-modal"
+        overlayClassName="game-session-recovery-scrim"
+        overlayScroll
+        showCloseButton={false}
+        aria-describedby="game-session-recovery-desc"
+      >
+        <div className="game-session-recovery-prompt">
+          <div className="game-session-recovery-prompt-icon" aria-hidden="true">
+            <RotateCcw />
+          </div>
+          <div className="game-session-recovery-prompt-body">
+            <DialogTitle className="game-session-recovery-prompt-title">
+              Welcome back — pick up where you left off?
+            </DialogTitle>
+            <p
+              id="game-session-recovery-desc"
+              className="game-session-recovery-prompt-lead"
+            >
+              Your last session ended before you could save your spot. Don&apos;t
+              worry — your story was kept safe. Jump back in right where you left
+              off.
+            </p>
+            <dl className="game-session-recovery-prompt-details">
+              <div className="game-session-recovery-prompt-detail">
+                <dt>World</dt>
+                <dd>{worldName}</dd>
+              </div>
+              <div className="game-session-recovery-prompt-detail">
+                <dt>Character</dt>
+                <dd>{characterName}</dd>
+              </div>
+              {narrativeCount > 0 && (
+                <div className="game-session-recovery-prompt-detail">
+                  <dt>Progress</dt>
+                  <dd>
+                    {narrativeCount} {narrativeCount === 1 ? 'scene' : 'scenes'}
+                  </dd>
+                </div>
+              )}
+              <div className="game-session-recovery-prompt-detail">
+                <dt>Last played</dt>
+                <dd>{relativeTime}</dd>
+              </div>
+            </dl>
+            <div className="game-session-recovery-prompt-actions">
+              <Button
+                variant="outline"
+                onClick={onDismiss}
+                aria-label="Dismiss recovery and start fresh"
+              >
+                Start fresh
+              </Button>
+              <Button
+                ref={continueButtonRef}
+                variant="default"
+                onClick={onRestore}
+                aria-label="Continue your recovered adventure"
+              >
+                Continue adventure
+              </Button>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/GameSession/SessionRecoveryManager.tsx
+++ b/src/components/GameSession/SessionRecoveryManager.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import React from 'react';
+import { useSessionRecovery } from '@/hooks/useSessionRecovery';
+import { useWorldStore } from '@/state/worldStore';
+import { useCharacterStore } from '@/state/characterStore';
+import { GameSessionRecoveryPrompt } from './GameSessionRecoveryPrompt';
+
+/**
+ * Watches for a session that ended abnormally and surfaces the recovery prompt
+ * anywhere in the app, since a crash can drop the player on any page (issue #221).
+ * Mounted once at the app shell level.
+ */
+export function SessionRecoveryManager() {
+  const { recovery, restore, dismiss } = useSessionRecovery();
+
+  const worldName = useWorldStore((state) =>
+    recovery ? state.worlds[recovery.worldId]?.name : undefined
+  );
+  const characterName = useCharacterStore((state) =>
+    recovery ? state.characters[recovery.characterId]?.name : undefined
+  );
+
+  if (!recovery) {
+    return null;
+  }
+
+  return (
+    <GameSessionRecoveryPrompt
+      isOpen
+      worldName={worldName ?? 'your world'}
+      characterName={characterName ?? 'your character'}
+      lastActivity={recovery.lastActivity}
+      narrativeCount={recovery.narrativeCount}
+      onRestore={restore}
+      onDismiss={dismiss}
+    />
+  );
+}

--- a/src/components/GameSession/__tests__/GameSessionRecoveryPrompt.test.tsx
+++ b/src/components/GameSession/__tests__/GameSessionRecoveryPrompt.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GameSessionRecoveryPrompt } from '../GameSessionRecoveryPrompt';
+
+// Sidestep the Radix Dialog portal/focus-trap — assert against the content.
+jest.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div role="dialog">{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}));
+
+const baseProps = {
+  isOpen: true,
+  worldName: 'Aetheria',
+  characterName: 'Kael',
+  lastActivity: new Date(Date.now() - 3 * 60 * 1000).toISOString(),
+  narrativeCount: 4,
+  onRestore: jest.fn(),
+  onDismiss: jest.fn(),
+};
+
+describe('GameSessionRecoveryPrompt (issue #221)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('presents the recovered session details and recovery options', () => {
+    render(<GameSessionRecoveryPrompt {...baseProps} />);
+
+    expect(screen.getByText('Aetheria')).toBeInTheDocument();
+    expect(screen.getByText('Kael')).toBeInTheDocument();
+    expect(screen.getByText('4 scenes')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /continue your recovered adventure/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /dismiss recovery and start fresh/i })
+    ).toBeInTheDocument();
+  });
+
+  it('restores when the player chooses to continue', async () => {
+    const user = userEvent.setup();
+    render(<GameSessionRecoveryPrompt {...baseProps} />);
+
+    await user.click(
+      screen.getByRole('button', { name: /continue your recovered adventure/i })
+    );
+
+    expect(baseProps.onRestore).toHaveBeenCalledTimes(1);
+    expect(baseProps.onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('dismisses when the player chooses to start fresh', async () => {
+    const user = userEvent.setup();
+    render(<GameSessionRecoveryPrompt {...baseProps} />);
+
+    await user.click(
+      screen.getByRole('button', { name: /dismiss recovery and start fresh/i })
+    );
+
+    expect(baseProps.onDismiss).toHaveBeenCalledTimes(1);
+    expect(baseProps.onRestore).not.toHaveBeenCalled();
+  });
+
+  it('omits the progress row when no scenes were recorded', () => {
+    render(<GameSessionRecoveryPrompt {...baseProps} narrativeCount={0} />);
+    expect(screen.queryByText(/scene/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/GameSession/hooks/useGameSessionState.ts
+++ b/src/components/GameSession/hooks/useGameSessionState.ts
@@ -234,11 +234,15 @@ export const useGameSessionState = ({
     // Get current store state to check for existing session
     const currentStoreState = useSessionStore.getState();
     
-    // If store already has an active session that matches our requirements, don't initialize
+    // If store already has an active session that matches our requirements, don't
+    // re-initialize — but re-arm the crash-recovery marker. A clean refresh clears
+    // it on pagehide, and this remount path skips initializeSession/resumeSavedSession,
+    // so without this a crash before the next save would leave no marker (issue #221).
     if (!disableAutoResume &&
         currentStoreState.status === 'active' &&
         currentStoreState.worldId === worldId &&
         currentStoreState.characterId === sessionCharacterId) {
+      currentStoreState.refreshRecoveryMarker?.();
       return;
     }
     

--- a/src/hooks/__tests__/useAutoSave.test.ts
+++ b/src/hooks/__tests__/useAutoSave.test.ts
@@ -51,6 +51,7 @@ const mockSessionStore: SessionStore = {
   },
   initializeSession: jest.fn(),
   endSession: jest.fn(),
+  refreshRecoveryMarker: jest.fn(),
   setStatus: jest.fn(),
   setError: jest.fn(),
   setPlayerChoices: jest.fn(),

--- a/src/hooks/__tests__/useSessionRecovery.test.ts
+++ b/src/hooks/__tests__/useSessionRecovery.test.ts
@@ -1,0 +1,89 @@
+import { renderHook, act } from '@testing-library/react';
+import { useRouter } from 'next/navigation';
+import { useSessionRecovery } from '../useSessionRecovery';
+import {
+  writeRecoveryMarker,
+  readRecoveryMarker,
+} from '@/lib/utils/sessionRecoveryMarker';
+
+const mockPush = jest.fn();
+
+// Control the recovered narrative count without spinning up the real store.
+jest.mock('@/state/narrativeStore', () => ({
+  useNarrativeStore: {
+    getState: () => ({
+      getSessionSegments: (sessionId: string) =>
+        sessionId === 'session-crashed' ? [{}, {}, {}] : [],
+    }),
+  },
+}));
+
+const crashMarker = {
+  sessionId: 'session-crashed',
+  worldId: 'world-1',
+  characterId: 'character-1',
+  lastActivity: '2026-05-28T12:00:00.000Z',
+};
+
+describe('useSessionRecovery (issue #221)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    mockPush.mockClear();
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
+  });
+
+  it('surfaces recovery when an abnormal-exit marker survives', () => {
+    // Simulate a crash: the previous run left its live-session marker behind.
+    writeRecoveryMarker(crashMarker);
+
+    const { result } = renderHook(() => useSessionRecovery());
+
+    expect(result.current.recovery).toEqual({
+      sessionId: 'session-crashed',
+      worldId: 'world-1',
+      characterId: 'character-1',
+      lastActivity: '2026-05-28T12:00:00.000Z',
+      narrativeCount: 3,
+    });
+  });
+
+  it('does not surface recovery after a clean exit (no marker)', () => {
+    const { result } = renderHook(() => useSessionRecovery());
+    expect(result.current.recovery).toBeNull();
+  });
+
+  it('restore routes back into the recovered session', () => {
+    writeRecoveryMarker(crashMarker);
+    const { result } = renderHook(() => useSessionRecovery());
+
+    act(() => {
+      result.current.restore();
+    });
+
+    expect(mockPush).toHaveBeenCalledWith('/worlds/world-1/play');
+    expect(result.current.recovery).toBeNull();
+  });
+
+  it('dismiss clears the marker and hides the prompt', () => {
+    writeRecoveryMarker(crashMarker);
+    const { result } = renderHook(() => useSessionRecovery());
+
+    act(() => {
+      result.current.dismiss();
+    });
+
+    expect(readRecoveryMarker()).toBeNull();
+    expect(result.current.recovery).toBeNull();
+  });
+
+  it('clears the marker on a graceful unload so a refresh is not seen as a crash', () => {
+    writeRecoveryMarker(crashMarker);
+    renderHook(() => useSessionRecovery());
+
+    act(() => {
+      window.dispatchEvent(new Event('pagehide'));
+    });
+
+    expect(readRecoveryMarker()).toBeNull();
+  });
+});

--- a/src/hooks/useSessionRecovery.ts
+++ b/src/hooks/useSessionRecovery.ts
@@ -1,0 +1,118 @@
+'use client';
+
+/**
+ * useSessionRecovery — detects a session that ended abnormally and offers to
+ * restore it (issue #221).
+ *
+ * A surviving recovery marker (see sessionRecoveryMarker) means the previous run
+ * never shut down cleanly. The persisted session + narrative state is already
+ * intact in IndexedDB, so "restore" just routes the player back into the live
+ * session; "dismiss" clears the marker and leaves the auto-saved progress untouched
+ * for the normal resume flow.
+ *
+ * The hook also clears the marker on a graceful unload, so a deliberate refresh
+ * or close isn't mistaken for a crash on the next load.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useNarrativeStore } from '@/state/narrativeStore';
+import {
+  clearRecoveryMarker,
+  readRecoveryMarker,
+} from '@/lib/utils/sessionRecoveryMarker';
+
+interface SessionRecoveryDetails {
+  sessionId: string;
+  worldId: string;
+  characterId: string;
+  /** ISO timestamp of the last recorded activity before the crash. */
+  lastActivity: string;
+  /** Number of narrative segments recovered for this session. */
+  narrativeCount: number;
+}
+
+export interface UseSessionRecoveryResult {
+  recovery: SessionRecoveryDetails | null;
+  restore: () => void;
+  dismiss: () => void;
+}
+
+const countSessionSegments = (sessionId: string): number => {
+  try {
+    return useNarrativeStore.getState().getSessionSegments(sessionId).length;
+  } catch {
+    return 0;
+  }
+};
+
+type NarrativePersistApi = {
+  hasHydrated?: () => boolean;
+  onFinishHydration?: (callback: () => void) => () => void;
+};
+
+const getNarrativePersistApi = (): NarrativePersistApi | undefined =>
+  (useNarrativeStore as unknown as { persist?: NarrativePersistApi }).persist;
+
+export function useSessionRecovery(): UseSessionRecoveryResult {
+  const router = useRouter();
+  const [recovery, setRecovery] = useState<SessionRecoveryDetails | null>(null);
+
+  useEffect(() => {
+    const marker = readRecoveryMarker();
+
+    let unsubscribeHydration: (() => void) | undefined;
+
+    if (marker) {
+      setRecovery({
+        sessionId: marker.sessionId,
+        worldId: marker.worldId,
+        characterId: marker.characterId,
+        lastActivity: marker.lastActivity,
+        narrativeCount: countSessionSegments(marker.sessionId),
+      });
+
+      // Narrative segments may still be rehydrating from IndexedDB; refresh the
+      // displayed count once hydration finishes.
+      const persistApi = getNarrativePersistApi();
+      if (persistApi?.onFinishHydration && !persistApi.hasHydrated?.()) {
+        unsubscribeHydration = persistApi.onFinishHydration(() => {
+          setRecovery((prev) =>
+            prev
+              ? { ...prev, narrativeCount: countSessionSegments(prev.sessionId) }
+              : prev
+          );
+        });
+      }
+    }
+
+    // A graceful refresh/close fires these; clearing the marker means the next
+    // load only sees it after a true crash.
+    const handleCleanExit = () => clearRecoveryMarker();
+    window.addEventListener('pagehide', handleCleanExit);
+    window.addEventListener('beforeunload', handleCleanExit);
+
+    return () => {
+      window.removeEventListener('pagehide', handleCleanExit);
+      window.removeEventListener('beforeunload', handleCleanExit);
+      unsubscribeHydration?.();
+    };
+  }, []);
+
+  const restore = useCallback(() => {
+    const target = recovery;
+    setRecovery(null);
+    if (target) {
+      // The persisted session is still active, so the play page resumes it.
+      router?.push(`/worlds/${target.worldId}/play`);
+    }
+  }, [recovery, router]);
+
+  const dismiss = useCallback(() => {
+    // Non-destructive: progress stays auto-saved and reachable via normal resume.
+    clearRecoveryMarker();
+    setRecovery(null);
+  }, []);
+
+  return { recovery, restore, dismiss };
+}

--- a/src/lib/utils/__tests__/sessionRecoveryMarker.test.ts
+++ b/src/lib/utils/__tests__/sessionRecoveryMarker.test.ts
@@ -1,0 +1,42 @@
+import {
+  writeRecoveryMarker,
+  readRecoveryMarker,
+  clearRecoveryMarker,
+  SessionRecoveryMarker,
+} from '../sessionRecoveryMarker';
+
+const marker: SessionRecoveryMarker = {
+  sessionId: 'session-1',
+  worldId: 'world-1',
+  characterId: 'character-1',
+  lastActivity: '2026-05-28T12:00:00.000Z',
+};
+
+describe('sessionRecoveryMarker', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('round-trips a written marker', () => {
+    writeRecoveryMarker(marker);
+    expect(readRecoveryMarker()).toEqual(marker);
+  });
+
+  it('returns null when no marker has been written (clean state)', () => {
+    expect(readRecoveryMarker()).toBeNull();
+  });
+
+  it('clears the marker so a clean exit is not seen as a crash', () => {
+    writeRecoveryMarker(marker);
+    clearRecoveryMarker();
+    expect(readRecoveryMarker()).toBeNull();
+  });
+
+  it('ignores malformed stored data', () => {
+    window.localStorage.setItem('narraitor-session-recovery', '{not json');
+    expect(readRecoveryMarker()).toBeNull();
+
+    window.localStorage.setItem('narraitor-session-recovery', JSON.stringify({ sessionId: 'x' }));
+    expect(readRecoveryMarker()).toBeNull();
+  });
+});

--- a/src/lib/utils/sessionRecoveryMarker.ts
+++ b/src/lib/utils/sessionRecoveryMarker.ts
@@ -1,0 +1,103 @@
+/**
+ * Session recovery marker — a synchronous localStorage "dirty bit" used to tell
+ * an abnormal session end (browser crash, tab killed, power loss) apart from a
+ * clean exit.
+ *
+ * While a session is live we write the marker on activation and on each
+ * save/heartbeat. A clean exit (endSession, or a deliberate refresh/close that
+ * fires pagehide) removes it. If the marker is still here on the next app load,
+ * the previous run never shut down cleanly — that's the crash signal that routes
+ * the player into recovery.
+ *
+ * localStorage is deliberate over the app's IndexedDB persistence: its
+ * reads/writes are synchronous, so the "clean exit" removal actually completes
+ * inside a pagehide handler, where an async IndexedDB write can't be awaited.
+ */
+
+const MARKER_KEY = 'narraitor-session-recovery';
+
+export interface SessionRecoveryMarker {
+  sessionId: string;
+  worldId: string;
+  characterId: string;
+  /** ISO timestamp of the last recorded activity in the session. */
+  lastActivity: string;
+}
+
+function isStorageAvailable(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  try {
+    const testKey = '__narraitor_recovery_test__';
+    window.localStorage.setItem(testKey, 'test');
+    window.localStorage.removeItem(testKey);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Record that a session is live (or refresh its last-activity timestamp).
+ */
+export function writeRecoveryMarker(marker: SessionRecoveryMarker): void {
+  if (!isStorageAvailable()) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(MARKER_KEY, JSON.stringify(marker));
+  } catch {
+    // Best-effort: quota/serialization failures shouldn't break gameplay.
+  }
+}
+
+/**
+ * Read the marker left by the previous run, if any. A non-null result means the
+ * last session was never cleanly closed.
+ */
+export function readRecoveryMarker(): SessionRecoveryMarker | null {
+  if (!isStorageAvailable()) {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(MARKER_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as Partial<SessionRecoveryMarker>;
+    if (
+      parsed &&
+      typeof parsed.sessionId === 'string' &&
+      typeof parsed.worldId === 'string' &&
+      typeof parsed.characterId === 'string' &&
+      typeof parsed.lastActivity === 'string'
+    ) {
+      return parsed as SessionRecoveryMarker;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Clear the marker. Called on a clean exit so the next load doesn't mistake a
+ * deliberate close for a crash.
+ */
+export function clearRecoveryMarker(): void {
+  if (!isStorageAvailable()) {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(MARKER_KEY);
+  } catch {
+    // Best-effort.
+  }
+}

--- a/src/state/__tests__/sessionStore.crashRecovery.test.ts
+++ b/src/state/__tests__/sessionStore.crashRecovery.test.ts
@@ -88,4 +88,24 @@ describe('sessionStore crash-recovery marker (issue #221)', () => {
     useSessionStore.getState().updateSavedSessionNarrativeCount('orphan-session', 1);
     expect(readRecoveryMarker()).toBeNull();
   });
+
+  it('re-arms the marker for an active session after a clean refresh cleared it', () => {
+    // A clean refresh fires pagehide and clears the marker, but the session is
+    // still live in the persisted store. Remounting the play surface skips
+    // activation, so refreshRecoveryMarker must re-arm it (issue #221).
+    activateSession('session-refreshed', 'world-1', 'character-1');
+    expect(readRecoveryMarker()).toBeNull(); // cleared by the refresh
+
+    useSessionStore.getState().refreshRecoveryMarker();
+
+    const marker = readRecoveryMarker();
+    expect(marker?.sessionId).toBe('session-refreshed');
+    expect(marker?.worldId).toBe('world-1');
+    expect(marker?.characterId).toBe('character-1');
+  });
+
+  it('refreshRecoveryMarker does not arm when no session is active', () => {
+    useSessionStore.getState().refreshRecoveryMarker();
+    expect(readRecoveryMarker()).toBeNull();
+  });
 });

--- a/src/state/__tests__/sessionStore.crashRecovery.test.ts
+++ b/src/state/__tests__/sessionStore.crashRecovery.test.ts
@@ -1,0 +1,91 @@
+import { useSessionStore } from '../sessionStore';
+import { readRecoveryMarker } from '@/lib/utils/sessionRecoveryMarker';
+
+jest.mock('@/lib/utils/logger', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  })),
+}));
+
+jest.mock('../persistence', () => ({
+  createIndexedDBStorage: () => ({
+    getItem: jest.fn().mockResolvedValue(null),
+    setItem: jest.fn().mockResolvedValue(undefined),
+    removeItem: jest.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+const resetSessionStore = () => {
+  useSessionStore.setState({
+    id: null,
+    status: 'initializing',
+    currentSceneId: null,
+    playerChoices: [],
+    error: null,
+    worldId: null,
+    characterId: null,
+    savedSessions: {},
+    sessionLifecycle: {},
+    templateHistory: [],
+    autoSave: {
+      enabled: true,
+      lastSaveTime: null,
+      status: 'idle',
+      errorMessage: null,
+      totalSaves: 0,
+    },
+    narrativeHeight: 600,
+  });
+};
+
+const activateSession = (sessionId: string, worldId: string, characterId: string) => {
+  useSessionStore.setState({
+    id: sessionId,
+    worldId,
+    characterId,
+    status: 'active',
+  });
+};
+
+describe('sessionStore crash-recovery marker (issue #221)', () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+    window.localStorage.clear();
+    resetSessionStore();
+  });
+
+  it('writes a recovery marker while a session is live (heartbeat)', () => {
+    // Simulate an active session, as if mid-play.
+    activateSession('session-live', 'world-1', 'character-1');
+
+    // A save/heartbeat fires as the story progresses.
+    useSessionStore.getState().updateSavedSessionNarrativeCount('session-live', 1);
+
+    const marker = readRecoveryMarker();
+    expect(marker).not.toBeNull();
+    expect(marker?.sessionId).toBe('session-live');
+    expect(marker?.worldId).toBe('world-1');
+    expect(marker?.characterId).toBe('character-1');
+    expect(marker?.lastActivity).toBeDefined();
+  });
+
+  it('clears the marker on a clean endSession so the next load does NOT trigger recovery', async () => {
+    activateSession('session-clean', 'world-1', 'character-1');
+    useSessionStore.getState().updateSavedSessionNarrativeCount('session-clean', 1);
+    expect(readRecoveryMarker()).not.toBeNull();
+
+    await useSessionStore.getState().endSession();
+
+    expect(readRecoveryMarker()).toBeNull();
+  });
+
+  it('does not write a marker for an inactive session', () => {
+    // No active session set: a stray count update must not arm recovery.
+    useSessionStore.getState().updateSavedSessionNarrativeCount('orphan-session', 1);
+    expect(readRecoveryMarker()).toBeNull();
+  });
+});

--- a/src/state/sessionStore.ts
+++ b/src/state/sessionStore.ts
@@ -8,6 +8,7 @@ import Logger from '@/lib/utils/logger';
 import { createIndexedDBStorage } from './persistence';
 import { formatSessionDuration, calculateNextSessionNumber } from '@/lib/utils/sessionUtils';
 import { getTimestamp } from '@/lib/utils/timestamp';
+import { writeRecoveryMarker, clearRecoveryMarker } from '@/lib/utils/sessionRecoveryMarker';
 
 /**
  * Create logger instance for this store
@@ -38,6 +39,25 @@ const buildLifecycleMetadata = (
   status: params.status ?? 'active',
   lastActivity: params.lastActivity ?? getTimestamp(),
 });
+
+/**
+ * Keep the crash-recovery marker in step with the live session. Only an active
+ * session with full world/character context is recoverable, so that's the only
+ * shape we record. Called on activation and on each save/heartbeat (issue #221).
+ */
+const syncRecoveryMarker = (
+  state: Pick<SessionStore, 'id' | 'status' | 'worldId' | 'characterId'>,
+  lastActivity: string
+): void => {
+  if (state.status === 'active' && state.id && state.worldId && state.characterId) {
+    writeRecoveryMarker({
+      sessionId: state.id,
+      worldId: state.worldId,
+      characterId: state.characterId,
+      lastActivity,
+    });
+  }
+};
 
 /**
  * Initial state for the session store
@@ -214,8 +234,11 @@ export const useSessionStore = create<SessionStore>()(
           }
         };
       });
-      
-      
+
+      // Mark the session live for crash recovery (issue #221)
+      syncRecoveryMarker(get(), activationTimestamp);
+
+
       // Create session start journal entry (Issue #176)
       try {
         // Cache imported store modules to avoid repeated dynamic imports
@@ -288,7 +311,11 @@ export const useSessionStore = create<SessionStore>()(
   endSession: async () => {
     const state = get();
     const lifecycleUpdateTime = getTimestamp();
-    
+
+    // Clean exit: drop the crash-recovery marker so the next load doesn't
+    // mistake this for an abnormal end (issue #221)
+    clearRecoveryMarker();
+
     if (state.id && state.worldId && state.characterId) {
       
       // Create session end journal entry (Issue #176)
@@ -523,6 +550,8 @@ export const useSessionStore = create<SessionStore>()(
           sessionLifecycle: nextLifecycle,
         };
       });
+      // Mark the resumed session live for crash recovery (issue #221)
+      syncRecoveryMarker(get(), activationTimestamp);
       return true;
     }
     return false;
@@ -637,6 +666,10 @@ export const useSessionStore = create<SessionStore>()(
         sessionLifecycle: nextLifecycle,
       };
     });
+
+    // Heartbeat: refresh the crash-recovery marker as the story progresses so a
+    // crash recovers state from at most a few minutes ago (issue #221)
+    syncRecoveryMarker(get(), getTimestamp());
   },
 
   upsertSessionLifecycle: (metadata: SessionLifecycleMetadata) => {

--- a/src/state/sessionStore.ts
+++ b/src/state/sessionStore.ts
@@ -307,6 +307,15 @@ export const useSessionStore = create<SessionStore>()(
     }
   },
 
+  // Re-arm the crash-recovery marker for the current live session without
+  // re-running activation. The play surface clears the marker on a clean
+  // refresh (pagehide), but remounting an already-active session skips
+  // initializeSession/resumeSavedSession — so without this, a crash in the
+  // window before the next save would leave no marker and no recovery (issue #221).
+  refreshRecoveryMarker: () => {
+    syncRecoveryMarker(get(), getTimestamp());
+  },
+
   // End the current session (save it instead of destroying)
   endSession: async () => {
     const state = get();

--- a/src/styles/session-recovery.css
+++ b/src/styles/session-recovery.css
@@ -1,0 +1,130 @@
+/* Game session crash-recovery prompt (issue #221).
+   Self-contained modal built on the Radix dialog primitives — owns its own
+   scrim and surface so it presents as a centered overlay. Tokens only, so the
+   three design-system themes restyle it for free. */
+
+.game-session-recovery-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-4);
+  overflow-y: auto;
+  background: var(--color-scrim);
+}
+
+.game-session-recovery-modal {
+  width: 100%;
+  max-width: 32rem;
+  padding: var(--space-5);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-overlay);
+}
+
+.game-session-recovery-prompt {
+  display: flex;
+  gap: var(--space-4);
+  align-items: flex-start;
+  text-align: left;
+}
+
+.game-session-recovery-prompt-icon {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: var(--space-8);
+  height: var(--space-8);
+  color: var(--color-info);
+  background: var(--info-muted);
+  border: 1px solid var(--info-border);
+  border-radius: var(--radius-full);
+}
+
+.game-session-recovery-prompt-icon svg {
+  width: var(--space-4);
+  height: var(--space-4);
+}
+
+.game-session-recovery-prompt-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.game-session-recovery-prompt-title {
+  margin: 0;
+  font-family: var(--font-interface);
+  font-size: 1.125rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--color-text-primary);
+}
+
+.game-session-recovery-prompt-lead {
+  margin: 0;
+  font-family: var(--font-interface);
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+}
+
+.game-session-recovery-prompt-details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-6);
+  margin: 0;
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-canvas);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.game-session-recovery-prompt-detail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-0_5);
+  min-width: 0;
+}
+
+.game-session-recovery-prompt-detail dt {
+  font-family: var(--font-system);
+  font-size: 0.6875rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.game-session-recovery-prompt-detail dd {
+  margin: 0;
+  font-family: var(--font-interface);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.game-session-recovery-prompt-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  justify-content: flex-end;
+  margin-top: var(--space-1);
+}
+
+@media (width <= 480px) {
+  .game-session-recovery-prompt {
+    flex-direction: column;
+  }
+
+  .game-session-recovery-prompt-actions {
+    justify-content: stretch;
+  }
+}

--- a/src/types/game.types.ts
+++ b/src/types/game.types.ts
@@ -91,6 +91,7 @@ export interface SessionStore {
   setCharacterId: (characterId: EntityID) => void;
   getSavedSession: (worldId: string, characterId: string) => SavedSessionInfo | undefined;
   resumeSavedSession: (sessionId: string) => boolean;
+  refreshRecoveryMarker: () => void;
   deleteSavedSession: (sessionId: string) => void;
   updateSavedSessionNarrativeCount: (sessionId: string, narrativeCount: number) => void;
   fixExistingSessionNarrativeCounts: () => Promise<void>;


### PR DESCRIPTION
## Description
Auto-save already persists session and narrative state to IndexedDB, but there was no recovery path when a session ended abnormally. If the browser crashed or the tab got killed mid-story, the player had to dig the session out of the saved list by hand — and nothing reassured them their progress was safe. This adds automatic crash detection and a transparent recovery prompt.

## Related Issue
Closes #221. Merges to `develop`, so `Closes` won't auto-close — close manually after merge.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
As a player, I want to recover from unexpected crashes without losing significant progress, so my story survives a browser crash or a killed tab. (#221)

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

## Implementation Notes
**The one tricky part.** Telling an *abnormal* end apart from a *clean* one — both leave the persisted state intact, so the persisted state alone can't tell you. So there's a small "live session" marker:
- On activation and on every save/heartbeat, `sessionStore` writes a marker (`sessionId`, `worldId`, `characterId`, `lastActivity`) to `localStorage`.
- A clean exit clears it: `endSession`, or a deliberate refresh/close caught via `pagehide`/`beforeunload`.
- If the marker survives to the next load, the previous run never shut down cleanly — that's the crash signal.

`localStorage` is deliberate over the app's IndexedDB persistence (which stays exactly as-is): its writes/removals are synchronous, so the clean-exit removal actually completes inside a `pagehide` handler, where an async IndexedDB write can't be awaited. That's what keeps a normal refresh from looking like a crash.

`SessionRecoveryManager` (mounted once in the app shell, since a crash can drop the player on any page) reads the marker on load and surfaces the prompt. **Restore** routes back into the still-intact persisted session. **Start fresh** is non-destructive — it just clears the marker and leaves the auto-saved progress reachable through the normal resume flow.

**UI.** The recovery prompt is built on the Radix dialog primitives directly, with its own scoped scrim and surface, so it presents as a proper centered modal. (The shared `SimpleModal`/`ConfirmationDialog` path currently renders in-flow — that looks like a pre-existing gap from the Tailwind removal, and restyling the shared modal felt out of scope here.) Styling is tokens only, so all three design-system themes restyle it for free.

## Testing Instructions
1. Simulate a crash: with an active session, kill the tab so the live-session marker survives into a fresh load → the recovery prompt renders centered and on-token, showing world, character, last-played, and scene count.
2. Graceful reload: refresh normally → marker is cleared, no prompt appears.
3. "Start fresh": confirm it closes the prompt and clears the marker, and the auto-saved progress is still reachable through the normal resume flow; "Restore" routes back into the persisted active session + narrative.

(Verified live in the worktree dev server via isolated headless Chrome / CDP.)

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [ ] No console.log statements in production code
- [ ] No unhandled promises

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
