### PR TITLE
refactor: thin NarrativeController by extracting skill-check + choice-gen seams

### DIFF
--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -10,14 +10,13 @@ import { NarrativeGenerator } from '@/lib/ai/narrativeGenerator';
 import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
 import { useNarrativeStore } from '@/state/narrativeStore';
 import { useEndingDetection } from './useEndingDetection';
+import { usePlayerChoices } from './hooks/usePlayerChoices';
 import {
   Decision,
   DecisionWeight,
-  NarrativeContext,
   NarrativeSegment,
   SkillCheckRoll,
 } from '@/types/narrative.types';
-import { truncate } from '@/lib/utils';
 import { isSessionEndingSegment } from '@/lib/narrative/isSessionEndingSegment';
 import { getNarrativeError } from '@/lib/narrative/narrativeErrors';
 import { evaluateDecisionSkillChecks } from '@/lib/narrative/evaluateDecisionSkillChecks';
@@ -66,7 +65,6 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
 }) => {
   const [segments, setSegments] = useState<NarrativeSegment[]>([]);
   const [isLoading, setIsLoading] = useState(false);
-  const [isGeneratingChoices, setIsGeneratingChoices] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const toast = useToast();
 
@@ -119,8 +117,6 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
   }, []);
   // Use a ref to track if we've initiated generation in this component instance
   const initialGenerationInitiated = useRef(false);
-  // Use a ref to prevent overlapping choice generation
-  const choiceGenerationInProgress = useRef(false);
   // Prevent duplicate initial-scene generation in dev StrictMode (effects can run twice across remounts)
   const initialGenerationLocksRef = useRef(new Set<string>());
 
@@ -130,6 +126,17 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
     characterId,
     segments,
     onEndingSuggested,
+  });
+
+  const { isGeneratingChoices, generatePlayerChoices } = usePlayerChoices({
+    sessionId,
+    worldId,
+    characterId,
+    narrativeGenerator,
+    warnMissingSessionId,
+    mountedRef,
+    onChoicesGenerated,
+    onError: setError,
   });
 
   // Initialize component state on mount
@@ -148,12 +155,10 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
 
     // Reset generation flags
     initialGenerationInitiated.current = false;
