### PR TITLE
test(visual): stop verify-fresh-session firing live AI that hangs CI (#1342)

### DIFF
--- a/tests/visual/utils/mockApi.ts
+++ b/tests/visual/utils/mockApi.ts
@@ -116,6 +116,24 @@ export async function mockApiEndpoints(
     });
   });
 
+  // Mock journal summarize endpoint. The journal flow
+  // (useActiveGameSessionJournal) calls this when narrative segments are added;
+  // it's normally skipped under isPlaywrightEnv(), but a spec that renders the
+  // session path without setting that flag would otherwise hit the live AI route,
+  // hang the single CI dev server, and time out unrelated specs (#1342).
+  await page.route('**/api/narrative/summarize', async (route) => {
+    console.log('🚫 Intercepted journal summarize API call - using mock summary');
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        summary: 'The character advanced through the latest events.',
+        entryType: 'character_event',
+        significance: 'minor',
+      }),
+    });
+  });
+
   // Mock world generation endpoint
   await page.route('**/api/generate-world', async (route) => {
     console.log('Intercepted generate-world API call');

--- a/tests/visual/verify-fresh-session.spec.ts
+++ b/tests/visual/verify-fresh-session.spec.ts
@@ -1,10 +1,19 @@
 import { test, expect } from '@playwright/test';
 import { getTimestamp } from '@/lib/utils';
+import { mockApiEndpoints } from './utils/mockApi';
 
 const GET_TIMESTAMP_SOURCE = getTimestamp.toString();
 
 // Targeted smoke check for fresh-session skeleton → content transition.
 // Assumes dev server is available at baseURL (default http://localhost:3000).
+//
+// This is the one /play spec that intentionally exercises the live generation
+// path (isPlaywrightEnv() stays false here so NarrativeController generates the
+// first scene instead of waiting for seeded segments). It must mock the AI
+// endpoints — otherwise the fresh-generation + journal-summarize calls hit the
+// real routes, hang the single CI dev server, and time out unrelated specs in
+// the other worker (#1342). Mocks keep the skeleton→content transition this test
+// checks, just deterministically.
 
 test.describe('Fresh GameSession skeleton → content', () => {
   test('shows skeleton, then reveals active session with choices', async ({
@@ -23,6 +32,10 @@ test.describe('Fresh GameSession skeleton → content', () => {
         logs.push(txt);
       }
     });
+    // Intercept AI routes so fresh generation + journal summarize are mocked,
+    // not live (see file header / #1342).
+    await mockApiEndpoints(page);
+
     const path =
       '/worlds/world_8b927b31-f6d0-4e17-8391-74033dd8323a/play?fresh=true';
     // Seed IndexedDB before any app script runs to avoid hydration overwrites


### PR DESCRIPTION
## Description

The visual/E2E suite (`E2E Tests` job) is flaky on `develop` and on every branch off it. Each run ends with one hard failure plus 8-14 flaky, and crucially **zero pixel diffs** — every failure is a navigation/hydration timeout (`page.goto` 20s, `page.waitForFunction` 10s, `networkidle` 8s), with the victim spec rotating run to run. That's a shared resource being saturated, not any one spec being broken.

Root cause: `tests/visual/verify-fresh-session.spec.ts` is the only `/play` spec that intentionally renders the **live generation path** — it keeps `isPlaywrightEnv()` false so `NarrativeController` generates the first scene instead of waiting for seeded segments (`src/components/Narrative/NarrativeController.tsx:218`) — **and it mocks nothing**. So its fresh-generation call and the journal `summarize` call (`useActiveGameSessionJournal.ts:65`) hit the real AI routes. On CI the single Next dev server stalls on those calls and concurrent `page.goto`s in the other worker time out. The dev-server log confirms a live call landing mid-run (`WARN [Summarize] ... at POST src/app/api/narrative/summarize/route.ts`). Same class of bug as #1323.

## Fix

- Mock `/api/narrative/summarize` in `tests/visual/utils/mockApi.ts` — it was unmocked everywhere, and the journal flow calls it whenever narrative segments are added.
- Apply `mockApiEndpoints(page)` in `verify-fresh-session.spec.ts` so its generation + summarize resolve from mocks. The skeleton -> active-session -> choices transition the test checks still runs, now deterministically and without saturating the dev server.

Deliberately **not** changing the global `isPlaywrightEnv()` gate (e.g. via a project-wide user agent): that path skips fresh-scene generation, which would defeat this spec's purpose. Mocking the AI is the correct, narrow fix.

## Related Issue

Closes #1342

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test addition or improvement

## TDD Compliance
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## Implementation Notes

- `verify-fresh-session` went from a 33s timeout failure to passing in ~6s locally; the summarize call now hits the mock instead of the live route.
- No app code changed; no baselines affected.
- Unblocks #1337 (DS1/DS2/DS3 visual coverage audit), which is verified-correct (0 pixel-diffs) and was failing only on this inherited flake.

## Quality Checks
- [x] Linting passed (`npm run lint`)
- [x] Type checking passed (`tsc --noEmit`)

## Testing Instructions

```
npm run dev   # in this worktree
npx playwright test tests/visual/verify-fresh-session.spec.ts --project=chromium --workers=1
```

Passes deterministically; server log shows `Intercepted journal summarize API call`, no live `[Summarize]` route hit.

## Checklist
- [x] Code follows the project's coding standards
- [x] Self-review of code performed
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
