### PR TITLE
feat(devtools): add TokenBudgetPanel for token budget observability (#1333)

### DIFF
--- a/src/components/devtools/DevToolsPanel/DevToolsPanel.tsx
+++ b/src/components/devtools/DevToolsPanel/DevToolsPanel.tsx
@@ -9,6 +9,7 @@ import { PortraitDebugSection } from '../PortraitDebugSection';
 import { EndingImageDebugSection } from '../EndingImageDebugSection';
 import { ConsistencyValidationSection } from '../ConsistencyValidationSection';
 import { LoreManagementSection } from '../LoreManagementSection';
+import { TokenBudgetPanel } from '../TokenBudgetPanel';
 import { AIMockingSection } from '../AIMockingSection';
 import { ErrorSection } from '../ErrorSection';
 import { DevToolsSection } from '../shared/DevToolsSection';
@@ -192,6 +193,7 @@ export const DevToolsPanel = () => {
               {(isSectionVisible(SectionId.AI_TESTING) ||
                 isSectionVisible(SectionId.AI_MOCKING) ||
                 isSectionVisible(SectionId.CONSISTENCY_VALIDATION) ||
+                isSectionVisible(SectionId.TOKEN_BUDGET) ||
                 isSectionVisible(SectionId.LORE_MANAGEMENT)) && (
                 <div>
                   <h3>
@@ -221,6 +223,12 @@ export const DevToolsPanel = () => {
                       <LoreManagementSection />
                     </CollapsibleSection>
                   )}
+
+                    {isSectionVisible(SectionId.TOKEN_BUDGET) && (
+                      <CollapsibleSection title="Token Budget" initialCollapsed={true}>
+                        <TokenBudgetPanel />
+                      </CollapsibleSection>
+                    )}
                 </div>
               </div>
             )}

--- a/src/components/devtools/TokenBudgetPanel/TokenBudgetPanel.css
+++ b/src/components/devtools/TokenBudgetPanel/TokenBudgetPanel.css
@@ -1,0 +1,117 @@
+/**
+ * TokenBudgetPanel (dev-only) styles.
+ * Token-driven; the four utilization levels map to semantic color tokens.
+ * No dedicated "orange" token exists, so the `high` level uses an hsl() literal.
+ */
+.token-budget-panel {
+  --tbp-ok: var(--color-success);
+  --tbp-warn: var(--color-warning);
+  --tbp-high: hsl(28deg 90% 48%);
+  --tbp-over: var(--color-danger);
+
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: 0.8125rem;
+}
+
+.token-budget-panel-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.5rem;
+  color: var(--color-text-muted);
+}
+
+.token-budget-panel-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+}
+
+.token-budget-panel-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.token-budget-panel-row-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.token-budget-panel-component {
+  font-weight: 600;
+  font-family: var(--font-mono, monospace);
+}
+
+.token-budget-panel-numbers {
+  margin-left: auto;
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.token-budget-panel-bar {
+  width: 100%;
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: var(--color-surface-muted, var(--color-border));
+  overflow: hidden;
+}
+
+.token-budget-panel-bar-fill {
+  height: 100%;
+  border-radius: 9999px;
+  transition: width 0.2s ease;
+}
+
+.token-budget-panel-bar-fill.is-ok {
+  background: var(--tbp-ok);
+}
+
+.token-budget-panel-bar-fill.is-warn {
+  background: var(--tbp-warn);
+}
+
+.token-budget-panel-bar-fill.is-high {
+  background: var(--tbp-high);
+}
+
+.token-budget-panel-bar-fill.is-over {
+  background: var(--tbp-over);
+}
+
+.token-budget-panel-suggestion {
+  margin: 0;
+  color: var(--color-danger);
+  font-size: 0.75rem;
+}
+
+.token-budget-panel-calibration {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.token-budget-panel-subheading {
+  margin: 0;
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+
+.token-budget-panel-calibration-figures {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.token-budget-panel-empty {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+}

--- a/src/components/devtools/TokenBudgetPanel/TokenBudgetPanel.tsx
+++ b/src/components/devtools/TokenBudgetPanel/TokenBudgetPanel.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { clsx } from 'clsx';
+import { Badge } from '@/components/ui/badge';
+import { useCalibrationStore } from '@/state/calibrationStore';
+import {
+  RequestBudget,
+  ComponentPriority,
+  DEFAULT_ALLOCATIONS,
+  DEFAULT_TOTAL_BUDGET,
+  type ComponentBudgetUsage,
+  type TokenBudgetSnapshot,
+} from '@/lib/promptContext/tokenBudgetManager';
+import './TokenBudgetPanel.css';
+
+type UtilizationLevel = 'ok' | 'warn' | 'high' | 'over';
+
+const PRIORITY_LABELS: Record<ComponentPriority, string> = {
+  [ComponentPriority.CRITICAL]: 'Critical',
+  [ComponentPriority.HIGH]: 'High',
+  [ComponentPriority.MEDIUM]: 'Medium',
+  [ComponentPriority.LOW]: 'Low',
+};
+
+/**
+ * Degradation guidance for an over-budget component, keyed by how aggressively
+ * the budget resolver drops it under pressure.
+ */
+const DEGRADATION_SUGGESTIONS: Record<ComponentPriority, string> = {
+  [ComponentPriority.CRITICAL]:
+    'Critical component — cannot be dropped; trim its source content to recover budget.',
+  [ComponentPriority.HIGH]:
+    'High priority — truncated only when budget is tight; consider trimming content.',
+  [ComponentPriority.MEDIUM]:
+    'Medium priority — degraded when budget runs low.',
+  [ComponentPriority.LOW]:
+    'Low priority — first to be dropped under budget pressure.',
+};
+
+const utilization = (estimated: number, allocation: number): number => {
+  if (allocation > 0) return estimated / allocation;
+  return estimated > 0 ? Infinity : 0;
+};
+
+const levelFor = (ratio: number): UtilizationLevel => {
+  if (ratio > 1) return 'over';
+  if (ratio >= 0.9) return 'high';
+  if (ratio >= 0.7) return 'warn';
+  return 'ok';
+};
+
+const formatTokens = (value: number): string => Math.round(value).toLocaleString();
+
+/**
+ * Resolve the default allocations (with zero usage) so the panel can show the
+ * budget allocation before any request has been captured.
+ */
+const buildFallbackSnapshot = (): TokenBudgetSnapshot =>
+  new RequestBudget(DEFAULT_ALLOCATIONS, DEFAULT_TOTAL_BUDGET, true).getSnapshot();
+
+const UsageRow = ({ component }: { component: ComponentBudgetUsage }) => {
+  const ratio = utilization(component.estimated, component.allocation);
+  const level = levelFor(ratio);
+  const isOver = level === 'over';
+  const fillPct = Number.isFinite(ratio) ? Math.min(100, ratio * 100) : 100;
+
+  return (
+    <div
+      className="token-budget-panel-row"
+      data-testid={`token-budget-row-${component.componentId}`}
+      data-level={level}
+    >
+      <div className="token-budget-panel-row-head">
+        <span className="token-budget-panel-component">{component.componentId}</span>
+        <Badge variant="outline-static" size="sm" className="token-budget-panel-priority">
+          {PRIORITY_LABELS[component.priority]}
+        </Badge>
+        {isOver && (
+          <Badge
+            variant="destructive-static"
+            size="sm"
+            data-testid={`token-budget-over-${component.componentId}`}
+          >
+            Over budget
+          </Badge>
+        )}
+        <span className="token-budget-panel-numbers">
+          {formatTokens(component.estimated)} / {formatTokens(component.allocation)}
+        </span>
+      </div>
+
+      <div className="token-budget-panel-bar" role="presentation">
+        <div
+          className={clsx('token-budget-panel-bar-fill', `is-${level}`)}
+          data-testid={`token-budget-bar-${component.componentId}`}
+          style={{ width: `${fillPct}%` }}
+        />
+      </div>
+
+      {isOver && (
+        <p
+          className="token-budget-panel-suggestion"
+          data-testid={`token-budget-suggestion-${component.componentId}`}
+        >
+          {DEGRADATION_SUGGESTIONS[component.priority]}
+        </p>
+      )}
+    </div>
+  );
+};
+
+const CalibrationSummary = ({
+  calibration,
+}: {
+  calibration: TokenBudgetSnapshot['calibration'];
+}) => {
+  const hasActual = typeof calibration.actual === 'number';
+
+  return (
+    <div className="token-budget-panel-calibration" data-testid="token-budget-calibration">
+      <h5 className="token-budget-panel-subheading">Estimate accuracy</h5>
+      {hasActual ? (
+        <div className="token-budget-panel-calibration-figures">
+          <span data-testid="token-budget-accuracy">
+            {calibration.accuracy !== undefined
+              ? `${calibration.accuracy.toFixed(2)}×`
+              : 'n/a'}
+          </span>
+          <span className="token-budget-panel-numbers">
+            actual {formatTokens(calibration.actual as number)} / estimated{' '}
+            {formatTokens(calibration.estimated)}
+          </span>
+        </div>
+      ) : (
+        <p
+          className="token-budget-panel-empty"
+          data-testid="token-budget-calibration-empty"
+        >
+          n/a until a provider token count is available (generate a narrative
+          segment with a live API key).
+        </p>
+      )}
+    </div>
+  );
+};
+
+/**
+ * TokenBudgetPanel
+ *
+ * Dev-only observability for the prompt token-budget system (#1333). Surfaces
+ * per-component allocation and usage bars, over-budget degradation guidance,
+ * and request-level estimate-vs-actual calibration captured after each
+ * narrative generation. Reads the latest snapshot from the calibration store
+ * and falls back to the static allocation config before any request is seen.
+ */
+export const TokenBudgetPanel = () => {
+  const snapshots = useCalibrationStore((state) => state.snapshots);
+
+  const { snapshot, isLive } = useMemo(() => {
+    const latest = snapshots.length > 0 ? snapshots[snapshots.length - 1] : null;
+    return latest
+      ? { snapshot: latest, isLive: true }
+      : { snapshot: buildFallbackSnapshot(), isLive: false };
+  }, [snapshots]);
+
+  return (
+    <div className="token-budget-panel" data-testid="devtools-token-budget-panel">
+      <div className="token-budget-panel-meta">
+        <span data-testid="token-budget-status">
+          {isLive ? 'Latest request' : 'No request captured yet — showing allocation config'}
+        </span>
+        <span className="token-budget-panel-numbers">
+          Total budget {formatTokens(snapshot.totalBudget)} ·{' '}
+          {snapshot.enabled ? 'enforcement on' : 'enforcement off'}
+        </span>
+      </div>
+
+      <div className="token-budget-panel-rows">
+        {snapshot.components.map((component) => (
+          <UsageRow key={component.componentId} component={component} />
+        ))}
+      </div>
+
+      <CalibrationSummary calibration={snapshot.calibration} />
+    </div>
+  );
+};

--- a/src/components/devtools/TokenBudgetPanel/__tests__/TokenBudgetPanel.test.tsx
+++ b/src/components/devtools/TokenBudgetPanel/__tests__/TokenBudgetPanel.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { TokenBudgetPanel } from '../TokenBudgetPanel';
+import { useCalibrationStore } from '@/state/calibrationStore';
+import {
+  ComponentPriority,
+  DEFAULT_ALLOCATIONS,
+  type TokenBudgetSnapshot,
+} from '@/lib/promptContext/tokenBudgetManager';
+
+jest.mock('@/state/calibrationStore', () => ({
+  useCalibrationStore: jest.fn(),
+}));
+
+const mockStore = useCalibrationStore as unknown as jest.Mock;
+
+/** Drive the panel with a fixed list of snapshots via the selector hook. */
+const withSnapshots = (snapshots: TokenBudgetSnapshot[]) => {
+  mockStore.mockImplementation((selector: (s: { snapshots: TokenBudgetSnapshot[] }) => unknown) =>
+    selector({ snapshots })
+  );
+};
+
+const sampleSnapshot: TokenBudgetSnapshot = {
+  enabled: true,
+  totalBudget: 80000,
+  components: [
+    // 0.5 -> ok
+    { componentId: 'base-template', priority: ComponentPriority.CRITICAL, allocation: 300, estimated: 150 },
+    // 0.75 -> warn
+    { componentId: 'goals', priority: ComponentPriority.HIGH, allocation: 300, estimated: 225 },
+    // 0.95 -> high
+    { componentId: 'lore-context', priority: ComponentPriority.MEDIUM, allocation: 800, estimated: 760 },
+    // 1.3 -> over
+    { componentId: 'examples', priority: ComponentPriority.LOW, allocation: 200, estimated: 260 },
+  ],
+  calibration: {
+    componentId: 'request-total',
+    estimated: 2000,
+    actual: 2200,
+    accuracy: 1.1,
+  },
+};
+
+describe('TokenBudgetPanel', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('renders a row per component from the latest snapshot', () => {
+    withSnapshots([sampleSnapshot]);
+    render(<TokenBudgetPanel />);
+
+    expect(screen.getByTestId('devtools-token-budget-panel')).toBeInTheDocument();
+    expect(screen.getByTestId('token-budget-status')).toHaveTextContent('Latest request');
+    for (const component of sampleSnapshot.components) {
+      expect(
+        screen.getByTestId(`token-budget-row-${component.componentId}`)
+      ).toBeInTheDocument();
+    }
+  });
+
+  it('colors usage bars by utilization threshold', () => {
+    withSnapshots([sampleSnapshot]);
+    render(<TokenBudgetPanel />);
+
+    expect(screen.getByTestId('token-budget-bar-base-template')).toHaveClass('is-ok');
+    expect(screen.getByTestId('token-budget-bar-goals')).toHaveClass('is-warn');
+    expect(screen.getByTestId('token-budget-bar-lore-context')).toHaveClass('is-high');
+    expect(screen.getByTestId('token-budget-bar-examples')).toHaveClass('is-over');
+  });
+
+  it('flags over-budget components with a degradation suggestion', () => {
+    withSnapshots([sampleSnapshot]);
+    render(<TokenBudgetPanel />);
+
+    expect(screen.getByTestId('token-budget-over-examples')).toBeInTheDocument();
+    expect(screen.getByTestId('token-budget-suggestion-examples')).toHaveTextContent(
+      /first to be dropped/i
+    );
+
+    // Components within budget carry no over-budget badge or suggestion.
+    expect(screen.queryByTestId('token-budget-over-base-template')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('token-budget-suggestion-base-template')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows calibration accuracy when an actual token count is present', () => {
+    withSnapshots([sampleSnapshot]);
+    render(<TokenBudgetPanel />);
+
+    expect(screen.getByTestId('token-budget-accuracy')).toHaveTextContent('1.10×');
+    expect(
+      screen.queryByTestId('token-budget-calibration-empty')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the calibration empty state when no actual is available', () => {
+    withSnapshots([
+      { ...sampleSnapshot, calibration: { estimated: 2000, actual: undefined } },
+    ]);
+    render(<TokenBudgetPanel />);
+
+    expect(screen.getByTestId('token-budget-calibration-empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('token-budget-accuracy')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the static allocation config when no request is captured', () => {
+    withSnapshots([]);
+    render(<TokenBudgetPanel />);
+
+    expect(screen.getByTestId('token-budget-status')).toHaveTextContent(
+      /No request captured yet/i
+    );
+    // Every configured component is shown from the default allocations.
+    for (const allocation of DEFAULT_ALLOCATIONS) {
+      expect(
+        screen.getByTestId(`token-budget-row-${allocation.componentId}`)
+      ).toBeInTheDocument();
+    }
+    expect(screen.getByTestId('token-budget-calibration-empty')).toBeInTheDocument();
+  });
+});

--- a/src/components/devtools/TokenBudgetPanel/index.ts
+++ b/src/components/devtools/TokenBudgetPanel/index.ts
@@ -1,0 +1,1 @@
+export { TokenBudgetPanel } from './TokenBudgetPanel';

--- a/src/lib/ai/__tests__/narrativeGenerator.calibration.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.calibration.test.ts
@@ -4,13 +4,18 @@
  * published to the calibration store. See #1333.
  */
 
-import { recordRequestCalibration } from '../narrativeGenerator.budget';
+import {
+  applyBudget,
+  limitNarrativeContextToBudget,
+  recordRequestCalibration,
+} from '../narrativeGenerator.budget';
 import {
   RequestBudget,
   DEFAULT_ALLOCATIONS,
   DEFAULT_TOTAL_BUDGET,
   REQUEST_TOTAL_COMPONENT_ID,
 } from '@/lib/promptContext/tokenBudgetManager';
+import type { NarrativeContext } from '@/types/narrative.types';
 
 const recordSnapshot = jest.fn();
 
@@ -59,5 +64,38 @@ describe('recordRequestCalibration', () => {
         (c: { componentId: string }) => c.componentId === REQUEST_TOTAL_COMPONENT_ID
       )
     ).toBe(false);
+  });
+});
+
+describe('measurement decoupled from enforcement (disabled budget)', () => {
+  it('applyBudget records the estimate but does not truncate when disabled', () => {
+    const budget = new RequestBudget(DEFAULT_ALLOCATIONS, DEFAULT_TOTAL_BUDGET, false);
+    const content = 'lore content that should not be truncated '.repeat(60);
+
+    const out = applyBudget(content, 'lore-context', budget);
+
+    expect(out).toBe(content); // untouched when enforcement is off
+    const lore = budget
+      .getSnapshot()
+      .components.find((c) => c.componentId === 'lore-context');
+    expect(lore?.estimated).toBeGreaterThan(0);
+  });
+
+  it('limitNarrativeContextToBudget records recent-narrative usage without dropping segments when disabled', () => {
+    const budget = new RequestBudget(DEFAULT_ALLOCATIONS, DEFAULT_TOTAL_BUDGET, false);
+    const context = {
+      recentSegments: [
+        { content: 'segment one '.repeat(80) },
+        { content: 'segment two '.repeat(80) },
+      ],
+    } as unknown as NarrativeContext;
+
+    const out = limitNarrativeContextToBudget(context, budget);
+
+    expect(out?.recentSegments).toHaveLength(2); // nothing dropped
+    const recent = budget
+      .getSnapshot()
+      .components.find((c) => c.componentId === 'recent-narrative');
+    expect(recent?.estimated).toBeGreaterThan(0);
   });
 });

--- a/src/lib/ai/__tests__/narrativeGenerator.calibration.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.calibration.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for the request-level calibration wiring: response.promptTokens fed
+ * into RequestBudget via recordUsage(..., { actualTokens }) and a snapshot
+ * published to the calibration store. See #1333.
+ */
+
+import { recordRequestCalibration } from '../narrativeGenerator.budget';
+import {
+  RequestBudget,
+  DEFAULT_ALLOCATIONS,
+  DEFAULT_TOTAL_BUDGET,
+  REQUEST_TOTAL_COMPONENT_ID,
+} from '@/lib/promptContext/tokenBudgetManager';
+
+const recordSnapshot = jest.fn();
+
+jest.mock('@/state/calibrationStore', () => ({
+  useCalibrationStore: {
+    getState: () => ({ recordSnapshot }),
+  },
+}));
+
+describe('recordRequestCalibration', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('feeds the provider prompt-token count as the actual for request-total', () => {
+    const budget = new RequestBudget(DEFAULT_ALLOCATIONS, DEFAULT_TOTAL_BUDGET, true);
+
+    recordRequestCalibration(budget, 'a fairly short prompt to estimate', {
+      promptTokens: 1500,
+    });
+
+    const calibration = budget.getCalibrationData(REQUEST_TOTAL_COMPONENT_ID);
+    expect(calibration.estimated).toBeGreaterThan(0);
+    expect(calibration.actual).toBe(1500);
+    expect(calibration.accuracy).toBeCloseTo(1500 / calibration.estimated);
+  });
+
+  it('records an estimate but no actual when the response omits promptTokens', () => {
+    const budget = new RequestBudget(DEFAULT_ALLOCATIONS, DEFAULT_TOTAL_BUDGET, true);
+
+    recordRequestCalibration(budget, 'prompt without token usage', {});
+
+    const calibration = budget.getCalibrationData(REQUEST_TOTAL_COMPONENT_ID);
+    expect(calibration.estimated).toBeGreaterThan(0);
+    expect(calibration.actual).toBeUndefined();
+  });
+
+  it('publishes a snapshot to the calibration store', () => {
+    const budget = new RequestBudget(DEFAULT_ALLOCATIONS, DEFAULT_TOTAL_BUDGET, true);
+
+    recordRequestCalibration(budget, 'prompt', { promptTokens: 900 });
+
+    expect(recordSnapshot).toHaveBeenCalledTimes(1);
+    const snapshot = recordSnapshot.mock.calls[0][0];
+    expect(snapshot.calibration.actual).toBe(900);
+    expect(
+      snapshot.components.some(
+        (c: { componentId: string }) => c.componentId === REQUEST_TOTAL_COMPONENT_ID
+      )
+    ).toBe(false);
+  });
+});

--- a/src/lib/ai/narrativeGenerator.budget.ts
+++ b/src/lib/ai/narrativeGenerator.budget.ts
@@ -2,6 +2,7 @@ import {
   RequestBudget,
   DEFAULT_ALLOCATIONS,
   DEFAULT_TOTAL_BUDGET,
+  REQUEST_TOTAL_COMPONENT_ID,
 } from '@/lib/promptContext/tokenBudgetManager';
 import {
   estimateTokenCount,
@@ -10,6 +11,7 @@ import {
 import type { NarrativeContext, NarrativeSegment } from '@/types/narrative.types';
 import { safeTrim } from '@/lib/utils';
 import { logger } from '@/lib/utils/logger';
+import { useCalibrationStore } from '@/state/calibrationStore';
 
 /** Fraction of a component's allocation above which we log an approaching-limit notice. */
 const APPROACHING_LIMIT_RATIO = 0.9;
@@ -24,11 +26,19 @@ export const applyBudget = (
   componentId: string,
   budget?: RequestBudget
 ): string => {
-  if (!budget || !budget.isEnabled()) {
+  if (!budget) {
     return content;
   }
 
   const estimatedTokens = estimateTokenCount(content);
+
+  // Measurement is decoupled from enforcement: when the budget is disabled we
+  // still record the estimate for observability, but never truncate or log.
+  if (!budget.isEnabled()) {
+    budget.recordUsage(componentId, estimatedTokens);
+    return content;
+  }
+
   const limit = budget.getAllocation(componentId);
 
   if (!Number.isFinite(limit) || limit <= 0) {
@@ -75,7 +85,19 @@ export const limitNarrativeContextToBudget = (
   narrativeContext: NarrativeContext | undefined,
   budget: RequestBudget
 ): NarrativeContext | undefined => {
-  if (!narrativeContext || !budget.isEnabled()) {
+  if (!narrativeContext) {
+    return narrativeContext;
+  }
+
+  // Measurement only when enforcement is disabled: record the recent-narrative
+  // estimate for observability without dropping any segments.
+  if (!budget.isEnabled()) {
+    const recentSegments = narrativeContext.recentSegments ?? [];
+    const totalTokens = recentSegments.reduce(
+      (sum, segment) => sum + estimateTokenCount(segment.content),
+      0
+    );
+    budget.recordUsage('recent-narrative', totalTokens);
     return narrativeContext;
   }
 
@@ -135,4 +157,45 @@ export const limitNarrativeContextToBudget = (
 
   budget.recordUsage('recent-narrative', totalTokens);
   return { ...narrativeContext, recentSegments: selected };
+};
+
+/**
+ * Record request-level calibration and publish a snapshot for the DevTools
+ * panel. Reconciles the whole-prompt heuristic estimate against the provider's
+ * actual prompt-token count (per-component actuals aren't available from the
+ * Gemini API). Runs regardless of enforcement — observability is decoupled from
+ * truncation.
+ */
+export const recordRequestCalibration = (
+  budget: RequestBudget,
+  fullPrompt: string,
+  response: { promptTokens?: number } | undefined
+): void => {
+  const actualTokens =
+    typeof response?.promptTokens === 'number' ? response.promptTokens : undefined;
+
+  budget.recordUsage(
+    REQUEST_TOTAL_COMPONENT_ID,
+    estimateTokenCount(fullPrompt),
+    actualTokens !== undefined ? { actualTokens } : undefined
+  );
+
+  publishBudgetSnapshot(budget);
+};
+
+/**
+ * Push a budget snapshot into the calibration store for the DevTools panel.
+ * Browser + non-production only; failures are swallowed so that observability
+ * never interferes with narrative generation.
+ */
+const publishBudgetSnapshot = (budget: RequestBudget): void => {
+  if (typeof window === 'undefined' || process.env.NODE_ENV === 'production') {
+    return;
+  }
+
+  try {
+    useCalibrationStore.getState().recordSnapshot(budget.getSnapshot());
+  } catch {
+    // Intentionally ignored — observability must never break generation.
+  }
 };

--- a/src/lib/ai/narrativeGenerator.prompt.personalization.ts
+++ b/src/lib/ai/narrativeGenerator.prompt.personalization.ts
@@ -116,7 +116,7 @@ export const enhancePromptWithPersonalization = async (
       return prompt;
     }
 
-    if (!budget || !budget.isEnabled()) {
+    if (!budget) {
       return `${prompt}${personalizationSection}`;
     }
 

--- a/src/lib/ai/narrativeGenerator.prompt.ts
+++ b/src/lib/ai/narrativeGenerator.prompt.ts
@@ -121,7 +121,7 @@ export const enhancePromptWithGoalContext = async (
     if (aiContext.goalContext && safeTrim(aiContext.goalContext)) {
       const goalSection = `\n\nCURRENT NARRATIVE GOALS:\n${aiContext.goalContext}\n\nPlease consider these goals when generating the narrative content.`;
 
-      if (!budget || !budget.isEnabled()) {
+      if (!budget) {
         return `${prompt}${goalSection}`;
       }
 
@@ -166,7 +166,7 @@ export const enhancePromptWithToneSettings = (
     cache.toneSettings.set(cacheKey, toneInstructions);
   }
 
-  if (!budget || !budget.isEnabled()) {
+  if (!budget) {
     return prompt + toneInstructions;
   }
 
@@ -286,7 +286,7 @@ Important:
 The items will be automatically added to the character's inventory with proper categorization and journal entries.`;
   }
 
-  if (!budget || !budget.isEnabled()) {
+  if (!budget) {
     return prompt + cache.itemAcquisitionInstructions;
   }
 

--- a/src/lib/ai/narrativeGenerator.prompt.ts
+++ b/src/lib/ai/narrativeGenerator.prompt.ts
@@ -211,7 +211,9 @@ export const enhancePromptWithInventory = (
     const guidance =
       'When generating narrative, naturally reference these items only if they matter to the current situation. Avoid forced mentions or repetitive callbacks.';
 
-    if (budget && budget.isEnabled()) {
+    // Record the estimate for observability whether or not enforcement is on;
+    // when disabled, content above is left untruncated.
+    if (budget) {
       budget.recordUsage('inventory', tokenCount);
     }
 

--- a/src/lib/ai/narrativeGenerator.ts
+++ b/src/lib/ai/narrativeGenerator.ts
@@ -78,15 +78,16 @@ export class NarrativeGenerator {
       const template = this.getTemplate('scene');
 
       const budget = createRequestBudget();
-      const requestForTemplate = budget.isEnabled()
-        ? ({
-            ...request,
-            narrativeContext: limitNarrativeContextToBudget(
-              request.narrativeContext,
-              budget
-            ),
-          } as NarrativeGenerationRequest)
-        : request;
+      // Always route through the budget helper: it records the recent-narrative
+      // estimate for observability and only truncates when enforcement is on
+      // (returns the context unchanged otherwise).
+      const requestForTemplate = {
+        ...request,
+        narrativeContext: limitNarrativeContextToBudget(
+          request.narrativeContext,
+          budget
+        ),
+      } as NarrativeGenerationRequest;
 
       const context = buildNarrativeContext(world, requestForTemplate);
       const prompt = template(context);
@@ -622,6 +623,7 @@ export class NarrativeGenerator {
       );
 
       const response = await this.geminiClient.generateContent(fullyEnhancedPrompt);
+      recordRequestCalibration(budget, fullyEnhancedPrompt, response);
 
       let result = await formatNarrativeResponse(
         response,

--- a/src/lib/ai/narrativeGenerator.ts
+++ b/src/lib/ai/narrativeGenerator.ts
@@ -38,6 +38,7 @@ import {
 import {
   createRequestBudget,
   limitNarrativeContextToBudget,
+  recordRequestCalibration,
 } from './narrativeGenerator.budget';
 import {
   buildNarrativeContext,
@@ -142,6 +143,7 @@ export class NarrativeGenerator {
       );
 
       const response = await this.geminiClient.generateContent(fullyEnhancedPrompt);
+      recordRequestCalibration(budget, fullyEnhancedPrompt, response);
 
       if (response.content) {
         try {
@@ -369,6 +371,7 @@ export class NarrativeGenerator {
       );
 
       const response = await this.geminiClient.generateContent(fullyEnhancedPrompt);
+      recordRequestCalibration(budget, fullyEnhancedPrompt, response);
 
       if (response.content) {
         try {

--- a/src/lib/devtools/sectionVisibilityStorage.ts
+++ b/src/lib/devtools/sectionVisibilityStorage.ts
@@ -23,7 +23,8 @@ export enum DevToolsSection {
   CONSISTENCY_VALIDATION = 'consistencyValidation',
   RELEVANCE_DEBUGGER = 'relevanceDebugger',
   LORE_MANAGEMENT = 'loreManagement',
-  ERROR_SECTION = 'errorSection'
+  ERROR_SECTION = 'errorSection',
+  TOKEN_BUDGET = 'tokenBudget'
 }
 
 /**
@@ -45,6 +46,7 @@ export const DEFAULT_SECTION_VISIBILITY: SectionVisibility = {
   [DevToolsSection.RELEVANCE_DEBUGGER]: true,
   [DevToolsSection.LORE_MANAGEMENT]: true,
   [DevToolsSection.ERROR_SECTION]: true,
+  [DevToolsSection.TOKEN_BUDGET]: true,
 };
 
 /**

--- a/src/lib/promptContext/__tests__/tokenBudgetManager.test.ts
+++ b/src/lib/promptContext/__tests__/tokenBudgetManager.test.ts
@@ -2,6 +2,7 @@ import {
   ComponentPriority,
   DEFAULT_ALLOCATIONS,
   DEFAULT_TOTAL_BUDGET,
+  REQUEST_TOTAL_COMPONENT_ID,
   RequestBudget,
 } from '../tokenBudgetManager';
 
@@ -108,5 +109,47 @@ describe('RequestBudget calibration', () => {
     // ...but actual/accuracy pair only the measured subset (800 -> 1000)
     expect(calibration.actual).toBe(1000);
     expect(calibration.accuracy).toBeCloseTo(1.25);
+  });
+});
+
+describe('RequestBudget.getSnapshot', () => {
+  it('lists the configured components with allocation and recorded usage', () => {
+    const budget = new RequestBudget(DEFAULT_ALLOCATIONS, DEFAULT_TOTAL_BUDGET, true);
+    budget.recordUsage('lore-context', 420);
+
+    const snapshot = budget.getSnapshot();
+
+    expect(snapshot.enabled).toBe(true);
+    expect(snapshot.totalBudget).toBe(DEFAULT_TOTAL_BUDGET);
+    expect(snapshot.components).toHaveLength(DEFAULT_ALLOCATIONS.length);
+
+    const lore = snapshot.components.find((c) => c.componentId === 'lore-context');
+    expect(lore?.estimated).toBe(420);
+    expect(lore?.allocation).toBeGreaterThan(0);
+    expect(lore?.priority).toBe(ComponentPriority.MEDIUM);
+  });
+
+  it('surfaces request-level calibration separately, not as a component row', () => {
+    const budget = new RequestBudget(DEFAULT_ALLOCATIONS, DEFAULT_TOTAL_BUDGET, true);
+    budget.recordUsage(REQUEST_TOTAL_COMPONENT_ID, 2000, { actualTokens: 2200 });
+
+    const snapshot = budget.getSnapshot();
+
+    expect(
+      snapshot.components.some((c) => c.componentId === REQUEST_TOTAL_COMPONENT_ID)
+    ).toBe(false);
+    expect(snapshot.calibration.estimated).toBe(2000);
+    expect(snapshot.calibration.actual).toBe(2200);
+    expect(snapshot.calibration.accuracy).toBeCloseTo(1.1);
+  });
+
+  it('reports a disabled snapshot with raw allocation targets', () => {
+    const budget = new RequestBudget(DEFAULT_ALLOCATIONS, DEFAULT_TOTAL_BUDGET, false);
+    const snapshot = budget.getSnapshot();
+
+    expect(snapshot.enabled).toBe(false);
+    const base = snapshot.components.find((c) => c.componentId === 'base-template');
+    expect(base?.allocation).toBe(300);
+    expect(base?.estimated).toBe(0);
   });
 });

--- a/src/lib/promptContext/tokenBudgetManager.ts
+++ b/src/lib/promptContext/tokenBudgetManager.ts
@@ -32,6 +32,33 @@ export interface CalibrationData {
 }
 
 /**
+ * Per-component usage figures for the observability snapshot. `allocation` is
+ * the resolved target budget (the bar denominator); `estimated` is the recorded
+ * heuristic token count for the most recent request.
+ */
+export interface ComponentBudgetUsage {
+  componentId: string;
+  priority: ComponentPriority;
+  allocation: number;
+  estimated: number;
+}
+
+/**
+ * A read-only snapshot of a request's budget state, consumed by the DevTools
+ * TokenBudgetPanel. `calibration` is the request-level estimate-vs-actual
+ * reconciliation (see `recordUsage('request-total', ...)`).
+ */
+export interface TokenBudgetSnapshot {
+  enabled: boolean;
+  totalBudget: number;
+  components: ComponentBudgetUsage[];
+  calibration: CalibrationData;
+}
+
+/** Reserved component id for the request-level whole-prompt calibration. */
+export const REQUEST_TOTAL_COMPONENT_ID = 'request-total';
+
+/**
  * Request budget instance for tracking allocations during a single request
  */
 export class RequestBudget {
@@ -39,6 +66,7 @@ export class RequestBudget {
   private usage: Map<string, number> = new Map();
   private actualUsage: Map<string, number> = new Map();
   private enabled: boolean;
+  private totalBudget: number;
 
   constructor(
     allocations: BudgetAllocation[],
@@ -46,6 +74,7 @@ export class RequestBudget {
     enabled: boolean = true
   ) {
     this.enabled = enabled;
+    this.totalBudget = totalBudget;
 
     if (!enabled) {
       // When disabled, store allocations but don't enforce limits
@@ -202,6 +231,32 @@ export class RequestBudget {
         : undefined;
 
     return { estimated, actual, accuracy };
+  }
+
+  /**
+   * Build a read-only snapshot of the current budget state for observability.
+   *
+   * Covers the configured components (the reserved `request-total` lives only in
+   * the usage map, so it is naturally excluded from the per-component list and
+   * surfaced separately as `calibration`).
+   */
+  getSnapshot(): TokenBudgetSnapshot {
+    const components: ComponentBudgetUsage[] = [];
+    for (const [componentId, allocation] of this.allocations) {
+      components.push({
+        componentId,
+        priority: allocation.priority,
+        allocation: allocation.target,
+        estimated: this.usage.get(componentId) ?? 0,
+      });
+    }
+
+    return {
+      enabled: this.enabled,
+      totalBudget: this.totalBudget,
+      components,
+      calibration: this.getCalibrationData(REQUEST_TOTAL_COMPONENT_ID),
+    };
   }
 }
 

--- a/src/state/calibrationStore.ts
+++ b/src/state/calibrationStore.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand';
+import type { TokenBudgetSnapshot } from '@/lib/promptContext/tokenBudgetManager';
+
+/**
+ * Maximum number of request snapshots retained for the DevTools panel. This is
+ * ephemeral, dev-only observability data so the history is intentionally small
+ * and never persisted.
+ */
+const MAX_SNAPSHOTS = 25;
+
+interface CalibrationState {
+  /** Captured request snapshots, oldest first. Newest is `snapshots.at(-1)`. */
+  snapshots: TokenBudgetSnapshot[];
+  /** Record a new snapshot, trimming history to the most recent MAX_SNAPSHOTS. */
+  recordSnapshot: (snapshot: TokenBudgetSnapshot) => void;
+  /** Clear all captured snapshots. */
+  clear: () => void;
+}
+
+/**
+ * Holds token-budget snapshots captured after each narrative generation so the
+ * DevTools TokenBudgetPanel can read live usage and calibration data. Populated
+ * client-side by `publishBudgetSnapshot` in `narrativeGenerator.budget.ts`.
+ */
+export const useCalibrationStore = create<CalibrationState>((set) => ({
+  snapshots: [],
+  recordSnapshot: (snapshot) =>
+    set((state) => ({
+      snapshots: [...state.snapshots, snapshot].slice(-MAX_SNAPSHOTS),
+    })),
+  clear: () => set({ snapshots: [] }),
+}));


### PR DESCRIPTION
## Description
Adds the DevTools panel half of #930 — a dev-only view of the prompt token budget so you can see, at a glance, which prompt components are tight, which are over, and how close the token estimate is to the provider's actual count.

The panel surfaces:
- **Allocation + usage bars** per component, colored by utilization (green `<0.7` / yellow `0.7–0.9` / orange `0.9–1.0` / red `>1.0`).
- **Over-budget highlighting** with a priority-derived degradation suggestion (LOW = "first to drop", CRITICAL = "cannot be dropped, trim source", etc.).
- **Request-level calibration** — whole-prompt estimate vs the provider's actual `promptTokens`, with an accuracy ratio (and an n/a state until a live API count is available).

It follows the existing DevTools section pattern (`StateSection`, `LoreManagementSection`), is registered in `DevToolsPanel` + the `SectionId` enum, and reads from a small client-side calibration store.

## Related Issue
Closes #1333

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
As a developer debugging prompt quality issues, I want a DevTools panel showing real-time budget usage and estimation accuracy so I can diagnose whether tight budgets are degrading narrative quality.

## Component Development
- [ ] Storybook stories created/updated
- [x] Components developed in isolation first
- [x] Visual consistency verified

This is a dev-only debug panel (no Storybook story, consistent with the other DevTools sections).

## Implementation Notes
Two facts about the codebase shaped the approach:

- **`NarrativeGenerator` runs client-side** (instantiated in `NarrativeController` with `ClientGeminiClient`, which posts the fully-built prompt string to `/api/narrative/generate` and gets back `promptTokens`). So the live `actualTokens` feed and snapshot capture happen client-side right after the response — no network plumbing.
- **`ENABLE_TOKEN_BUDGET_MANAGER` is a server-only env**, so in the browser `createRequestBudget()` is always disabled and per-component estimates were never recorded. To make the panel show live data, **measurement is decoupled from enforcement**: the budget now records per-component estimates regardless of the flag, but truncation stays gated on it. Prompt output is byte-identical when the flag is off — no user-facing behavior change.
- **Calibration is request-level** (the Gemini API only returns whole-prompt `promptTokenCount`, not per-component). Per-component actuals are deferred as a deeper-instrumentation follow-up, per the issue's technical notes.

One off-token value: the "orange" (`high`) utilization level uses an `hsl()` literal because no orange/amber design token exists — documented inline in the CSS.

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npx jest TokenBudgetPanel tokenBudgetManager narrativeGenerator.budgets narrativeGenerator.calibration` — all green (30 tests).
2. `npx tsc --noEmit`, `npm run lint`, `npx stylelint 'src/components/devtools/TokenBudgetPanel/*.css'` — all clean.
3. Manual (dev only): run the dev server, open the app in development, expand DevTools → **Token Budget**. Before generating, the panel shows the allocation config (fallback). After generating a narrative segment, it shows live per-component usage bars; calibration accuracy appears once a live API key returns a token count. Note: DevTools is intentionally hidden under `isPlaywrightEnv()`, so the panel is verified via RTL unit tests (which render the component directly) plus confirming the full app tree compiles with the panel mounted.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

> Note: "Closes #1333" won't auto-close on merge to `develop` (non-default branch) — close manually after merge.