### PR TITLE
ci: shard E2E job with one worker per shard to end timeout flake (#1344)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,16 @@ jobs:
     name: E2E Tests
     runs-on: macos-latest
     needs: [build]
+    # Shard across runners and force --workers=1 per shard. The visual suite's
+    # timeouts (#1344) come from worker concurrency against a single `next dev`
+    # server: two workers hitting two uncompiled routes at once stall the
+    # single-process dev server past the navigation timeout. One worker per shard
+    # removes that contention entirely; sharding keeps wall-clock reasonable.
+    # Stays on `next dev` so rendering (and committed baselines) is unchanged.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -306,19 +316,19 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
       - name: Run E2E tests (fail on visual diffs)
-        run: npm run test:e2e:critical
+        run: npm run test:e2e:critical -- --shard=${{ matrix.shard }}/2 --workers=1
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: e2e-test-failures
+          name: e2e-test-failures-shard${{ matrix.shard }}
           path: test-results/
           retention-days: 7
       - name: Upload HTML report
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: playwright-html-report
+          name: playwright-html-report-shard${{ matrix.shard }}
           path: |
             playwright-report/
             !playwright-report/**/*.zip

--- a/public_docs/development/visual-testing-best-practices.md
+++ b/public_docs/development/visual-testing-best-practices.md
@@ -304,14 +304,17 @@ pages — `dashboard-themes`, `main-pages` (home, home-empty-state, world-edit,
 character-edit), and `theme-switcher` (theme-ds*-home) — do **not** match local renders
 and have their baselines **adopted from CI output**. For these:
 - Do **not** regenerate locally (it will pass locally but fail in CI).
-- After an intentional change, let the `E2E Tests` check fail, then
-  `gh run download <run-id> -n e2e-test-failures`, verify each `*-actual.png` is a correct
-  render (not a seeding/empty flake), and copy the verified actuals over the corresponding
-  `*-chromium-darwin.png` baselines.
+- After an intentional change, let the `E2E Tests` check fail, then download the failed
+  shard artifacts — `gh run download <run-id> --pattern 'e2e-test-failures-shard*'` (the E2E
+  job is sharded, so artifacts are named `e2e-test-failures-shard1` / `-shard2`; only failed
+  shards upload). Or just run `./scripts/download-playwright-report.sh <pr>`, which handles
+  this. Verify each `*-actual.png` is a correct render (not a seeding/empty flake), and copy
+  the verified actuals over the corresponding `*-chromium-darwin.png` baselines.
 
-**Parallel-load flakiness**: running many visual specs across workers can time out
-`waitForStoreReady` (store hydration). Re-run the affected specs with `--workers=1` — they
-pass reliably when not competing for the dev server.
+**Parallel-load flakiness**: worker concurrency against the single `next dev` server can time
+out navigations / `waitForStoreReady` (store hydration). CI runs the E2E job sharded with
+`--workers=1` per shard to avoid this (see `.github/workflows/ci.yml`). Locally, re-run the
+affected specs with `--workers=1` — they pass reliably when not competing for the dev server.
 
 ## Baseline Management and Review Process
 

--- a/scripts/download-playwright-report.sh
+++ b/scripts/download-playwright-report.sh
@@ -21,8 +21,10 @@ fi
 
 echo "📋 Checking PR #$PR_NUMBER for failed Playwright tests..."
 
-# Get the failed E2E Tests (which include visual regression tests) run ID
-RUN_ID=$(gh pr view $PR_NUMBER --json statusCheckRollup | jq -r '.statusCheckRollup[] | select(.name == "E2E Tests" and .conclusion == "FAILURE") | .detailsUrl' | head -1 | sed 's|.*/runs/||' | sed 's|/job/.*||')
+# Get the failed E2E Tests (which include visual regression tests) run ID.
+# The E2E job is sharded, so its checks are named "E2E Tests (1)" / "E2E Tests (2)";
+# match any failed shard leg (all shards share one workflow run id).
+RUN_ID=$(gh pr view $PR_NUMBER --json statusCheckRollup | jq -r '.statusCheckRollup[] | select((.name | startswith("E2E Tests")) and .conclusion == "FAILURE") | .detailsUrl' | head -1 | sed 's|.*/runs/||' | sed 's|/job/.*||')
 
 if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
     echo "❌ No failed E2E Tests found for PR #$PR_NUMBER"
@@ -66,12 +68,26 @@ if [ -f "index.html" ]; then
     rm -f index.html
 fi
 
-# Download the artifacts
-echo "📦 Downloading test results..."
-gh run download $RUN_ID --name e2e-test-failures --dir "$ARTIFACTS_DIR"
+# Download the artifacts. The E2E job is sharded and only failed shards upload,
+# so artifacts are named e2e-test-failures-shard{1,2} / playwright-html-report-shard{1,2}.
+# Pull every failed shard by pattern (|| true: a pattern may match nothing if only
+# one shard failed or the report wasn't produced).
+echo "📦 Downloading test results (failed shards)..."
+gh run download "$RUN_ID" --pattern 'e2e-test-failures-shard*' --dir "$ARTIFACTS_DIR" || true
 
-echo "📦 Downloading HTML report..."
-gh run download $RUN_ID --name playwright-html-report --dir "$ARTIFACTS_DIR"
+echo "📦 Downloading HTML report (failed shards)..."
+gh run download "$RUN_ID" --pattern 'playwright-html-report-shard*' --dir "$ARTIFACTS_DIR" || true
+
+# gh --pattern nests each artifact in its own subdir; flatten the shard subdirs
+# (merging contents) into the layout the rest of this script expects.
+shopt -s nullglob
+for shard_dir in "$ARTIFACTS_DIR"/e2e-test-failures-shard* "$ARTIFACTS_DIR"/playwright-html-report-shard*; do
+    [ -d "$shard_dir" ] || continue
+    echo "📁 Flattening $(basename "$shard_dir")..."
+    cp -R "$shard_dir"/. "$ARTIFACTS_DIR"/
+    rm -rf "$shard_dir"
+done
+shopt -u nullglob
 
 # Note: e2e-test-failures contains all the test results, images and diffs
 # playwright-html-report contains the interactive HTML report


### PR DESCRIPTION
## Description

The visual/E2E job (`E2E Tests`, `playwright test --project=chromium`, 2 workers) runs near capacity. Its failures are navigation/hydration **timeouts with zero pixel diffs**, on a *rotating* set of pre-existing heavy specs (game-session, main-pages, manuscript-breakpoints, characters-themes...). Root cause: worker concurrency against a single `next dev` server — two workers hitting two not-yet-compiled routes at once stall the single-process dev server past the 20s navigation timeout. Raising workers doesn't help (the config already notes 4 workers showed no improvement); the bottleneck is the one server, not CPU.

## Fix

Shard the E2E job across two `macos-latest` runners and force `--workers=1` per shard:

```yaml
strategy:
  fail-fast: false
  matrix:
    shard: [1, 2]
# ...
run: npm run test:e2e:critical -- --shard=${{ matrix.shard }}/2 --workers=1
```

One worker per server removes the concurrency contention entirely — this is the known `--workers=1` workaround, applied in CI, with sharding so wall-clock stays close to the current single 2-worker run. It stays on `next dev`, so rendering and all committed baselines are unchanged (no regeneration).

Artifact names gain a `-shard{n}` suffix (matrix uploads must be unique). The CI-adopted-baseline refresh process now downloads `e2e-test-failures-shard1` / `e2e-test-failures-shard2`.

## Related Issue

Closes #1344

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (CI infrastructure)

## TDD Compliance
- [x] N/A — CI infrastructure change; no app code or baselines touched

## Implementation Notes

- The `E2E Tests` check becomes two matrix legs (`E2E Tests (1)` / `E2E Tests (2)`); both must pass.
- Unblocks #1337 (DS1/DS2/DS3 visual coverage audit), which is verified-correct (0 pixel diffs) and was tipping the un-sharded run over capacity. After this merges, #1337 rebases and rides in clean.

## Quality Checks
- [x] No app code changed; baselines untouched

## Testing Instructions

This is validated by CI itself: the two sharded `E2E Tests` legs should run without the navigation-timeout flake. Local single-spec runs already pass with `--workers=1`.

## Checklist
- [x] Code follows the project's coding standards
- [x] Self-review performed
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
