### PR TITLE
refactor: clear out a batch of embarrassing code

### DIFF
--- a/src/components/CharacterEditor/CharacterEditor.tsx
+++ b/src/components/CharacterEditor/CharacterEditor.tsx
@@ -102,8 +102,6 @@ const CharacterEditor: React.FC<CharacterEditorProps> = ({ characterId }) => {
       const { updateCharacter } = useCharacterStore.getState();
       updateCharacter(characterId, editingCharacter);
 
-      await new Promise(resolve => setTimeout(resolve, 500));
-
       router.push(`/characters/${characterId}`);
     } catch (err) {
       setLoadError('Failed to save character');

--- a/src/components/CharacterEditor/__tests__/CharacterEditor.test.tsx
+++ b/src/components/CharacterEditor/__tests__/CharacterEditor.test.tsx
@@ -176,15 +176,11 @@ describe('CharacterEditor MVP Tests', () => {
     const saveButton = screen.getByText('Save Changes');
     fireEvent.click(saveButton);
 
-    // Verify saving feedback is shown
-    await waitFor(() => {
-      expect(screen.getByText('Saving...')).toBeInTheDocument();
-    });
-
-    // Verify updateCharacter was called
+    // Verify updateCharacter was called and navigation occurred
     await waitFor(() => {
       expect(mockUpdateCharacter).toHaveBeenCalled();
     });
+    expect(mockRouter.push).toHaveBeenCalledWith('/characters/test-char-1');
   });
 
   // Acceptance Criteria 5: Users can cancel edits without saving changes

--- a/src/components/GameSession/GameSession.tsx
+++ b/src/components/GameSession/GameSession.tsx
@@ -30,9 +30,6 @@ interface GameSessionProps {
     sessionStore: Partial<ReturnType<typeof useSessionStore.getState>> | (() => Partial<ReturnType<typeof useSessionStore.getState>>);
     characterStore?: Partial<ReturnType<typeof useCharacterStore.getState>> | (() => Partial<ReturnType<typeof useCharacterStore.getState>>);
   };
-  _router?: {
-    push: (url: string) => void;
-  };
 }
 
 /**
@@ -47,15 +44,11 @@ const GameSession: React.FC<GameSessionProps> = ({
   initialState,
   disableAutoResume = false,
   _stores,
-  _router,
 }) => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [isClient, setIsClient] = useState(false);
-  
-  // Use provided router or real router
-  const actualRouter = _router || router;
-  
+
   // Check for auto-resume parameter
   const autoResume = searchParams?.get('autoResume') === 'true';
   const [hasAutoResumed, setHasAutoResumed] = useState(false);
@@ -84,7 +77,7 @@ const GameSession: React.FC<GameSessionProps> = ({
     onSessionEnd,
     initialState: testSessionState || initialState,
     disableAutoResume,
-    router: actualRouter,
+    router,
     _stores,
   });
 
@@ -330,7 +323,7 @@ const GameSession: React.FC<GameSessionProps> = ({
             </p>
             <Button
               variant="default"
-              onClick={() => actualRouter?.push(`/characters/create?worldId=${worldId}`)}
+              onClick={() => router?.push(`/characters/create?worldId=${worldId}`)}
             >
               Create Character
             </Button>

--- a/src/components/WorldCard/WorldCard.tsx
+++ b/src/components/WorldCard/WorldCard.tsx
@@ -29,14 +29,6 @@ interface WorldCardProps {
   onDelete: (worldId: string) => void;
   /** Characters in this world */
   characters?: Character[];