-    choiceGenerationInProgress.current = false;
 
     return () => {
       mountedRef.current = false;
       initialGenerationInitiated.current = false; // Reset generation init flag
-      choiceGenerationInProgress.current = false; // Reset choice generation flag
       // NOTE: We intentionally do NOT delete initialGenerationLocksRef here.
       // The lock is owned by the in-flight generation (released in its finally
       // block); releasing it on unmount allows a remounted instance to start a
@@ -261,236 +266,6 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
     isLoading,
     sessionId,
     sessionKey,
-  ]);
-
-  /**
-   * Generate player choices based on current narrative context
-   */
-  const generatePlayerChoices = useCallback(async () => {
-    if (!mountedRef.current) {
-      return;
-    }
-    if (!sessionId) {
-      warnMissingSessionId('choice');
-      return;
-    }
-
-    // Prevent overlapping choice generation using ref (more reliable than state)
-    if (choiceGenerationInProgress.current) {
-      return;
-    }
-
-    choiceGenerationInProgress.current = true;
-
-    // Get fresh segments from the store instead of relying on component state
-    const currentSegments = useNarrativeStore
-      .getState()
-      .getSessionSegments(sessionId);
-
-    if (currentSegments.length === 0) {
-      choiceGenerationInProgress.current = false;
-      return;
-    }
-    setIsGeneratingChoices(true);
-
-    // Use recent segments for context - get from fresh data
-    const recentSegments = currentSegments.slice(-5);
-
-    // Create fallback choices upfront - we'll use these immediately if something fails
-    let usedFallbackDecision = false;
-    const fallbackId = `decision-fallback-${Date.now()}`;
-    const fallbackDecision: Decision = {
-      id: fallbackId,
-      prompt: 'What will you do?',
-      options: [
-        {
-          id: `option-${fallbackId}-1`,
-          text: 'Investigate further',
-          alignment: 'neutral',
-          requirements: [{ type: 'skill', targetId: 'generic-skill-check', operator: 'gte', value: 1 }],
-        },
-        {
-          id: `option-${fallbackId}-2`,
-          text: 'Talk to nearby characters',
-          alignment: 'lawful',
-          requirements: [{ type: 'skill', targetId: 'generic-skill-check', operator: 'gte', value: 1 }],
-        },
-        {
-          id: `option-${fallbackId}-3`,
-          text: 'Move to a new location',
-          alignment: 'neutral',
-          requirements: [{ type: 'skill', targetId: 'generic-skill-check', operator: 'gte', value: 1 }],
-        },
-      ],
-      decisionWeight: 'minor',
-      contextSummary:
-        recentSegments.length > 0
-          ? `${recentSegments[recentSegments.length - 1]?.metadata?.location || 'Unknown location'}: ${truncate(recentSegments[recentSegments.length - 1]?.content || 'Making a decision', 100)}`
-          : 'Making a decision in an unknown location.',
-    };
-
-    try {
-      const choiceCharacterIds = characterId ? [characterId] : [];
-      // Create narrative context for choice generation
-      const narrativeContext: NarrativeContext = {
-        worldId,
-        currentSceneId: `scene-${Date.now()}`,
-        characterIds: choiceCharacterIds,
-        previousSegments: recentSegments,
-        currentTags:
-          recentSegments[recentSegments.length - 1]?.metadata?.tags || [],
-        sessionId: sessionId || 'temp-session',
-        recentSegments,
-        currentLocation:
-          recentSegments[recentSegments.length - 1]?.metadata?.location ||
-          undefined,
-      };
-
-      // Generate choices with a 15-second timeout for real API calls
-      let decision;
-      try {
-        // Set up a race between the AI generation and a timeout
-        const timeoutPromise = new Promise<Decision>((_, reject) => {
-          setTimeout(
-            () =>
-              reject(
-                new Error(`AI choice generation timed out after ${AI_GENERATION_TIMEOUT_MS}ms`)
-              ),
-            AI_GENERATION_TIMEOUT_MS
-          );
-        });
-
-        decision = await Promise.race([
-          narrativeGenerator.generatePlayerChoices(
-            worldId,
-            narrativeContext,
-            choiceCharacterIds
-          ),
-          timeoutPromise,
-        ]);
-      } catch (error) {
-        logger.warn('Choice generation failed, using fallback choices', error);
-        decision = fallbackDecision;
-        usedFallbackDecision = true;
-      }
-
-      // Skip if component unmounted during async operation
-      if (!mountedRef.current) {
-        return;
-      }
-
-      // Verify decision structure and use fallback if invalid
-      if (
-        !decision ||
-        !decision.options ||
-        (decision.options?.length || 0) === 0
-      ) {
-        decision = fallbackDecision;
-        usedFallbackDecision = true;
-      }
-
-      // Add decision to store and get the actual stored ID
-      const storedDecisionId = useNarrativeStore
-        .getState()
-        .addDecision(sessionId, {
-          prompt: decision.prompt,
-          options: decision.options,
-          decisionWeight: decision.decisionWeight,
-          contextSummary: decision.contextSummary,
-        });
-
-      // Update the decision with the stored ID before passing to parent
-      decision.id = storedDecisionId;
-
-      // Only notify parent component if we have AI-generated choices (not fallback)
-      if (!usedFallbackDecision) {
-        if (onChoicesGenerated) {
-          try {
-            // Create a deep copy of the decision to ensure React state updates
-            const decisionCopy = structuredClone(decision);
-            onChoicesGenerated(decisionCopy);
-          } catch (error) {
-            logger.error('Error calling onChoicesGenerated callback:', error);
-          }
-        }
-      }
-    } catch (error) {
-      // Unhandled error in generatePlayerChoices
-      setError(getNarrativeError(error as Error).message);
-
-      // Even if we get an unhandled error, try to provide fallback choices
-
-      try {
-        // Only try to create fallback choices if we haven't already added any for this session
-        const existingDecisions = useNarrativeStore
-          .getState()
-          .getSessionDecisions(sessionId);
-
-        if (existingDecisions.length === 0 && mountedRef.current) {
-          // Create and add fallback choices to the store
-          const fallbackId = `decision-fallback-error-${Date.now()}`;
-          const fallbackDecision: Decision = {
-            id: fallbackId,
-            prompt: 'What will you do now?',
-            options: [
-              {
-                id: `option-${fallbackId}-1`,
-                text: 'Investigate the situation',
-                alignment: 'neutral',
-                requirements: [{ type: 'skill', targetId: 'generic-skill-check', operator: 'gte', value: 1 }],
-              },
-              {
-                id: `option-${fallbackId}-2`,
-                text: 'Speak with someone nearby',
-                alignment: 'lawful',
-                requirements: [{ type: 'skill', targetId: 'generic-skill-check', operator: 'gte', value: 1 }],
-              },
-              {
-                id: `option-${fallbackId}-3`,
-                text: 'Move to a different area',
-                alignment: 'neutral',
-                requirements: [{ type: 'skill', targetId: 'generic-skill-check', operator: 'gte', value: 1 }],
-              },
-            ],
-            decisionWeight: 'minor',
-            contextSummary: 'Error occurred during choice generation.',
-          };
-
-          // Add to store and get the actual stored ID
-          const storedFallbackId = useNarrativeStore
-            .getState()
-            .addDecision(sessionId, {
-              prompt: fallbackDecision.prompt,
-              options: fallbackDecision.options,
-              decisionWeight: fallbackDecision.decisionWeight,
-              contextSummary: fallbackDecision.contextSummary,
-            });
-
-          // Update the fallback decision with the stored ID
-          fallbackDecision.id = storedFallbackId;
-
-          // Notify parent
-          if (onChoicesGenerated && mountedRef.current) {
-            const decisionCopy = structuredClone(fallbackDecision);
-            onChoicesGenerated(decisionCopy);
-          }
-        }
-      } catch {
-        // Failed to provide fallback choices
-      }
-    } finally {
-      choiceGenerationInProgress.current = false;
-      if (mountedRef.current) {
-        setIsGeneratingChoices(false);
-      }
-    }
-  }, [
-    sessionId,
-    worldId,
-    characterId,
-    onChoicesGenerated,
-    narrativeGenerator,
-    warnMissingSessionId,
   ]);
 
   // Load segments after hydration is complete

--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -12,7 +12,6 @@ import { useNarrativeStore } from '@/state/narrativeStore';
 import { useEndingDetection } from './useEndingDetection';
 import {
   Decision,
-  DecisionOutcome,
   DecisionWeight,
   NarrativeContext,
   NarrativeSegment,
@@ -21,14 +20,13 @@ import {
 import { truncate } from '@/lib/utils';
 import { isSessionEndingSegment } from '@/lib/narrative/isSessionEndingSegment';
 import { getNarrativeError } from '@/lib/narrative/narrativeErrors';
+import { evaluateDecisionSkillChecks } from '@/lib/narrative/evaluateDecisionSkillChecks';
 import { logger } from '@/lib/utils/logger';
 import { AI_GENERATION_TIMEOUT_MS } from '@/lib/constants/timeouts';
 import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
 import { useCharacterStore } from '@/state/characterStore';
 import { useWorldStore } from '@/state/worldStore';
 import { useNPCStore } from '@/state/npcStore';
-import { evaluateSkillCheck } from '@/utils/skillCheckEvaluator';
-import type { Character as UtilCharacter } from '@/types/character.types';
 import { useToast } from '@/components/ui/toast/toaster';
 
 const EMPTY_NPC_IDS: string[] = [];
@@ -830,170 +828,18 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
         }
       }
 
