### PR TITLE
test: add jest lint guards, cut 8 dead tests, fix 3 vacuous archetype tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { FlatCompat } from "@eslint/eslintrc";
+import jest from "eslint-plugin-jest";
 import noHardcodedColors from "./eslint-rules/no-hardcoded-colors.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -59,6 +60,24 @@ const eslintConfig = [
       "design-tokens/no-hardcoded-colors": "off", // Allow hardcoded colors in tests, dev tools, design tokens, and stories
       "no-console": "off", // Dev tooling, tests, and stories legitimately use console
       "@typescript-eslint/no-explicit-any": "warn", // Allow `any` in dev tools and tests, but flag it
+    },
+  },
+  {
+    // Dead/low-value test detection. Scoped to real test files (not stories or
+    // dev tooling). warn keeps these out of the blocking CI gate as a first-pass
+    // introduction, matching the markup-hygiene rules above.
+    files: [
+      "**/*.test.{js,jsx,ts,tsx}",
+      "**/__tests__/**/*.{js,jsx,ts,tsx}",
+    ],
+    plugins: { jest },
+    rules: {
+      // A test with no expect() asserts nothing. Recognize custom assertion
+      // helpers (assertChoicesVisible, etc.) so delegating tests aren't flagged.
+      "jest/expect-expect": ["warn", { assertFunctionNames: ["expect", "assert*"] }],
+      // Indefinitely skipped / commented-out tests are dead weight.
+      "jest/no-disabled-tests": "warn",
+      "jest/no-commented-out-tests": "warn",
     },
   },
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,8 +44,8 @@ const eslintConfig = [
   },
   {
     files: [
-      "**/*.test.{js,jsx,ts,tsx}",
-      "**/__tests__/**/*.{js,jsx,ts,tsx}",
+      "**/*.test.{js,mjs,jsx,ts,tsx}",
+      "**/__tests__/**/*.{js,mjs,jsx,ts,tsx}",
       "**/__mocks__/**/*.{js,jsx,ts,tsx}",
       "**/*.stories.{js,jsx,ts,tsx}",
       "**/*.stories.helpers.{js,jsx,ts,tsx}",
@@ -67,8 +67,8 @@ const eslintConfig = [
     // dev tooling). warn keeps these out of the blocking CI gate as a first-pass
     // introduction, matching the markup-hygiene rules above.
     files: [
-      "**/*.test.{js,jsx,ts,tsx}",
-      "**/__tests__/**/*.{js,jsx,ts,tsx}",
+      "**/*.test.{js,mjs,jsx,ts,tsx}",
+      "**/__tests__/**/*.{js,mjs,jsx,ts,tsx}",
     ],
     plugins: { jest },
     rules: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "eslint": "^9.25.1",
         "eslint-config-next": "^15.5.7",
         "eslint-config-prettier": "^10.1.2",
+        "eslint-plugin-jest": "^29.15.2",
         "eslint-plugin-storybook": "^0.12.0",
         "gh-pages": "^6.3.0",
         "glob": "^11.0.2",
@@ -11390,6 +11391,36 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-jest": {
+      "version": "29.15.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.2.tgz",
+      "integrity": "sha512-kEN4r9RZl1xcsb4arGq89LrcVdOUFII/JSCwtTPJyv16mDwmPrcuEQwpxqZHeINvcsd7oK5O/rhdGlxFRaZwvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.0.0"
+      },
+      "engines": {
+        "node": "^20.12.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "jest": "*",
+        "typescript": ">=4.8.4 <7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "next build && rm -rf public/storybook-static && npm run build-storybook && cp -r storybook-static public/",
     "build:app": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "next lint && eslint \"__tests__/**/*.test.{js,jsx,ts,tsx}\" \"scripts/**/*.test.{js,mjs}\"",
     "lint:layout-usage": "node scripts/verify-page-layout-usage.cjs",
     "lint:ds-canon": "node scripts/verify-ds-canon.cjs",
     "lint:css": "stylelint \"**/*.css\"",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "eslint": "^9.25.1",
     "eslint-config-next": "^15.5.7",
     "eslint-config-prettier": "^10.1.2",
+    "eslint-plugin-jest": "^29.15.2",
     "eslint-plugin-storybook": "^0.12.0",
     "gh-pages": "^6.3.0",
     "glob": "^11.0.2",

--- a/src/components/GameSession/__tests__/ManuscriptSessionShell.test.tsx
+++ b/src/components/GameSession/__tests__/ManuscriptSessionShell.test.tsx
@@ -7,25 +7,6 @@ jest.mock('@/lib/theme/ThemeProvider', () => ({
 }));
 
 describe('ManuscriptSessionShell', () => {
-  beforeAll(() => {
-    // Mock global CSS variables that would normally come from globals.css
-    document.body.style.setProperty('--color-overlay-surface', 'rgba(255, 255, 255, 0.9)');
-    document.body.style.setProperty('--color-overlay-surface-strong', 'rgba(255, 255, 255, 0.95)');
-    document.body.style.setProperty('--color-manuscript-gradient-start', 'rgba(255, 255, 255, 0.92)');
-    document.body.style.setProperty('--color-manuscript-gradient-end', 'rgba(244, 244, 245, 0.92)');
-    document.body.style.setProperty('--color-scrim', 'rgba(17, 17, 17, 0.45)');
-    document.body.style.setProperty('--shadow-overlay', '0 6px 18px rgba(0, 0, 0, 0.08)');
-  });
-
-  afterAll(() => {
-    document.body.style.removeProperty('--color-overlay-surface');
-    document.body.style.removeProperty('--color-overlay-surface-strong');
-    document.body.style.removeProperty('--color-manuscript-gradient-start');
-    document.body.style.removeProperty('--color-manuscript-gradient-end');
-    document.body.style.removeProperty('--color-scrim');
-    document.body.style.removeProperty('--shadow-overlay');
-  });
-
   it('renders children and hud', () => {
     render(
       <ManuscriptSessionShell hud={<div data-testid="hud" />}>
@@ -57,23 +38,6 @@ describe('ManuscriptSessionShell', () => {
 
     const marginElement = screen.getByTestId('margin').parentElement;
     expect(marginElement).toHaveClass('manuscript-characters-rail');
-  });
-
-  it('exposes manuscript overlay CSS variables', () => {
-    render(
-      <ManuscriptSessionShell>
-        <div>Main Content</div>
-      </ManuscriptSessionShell>
-    );
-
-    // In JSDOM, getComputedStyle doesn't always handle inherited custom properties well.
-    // We check document.body.style directly to verify they are defined in the environment.
-    expect(document.body.style.getPropertyValue('--color-overlay-surface')).not.toBe('');
-    expect(document.body.style.getPropertyValue('--color-overlay-surface-strong')).not.toBe('');
-    expect(document.body.style.getPropertyValue('--color-manuscript-gradient-start')).not.toBe('');
-    expect(document.body.style.getPropertyValue('--color-manuscript-gradient-end')).not.toBe('');
-    expect(document.body.style.getPropertyValue('--color-scrim')).not.toBe('');
-    expect(document.body.style.getPropertyValue('--shadow-overlay')).not.toBe('');
   });
 
   it('uses semantic manuscript overlay classes', () => {

--- a/src/components/GuidedFirstTimeExperience/GuidedFirstTimeExperience.test.tsx
+++ b/src/components/GuidedFirstTimeExperience/GuidedFirstTimeExperience.test.tsx
@@ -92,33 +92,9 @@ describe('GuidedFirstTimeExperience', () => {
         await user.click(nextButton);
       }
     });
-
-    it('completes the onboarding flow', async () => {
-      const user = userEvent.setup();
-      render(<GuidedFirstTimeExperience />);
-
-      const completeButton = screen.queryByText(/finish/i) || screen.queryByText(/complete/i) || screen.queryByText(/done/i);
-
-      if (completeButton) {
-        await user.click(completeButton);
-        expect(mockSessionStore.completeTutorialPhase).toHaveBeenCalledWith('intro');
-      }
-    });
   });
 
   describe('Integration', () => {
-    it('creates world during guided experience when requested', async () => {
-      const user = userEvent.setup();
-      render(<GuidedFirstTimeExperience />);
-
-      const createWorldButton = screen.queryByText(/create world/i) || screen.queryByText(/new world/i);
-
-      if (createWorldButton) {
-        await user.click(createWorldButton);
-        expect(mockWorldStore.createWorld).toHaveBeenCalled();
-      }
-    });
-
     it('navigates to appropriate page after completion', async () => {
       // Mock completed onboarding
       mockSessionStore.isFirstTimeUser = jest.fn(() => false);

--- a/src/components/Narrative/__tests__/ChoiceOutcomeCallout.test.tsx
+++ b/src/components/Narrative/__tests__/ChoiceOutcomeCallout.test.tsx
@@ -22,13 +22,6 @@ describe('ChoiceOutcomeCallout', () => {
     expect(badge).toBeInTheDocument();
   });
 
-  it('should use small size variant', () => {
-    const { container } = render(<ChoiceOutcomeCallout {...defaultProps} />);
-
-    const callout = container.querySelector('.choice-outcome-callout');
-    expect(callout).toBeInTheDocument();
-  });
-
   it('should accept custom className', () => {
     const { container } = render(
       <ChoiceOutcomeCallout {...defaultProps} className="test-class" />

--- a/src/lib/test-utils/__tests__/mockStoreFactories.test.ts
+++ b/src/lib/test-utils/__tests__/mockStoreFactories.test.ts
@@ -47,16 +47,6 @@ describe('mockZustandStore', () => {
     const result = mockHook();
     expect(result).toMatchObject({ loading: true });
   });
-
-  it('properly types the mock return value', () => {
-    const mockHook = jest.fn();
-    const mockState = createMockCharacterStore();
-
-    const typedMock = mockZustandStore(mockHook, mockState);
-
-    // This test verifies TypeScript compilation - if types are wrong, this won't compile
-    expect(jest.isMockFunction(typedMock)).toBe(true);
-  });
 });
 
 describe('createMockCharacterStore', () => {
@@ -72,13 +62,6 @@ describe('createMockCharacterStore', () => {
     expect(mock.create).toBe(customCreate);
     expect(mock.loading).toBe(true);
     expect(mock.characters).toHaveProperty('char-1');
-  });
-
-  it('returns properly typed CharacterStore', () => {
-    const mock = createMockCharacterStore();
-
-    // TypeScript compilation ensures type safety
-    expect(mock).toBeDefined();
   });
 });
 

--- a/src/lib/utils/__tests__/characterArchetypes.test.ts
+++ b/src/lib/utils/__tests__/characterArchetypes.test.ts
@@ -53,31 +53,29 @@ describe('characterArchetypes', () => {
       const world = createMockWorld('fantasy');
       const archetypes = await generateCharacterArchetypes(world);
       
-      // Find the warrior archetype (should have high Strength)
-      const warrior = archetypes.find(a => a.name.includes('Warrior') || a.name.includes('Fighter'));
-      if (warrior) {
-        const strengthAttr = warrior.attributes.find(a => a.name === 'Strength');
-        expect(strengthAttr?.value).toBeGreaterThan(6); // Should be above average
-      }
-      
-      // Find the mage archetype (should have high Intelligence)  
-      const mage = archetypes.find(a => a.name.includes('Mage') || a.name.includes('Wizard'));
-      if (mage) {
-        const intAttr = mage.attributes.find(a => a.name === 'Intelligence');
-        expect(intAttr?.value).toBeGreaterThan(6); // Should be above average
-      }
+      // Find the warrior archetype by its role description (a.name is a generated
+      // character name, not the role, so it can't be matched on).
+      const warrior = archetypes.find(a => a.description.includes('fighter'));
+      expect(warrior).toBeDefined();
+      const strengthAttr = warrior!.attributes.find(a => a.name === 'Strength');
+      expect(strengthAttr?.value).toBeGreaterThan(6); // Should be above average
+
+      // Find the mage archetype (should have high Intelligence)
+      const mage = archetypes.find(a => a.description.includes('mystical arts'));
+      expect(mage).toBeDefined();
+      const intAttr = mage!.attributes.find(a => a.name === 'Intelligence');
+      expect(intAttr?.value).toBeGreaterThan(6); // Should be above average
     });
 
     test('ensures skill levels are appropriate for archetype roles', async () => {
       const world = createMockWorld('fantasy');
       const archetypes = await generateCharacterArchetypes(world);
 
-      // Find the warrior archetype (should have high Combat skill)
-      const warrior = archetypes.find(a => a.name.includes('Warrior') || a.name.includes('Fighter'));
-      if (warrior) {
-        const combatSkill = warrior.skills.find(s => s.name === 'Combat');
-        expect(combatSkill?.level).toBeGreaterThan(5); // Should be competent or better
-      }
+      // Find the warrior archetype by its role description.
+      const warrior = archetypes.find(a => a.description.includes('fighter'));
+      expect(warrior).toBeDefined();
+      const combatSkill = warrior!.skills.find(s => s.name === 'Combat');
+      expect(combatSkill?.level).toBeGreaterThan(5); // Should be competent or better
     });
 
     test('respects world attribute and skill bounds', async () => {

--- a/src/state/__tests__/persistence/mvp.test.ts
+++ b/src/state/__tests__/persistence/mvp.test.ts
@@ -1,6 +1,3 @@
-import { useWorldStore } from '../../worldStore';
-import { useCharacterStore } from '../../characterStore';
-
 // Mock the module with our mock adapter
 jest.mock('../../../lib/storage/indexedDBAdapter', () => {
   const mockGetItem = jest.fn().mockResolvedValue(null);
@@ -95,24 +92,6 @@ describe('MVP IndexedDB Persistence', () => {
       
       // Restore original implementation
       mockFunctions.create = originalCreate;
-    });
-  });
-
-  describe('Store Persistence', () => {
-    test('useWorldStore should have persist middleware configured', () => {
-      // Check that the store is configured with persistence
-      const state = useWorldStore.getState();
-      expect(state).toBeDefined();
-      expect(state.worlds).toBeDefined();
-      expect(state.currentWorldId).toBeDefined();
-    });
-
-    test('useCharacterStore should have persist middleware configured', () => {
-      // Check that the store is configured with persistence
-      const state = useCharacterStore.getState();
-      expect(state).toBeDefined();
-      expect(state.characters).toBeDefined();
-      expect(state.currentCharacterId).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Description
A dead-test hunt that leaned on tooling for the hard category — tests that pass no matter what the code does. Manual and agent sweeps came up nearly empty (the suite's cleaner than it looked), so the durable win here is a lint guard plus a handful of genuinely dead/vacuous tests fixed or removed.

- Wired `eslint-plugin-jest` into the existing `next lint` gate, scoped to test files, three standing rules at `warn`: `expect-expect` (recognizes `assert*` helpers so delegating tests aren't false-flagged), `no-disabled-tests`, `no-commented-out-tests`.
- Left `no-conditional-expect` out as a permanent rule — ~22% precision against legitimate parameterized `if/else` tests, too noisy to keep. It earned its keep as a one-time audit lens by catching the archetype bug below.

## Related Issue
N/A — ad-hoc test-health cleanup, no tracking issue.

## Type of Change
- [x] Refactoring (code improvements without changing functionality)
- [x] Test addition or improvement

## TDD Compliance
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## Implementation Notes
**The real find:** the `characterArchetypes` tests matched archetypes by `name.includes('Warrior')`, but `.name` is a random character name — the role lives in `.description`. So `find()` never matched and the assertions never ran. Repointed them to match on `description`, added a `toBeDefined` guard, and confirmed the now-active assertions actually hold (Strength > 6, Intelligence > 6, Combat > 5). These went from asserting nothing to verifying real stat distribution. Neither manual review nor the agent sweep caught this — the lint rule did, which is the argument for keeping the guards in CI.

**Removed 8 genuinely dead tests:**
- `mvp`: two persist "configured" tests that only checked default props existed
- `mockStoreFactories`: two existence / `isMockFunction` tautologies
- `GuidedFirstTimeExperience`: two tests whose only `expect` lived inside an `if` that never matched
- `ChoiceOutcomeCallout`: `should use small size variant` asserted nothing about size
- `ManuscriptSessionShell`: a CSS-var test that asserted its own `beforeAll` setup (plus the orphaned setup)

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
- `npx jest --config=jest.config.cjs` on the 6 touched suites → 32 tests pass
- `npx eslint "src/**/*.test.{ts,tsx}" "src/**/__tests__/**/*.{ts,tsx}"` → 0 jest-rule warnings, 0 errors

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)