### PR TITLE
fix(design-system): render real Button/Badge in DS2 colour demo, drop DS3 dead CSS (#1276)

### DIFF
--- a/src/app/dev/design-system-2/DS2Page.tsx
+++ b/src/app/dev/design-system-2/DS2Page.tsx
@@ -6,6 +6,8 @@ import { useActiveSection } from '@/hooks/useActiveSection';
 import { SessionShowcase } from '../design-system/_ui/SessionShowcase';
 import { ComponentShowcase } from '../design-system/_ui/ComponentShowcase';
 import { OverlayShowcase } from '../design-system/_ui/OverlayShowcase';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import './design-system-2.css';
 
 // ─────────────────────────────────────────────────────────────────
@@ -287,27 +289,23 @@ export default function DesignSystem2Page() {
           <div className="ds2-reveal" style={{ marginBottom: '48px' }}>
             <div className="ds2-component-label">Olive Moss Accent</div>
             <div className="ds2-accent-demo">
-              <div className="ds2-accent-panel ds2-accent-panel-light">
-                <div style={{ fontFamily: 'var(--font-system)', fontSize: '10px', letterSpacing: '0.12em', textTransform: 'uppercase', marginBottom: '16px', color: '#9C8D7E', fontWeight: 600 }}>
+              <div className="ds2-accent-panel ds2-accent-panel-light" data-theme="ds2">
+                <div style={{ fontFamily: 'var(--font-system)', fontSize: '10px', letterSpacing: '0.12em', textTransform: 'uppercase', marginBottom: '16px', color: 'var(--color-text-muted)', fontWeight: 600 }}>
                   Light Mode — #7C8B6F (Olive Moss)
                 </div>
                 <p style={{ fontFamily: 'var(--font-narrative)', fontSize: '1.0625rem', lineHeight: 1.7, marginBottom: '16px' }}>
-                  The archivist gestured toward <span style={{ color: '#7C8B6F', textDecoration: 'underline', textDecorationThickness: '2px', textUnderlineOffset: '3px', fontWeight: 500 }}>The Chronicle of Collected Memories</span>, its moss-green binding soft against weathered pages.
+                  The archivist gestured toward <span style={{ color: 'var(--color-accent)', textDecoration: 'underline', textDecorationThickness: '2px', textUnderlineOffset: '3px', fontWeight: 500 }}>The Chronicle of Collected Memories</span>, its moss-green binding soft against weathered pages.
                 </p>
-                <button type="button" style={{ padding: '10px 20px', background: '#7C8B6F', color: 'white', border: 'none', borderRadius: '8px', fontFamily: 'var(--font-interface)', fontSize: '0.875rem', fontWeight: 600, cursor: 'default' }}>
-                  Open Chronicle
-                </button>
+                <Button className="ds2-accent-button">Open Chronicle</Button>
               </div>
-              <div className="ds2-accent-panel ds2-accent-panel-dark">
-                <div style={{ fontFamily: 'var(--font-system)', fontSize: '10px', letterSpacing: '0.12em', textTransform: 'uppercase', marginBottom: '16px', color: '#9C8D7E', fontWeight: 600 }}>
+              <div className="ds2-accent-panel ds2-accent-panel-dark dark" data-theme="ds2">
+                <div style={{ fontFamily: 'var(--font-system)', fontSize: '10px', letterSpacing: '0.12em', textTransform: 'uppercase', marginBottom: '16px', color: 'var(--color-text-muted)', fontWeight: 600 }}>
                   Dark Mode — #9CAA8A (Lighter Moss)
                 </div>
                 <p style={{ fontFamily: 'var(--font-narrative)', fontSize: '1.0625rem', lineHeight: 1.7, marginBottom: '16px' }}>
-                  The archivist gestured toward <span style={{ color: '#9CAA8A', textDecoration: 'underline', textDecorationThickness: '2px', textUnderlineOffset: '3px', fontWeight: 500 }}>The Chronicle of Collected Memories</span>, its moss-green binding soft against weathered pages.
+                  The archivist gestured toward <span style={{ color: 'var(--color-accent)', textDecoration: 'underline', textDecorationThickness: '2px', textUnderlineOffset: '3px', fontWeight: 500 }}>The Chronicle of Collected Memories</span>, its moss-green binding soft against weathered pages.
                 </p>
-                <button type="button" style={{ padding: '10px 20px', background: '#9CAA8A', color: '#1A1614', border: 'none', borderRadius: '8px', fontFamily: 'var(--font-interface)', fontSize: '0.875rem', fontWeight: 600, cursor: 'default' }}>
-                  Open Chronicle
-                </button>
+                <Button className="ds2-accent-button">Open Chronicle</Button>
               </div>
             </div>
           </div>
@@ -315,18 +313,18 @@ export default function DesignSystem2Page() {
           {/* Semantic colors in narrative context */}
           <div className="ds2-reveal">
             <div className="ds2-component-label">Semantic Colors — In Context</div>
-            <div style={{ fontFamily: 'var(--font-narrative)', fontSize: '1.125rem', lineHeight: 1.7, color: 'var(--color-text-primary)', maxWidth: '700px' }}>
+            <div data-theme="ds2" style={{ fontFamily: 'var(--font-narrative)', fontSize: '1.125rem', lineHeight: 1.7, color: 'var(--color-text-primary)', maxWidth: '700px' }}>
               <p style={{ marginBottom: '16px' }}>
                 The curator examined each scroll carefully, marking verified histories with a gentle stamp:{' '}
-                <span style={{ display: 'inline-flex', alignItems: 'center', borderRadius: 9999, padding: '3px 12px', fontSize: '0.8125rem', fontWeight: 600, fontFamily: 'var(--font-interface)', background: 'rgba(6, 95, 70, 0.12)', color: '#065f46' }}>Verified</span>.
+                <Badge variant="success-static" className="ds2-semantic-badge">Verified</Badge>.
                 Questionable accounts received a cautious note{' '}
-                <span style={{ display: 'inline-flex', alignItems: 'center', borderRadius: 9999, padding: '3px 12px', fontSize: '0.8125rem', fontWeight: 600, fontFamily: 'var(--font-interface)', background: 'rgba(146, 64, 14, 0.12)', color: '#92400e' }}>Needs review</span>,
+                <Badge variant="warning-static" className="ds2-semantic-badge">Needs review</Badge>,
                 while lost narratives were sealed away{' '}
-                <span style={{ display: 'inline-flex', alignItems: 'center', borderRadius: 9999, padding: '3px 12px', fontSize: '0.8125rem', fontWeight: 600, fontFamily: 'var(--font-interface)', background: 'rgba(159, 18, 57, 0.12)', color: '#9f1239' }}>Incomplete</span>.
+                <Badge variant="destructive-static" className="ds2-semantic-badge">Incomplete</Badge>.
               </p>
               <p>
                 A small notation in warm ink read:{' '}
-                <span style={{ display: 'inline-flex', alignItems: 'center', borderRadius: 9999, padding: '3px 12px', fontSize: '0.8125rem', fontWeight: 600, fontFamily: 'var(--font-interface)', background: 'rgba(7, 89, 133, 0.12)', color: '#075985' }}>5 stories awaiting classification</span>.
+                <Badge variant="info-static" className="ds2-semantic-badge">5 stories awaiting classification</Badge>.
               </p>
             </div>
           </div>

--- a/src/app/dev/design-system-2/design-system-2.css
+++ b/src/app/dev/design-system-2/design-system-2.css
@@ -505,13 +505,13 @@
 }
 
 .ds2-accent-panel-light {
-  background: #FFFDF7;
-  color: #2D2520;
+  background: var(--color-surface);
+  color: var(--color-text-primary);
 }
 
 .ds2-accent-panel-dark {
-  background: #1A1614;
-  color: #F5F1E8;
+  background: var(--color-canvas);
+  color: var(--color-text-primary);
 }
 
 /* ── Contrast Cards ──────────────────────────────────────────── */

--- a/src/app/dev/design-system-3/design-system-3.css
+++ b/src/app/dev/design-system-3/design-system-3.css
@@ -1067,156 +1067,6 @@
   overflow-x: auto;
 }
 
-/* ═══════════════════════════════════════════════════════════════
-   GAME SESSION DEMO STYLES
-   ═══════════════════════════════════════════════════════════════ */
-
-.ds3-session {
-  position: relative;
-  background: var(--color-canvas);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  min-height: 700px;
-  overflow: hidden;
-}
-
-.ds3-session-grid {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background-image: radial-gradient(circle,
-      var(--grid-dot-color) calc(var(--grid-dot-size) / 2),
-      transparent calc(var(--grid-dot-size) / 2));
-  background-size: var(--grid-dot-spacing) var(--grid-dot-spacing);
-  opacity: var(--grid-dot-opacity);
-}
-
-/* ── Floating HUD — Character Stats ──────────────────────────── */
-.ds3-hud-char {
-  position: absolute;
-  top: 16px;
-  left: 16px;
-  z-index: 10;
-}
-
-.ds3-hud-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 16px;
-  background: var(--color-surface);
-  backdrop-filter: blur(var(--blur));
-  border: 1px solid var(--color-border);
-  border-radius: 9999px;
-  cursor: pointer;
-  transition: all 0.15s;
-  font-family: var(--font-system);
-  font-size: 13px;
-  color: var(--color-text-primary);
-  font-weight: 500;
-}
-
-.ds3-hud-pill:hover {
-  border-color: var(--color-accent);
-}
-
-.ds3-hud-panel {
-  width: 280px;
-  background: var(--color-surface);
-  backdrop-filter: blur(var(--blur));
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-float);
-  padding: 16px;
-  animation: ds3-fade-in 0.15s ease;
-}
-
-@keyframes ds3-fade-in {
-  from {
-    opacity: 0;
-    transform: translateY(-4px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.ds3-hud-name {
-  font-family: var(--font-interface);
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--color-text-primary);
-}
-
-.ds3-hud-level {
-  font-family: var(--font-system);
-  font-size: 10px;
-  color: var(--color-text-muted);
-  letter-spacing: 0.06em;
-}
-
-.ds3-hud-stat-row {
-  display: flex;
-  justify-content: space-between;
-  padding: 3px 0;
-}
-
-.ds3-hud-stat-label {
-  font-family: var(--font-system);
-  font-size: 13px;
-  color: var(--color-text-secondary);
-}
-
-.ds3-hud-stat-value {
-  font-family: var(--font-system);
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--color-text-primary);
-}
-
-.ds3-hud-location {
-  font-family: var(--font-interface);
-  font-size: 12px;
-  color: var(--color-text-secondary);
-  font-style: italic;
-}
-
-/* ── Floating HUD — Session Controls ─────────────────────────── */
-.ds3-hud-controls {
-  position: absolute;
-  top: 16px;
-  right: 16px;
-  z-index: 10;
-  display: flex;
-  gap: 2px;
-  background: var(--color-surface);
-  backdrop-filter: blur(var(--blur));
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  padding: 4px;
-}
-
-.ds3-hud-ctrl-btn {
-  width: 36px;
-  height: 36px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  border: none;
-  border-radius: var(--radius-md);
-  color: var(--color-text-secondary);
-  cursor: pointer;
-  transition: all 0.15s;
-}
-
-.ds3-hud-ctrl-btn:hover {
-  background: var(--color-accent-soft);
-  color: var(--color-accent);
-}
-
 /* ── Skip Link ───────────────────────────────────────────────── */
 .ds3-skip-link {
   position: absolute;
@@ -1301,10 +1151,6 @@
 
 /* ── True Marginalia — Desktop ───────────────────────────────── */
 @media (min-width: 1200px) {
-  .ds3-session {
-    overflow: visible;
-  }
-
   .ds3-narrative-col {
     overflow: visible;
   }
@@ -1533,29 +1379,6 @@
   }
 }
 
-/* ── Session State Overlays ──────────────────────────────────── */
-.ds3-overlay-frosted {
-  position: absolute;
-  inset: 0;
-  background: var(--color-surface);
-  backdrop-filter: blur(16px);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 16px;
-  z-index: 50;
-  border-radius: var(--radius-lg);
-}
-
-.ds3-overlay-frosted h3 {
-  font-family: var(--font-interface);
-  font-size: 20px;
-  font-weight: 500;
-  color: var(--color-text-primary);
-  margin: 0;
-}
-
 /* ── Loading Skeletons ───────────────────────────────────────── */
 .ds3-skeleton {
   height: 14px;
@@ -1611,13 +1434,6 @@
   border: 1px solid var(--color-border);
   vertical-align: middle;
   margin-right: 8px;
-}
-
-/* ── HUD Panel Demos ─────────────────────────────────────────── */
-.ds3-hud-demo {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 16px;
 }
 
 /* ── Responsive ──────────────────────────────────────────────── */


### PR DESCRIPTION
## Description

Last bit of residual drift for the DS showcase canon epic. The DS2 "colour" section was still hand-building its accent buttons and semantic pills with inline styles and hardcoded hex — the exact `#7C8B6F` / `#9CAA8A` the issue flagged at `:295/:308`. They now render the real `Button` and `Badge`, scoped under `data-theme="ds2"` (the dark panel also gets `.dark`) so the canonical tokens resolve and the dark panel genuinely shows the lighter-moss accent. The hex equals the tokens, so the colours don't move.

Also dropped a chunk of orphaned DS3 mockup CSS (`.ds3-session*`, `.ds3-hud-*`, `.ds3-overlay-frosted`) left over from before that section rendered the real `SessionShowcase`.

## Related Issue
Closes #1276

(Merging to `develop` won't auto-close it — I'll close it manually after merge.)

## Type of Change
- [x] Refactoring (code improvements without changing functionality)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Test addition or improvement

## Implementation Notes

The DS2 page root uses a parallel `.ds2` token scope that only defines a subset of tokens (it has `--color-accent` but not `--color-text-inverse` or the semantic badge tokens). The canonical tokens live under `[data-theme="ds2"]` / `[data-theme="ds2"].dark`. So the real components are scoped with `data-theme` — the same pattern `ComponentShowcase` already uses — which is what lets the dark panel resolve the lighter-moss accent (`rgb(156 170 138)` = `#9CAA8A`) without hardcoding it.

No visual baseline screenshots the DS2 colour section (the three DS-showcase specs capture scoped locators — `ds-components`, overlay, session), and the DS3 removals touch no rendered element, so no baseline regen was needed.

## Component Development
- [ ] Storybook stories created/updated — n/a (no new components; renders existing primitives)
- [x] Visual consistency verified — screenshotted the accent demo: olive Button in light, lighter-moss Button in dark

## Quality Checks
- [x] Linting passed (`stylelint`, `eslint`)
- [x] Type checking passed (page compiles + renders)
- [x] DS canon guard passed (`npm run lint:ds-canon`)
- [x] No console.log statements in production code

## Testing Instructions

1. `npm run dev`, open `/dev/design-system/2`, scroll to **Colour → Olive Moss Accent**.
2. Light panel: real Button in olive moss + olive underlined link. Dark panel: real Button in lighter moss on the dark canvas.
3. **Semantic Colors — In Context**: the four pills are real Badges (success / warning / destructive / info static variants).
4. `/dev/design-system/3` Session section renders unchanged.
5. Visual specs (no diff): `npx playwright test tests/visual/design-system-{components,overlay,session}.spec.ts --project=chromium` — 9/9 pass.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected
- [x] Self-review of code performed
- [x] No new warnings generated
- [x] Accessibility considerations addressed (real Button/Badge keep semantic markup)