-      // Evaluate skill requirements if present
-      const skillCheckTags: string[] = [];
-      const rollResults: SkillCheckRoll[] = [];
-
-      if (selectedOption?.requirements && characterId) {
-        const character = characters[characterId];
-        const world = worlds[worldId];
-
-        if (character && world) {
-          // Filter for skill requirements only
-          const skillRequirements = selectedOption.requirements.filter(
-            (req) => req.type === 'skill'
-          );
-
-          for (const requirement of skillRequirements) {
-            const requiredLevel =
-              typeof requirement.value === 'number'
-                ? requirement.value
-                : parseInt(requirement.value, 10);
-
-            // ChoiceGenerator has already converted skill names to IDs
-            // targetId now contains the skill ID directly
-            const skillCheck = {
-              skillId: requirement.targetId,
-              difficulty: requiredLevel,
-            };
-
-            // Adapt store character format to evaluator's expected format
-            const adaptedCharacter: UtilCharacter = {
-              id: character.id,
-              name: character.name,
-              description: character.description,
-              worldId: character.worldId,
-              skills: character.skills.map((skill) => ({
-                skillId: skill.worldSkillId || skill.id,
-                level: skill.level,
-                experience: 0,
-                isActive: true,
-              })),
-              attributes: character.attributes.map((attr) => ({
-                attributeId: attr.worldAttributeId || attr.id,
-                value: attr.modifiedValue || attr.baseValue,
-              })),
-              derivedStats: [],
-              background: {
-                history: character.background?.history || '',
-                personality: character.background?.personality || '',
-                goals: character.background?.goals || [],
-                fears: character.background?.fears || [],
-                relationships: [],
-              },
-              inventory: {
-                characterId: character.inventory.characterId,
-                items: [],
-                capacity: character.inventory.capacity,
-                categories: [],
-                itemOrder: [],
-              },
-              status: character.status,
-              createdAt: character.createdAt,
-              updatedAt: character.updatedAt,
-            };
-
-            try {
-              const rollResult = evaluateSkillCheck(
-                adaptedCharacter,
-                skillCheck,
-                world.skills || []
-              );
-              rollResults.push(rollResult);
-
-              // Build tags based on outcome
-              if (rollResult.isCriticalSuccess) {
-                skillCheckTags.push(
-                  `skill-critical-success:${requirement.targetId}`
-                );
-              } else if (rollResult.isCriticalFailure) {
-                skillCheckTags.push(
-                  `skill-critical-failure:${requirement.targetId}`
-                );
-              } else if (rollResult.success) {
-                skillCheckTags.push(`skill-success:${requirement.targetId}`);
-              } else {
-                skillCheckTags.push(`skill-failure:${requirement.targetId}`);
-              }
-
-              skillCheckTags.push(`skill-roll:${rollResult.diceRoll}`);
-            } catch (error) {
-              logger.error('Skill check failed:', error);
-              skillCheckTags.push(`skill-error:${requirement.targetId}`);
-            }
-          }
-        }
-      }
-
-      // Pass results to parent component
-      onSkillCheckPerformed?.(rollResults);
-
-      // Show toast notifications for skill check results
-      // Use longer duration (8 seconds) so players have time to read the roll details
-      rollResults.forEach((result) => {
-        // Build detailed breakdown for description
-        const buildBreakdown = () => {
-          const parts = [`d20: ${result.diceRoll}`];
-          if (result.skillLevel > 0) parts.push(`skill: +${result.skillLevel}`);
-          if (result.attributeBonus > 0)
-            parts.push(`attribute: +${result.attributeBonus}`);
-
-          // If no bonuses, explicitly show that
-          const hasAnyBonus =
-            result.skillLevel > 0 || result.attributeBonus > 0;
-          const breakdown = hasAnyBonus
-            ? parts.join(', ')
-            : `${parts[0]} (no bonuses)`;
-
-          return `${breakdown} = ${result.total} (need ${result.dc})`;
-        };
-
-        if (result.isCriticalSuccess) {
-          toast.addToast({
-            title: `Critical Success! ${result.skillName}`,
-            description: `Natural 20! Automatic success regardless of modifiers.`,
-            variant: 'success',
-            duration: 8000,
-          });
-        } else if (result.isCriticalFailure) {
-          toast.addToast({
-            title: `Critical Failure! ${result.skillName}`,
-            description: `Natural 1! Automatic failure regardless of modifiers.`,
-            variant: 'error',
-            duration: 8000,
-          });
-        } else if (result.success) {
-          toast.addToast({
-            title: `${result.skillName} Check: Success`,
-            description: buildBreakdown(),
-            variant: 'success',
-            duration: 8000,
-          });
-        } else {
-          toast.addToast({
-            title: `${result.skillName} Check: Failed`,
-            description: buildBreakdown(),
-            variant: 'warning',
-            duration: 8000,
-          });
-        }
-      });
-
-      let decisionOutcome: DecisionOutcome | undefined;
-      if (rollResults.length > 0) {
-        const successCount = rollResults.filter((r) => r.success).length;
-        const failureCount = rollResults.length - successCount;
-        const hasCriticalSuccess = rollResults.some((r) => r.isCriticalSuccess);
-        const hasCriticalFailure = rollResults.some((r) => r.isCriticalFailure);
-
-        if (failureCount === 0) {
-          decisionOutcome = hasCriticalSuccess ? 'critical-success' : 'success';
-        } else if (successCount === 0) {
-          decisionOutcome = hasCriticalFailure ? 'critical-failure' : 'failure';
-        } else {
-          decisionOutcome = 'mixed';
-        }
-      }
+      // Evaluate skill requirements (rolls, tags, outcome, per-roll toasts, and
+      // the parent onSkillCheckPerformed notification are handled in the helper)
+      const character = characterId ? characters[characterId] : undefined;
+      const world = worlds[worldId];
+      const { skillCheckTags, rollResults, decisionOutcome } =
+        evaluateDecisionSkillChecks({
+          selectedOption,
+          character,
+          world,
+          toast,
+          onSkillCheckPerformed,
+        });
 
       // Fatal outcome check: Any failure on a critical decision ends the game
       // This makes critical decisions truly life-or-death

--- a/src/components/Narrative/__tests__/NarrativeController.contextSummaryPersistence.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeController.contextSummaryPersistence.test.tsx
@@ -142,5 +142,8 @@ describe('NarrativeController context summary persistence', () => {
         contextSummary: 'A tense standoff unfolds at the crossroads.',
       })
     );
