### PR TITLE
refactor: reuse Dialog primitive in LoadingOverlay, drop dead EmptyState variant

### DIFF
--- a/src/components/Journal/JournalPage.tsx
+++ b/src/components/Journal/JournalPage.tsx
@@ -137,7 +137,6 @@ export const JournalPage: React.FC<JournalPageProps> = ({ worldId }) => {
         <EmptyState
           title="No active session"
           description="Start or resume a session to view its journal entries."
-          variant="centered"
         />
       );
     }
@@ -173,7 +172,6 @@ export const JournalPage: React.FC<JournalPageProps> = ({ worldId }) => {
             <EmptyState
               title="This journal awaits its first entry"
               description="Updates will appear here as things unfold"
-              variant="centered"
             />
           </div>
         ) : (

--- a/src/components/inventory/InventoryList.tsx
+++ b/src/components/inventory/InventoryList.tsx
@@ -128,7 +128,6 @@ export const InventoryList: React.FC<InventoryListProps> = ({
         <EmptyState
           title="No items in inventory"
           description="Items will appear here as they are added"
-          variant="centered"
         />
       </div>
     );

--- a/src/components/shared/LoadingOverlay.tsx
+++ b/src/components/shared/LoadingOverlay.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import React, { useEffect, useRef } from 'react';
-import { LoadingState, LoadingVariant } from '@/components/ui/LoadingState/LoadingState';
-import { Button } from '@/components/ui/button';
+import React from 'react';
 import { clsx } from 'clsx';
+import { LoadingState, LoadingVariant } from '@/components/ui/LoadingState/LoadingState';
+import { SimpleModal } from '@/components/shared/SimpleModal';
+import { Button } from '@/components/ui/button';
 
 export interface LoadingOverlayProps {
   /** Whether the overlay is visible */
@@ -14,25 +15,27 @@ export interface LoadingOverlayProps {
   message?: string;
   /** Optional cancel callback - shows cancel button if provided */
   onCancel?: () => void;
-  /** Additional CSS classes for the overlay */
+  /** Additional CSS classes for the overlay content */
   className?: string;
 }
 
 /**
- * LoadingOverlay - Full-screen loading overlay for navigation transitions
- * 
- * Provides a consistent loading experience across the application with:
- * - Full-screen modal overlay that prevents interaction
- * - Multiple loading variants (spinner, skeleton, dots, pulse)
- * - Optional cancel functionality for long operations
- * - Proper accessibility with ARIA attributes and focus management
- * - Keyboard support (Escape key to cancel)
- * 
- * @param props LoadingOverlayProps
- * @returns JSX element or null if not visible
- * 
+ * LoadingOverlay - Full-screen loading overlay for navigation transitions.
+ *
+ * Reuses the shared SimpleModal/Dialog primitive for dialog semantics, focus
+ * trapping, and Escape handling instead of hand-rolling them. The overlay is
+ * not dismissable by backdrop click; Escape cancels only when an `onCancel`
+ * handler is provided (i.e. recoverable/error states).
+ *
  * @example
- * ```tsx * <LoadingOverlay * isVisible={isLoading} * variant="skeleton" * message="Loading your world..." * onCancel={() => setIsLoading(false)} * /> *```
+ * ```tsx
+ * <LoadingOverlay
+ *   isVisible={isLoading}
+ *   variant="skeleton"
+ *   message="Loading your world..."
+ *   onCancel={() => setIsLoading(false)}
+ * />
+ * ```
  */
 export const LoadingOverlay: React.FC<LoadingOverlayProps> = ({
   isVisible,
@@ -41,112 +44,32 @@ export const LoadingOverlay: React.FC<LoadingOverlayProps> = ({
   onCancel,
   className,
 }) => {
-  const dialogRef = useRef<HTMLDivElement>(null);
-
-  // Handle keyboard events and focus trapping
-  useEffect(() => {
-    if (!isVisible) return;
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape' && onCancel) {
-        onCancel();
-      }
-      
-      // Simple focus trap - keep focus within the dialog
-      if (event.key === 'Tab') {
-        const dialog = dialogRef.current;
-        if (!dialog) return;
-        
-        const focusableElements = dialog.querySelectorAll(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-        );
-        
-        if (focusableElements.length === 0) return;
-        
-        const firstElement = focusableElements[0] as HTMLElement;
-        const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
-        
-        if (event.shiftKey) {
-          if (document.activeElement === firstElement) {
-            event.preventDefault();
-            lastElement.focus();
-          }
-        } else {
-          if (document.activeElement === lastElement) {
-            event.preventDefault();
-            firstElement.focus();
-          }
-        }
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isVisible, onCancel]);
-
-  // Don't render if not visible
-  if (!isVisible) {
-    return null;
-  }
-
   return (
-    <div
-      ref={dialogRef}
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="loading-overlay-title"
-      className={clsx(
-        '',
-        '',
-        className
-      )}
+    <SimpleModal
+      isOpen={isVisible}
+      onClose={() => onCancel?.()}
+      title="Please wait"
+      description={message}
+      showCloseButton={false}
+      closeOnBackdropClick={false}
+      closeOnEscape={Boolean(onCancel)}
+      className={clsx('component-loading-overlay', className)}
+      footer={
+        onCancel ? (
+          <Button variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+        ) : undefined
+      }
     >
-      <div>
-        <div>
-          {/* Loading indicator */}
-          <div>
-            <div aria-live="polite" aria-label="Loading">
-              <LoadingState
-                variant={variant}
-                size="lg"
-                theme="light"
-                
-                centered={false}
-              />
-            </div>
-          </div>
-
-          {/* Message */}
-          <div>
-            <h2 
-              id="loading-overlay-title"
-              
-            >
-              Please wait
-            </h2>
-            <p 
-              
-              aria-live="polite"
-            >
-              {message}
-            </p>
-          </div>
-
-          {/* Cancel button */}
-          {onCancel && (
-            <div>
-              <Button
-                variant="outline"
-                onClick={onCancel}
-                
-                tabIndex={0}
-              >
-                Cancel
-              </Button>
-            </div>
-          )}
-        </div>
+      <div aria-live="polite" aria-label="Loading">
+        <LoadingState
+          variant={variant}
+          size="lg"
+          theme="light"
+          centered={false}
+        />
       </div>
-    </div>
+    </SimpleModal>
   );
 };

--- a/src/components/ui/EmptyState/EmptyState.tsx
+++ b/src/components/ui/EmptyState/EmptyState.tsx
@@ -6,53 +6,33 @@ export interface EmptyStateProps {
   description?: string;
   icon?: React.ReactNode;
   action?: React.ReactNode;
-  variant?: 'centered' | 'compact';
   className?: string;
 }
 
 /**
  * Reusable empty state component
  * Provides consistent styling for empty states across the application.
- * The `variant` prop supports 'centered' and 'compact' options.
  */
 export const EmptyState: React.FC<EmptyStateProps> = ({
   title,
   description,
   icon,
   action,
-  variant = 'centered',
   className,
 }) => {
-  const baseClasses = variant === 'compact' 
-    ? ''
-    : '';
-
-  const titleClasses = variant === 'compact'
-    ? ''
-    : '';
-
-  const descriptionClasses = variant === 'compact'
-    ? ''
-    : '';
-
   return (
-    <div className={clsx(
-      'component-empty-state',
-      '',
-      baseClasses,
-      className
-    )}>
+    <div className={clsx('component-empty-state', className)}>
       {icon && (
         <div>
           {icon}
         </div>
       )}
       <div>
-        <h3 className={titleClasses}>
+        <h3>
           {title}
         </h3>
         {description && (
-          <p className={descriptionClasses}>
+          <p>
             {description}
           </p>
         )}

--- a/src/stories/01-atoms/feedback/EmptyState.stories.tsx
+++ b/src/stories/01-atoms/feedback/EmptyState.stories.tsx
@@ -29,11 +29,6 @@ const meta: Meta<typeof EmptyState> = {
     action: {
       description: 'Optional action button or element'
     },
-    variant: {
-      control: 'select',
-      options: ['default', 'centered', 'compact'],
-      description: 'Visual variant of the empty state'
-    },
     className: {
       control: 'text',
       description: 'Additional CSS classes'
@@ -68,7 +63,6 @@ export const JournalEmpty: Story = {
     title: 'This journal awaits its first entry',
     description: 'Updates will appear here as things unfold',
     icon: JournalIcon,
-    variant: 'centered',
   },
   parameters: {
     docs: {
@@ -86,7 +80,6 @@ export const WithAction: Story = {
     action: (
       <Button>Create World</Button>
     ),
-    variant: 'centered',
   },
   parameters: {
     docs: {
@@ -97,25 +90,9 @@ export const WithAction: Story = {
   },
 };
 
-export const Compact: Story = {
-  args: {
-    title: 'No results found',
-    description: 'Try adjusting your search criteria',
-    variant: 'compact',
-  },
-  parameters: {
-    docs: {
-      description: {
-        story: 'Compact variant for smaller spaces.',
-      },
-    },
-  },
-};
-
 export const TitleOnly: Story = {
   args: {
     title: 'Nothing to show',
-    variant: 'centered',
   },
   parameters: {
     docs: {


### PR DESCRIPTION
## Description
Round 7 of the overengineering sweep. Two changes that fold code back into existing patterns instead of hand-rolling.

1. **LoadingOverlay reuses the SimpleModal/Dialog primitive.** It was the only component in the app reinventing dialog semantics -- its own `role="dialog"`/`aria-modal` wiring and a hand-rolled Tab focus-trap. Everything else already gets focus trapping and Escape handling from the shared Radix Dialog. Routing it through `SimpleModal` deletes that duplicated a11y code and, as a side effect, gives the overlay real styling: its CSS was emptied out during the Tailwind removal and never replaced, so it had been rendering as bare unstyled divs. Behavior is unchanged -- non-dismissable by backdrop, Escape cancels only when an `onCancel` handler is present. 152 lines down to ~80.

2. **EmptyState dead `variant` prop removed.** Both `'centered'` and `'compact'` branches mapped to empty strings -- the prop did nothing. Removed it and its branching, the three call sites that passed it, and the story args (including a Compact story that rendered identically to centered).

Net -123 lines.

## Related Issue
N/A -- proactive cleanup, no tracking issue.

## Type of Change
- [x] Refactoring (code improvements without changing functionality)

## TDD Compliance
- [ ] Tests written before implementation _(refactor -- existing tests define the contract)_
- [x] All new code is tested _(existing LoadingOverlay + EmptyState-consumer suites cover it)_
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## Component Development
- [x] Storybook stories created/updated _(EmptyState story updated for removed prop)_
- [x] Components developed in isolation first
- [ ] Visual consistency verified _(see Testing Instructions -- overlay appearance changes; no visual spec covers it)_

## Implementation Notes
- LoadingOverlay's 5 existing unit tests pass unchanged against the SimpleModal-based rewrite (role, "Please wait", custom message, Cancel click, Escape->onCancel).
- The Radix "Missing Description" console warning the overlay now emits is pre-existing repo-wide -- every SimpleModal-based dialog (ConfirmationDialog, DeleteConfirmationDialog, etc.) produces it because SimpleModal renders its description as a plain div rather than via Radix's DialogDescription. Not introduced here; worth a separate SimpleModal fix.

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed _(no security-relevant changes)_
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm test -- src/components/shared/__tests__/LoadingOverlay.test.tsx src/components/Journal src/components/inventory` -- all green.
2. Manual: trigger a navigation transition (the overlay shows globally via NavigationLoadingProvider) and confirm the loading overlay renders as a styled centered dialog with the spinner/message, Escape cancels in error/recoverable states, and Tab stays trapped. This is the one path not covered by an automated visual spec.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) _(none needed)_
- [x] No new warnings generated _(the one Radix warning is pre-existing repo-wide, not new)_
- [x] Accessibility considerations addressed _(focus trap + Escape now come from the audited Dialog primitive)_