-  /** Optional store actions for testing */
-  _storeActions?: {
-    setCurrentWorld: (id: string) => void;
-  };
-  /** Optional router for testing */
-  _router?: {
-    push: (url: string) => void;
-  };
 }
 
 /**
@@ -74,13 +66,8 @@ const WorldCard: React.FC<WorldCardProps> = ({
   onToggleSelect,
   onDelete,
   characters = [],
-  _storeActions,
-  _router,
 }) => {
-  // Only call useRouter if no mock is provided
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const router = _router ? null : useRouter();
-  const actualRouter = _router || router;
+  const router = useRouter();
 
   const handleMakeActive = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -93,8 +80,7 @@ const WorldCard: React.FC<WorldCardProps> = ({
 
   const handlePlayClick = () => {
     try {
-      const storeActions = _storeActions || useWorldStore.getState();
-      storeActions.setCurrentWorld(world.id);
+      useWorldStore.getState().setCurrentWorld(world.id);
 
       // Check for characters in this world
       const characterState = useCharacterStore.getState();
@@ -104,29 +90,20 @@ const WorldCard: React.FC<WorldCardProps> = ({
 
       if (worldCharacters.length === 0) {
         // No characters exist - redirect to characters page
-        if (actualRouter) {
-          actualRouter.push(`/characters?worldId=${world.id}`);
-        }
+        router.push(`/characters?worldId=${world.id}`);
         return;
       }
 
       // Check for saved session
-      let hasSession = false;
       const savedSession = useSessionStore
         .getState()
         .getSavedSession(world.id, worldCharacters[0]?.id);
 
-      if (savedSession) {
-        hasSession = true;
-      }
-
-      if (actualRouter) {
-        // Add query parameter to auto-resume if there's a saved session
-        const url = hasSession
-          ? `/worlds/${world.id}/play?autoResume=true`
-          : `/worlds/${world.id}/play`;
-        actualRouter.push(url);
-      }
+      // Add query parameter to auto-resume if there's a saved session
+      const url = savedSession
+        ? `/worlds/${world.id}/play?autoResume=true`
+        : `/worlds/${world.id}/play`;
+      router.push(url);
     } catch {
       // Handle navigation errors gracefully
     }
@@ -134,9 +111,7 @@ const WorldCard: React.FC<WorldCardProps> = ({
 
   const handleEditClick = () => {
     try {
-      if (actualRouter) {
-        actualRouter.push(`/worlds/${world.id}/edit`);
-      }
+      router.push(`/worlds/${world.id}/edit`);
     } catch {
       // Handle navigation errors gracefully
     }
@@ -205,9 +180,7 @@ const WorldCard: React.FC<WorldCardProps> = ({
                     className="world-card-character-pill"
                     onClick={(e) => {
                       e.stopPropagation();
-                      if (actualRouter) {
-                        actualRouter.push(`/characters/${char.id}`);
-                      }
+                      router.push(`/characters/${char.id}`);
                     }}
                     title={`Play as ${char.name} - Level ${char.level}`}
                   >
@@ -287,9 +260,7 @@ const WorldCard: React.FC<WorldCardProps> = ({
                   text: 'Manage Characters',
                   onClick: (e) => {
                     e.stopPropagation();
-                    if (actualRouter) {
-                      actualRouter.push(`/characters?worldId=${world.id}`);
-                    }
+                    router.push(`/characters?worldId=${world.id}`);
                   },
                   variant: 'primary',
                   flex: true,
@@ -310,9 +281,7 @@ const WorldCard: React.FC<WorldCardProps> = ({
                   text: 'View',
                   onClick: (e) => {
                     e.stopPropagation();
-                    if (actualRouter) {
-                      actualRouter.push(`/worlds/${world.id}`);
-                    }
+                    router.push(`/worlds/${world.id}`);
                   },
                   variant: 'secondary',
                   icon: <Eye aria-hidden="true" />,

--- a/src/components/WorldCard/__tests__/WorldCard.test.tsx
+++ b/src/components/WorldCard/__tests__/WorldCard.test.tsx
@@ -3,6 +3,16 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import WorldCard from '../WorldCard';
 import { createMockWorld } from '@/lib/test-utils/testDataFactory';
 import { formatDate } from '@/lib/utils';
+import { useWorldStore } from '@/state/worldStore';
+
+const mockRouterPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}));
+
+beforeEach(() => {
+  mockRouterPush.mockClear();
+});
 
 // Regression: a world with no image previously rendered a white 1x1 data-URI
 // placeholder that showed as a bright rectangle in dark mode (#1113).
@@ -80,29 +90,23 @@ describe('WorldCard', () => {
 
   // New test for Play functionality (navigates to characters when no characters exist)
   test('sets current world and navigates to characters when Play is clicked', () => {
-    // Setup mocks
-    const mockSetCurrentWorld = jest.fn();
-    const mockRouterPush = jest.fn();
-    
-    // Directly pass mock dependencies to the component
-    render(
-      <WorldCard 
-        world={mockWorld} 
-        onSelect={jest.fn()} 
-        onDelete={jest.fn()}
-        _storeActions={{ setCurrentWorld: mockSetCurrentWorld }}
-        _router={{ push: mockRouterPush }}
-      />
+    const setCurrentWorldSpy = jest.spyOn(
+      useWorldStore.getState(),
+      'setCurrentWorld'
     );
-    
+
+    render(<WorldCard world={mockWorld} onSelect={jest.fn()} onDelete={jest.fn()} />);
+
     // Find and click the Play button
     fireEvent.click(screen.getByTestId('world-card-actions-play-button'));
-    
-    // Verify world is set as current world
-    expect(mockSetCurrentWorld).toHaveBeenCalledWith(mockWorld.id);
-    
+
+    // Verify world is set as current world via the store
+    expect(setCurrentWorldSpy).toHaveBeenCalledWith(mockWorld.id);
+
     // Verify navigation to characters page (since no characters exist in the world)
     expect(mockRouterPush).toHaveBeenCalledWith(`/characters?worldId=${mockWorld.id}`);
+
+    setCurrentWorldSpy.mockRestore();
   });
 
   // Test for character avatar pill styling
@@ -131,7 +135,6 @@ describe('WorldCard', () => {
         onSelect={jest.fn()}
         onDelete={jest.fn()}
         characters={[mockCharacter]}
-        _router={{ push: jest.fn() }}
       />
     );
 
@@ -174,22 +177,11 @@ describe('WorldCard', () => {
 
   // Test for Edit functionality
   test('navigates to edit page when Edit is clicked', () => {
-    // Setup mocks
-    const mockRouterPush = jest.fn();
-    
-    // Directly pass mock dependencies to the component
-    render(
-      <WorldCard 
-        world={mockWorld} 
-        onSelect={jest.fn()} 
-        onDelete={jest.fn()}
-        _router={{ push: mockRouterPush }}
-      />
-    );
-    
+    render(<WorldCard world={mockWorld} onSelect={jest.fn()} onDelete={jest.fn()} />);
+
     // Find and click the Edit button
     fireEvent.click(screen.getByTestId('world-card-actions-edit-button'));
-    
+
     // Verify navigation to edit page
     expect(mockRouterPush).toHaveBeenCalledWith(`/worlds/${mockWorld.id}/edit`);
   });

--- a/src/components/WorldCreationWizard/WorldCreationWizard.tsx
+++ b/src/components/WorldCreationWizard/WorldCreationWizard.tsx
@@ -30,28 +30,15 @@ import FinalizeStep from './steps/FinalizeStep';
 import QuickStartStep from './steps/QuickStartStep';
 import { AttributeSuggestion, SkillSuggestion, WIZARD_STEPS } from './WizardState';
 import { AIGuidanceSource } from '@/lib/constants/worldGuidance';
-import { getTimestamp } from '@/lib/utils';
 import { generateWorldImage } from '@/lib/ai/worldImageGenerator';
 import { analyzeWorldDescriptionClient } from '@/lib/ai/worldAnalyzerClient';
 import { Button } from '@/components/ui/button';
 import { ensureWorldNpcRoster } from '@/lib/services/worldCreationService';
 import { useTutorial } from '@/components/TutorialProvider';
 import { tourStepToWizardStep } from '@/lib/tutorial/worldCreationTour';
-import { safeJsonParse } from '@/lib/safeJsonParse';
 
 import Logger from '@/lib/utils/logger';
 const logger = new Logger('WorldCreationWizard');
-
-type PersistedWorldSummary = {
-  id: string;
-  name?: string;
-  genre?: string;
-  description?: string;
-  createdAt: string;
-  attributes: unknown[];
-  skills: unknown[];
-  image?: unknown;
-};
 
 // Efficient deep comparison for arrays of objects
 const areArraysEqual = <T extends object>(a: T[] = [], b: T[] = []): boolean => {
@@ -423,25 +410,6 @@ export default function WorldCreationWizard({
         // Start image generation in the background
         runWorldImageGeneration();
       }
-      
-      // Save to localStorage as temporary solution
-      if (typeof window !== 'undefined') {
-        const worlds = safeJsonParse<PersistedWorldSummary[]>(
-          localStorage.getItem('worlds'),
-          []
-        );
-        worlds.push({
-          id: worldId,
-          name: data.name,
-          genre: data.genre,
-          description: data.description,
-          createdAt: getTimestamp(),
-          attributes: data.attributes || [],
-          skills: data.skills || [],
-          image: data.image,
-        });
-        localStorage.setItem('worlds', JSON.stringify(worlds));
-      }
 
       void ensureWorldNpcRoster(worldId);
 
@@ -451,23 +419,6 @@ export default function WorldCreationWizard({
       // Fallback error handling — log so failures are observable
       logger.error('[WorldCreationWizard] handleComplete failed, using fallback world id:', error);
       const worldId = `world-${Date.now()}`;
-      if (typeof window !== 'undefined') {
-        const worlds = safeJsonParse<PersistedWorldSummary[]>(
-          localStorage.getItem('worlds'),
-          []
-        );
-        worlds.push({
-          id: worldId,
-          name: data.name,
-          genre: data.genre,
-          description: data.description,
-          createdAt: getTimestamp(),
-          attributes: data.attributes || [],
-          skills: data.skills || [],
-          image: data.image,
-        });
-        localStorage.setItem('worlds', JSON.stringify(worlds));
-      }
 
       // Store the world ID and move to quick start
       wizard.updateData({ createdWorldId: worldId });

--- a/src/components/WorldEditor/WorldEditor.tsx
+++ b/src/components/WorldEditor/WorldEditor.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useWorldStore } from '@/state/worldStore';
 import { World } from '@/types/world.types';
+import Logger from '@/lib/utils/logger';
 import { ActionButtonGroup } from '@/components/shared/ActionButtonGroup';
 import { Button } from '@/components/ui/button';
 import { CollapsibleSection } from '@/components/ui/CollapsibleSection';
@@ -16,6 +17,8 @@ import WorldImageForm from '@/components/forms/WorldImageForm';
 interface WorldEditorProps {
   worldId: string;
 }
+
+const logger = new Logger('WorldEditor');
 
 const WorldEditor: React.FC<WorldEditorProps> = ({ worldId }) => {
   const router = useRouter();
@@ -32,8 +35,10 @@ const WorldEditor: React.FC<WorldEditorProps> = ({ worldId }) => {
 
   // Kick off store hydration on mount
   useEffect(() => {
-    fetchWorlds().catch(() => {
-      // Swallow errors; UI will show fallback error state
+    fetchWorlds().catch((err) => {
+      logger.error('Failed to load worlds:', err);
+      setError('Failed to load world');
+      setLoading(false);
     });
   }, [fetchWorlds]);
 
@@ -70,9 +75,6 @@ const WorldEditor: React.FC<WorldEditorProps> = ({ worldId }) => {
     try {
       const { updateWorld } = useWorldStore.getState();
       updateWorld(worldId, world);
-
-      // Small delay to show save state
-      await new Promise((resolve) => setTimeout(resolve, 500));
 
       router.push('/worlds'); // Navigate back to worlds list
     } catch {

--- a/src/components/WorldEditor/__tests__/WorldEditor.test.tsx
+++ b/src/components/WorldEditor/__tests__/WorldEditor.test.tsx
@@ -252,25 +252,18 @@ describe('WorldEditor - MVP Level Tests', () => {
     });
   });
 
-  // Test save button state during save operation
-  test('disables save and cancel buttons while saving', async () => {
+  // Saving completes and navigates back to the worlds list
+  test('navigates back to worlds list after saving', async () => {
     render(<WorldEditor worldId="world-123" />);
 
     await waitFor(() => {
       expect(screen.getByText('Basic Info Form')).toBeInTheDocument();
     });
 
-    const saveButton = screen.getByText('Save Changes');
-    const cancelButton = screen.getByText('Cancel');
+    fireEvent.click(screen.getByText('Save Changes'));
 
-    // Click save
-    fireEvent.click(saveButton);
-
-    // Re-query after label switches to 'Saving...' (label change remounts the button)
     await waitFor(() => {
-      const savingButton = screen.getByText('Saving...');
-      expect(savingButton).toBeDisabled();
-      expect(cancelButton).toBeDisabled();
+      expect(mockPush).toHaveBeenCalledWith('/worlds');
     });
   });
 });

--- a/src/components/WorldList/WorldList.tsx
+++ b/src/components/WorldList/WorldList.tsx
@@ -12,12 +12,6 @@ interface WorldListProps {
   onDeleteWorld: (worldId: string) => void;
   selectedWorldIds?: EntityID[];
   onToggleSelect?: (worldId: EntityID) => void;
-  _router?: {
-    push: (url: string) => void;
-  };
-  _storeActions?: {
-    setCurrentWorld: (id: string) => void;
-  };
 }
 
 const WorldList: React.FC<WorldListProps> = ({
@@ -27,8 +21,6 @@ const WorldList: React.FC<WorldListProps> = ({
   onDeleteWorld,
   selectedWorldIds = [],
   onToggleSelect,
-  _router,
-  _storeActions,
 }) => {
   // Get character counts and character data for each world using proper hook
   const characters = useCharacterStore((state) => state.characters);
@@ -106,8 +98,6 @@ const WorldList: React.FC<WorldListProps> = ({
             characters={charactersByWorld[world.id] || []}
             onSelect={onSelectWorld}
             onDelete={onDeleteWorld}
-            _router={_router}
-            _storeActions={_storeActions}
           />
         ))}
       </div>

--- a/src/components/WorldListScreen/WorldListScreen.tsx
+++ b/src/components/WorldListScreen/WorldListScreen.tsx
@@ -21,19 +21,11 @@ import {
 import { readString, writeString } from '@/lib/utils/browserStorage';
 
 interface WorldListScreenProps {
-  _router?: {
-    push: (url: string) => void;
-  };
-  _storeActions?: {
-    setCurrentWorld: (id: string) => void;
-  };
   /** Callback to pass the view toggle component to parent for header placement */
   onViewToggleRender?: (toggle: React.ReactNode) => void;
 }
 
 const WorldListScreen: React.FC<WorldListScreenProps> = ({
-  _router,
-  _storeActions,
   onViewToggleRender,
 }) => {
   const [worlds, setWorlds] = useState<World[]>([]);
@@ -178,8 +170,6 @@ const WorldListScreen: React.FC<WorldListScreenProps> = ({
           onDeleteWorld={(id) => handleDeleteClick(id)}
           selectedWorldIds={selectedWorldIds}
           onToggleSelect={toggleWorldSelection}
-          _router={_router}
-          _storeActions={_storeActions}
         />
       )}
       <DeleteConfirmationDialog

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -3,8 +3,10 @@
 import { AIConfig, GenerationConfig, SafetySetting } from './types';
 
 /**
- * Gets AI configuration from environment variables
- * Following the pattern from Boot Hill project
+ * Gets AI configuration from environment variables.
+ * A missing key falls back to '' here rather than throwing, because config is
+ * also read in mock/test contexts; callers that make real requests validate it
+ * (see validateAPIKey in apiHelpers and the MOCK_API_KEY sentinel).
  * @returns Configuration object
  */
 export const getAIConfig = (): AIConfig => {

--- a/src/lib/ai/worldAnalyzer.ts
+++ b/src/lib/ai/worldAnalyzer.ts
@@ -104,9 +104,6 @@ export async function analyzeWorldDescription(description: string): Promise<Worl
       safetySettings: getSafetySettings()
     });
     