+
+    // Post-hydration choice generation should fire exactly once (no double-trigger).
+    expect(addDecision).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/Narrative/hooks/__tests__/usePlayerChoices.test.ts
+++ b/src/components/Narrative/hooks/__tests__/usePlayerChoices.test.ts
@@ -1,0 +1,134 @@
+import { renderHook, act } from '@testing-library/react';
+import { usePlayerChoices } from '../usePlayerChoices';
+import { useNarrativeStore } from '@/state/narrativeStore';
+import { createMockNarrativeStore, mockZustandStore } from '@/lib/test-utils';
+import type { NarrativeGenerator } from '@/lib/ai/narrativeGenerator';
+
+jest.mock('@/state/narrativeStore', () => ({ useNarrativeStore: jest.fn() }));
+
+const baseSegment = {
+  id: 'seg-1',
+  sessionId: 's1',
+  worldId: 'w1',
+  content: 'The hero pauses.',
+  type: 'scene',
+  metadata: { tags: [] },
+  timestamp: new Date('2025-01-01T00:00:00Z'),
+};
+
+const aiDecision = {
+  id: 'ai-d',
+  prompt: 'What do you do?',
+  options: [{ id: 'o1', text: 'Press on', alignment: 'neutral' }],
+  decisionWeight: 'major',
+  contextSummary: 'A fork in the road.',
+};
+
+function setupStore(overrides: Record<string, unknown> = {}) {
+  const addDecision = jest.fn().mockReturnValue('stored-decision-1');
+  const getSessionSegments = jest.fn().mockReturnValue([baseSegment]);
+  const getSessionDecisions = jest.fn().mockReturnValue([]);
+  mockZustandStore(
+    useNarrativeStore as jest.MockedFunction<typeof useNarrativeStore>,
+    createMockNarrativeStore({
+      addDecision,
+      getSessionSegments,
+      getSessionDecisions,
+      ...overrides,
+    })
+  );
+  return { addDecision, getSessionSegments, getSessionDecisions };
+}
+
+function renderPlayerChoices() {
+  const aiGenerate = jest.fn().mockResolvedValue(aiDecision);
+  const onChoicesGenerated = jest.fn();
+  const onError = jest.fn();
+  const warnMissingSessionId = jest.fn();
+  const mountedRef = { current: true };
+  const narrativeGenerator = {
+    generatePlayerChoices: aiGenerate,
+  } as unknown as NarrativeGenerator;
+
+  const utils = renderHook(() =>
+    usePlayerChoices({
+      sessionId: 's1',
+      worldId: 'w1',
+      characterId: 'c1',
+      narrativeGenerator,
+      warnMissingSessionId,
+      mountedRef,
+      onChoicesGenerated,
+      onError,
+    })
+  );
+
+  return { ...utils, aiGenerate, onChoicesGenerated, onError, mountedRef };
+}
+
+describe('usePlayerChoices', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    // structuredClone is undefined in the jest/jsdom env; the hook uses it to
+    // deep-copy the decision before notifying. Polyfill so we exercise the real
+    // (browser) notify path rather than the silently-caught failure branch.
+    if (typeof globalThis.structuredClone !== 'function') {
+      globalThis.structuredClone = ((val: unknown) =>
+        JSON.parse(JSON.stringify(val))) as typeof structuredClone;
+    }
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('generates AI choices, persists the decision, and notifies the parent', async () => {
+    const { addDecision } = setupStore();
+    const { result, aiGenerate, onChoicesGenerated } = renderPlayerChoices();
+
+    await act(async () => {
+      await result.current.generatePlayerChoices();
+    });
+
+    expect(aiGenerate).toHaveBeenCalledWith('w1', expect.any(Object), ['c1']);
+    expect(addDecision).toHaveBeenCalledWith(
+      's1',
+      expect.objectContaining({
+        prompt: 'What do you do?',
+        decisionWeight: 'major',
+        contextSummary: 'A fork in the road.',
+      })
+    );
+    expect(onChoicesGenerated).toHaveBeenCalledTimes(1);
+  });
+
+  it('guards against overlapping generation (second call is a no-op)', async () => {
+    setupStore();
+    const { result, aiGenerate } = renderPlayerChoices();
+
+    await act(async () => {
+      const gen = result.current.generatePlayerChoices;
+      const first = gen();
+      const second = gen();
+      await Promise.all([first, second]);
+    });
+
+    expect(aiGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns early without an AI call when the session has no segments', async () => {
+    const { addDecision } = setupStore({
+      getSessionSegments: jest.fn().mockReturnValue([]),
+    });
+    const { result, aiGenerate } = renderPlayerChoices();
+
+    await act(async () => {
+      await result.current.generatePlayerChoices();
+    });
+
+    expect(aiGenerate).not.toHaveBeenCalled();
+    expect(addDecision).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Narrative/hooks/usePlayerChoices.ts
+++ b/src/components/Narrative/hooks/usePlayerChoices.ts
@@ -132,7 +132,7 @@ export function usePlayerChoices({
         previousSegments: recentSegments,
         currentTags:
           recentSegments[recentSegments.length - 1]?.metadata?.tags || [],
-        sessionId: sessionId || 'temp-session',
+        sessionId,
         recentSegments,
         currentLocation:
           recentSegments[recentSegments.length - 1]?.metadata?.location ||

--- a/src/components/Narrative/hooks/usePlayerChoices.ts
+++ b/src/components/Narrative/hooks/usePlayerChoices.ts
@@ -1,0 +1,292 @@
+import {
+  useState,
+  useRef,
+  useCallback,
+  useEffect,
+  type MutableRefObject,
+} from 'react';
+import { useNarrativeStore } from '@/state/narrativeStore';
+import { truncate } from '@/lib/utils';
+import { getNarrativeError } from '@/lib/narrative/narrativeErrors';
+import { logger } from '@/lib/utils/logger';
+import { AI_GENERATION_TIMEOUT_MS } from '@/lib/constants/timeouts';
+import type { NarrativeGenerator } from '@/lib/ai/narrativeGenerator';
+import type { Decision, NarrativeContext } from '@/types/narrative.types';
+
+interface UsePlayerChoicesParams {
+  sessionId: string;
+  worldId: string;
+  characterId?: string;
+  narrativeGenerator: NarrativeGenerator;
+  warnMissingSessionId: (context: string) => void;
+  /** Shared with the controller so unmount/skip semantics stay consistent. */
+  mountedRef: MutableRefObject<boolean>;
+  onChoicesGenerated?: (decision: Decision) => void;
+  /** Surfaces an error message to the controller (wraps its setError). */
+  onError: (message: string) => void;
+}
+
+interface UsePlayerChoicesResult {
+  isGeneratingChoices: boolean;
+  generatePlayerChoices: () => Promise<void>;
+}
+
+/**
+ * Owns player-choice generation for the active session: the AI call (with a
+ * timeout race and fallback choices), decision persistence, and the overlap
+ * guard. Extracted from NarrativeController with no behavior change.
+ */
+export function usePlayerChoices({
+  sessionId,
+  worldId,
+  characterId,
+  narrativeGenerator,
+  warnMissingSessionId,
+  mountedRef,
+  onChoicesGenerated,
+  onError,
+}: UsePlayerChoicesParams): UsePlayerChoicesResult {
+  const [isGeneratingChoices, setIsGeneratingChoices] = useState(false);
+  // Prevent overlapping choice generation (more reliable than state).
+  const choiceGenerationInProgress = useRef(false);
+
+  // Reset the overlap guard when the session changes or the component unmounts,
+  // mirroring the controller's original mount-effect resets.
+  useEffect(() => {
+    choiceGenerationInProgress.current = false;
+    return () => {
+      choiceGenerationInProgress.current = false;
+    };
+  }, [sessionId, worldId, characterId]);
+
+  const generatePlayerChoices = useCallback(async () => {
+    if (!mountedRef.current) {
+      return;
+    }
+    if (!sessionId) {
+      warnMissingSessionId('choice');
+      return;
+    }
+
+    // Prevent overlapping choice generation using ref (more reliable than state)
+    if (choiceGenerationInProgress.current) {
+      return;
+    }
+
+    choiceGenerationInProgress.current = true;
+
+    // Get fresh segments from the store instead of relying on component state
+    const currentSegments = useNarrativeStore
+      .getState()
+      .getSessionSegments(sessionId);
+
+    if (currentSegments.length === 0) {
+      choiceGenerationInProgress.current = false;
+      return;
+    }
+    setIsGeneratingChoices(true);
+
+    // Use recent segments for context - get from fresh data
+    const recentSegments = currentSegments.slice(-5);
+
+    // Create fallback choices upfront - we'll use these immediately if something fails
+    let usedFallbackDecision = false;
+    const fallbackId = `decision-fallback-${Date.now()}`;
+    const fallbackDecision: Decision = {
+      id: fallbackId,
+      prompt: 'What will you do?',
+      options: [
+        {
+          id: `option-${fallbackId}-1`,
+          text: 'Investigate further',
+          alignment: 'neutral',
+          requirements: [{ type: 'skill', targetId: 'generic-skill-check', operator: 'gte', value: 1 }],
+        },
+        {
+          id: `option-${fallbackId}-2`,
+          text: 'Talk to nearby characters',
+          alignment: 'lawful',
+          requirements: [{ type: 'skill', targetId: 'generic-skill-check', operator: 'gte', value: 1 }],
+        },
+        {
+          id: `option-${fallbackId}-3`,
+          text: 'Move to a new location',
+          alignment: 'neutral',
+          requirements: [{ type: 'skill', targetId: 'generic-skill-check', operator: 'gte', value: 1 }],
+        },
+      ],
+      decisionWeight: 'minor',
+      contextSummary:
+        recentSegments.length > 0
+          ? `${recentSegments[recentSegments.length - 1]?.metadata?.location || 'Unknown location'}: ${truncate(recentSegments[recentSegments.length - 1]?.content || 'Making a decision', 100)}`
+          : 'Making a decision in an unknown location.',
+    };
+
+    try {
+      const choiceCharacterIds = characterId ? [characterId] : [];
+      // Create narrative context for choice generation
+      const narrativeContext: NarrativeContext = {
+        worldId,
+        currentSceneId: `scene-${Date.now()}`,
+        characterIds: choiceCharacterIds,
+        previousSegments: recentSegments,
+        currentTags:
+          recentSegments[recentSegments.length - 1]?.metadata?.tags || [],
+        sessionId: sessionId || 'temp-session',
+        recentSegments,
+        currentLocation:
+          recentSegments[recentSegments.length - 1]?.metadata?.location ||
+          undefined,
+      };
+
+      // Generate choices with a 15-second timeout for real API calls
+      let decision;
+      try {
+        // Set up a race between the AI generation and a timeout
+        const timeoutPromise = new Promise<Decision>((_, reject) => {
+          setTimeout(
+            () =>
+              reject(
+                new Error(`AI choice generation timed out after ${AI_GENERATION_TIMEOUT_MS}ms`)
+              ),
+            AI_GENERATION_TIMEOUT_MS
+          );
+        });
+
+        decision = await Promise.race([
+          narrativeGenerator.generatePlayerChoices(
+            worldId,
+            narrativeContext,
+            choiceCharacterIds
+          ),
+          timeoutPromise,
+        ]);
+      } catch (error) {
+        logger.warn('Choice generation failed, using fallback choices', error);
+        decision = fallbackDecision;
+        usedFallbackDecision = true;
+      }
+
+      // Skip if component unmounted during async operation
+      if (!mountedRef.current) {
+        return;
+      }
+
+      // Verify decision structure and use fallback if invalid
+      if (
+        !decision ||
+        !decision.options ||
+        (decision.options?.length || 0) === 0
+      ) {
+        decision = fallbackDecision;
+        usedFallbackDecision = true;
+      }
+
+      // Add decision to store and get the actual stored ID
+      const storedDecisionId = useNarrativeStore
+        .getState()
+        .addDecision(sessionId, {
+          prompt: decision.prompt,
+          options: decision.options,
+          decisionWeight: decision.decisionWeight,
+          contextSummary: decision.contextSummary,
+        });
+
+      // Update the decision with the stored ID before passing to parent
+      decision.id = storedDecisionId;
+
+      // Only notify parent component if we have AI-generated choices (not fallback)
+      if (!usedFallbackDecision) {
+        if (onChoicesGenerated) {
+          try {
+            // Create a deep copy of the decision to ensure React state updates
+            const decisionCopy = structuredClone(decision);
+            onChoicesGenerated(decisionCopy);
+          } catch (error) {
+            logger.error('Error calling onChoicesGenerated callback:', error);
+          }
+        }
+      }
+    } catch (error) {
+      // Unhandled error in generatePlayerChoices
+      onError(getNarrativeError(error as Error).message);
+
+      // Even if we get an unhandled error, try to provide fallback choices
+
+      try {
+        // Only try to create fallback choices if we haven't already added any for this session
+        const existingDecisions = useNarrativeStore
+          .getState()
+          .getSessionDecisions(sessionId);
+
+        if (existingDecisions.length === 0 && mountedRef.current) {
+          // Create and add fallback choices to the store
+          const fallbackId = `decision-fallback-error-${Date.now()}`;
+          const fallbackDecision: Decision = {
+            id: fallbackId,
+            prompt: 'What will you do now?',
+            options: [
+              {
+                id: `option-${fallbackId}-1`,
+                text: 'Investigate the situation',
+                alignment: 'neutral',
+                requirements: [{ type: 'skill', targetId: 'generic-skill-check', operator: 'gte', value: 1 }],
+              },
+              {
+                id: `option-${fallbackId}-2`,
+                text: 'Speak with someone nearby',
+                alignment: 'lawful',
+                requirements: [{ type: 'skill', targetId: 'generic-skill-check', operator: 'gte', value: 1 }],
+              },
+              {
+                id: `option-${fallbackId}-3`,
+                text: 'Move to a different area',
+                alignment: 'neutral',
+                requirements: [{ type: 'skill', targetId: 'generic-skill-check', operator: 'gte', value: 1 }],
+              },
+            ],
+            decisionWeight: 'minor',
+            contextSummary: 'Error occurred during choice generation.',
+          };
+
+          // Add to store and get the actual stored ID
+          const storedFallbackId = useNarrativeStore
+            .getState()
+            .addDecision(sessionId, {
+              prompt: fallbackDecision.prompt,
+              options: fallbackDecision.options,
+              decisionWeight: fallbackDecision.decisionWeight,
+              contextSummary: fallbackDecision.contextSummary,
+            });
+
+          // Update the fallback decision with the stored ID
+          fallbackDecision.id = storedFallbackId;
+
+          // Notify parent
+          if (onChoicesGenerated && mountedRef.current) {
+            const decisionCopy = structuredClone(fallbackDecision);
+            onChoicesGenerated(decisionCopy);
+          }
+        }
+      } catch {
+        // Failed to provide fallback choices
+      }
+    } finally {
+      choiceGenerationInProgress.current = false;
+      if (mountedRef.current) {
+        setIsGeneratingChoices(false);
+      }
+    }
+  }, [
+    sessionId,
+    worldId,
+    characterId,
+    onChoicesGenerated,
+    narrativeGenerator,
+    warnMissingSessionId,
+    mountedRef,
+    onError,
+  ]);
+
+  return { isGeneratingChoices, generatePlayerChoices };
+}

--- a/src/lib/narrative/__tests__/evaluateDecisionSkillChecks.test.ts
+++ b/src/lib/narrative/__tests__/evaluateDecisionSkillChecks.test.ts
@@ -1,0 +1,113 @@
+import { evaluateDecisionSkillChecks } from '../evaluateDecisionSkillChecks';
+import type { Character as StoreCharacter } from '@/state/characterStore';
+import type { World, WorldSkill } from '@/types/world.types';
+import type { DecisionOption } from '@/types/narrative.types';
+
+const worldSkill = (id: string, name: string): WorldSkill =>
+  ({ id, name, attributeIds: [] } as unknown as WorldSkill);
+
+const buildWorld = (skills: WorldSkill[]): World =>
+  ({ skills } as unknown as World);
+
+const buildCharacter = (): StoreCharacter =>
+  ({
+    id: 'char-1',
+    name: 'Hero',
+    description: '',
+    worldId: 'world-1',
+    attributes: [],
+    skills: [
+      {
+        id: 'cs-1',
+        characterId: 'char-1',
+        worldSkillId: 'skill-1',
+        name: 'Stealth',
+        level: 3,
+      },
+    ],
+    background: { history: '', personality: '', goals: [], fears: [], relationships: [] },
+    status: { health: 10, maxHealth: 10, conditions: [] },
+    inventory: { characterId: 'char-1', items: [], capacity: 10, categories: [], itemOrder: [] },
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+  } as unknown as StoreCharacter);
+
+const optionWithSkill = (): DecisionOption => ({
+  id: 'opt-1',
+  text: 'Sneak past',
+  requirements: [{ type: 'skill', targetId: 'skill-1', operator: 'gte', value: 1 }],
+});
+
+describe('evaluateDecisionSkillChecks', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns empty results and notifies with no rolls when the option has no requirements', () => {
+    const onSkillCheckPerformed = jest.fn();
+    const addToast = jest.fn();
+
+    const result = evaluateDecisionSkillChecks({
+      selectedOption: { id: 'opt-0', text: 'Wait' },
+      character: buildCharacter(),
+      world: buildWorld([worldSkill('skill-1', 'Stealth')]),
+      toast: { addToast },
+      onSkillCheckPerformed,
+    });
+
+    expect(result.rollResults).toHaveLength(0);
+    expect(result.skillCheckTags).toEqual([]);
+    expect(result.decisionOutcome).toBeUndefined();
+    expect(onSkillCheckPerformed).toHaveBeenCalledWith([]);
+    expect(addToast).not.toHaveBeenCalled();
+  });
+
+  it('skips evaluation when character or world is missing', () => {
+    const addToast = jest.fn();
+
+    const result = evaluateDecisionSkillChecks({
+      selectedOption: optionWithSkill(),
+      character: undefined,
+      world: buildWorld([]),
+      toast: { addToast },
+    });
+
+    expect(result.rollResults).toHaveLength(0);
+    expect(result.skillCheckTags).toEqual([]);
+    expect(addToast).not.toHaveBeenCalled();
+  });
+
+  it('builds success tags + outcome and fires a success toast on a passing roll', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.5); // d20 -> 11
+    const addToast = jest.fn();
+
+    const result = evaluateDecisionSkillChecks({
+      selectedOption: optionWithSkill(),
+      character: buildCharacter(),
+      world: buildWorld([worldSkill('skill-1', 'Stealth')]),
+      toast: { addToast },
+    });
+
+    expect(result.skillCheckTags).toEqual(['skill-success:skill-1', 'skill-roll:11']);
+    expect(result.decisionOutcome).toBe('success');
+    expect(result.rollResults).toHaveLength(1);
+    expect(addToast).toHaveBeenCalledTimes(1);
+    expect(addToast.mock.calls[0][0]).toMatchObject({ variant: 'success' });
+  });
+
+  it('builds critical-failure tags + outcome and fires an error toast on a natural 1', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0); // d20 -> 1
+    const addToast = jest.fn();
+
+    const result = evaluateDecisionSkillChecks({
+      selectedOption: optionWithSkill(),
+      character: buildCharacter(),
+      world: buildWorld([worldSkill('skill-1', 'Stealth')]),
+      toast: { addToast },
+    });
+
+    expect(result.skillCheckTags).toEqual(['skill-critical-failure:skill-1', 'skill-roll:1']);
+    expect(result.decisionOutcome).toBe('critical-failure');
+    expect(addToast.mock.calls[0][0]).toMatchObject({ variant: 'error' });
+  });
+});

