### PR TITLE
refactor: drop unused generateCount ref from NarrativeController

### DIFF
--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -108,7 +108,6 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
     new Set()
   );
   const mountedRef = useRef(false);
-  const generateCount = useRef(0);
   const warnedMissingSessionIdRef = useRef(false);
 
   const warnMissingSessionId = useCallback((context: string) => {
@@ -143,7 +142,6 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
     // Reset state when session changes
     setProcessedChoices(new Set());
     setError(null);
-    generateCount.current = 0;
 
     // Set mounted flag
     mountedRef.current = true;
@@ -235,7 +233,6 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
         setInitialGenerationCompleted(true);
         initialGenerationInitiated.current = true;
 
-        generateCount.current += 1;
         generateInitialNarrative();
       }
       // Choice-based generation (only if we haven't processed this choice already)
@@ -248,7 +245,6 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
           return updated;
         });
 
-        generateCount.current += 1;
         generateNextSegment(choiceId);
       }
       // Log if we're skipping generation


### PR DESCRIPTION
## Description

Removes the `generateCount` ref from `NarrativeController` — leftover instrumentation. It got incremented on every narrative generation, but its `.current` value was never read anywhere: no comparison, log, return, or dependency array. A counter nobody consumes.

I verified it was truly dead before touching anything — grep across `src/` turned up only the 4 write sites (declaration, mount-effect reset, two increments) and zero reads, tests, or other references. Also confirmed the in-flight hook refactor (`useNarrativeGeneration`) hasn't landed, so the ref still lived in the controller, not an extracted hook.

## Related Issue

N/A — small dead-code cleanup, no associated issue.

## Type of Change
- [x] Refactoring (code improvements without changing functionality)

## TDD Compliance
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Pure deletion, so there's no new code to test. The existing Narrative suite already exercises the surrounding generation logic and stays green.

## Implementation Notes

Four lines gone, nothing else:
- the declaration (`const generateCount = useRef(0)`)
- the mount-effect reset (`generateCount.current = 0`)
- both increments, before `generateInitialNarrative()` and `generateNextSegment()`

Left the neighboring refs alone — `mountedRef`, `initialGenerationInitiated`, `choiceGenerationInProgress`, `warnedMissingSessionIdRef`, and `initialGenerationLocksRef` are all genuinely used. No behavior change, since nothing ever read the counter.

## Component Development

N/A — no UI or visual change.

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

- `npx jest src/components/Narrative` -> 16 suites, 118 tests pass
- `npx tsc --noEmit` -> clean
- `npx eslint src/components/Narrative/NarrativeController.tsx` -> clean

No browser check needed — the value was never read, so runtime behavior is provably unchanged.

## Checklist
- [x] Code follows the project's coding standards
- [x] Self-review of code performed
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)