-    // Add a small delay to ensure loading overlay appears
-    await new Promise(resolve => setTimeout(resolve, 500));
-    
     logger.debug('Making AI request...');
     const response = await client.generateContent(prompt);
     logger.debug('Response received, length:', response.content.length);

--- a/src/stories/03-organisms/world/display/WorldCard.stories.tsx
+++ b/src/stories/03-organisms/world/display/WorldCard.stories.tsx
@@ -128,32 +128,10 @@ const mockWorld: World = {
   createdAt: '2023-01-01T10:00:00Z',
   updatedAt: '2023-12-15T14:30:00Z',
 };
-// Create a wrapper component that provides both router and store mocks
-const WorldCardWrapper = (args: Parameters<typeof WorldCard>[0]) => {
-  const mockRouter = {
-    push: (url: string) => {
-      console.log(`[Storybook] Navigating to: ${url}`);
-      return Promise.resolve();
-    },
-  };
-  const mockStoreActions = {
-    setCurrentWorld: (id: string) => {
-      console.log(`[Storybook] Setting current world: ${id}`);
-    },
-  };
-  // Use the component's test props to inject mocks
-  return (
-    <WorldCard
-      {...args}
-      _router={mockRouter}
-      _storeActions={mockStoreActions}
-    />
-  );
-};
 const meta: Meta<typeof WorldCard> = {
   title: '03-Organisms/world/display/WorldCard',
   component: WorldCard,
-  render: (args) => <WorldCardWrapper {...args} />,
+  render: (args) => <WorldCard {...args} />,
   parameters: {
     layout: 'centered',
     docs: {

--- a/src/stories/03-organisms/world/lists/WorldList.stories.tsx
+++ b/src/stories/03-organisms/world/lists/WorldList.stories.tsx
@@ -72,17 +72,6 @@ const meta: Meta<typeof WorldList> = {
     onDeleteWorld: (worldId: string) => {
       console.log(`[Storybook] World deleted: ${worldId}`);
     },
-    _router: {
-      push: (url: string) => {
-        console.log(`[Storybook] Navigating to: ${url}`);
-        return Promise.resolve();
-      }
-    },
-    _storeActions: {
-      setCurrentWorld: (id: string) => {
-        console.log(`[Storybook] Setting current world: ${id}`);
-      }
-    }
   }
 };
 

--- a/src/stories/04-templates/layouts/WorldListScreen.stories.tsx
+++ b/src/stories/04-templates/layouts/WorldListScreen.stories.tsx
@@ -78,19 +78,6 @@ const meta: Meta<typeof WorldListScreen> = {
       return <Story />;
     },
   ],
-  args: {
-    _router: {
-      push: (url: string) => {
-        console.log(`[Storybook] Navigating to: ${url}`);
-        return Promise.resolve();
-      }
-    },
-    _storeActions: {
-      setCurrentWorld: (id: string) => {
-        console.log(`[Storybook] Setting current world: ${id}`);
-      }
-    }
-  }
 };
 
 export default meta;