--- a/src/lib/narrative/evaluateDecisionSkillChecks.ts
+++ b/src/lib/narrative/evaluateDecisionSkillChecks.ts
@@ -1,0 +1,203 @@
+// Evaluates a chosen decision option's skill requirements: rolls each skill
+// check, builds the narrative tags that get merged into the next segment,
+// derives an overall decision outcome, and surfaces per-roll toasts. Extracted
+// from NarrativeController.generateNextSegment as a pure (no React state) unit;
+// side effects are limited to the two injected callbacks (toast, onSkillCheckPerformed).
+
+import { evaluateSkillCheck } from '@/utils/skillCheckEvaluator';
+import { logger } from '@/lib/utils/logger';
+import type { Character as UtilCharacter } from '@/types/character.types';
+import type { Character as StoreCharacter } from '@/state/characterStore';
+import type { World } from '@/types/world.types';
+import type {
+  DecisionOption,
+  DecisionOutcome,
+  SkillCheckRoll,
+} from '@/types/narrative.types';
+import type { ToastData } from '@/components/ui/toast/toaster';
+
+interface ToastNotifier {
+  addToast: (toast: Omit<ToastData, 'id'>) => string;
+}
+
+export interface DecisionSkillCheckParams {
+  selectedOption: DecisionOption | null;
+  character: StoreCharacter | undefined;
+  world: World | undefined;
+  toast: ToastNotifier;
+  onSkillCheckPerformed?: (results: SkillCheckRoll[]) => void;
+}
+
+export interface DecisionSkillCheckResult {
+  skillCheckTags: string[];
+  rollResults: SkillCheckRoll[];
+  decisionOutcome?: DecisionOutcome;
+}
+
+// Adapt the store's character shape to the skill-check evaluator's expected format.
+function adaptStoreCharacterToUtil(character: StoreCharacter): UtilCharacter {
+  return {
+    id: character.id,
+    name: character.name,
+    description: character.description,
+    worldId: character.worldId,
+    skills: character.skills.map((skill) => ({
+      skillId: skill.worldSkillId || skill.id,
+      level: skill.level,
+      experience: 0,
+      isActive: true,
+    })),
+    attributes: character.attributes.map((attr) => ({
+      attributeId: attr.worldAttributeId || attr.id,
+      value: attr.modifiedValue || attr.baseValue,
+    })),
+    derivedStats: [],
+    background: {
+      history: character.background?.history || '',
+      personality: character.background?.personality || '',
+      goals: character.background?.goals || [],
+      fears: character.background?.fears || [],
+      relationships: [],
+    },
+    inventory: {
+      characterId: character.inventory.characterId,
+      items: [],
+      capacity: character.inventory.capacity,
+      categories: [],
+      itemOrder: [],
+    },
+    status: character.status,
+    createdAt: character.createdAt,
+    updatedAt: character.updatedAt,
+  };
+}
+
+export function evaluateDecisionSkillChecks({
+  selectedOption,
+  character,
+  world,
+  toast,
+  onSkillCheckPerformed,
+}: DecisionSkillCheckParams): DecisionSkillCheckResult {
+  const skillCheckTags: string[] = [];
+  const rollResults: SkillCheckRoll[] = [];
+
+  if (selectedOption?.requirements && character && world) {
+    // Filter for skill requirements only
+    const skillRequirements = selectedOption.requirements.filter(
+      (req) => req.type === 'skill'
+    );
+
+    for (const requirement of skillRequirements) {
+      const requiredLevel =
+        typeof requirement.value === 'number'
+          ? requirement.value
+          : parseInt(requirement.value, 10);
+
+      // ChoiceGenerator has already converted skill names to IDs
+      // targetId now contains the skill ID directly
+      const skillCheck = {
+        skillId: requirement.targetId,
+        difficulty: requiredLevel,
+      };
+
+      const adaptedCharacter = adaptStoreCharacterToUtil(character);
+
+      try {
+        const rollResult = evaluateSkillCheck(
+          adaptedCharacter,
+          skillCheck,
+          world.skills || []
+        );
+        rollResults.push(rollResult);
+
+        // Build tags based on outcome
+        if (rollResult.isCriticalSuccess) {
+          skillCheckTags.push(`skill-critical-success:${requirement.targetId}`);
+        } else if (rollResult.isCriticalFailure) {
+          skillCheckTags.push(`skill-critical-failure:${requirement.targetId}`);
+        } else if (rollResult.success) {
+          skillCheckTags.push(`skill-success:${requirement.targetId}`);
+        } else {
+          skillCheckTags.push(`skill-failure:${requirement.targetId}`);
+        }
+
+        skillCheckTags.push(`skill-roll:${rollResult.diceRoll}`);
+      } catch (error) {
+        logger.error('Skill check failed:', error);
+        skillCheckTags.push(`skill-error:${requirement.targetId}`);
+      }
+    }
+  }
+
+  // Pass results to parent component
+  onSkillCheckPerformed?.(rollResults);
+
+  // Show toast notifications for skill check results
+  // Use longer duration (8 seconds) so players have time to read the roll details
+  rollResults.forEach((result) => {
+    // Build detailed breakdown for description
+    const buildBreakdown = () => {
+      const parts = [`d20: ${result.diceRoll}`];
+      if (result.skillLevel > 0) parts.push(`skill: +${result.skillLevel}`);
+      if (result.attributeBonus > 0)
+        parts.push(`attribute: +${result.attributeBonus}`);
+
+      // If no bonuses, explicitly show that
+      const hasAnyBonus = result.skillLevel > 0 || result.attributeBonus > 0;
+      const breakdown = hasAnyBonus
+        ? parts.join(', ')
+        : `${parts[0]} (no bonuses)`;
+
+      return `${breakdown} = ${result.total} (need ${result.dc})`;
+    };
+
+    if (result.isCriticalSuccess) {
+      toast.addToast({
+        title: `Critical Success! ${result.skillName}`,
+        description: `Natural 20! Automatic success regardless of modifiers.`,
+        variant: 'success',
+        duration: 8000,
+      });
+    } else if (result.isCriticalFailure) {
+      toast.addToast({
+        title: `Critical Failure! ${result.skillName}`,
+        description: `Natural 1! Automatic failure regardless of modifiers.`,
+        variant: 'error',
+        duration: 8000,
+      });
+    } else if (result.success) {
+      toast.addToast({
+        title: `${result.skillName} Check: Success`,
+        description: buildBreakdown(),
+        variant: 'success',
+        duration: 8000,
+      });
+    } else {
+      toast.addToast({
+        title: `${result.skillName} Check: Failed`,
+        description: buildBreakdown(),
+        variant: 'warning',
+        duration: 8000,
+      });
+    }
+  });
+
+  let decisionOutcome: DecisionOutcome | undefined;
+  if (rollResults.length > 0) {
+    const successCount = rollResults.filter((r) => r.success).length;
+    const failureCount = rollResults.length - successCount;
+    const hasCriticalSuccess = rollResults.some((r) => r.isCriticalSuccess);
+    const hasCriticalFailure = rollResults.some((r) => r.isCriticalFailure);
+
+    if (failureCount === 0) {
+      decisionOutcome = hasCriticalSuccess ? 'critical-success' : 'success';
+    } else if (successCount === 0) {
+      decisionOutcome = hasCriticalFailure ? 'critical-failure' : 'failure';
+    } else {
+      decisionOutcome = 'mixed';
+    }
+  }
+
+  return { skillCheckTags, rollResults, decisionOutcome };
+}


### PR DESCRIPTION
## Description

`NarrativeController.tsx` was a 1221-line god-file — the perennial "still pending" item across eight overengineering-audit rounds. It's a hidden, generator-only component (~96% logic / ~4% JSX) that orchestrates narrative generation, player choices, skill checks, and ending detection.

This PR extracts the two genuinely separable, low-risk seams and leaves the timing-sensitive effect/StrictMode orchestration in place. Pure structural refactor — zero behavior change.

- **`evaluateDecisionSkillChecks`** (`src/lib/narrative/`, 203 LOC) — the ~160-line skill-requirement block out of `generateNextSegment`: rolls, tag building, decision-outcome derivation, per-roll toasts, and the `onSkillCheckPerformed` notification. It's synchronous compute plus two injected callbacks (no React state), so it's a free function, not a hook.
- **`usePlayerChoices`** (`src/components/Narrative/hooks/`, 292 LOC) — `generatePlayerChoices` (~225 lines) plus its `isGeneratingChoices` state and the `choiceGenerationInProgress` re-entrancy guard. The hook owns the guard + its reset effect (same `[sessionId, worldId, characterId]` deps the mount effect used) and shares the controller's `mountedRef`, so unmount/skip semantics are unchanged; `setError` is passed in as a narrow `onError` callback rather than threaded raw.