### PR DESCRIPTION
## Description

A grab-bag cleanup from an "embarrassing code" audit — the five things that made me wince most, fixed and verified. Net −173 lines across 15 files. No new behavior, just removing cruft and a genuine rules-of-hooks bug.

1. **Test-injection props gone.** `_router` / `_storeActions` are removed from `WorldCard`, `WorldList`, `WorldListScreen`, and `GameSession`. They existed purely so tests could thread in fakes — and `WorldCard` did it with a conditional `useRouter()` call hidden behind an `eslint-disable` for `react-hooks/rules-of-hooks`. `useRouter()` is now called unconditionally; the tests mock `next/navigation` at the module level and spy on the store instead. Stories use `@storybook/nextjs`'s built-in router mock.
2. **Fake save delays gone.** The 500ms `setTimeout` "show the spinner" sleeps in `WorldEditor`, `CharacterEditor`, and `worldAnalyzer` are deleted — save navigates immediately. Two tests asserted that transient `Saving...` window (which only existed because of the delay); they now assert the real contract: saved, then navigated.
3. **No more silent error swallow.** `WorldEditor` now logs `fetchWorlds()` failures and sets the error state instead of catching and ignoring.
4. **config.ts honesty pass.** Dropped the stale "Boot Hill project" comment and documented why the empty-key fallback is safe (server routes validate via `validateAPIKey`). Left as a follow-up: making it throw, which would be a behavior change since `GeminiClient` is also constructed client-side.
5. **Legacy localStorage writes removed.** The creation wizard wrote a hand-rolled `worlds` array to `localStorage` on top of the persisted store. Nothing reads that key except devtools, which already treats it as legacy and clears it. Removed both write blocks and the orphaned imports/type.

## Related Issue
Closes #
<!-- no tracking issue; ad-hoc cleanup -->

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (code improvements without changing functionality)

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## Component Development
- [x] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes

Scope was deliberately held to the five quick wins. Left untouched on purpose: the god-file refactors (NarrativeController, narrativeStore, inventoryStore — issue-sized, not inline), GameSession's larger `_stores` injection seam (same anti-pattern, bigger, tests depend on it), and the `exhaustive-deps` band-aids. Those are the honest next candidates.

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm test` — 183 tests pass across the touched suites; `npx tsc --noEmit`, `npx eslint`, and `npx knip` all clean.
2. Edit a world or character and save — it should navigate back immediately, no artificial pause.
3. Create a world through the wizard — still lands in the store and renders in the list.

## Checklist
- [x] Code follows the project's coding standards