Controller drops from **1221 → 842 LOC**. The four effects, StrictMode lock refs, and the two generate functions stay untouched — deliberately, since that's the part the existing tests don't really cover. The full thin-out (moving the effects into a `useNarrativeGeneration` hook) is left as a follow-up: it's mostly an aesthetic win and carries real timing-regression risk against a thin test net.

## Related Issue

N/A — overengineering-audit backlog (god-file item); no tracking issue.

## Type of Change
- [x] Refactoring (code improvements without changing functionality)

## TDD Compliance
- [ ] Tests written before implementation <!-- structural refactor; behavior was already guarded by the existing NarrativeController suites -->
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## Implementation Notes
- `evaluateDecisionSkillChecks` keeps the store-character → evaluator-character adaptation as an inline helper; `generateNextSegment` derives `hasCriticalFailure` inline since it also needs `decisionWeight`.
- One-directional imports (controller → hooks/lib → stores/types) — no new circular dependency; `skott` baseline (17) unchanged.
- Out of scope: the write-only `generateCount` ref (dead, flagged separately) and the full `useNarrativeGeneration` effect move.

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed <!-- not run; no security surface touched -->
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npx tsc --noEmit` and `npm run lint` — clean.
2. `npx jest src/components/Narrative src/lib/narrative` — 190 tests pass, including the three NarrativeController behavior-oracle suites (aiEndingDetection, contextSummaryPersistence, skillCheck.integration) plus the new `evaluateDecisionSkillChecks` and `usePlayerChoices` unit tests. The context-summary test now also asserts post-hydration choice generation fires exactly once (double-fire guard).
3. `npm run skott:circular` — within baseline. `npm run knip` — clean in a full checkout (a fresh worktree can flag unrelated devDeps/binaries due to its node_modules; main checkout is clean).
4. Live: dev server boots and `/dev/game-session` compiles (2352 modules, no errors) and serves 200 with the refactor. For a full interactive check, open `localhost:<port>/dev/game-session` in a normal browser (not Playwright — `isPlaywrightEnv` gates render-path AI) and confirm narrative + choices generate, a choice produces the next segment with correct skill/alignment tags, and choices don't double-fire.

## Checklist
- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file) <!-- NarrativeController 842 (down from 1221); full thin-out deferred. New files: usePlayerChoices 292, evaluateDecisionSkillChecks 203 — both under 300 -->
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) <!-- N/A -->
- [x] No new warnings generated
- [x] Accessibility considerations addressed <!-- no UI/markup change -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
