### PR TITLE
perf(bundle): lucide optimizePackageImports + lazy-load eager heavy client components

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,12 @@ const nextConfig: NextConfig = {
   // React strict mode for development warnings
   reactStrictMode: true,
 
+  // Tree-shake barrel imports from icon-heavy packages so a cold start only
+  // ships the icons actually used, not the full lucide-react module graph.
+  experimental: {
+    optimizePackageImports: ['lucide-react'],
+  },
+
   // Keep large server-only packages out of the Next.js bundle so they're
   // required natively by Node.js rather than compiled by webpack.
   serverExternalPackages: ['@lenml/tokenizer-gemini', '@lenml/tokenizers'],

--- a/src/app/characters/page.tsx
+++ b/src/app/characters/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo } from 'react';
+import dynamic from 'next/dynamic';
 import { Plus, Sparkles, Globe } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCharacterStore, type Character } from '@/state/characterStore';
@@ -11,7 +12,6 @@ import { deleteCharacterWithCleanup } from '@/services/characterDeletionService'
 import { getTimestamp } from '@/lib/utils';
 import { readString, writeString } from '@/lib/utils/browserStorage';
 import { CharacterCard } from '@/components/CharacterCard';
-import { CharacterTable } from '@/components/character/CharacterTable';
 import {
   CharacterViewToggle,
   type CharacterViewMode,
@@ -22,7 +22,6 @@ import { SSRClientOnly } from '@/components/shared/SSRClientOnly';
 import { ActionButtonGroup } from '@/components/shared/ActionButtonGroup';
 import { generateUniqueId } from '@/lib/utils/generateId';
 import type { GeneratedCharacterData } from '@/lib/ai/characterGenerator';
-import { GenerateCharacterDialog } from '@/components/GenerateCharacterDialog';
 import { World } from '@/types/world.types';
 import DeleteConfirmationDialog from '@/components/DeleteConfirmationDialog';
 import { Toast } from '@/components/ui/toast';
@@ -30,6 +29,24 @@ import { getGenreLabel } from '@/lib/constants/genres';
 import { GameSessionConfirmationDialog } from '@/components/GameSession/GameSessionConfirmationDialog';
 import type { GeneratedImage } from '@/types/common.types';
 import { generatePortrait } from '@/lib/api/generatePortrait';
+
+// CharacterTable pulls @tanstack/react-table but only renders in table view,
+// and the generate dialog only matters once the page is interactive. Load both
+// on demand so the grid-default list page ships less up front (issue #1357).
+const CharacterTable = dynamic(
+  () =>
+    import('@/components/character/CharacterTable').then((m) => ({
+      default: m.CharacterTable,
+    })),
+  { ssr: false }
+);
+const GenerateCharacterDialog = dynamic(
+  () =>
+    import('@/components/GenerateCharacterDialog').then((m) => ({
+      default: m.GenerateCharacterDialog,
+    })),
+  { ssr: false }
+);
 
 type CharacterPortraitUpdate = {
   portrait: GeneratedImage;

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useWorldStore } from '@/state/worldStore';
 import { useCharacterStore } from '@/state/characterStore';
 import { useSessionStore } from '@/state/sessionStore';
-import GameSession from '@/components/GameSession/GameSession';
 import { LoadingPulse } from '@/components/ui/LoadingState';
 import { ErrorDisplay } from '@/components/ui/ErrorDisplay';
 import { PageLayout } from '@/components/shared/PageLayout';
@@ -14,6 +14,13 @@ import { Button } from '@/components/ui/button';
 
 import Logger from '@/lib/utils/logger';
 const logger = new Logger('Play');
+
+// GameSession drags in the full narrative/AI chain; load it on demand and reuse
+// the page's existing loading state so first paint stays light (issue #1357).
+const GameSession = dynamic(() => import('@/components/GameSession/GameSession'), {
+  ssr: false,
+  loading: () => <LoadingPulse message="Preparing your adventure..." />,
+});
 
 type PersistApi = {
   persist?: {

--- a/src/app/worlds/[id]/play/__tests__/page.exitConfirmation.test.tsx
+++ b/src/app/worlds/[id]/play/__tests__/page.exitConfirmation.test.tsx
@@ -54,40 +54,42 @@ describe('PlayPage exit confirmation (#268)', () => {
     for (const key of Object.keys(segmentsBySession)) delete segmentsBySession[key];
   });
 
-  test('routes directly back when there is no narrative progress to abandon', () => {
+  // GameSession (which renders the mock back button) loads via next/dynamic,
+  // so await its appearance before interacting.
+  test('routes directly back when there is no narrative progress to abandon', async () => {
     render(<PlayPage />);
 
-    fireEvent.click(screen.getByTestId('mock-back-btn'));
+    fireEvent.click(await screen.findByTestId('mock-back-btn'));
 
     expect(pushMock).toHaveBeenCalledWith('/worlds/world-1');
     expect(screen.queryByText('Leave the Story?')).not.toBeInTheDocument();
   });
 
-  test('prompts for confirmation when there is narrative progress', () => {
+  test('prompts for confirmation when there is narrative progress', async () => {
     segmentsBySession['session-1'] = ['seg-a', 'seg-b'];
     render(<PlayPage />);
 
-    fireEvent.click(screen.getByTestId('mock-back-btn'));
+    fireEvent.click(await screen.findByTestId('mock-back-btn'));
 
     expect(pushMock).not.toHaveBeenCalled();
     expect(screen.getByText('Leave the Story?')).toBeInTheDocument();
   });
 
-  test('confirming the exit dialog navigates back to the world page', () => {
+  test('confirming the exit dialog navigates back to the world page', async () => {
     segmentsBySession['session-1'] = ['seg-a'];
     render(<PlayPage />);
 
-    fireEvent.click(screen.getByTestId('mock-back-btn'));
+    fireEvent.click(await screen.findByTestId('mock-back-btn'));
     fireEvent.click(screen.getByRole('button', { name: /leave story/i }));
 
     expect(pushMock).toHaveBeenCalledWith('/worlds/world-1');
   });
 
-  test('cancelling the exit dialog keeps the player on the page', () => {
+  test('cancelling the exit dialog keeps the player on the page', async () => {
     segmentsBySession['session-1'] = ['seg-a'];
     render(<PlayPage />);
 
-    fireEvent.click(screen.getByTestId('mock-back-btn'));
+    fireEvent.click(await screen.findByTestId('mock-back-btn'));
     fireEvent.click(screen.getByRole('button', { name: /keep playing/i }));
 
     expect(pushMock).not.toHaveBeenCalled();

--- a/src/app/worlds/[id]/play/__tests__/page.test.tsx
+++ b/src/app/worlds/[id]/play/__tests__/page.test.tsx
@@ -37,15 +37,15 @@ describe('Play Page', () => {
     expect(screen.queryByTestId('mock-game-session')).not.toBeInTheDocument();
   });
 
-  test('renders GameSession with worldId from params on client', () => {
+  test('renders GameSession with worldId from params on client', async () => {
     // Mock useState to simulate client-side rendering
     jest.spyOn(React, 'useState').mockImplementationOnce(() => [true, jest.fn()]);
-    
+
     // Act
     render(<PlayPage />);
 
-    // Assert
-    expect(screen.getByTestId('mock-game-session')).toBeInTheDocument();
+    // Assert — GameSession is loaded via next/dynamic, so await its appearance
+    expect(await screen.findByTestId('mock-game-session')).toBeInTheDocument();
     expect(screen.getByTestId('mock-game-session')).toHaveTextContent('Game Session for world-1');
   });
 
@@ -91,18 +91,18 @@ describe('Play Page', () => {
     expect(notFound).toHaveBeenCalled();
   });
   
-  test('passes the worldId correctly to GameSession component', () => {
+  test('passes the worldId correctly to GameSession component', async () => {
     // Mock useState to simulate client-side rendering
     jest.spyOn(React, 'useState').mockImplementationOnce(() => [true, jest.fn()]);
-    
+
     // Test with a specific worldId
     const testWorldId = 'test-world-123';
     (useParams as jest.Mock).mockReturnValueOnce({ id: testWorldId });
-    
+
     // Act
     render(<PlayPage />);
-    
-    // Assert
-    expect(screen.getByTestId('mock-game-session')).toHaveTextContent(`Game Session for ${testWorldId}`);
+
+    // Assert — GameSession is loaded via next/dynamic, so await its appearance
+    expect(await screen.findByTestId('mock-game-session')).toHaveTextContent(`Game Session for ${testWorldId}`);
   });
 });

--- a/src/app/worlds/[id]/play/page.tsx
+++ b/src/app/worlds/[id]/play/page.tsx
@@ -1,11 +1,24 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
+import dynamic from 'next/dynamic';
 import { notFound, useParams, useSearchParams, useRouter } from 'next/navigation';
-import GameSession from '@/components/GameSession/GameSession';
 import { useSessionStore } from '@/state/sessionStore';
 import { useNarrativeStore } from '@/state/narrativeStore';
 import { GameSessionConfirmationDialog } from '@/components/GameSession/GameSessionConfirmationDialog';
+
+// GameSession pulls the heaviest chain in the app (ActiveGameSession ->
+// NarrativeController -> @google/genai + every drawer panel). The page already
+// shows this same placeholder before it renders, so loading it on demand keeps
+// the play route's first paint cheap without changing what the user sees.
+const GameSession = dynamic(() => import('@/components/GameSession/GameSession'), {
+  ssr: false,
+  loading: () => (
+    <div className="manuscript-play-page-loading">
+      <p>Creating your game...</p>
+    </div>
+  ),
+});
 
 /**
  * Play page component that initializes a game session with a worldId

--- a/src/components/ClientOnlyDevTools.tsx
+++ b/src/components/ClientOnlyDevTools.tsx
@@ -1,8 +1,16 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { DevToolsPanel } from '@/components/devtools';
+import dynamic from 'next/dynamic';
 import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
+
+// Load the devtools panel only on demand so its module graph is reliably kept
+// out of the production bundle — the dev-only render guard below still gates
+// whether it ever renders (issue #1357).
+const DevToolsPanel = dynamic(
+  () => import('@/components/devtools').then((m) => ({ default: m.DevToolsPanel })),
+  { ssr: false }
+);
 
 /**
  * Client-only wrapper for development tools to prevent hydration mismatches

--- a/src/components/TutorialProvider/TutorialProvider.tsx
+++ b/src/components/TutorialProvider/TutorialProvider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { createContext, useState, useCallback, useEffect, ReactNode, useRef } from 'react';
-import Joyride, { Step, CallBackProps, STATUS, ACTIONS, EVENTS } from 'react-joyride';
+import type { Step, CallBackProps } from 'react-joyride';
 import { useSessionStore } from '@/state/sessionStore';
 import { joyrideStyles, getTourOptions } from '@/lib/tutorial/tutorialConfig';
 import { TutorialPhase } from '@/types/tutorial.types';
@@ -10,6 +10,9 @@ import Logger from '@/lib/utils/logger';
 import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
 import { useTutorialAutoScroll } from './useTutorialAutoScroll';
 import { useTourTargetRetry } from './useTourTargetRetry';
+
+// The full react-joyride module, loaded on demand (see ensureJoyrideRuntime).
+type JoyrideModule = typeof import('react-joyride');
 
 type PauseReason = 'end-of-page' | 'missing-target' | null;
 
@@ -82,6 +85,10 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
   const runRef = useRef(false);
   const isPausedRef = useRef(false);
   const missingTargetRef = useRef<{ index: number; target: string | null } | null>(null);
+  // Mirror the loaded runtime in a ref so the Joyride callback can read its
+  // STATUS/ACTIONS/EVENTS enums without re-subscribing; state drives the render.
+  const joyrideRuntimeRef = useRef<JoyrideModule | null>(null);
+  const [joyrideRuntime, setJoyrideRuntime] = useState<JoyrideModule | null>(null);
 
   useTutorialAutoScroll(run, steps, stepIndex);
 
@@ -128,6 +135,26 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
     isPausedRef.current = isPaused;
   }, [isPaused]);
 
+  // react-joyride bundles its whole runtime (tour engine + @floating-ui) into a
+  // single ~67KB module. TutorialProvider sits in the root layout, so a static
+  // import would ship that runtime on every page even though most sessions never
+  // start a tour. Load it on first tour start instead, and read its
+  // STATUS/ACTIONS/EVENTS enums from the loaded module (issue #1357).
+  const ensureJoyrideRuntime = useCallback(async (): Promise<JoyrideModule | null> => {
+    if (joyrideRuntimeRef.current) {
+      return joyrideRuntimeRef.current;
+    }
+    try {
+      const runtime = await import('react-joyride');
+      joyrideRuntimeRef.current = runtime;
+      setJoyrideRuntime(runtime);
+      return runtime;
+    } catch (error) {
+      logger.error('Failed to load tour runtime', error);
+      return null;
+    }
+  }, []);
+
   const startTour = useCallback(async (tourId: TutorialPhase | string, initialStepIndex = 0) => {
     const { steps: loadedSteps, mapping } = await loadTour(tourId);
     
@@ -151,6 +178,11 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
         }
       }
 
+      const runtime = await ensureJoyrideRuntime();
+      if (!runtime) {
+        return;
+      }
+
       setSteps(loadedSteps);
       setStepMapping(mapping);
       setActiveTour(tourId);
@@ -171,11 +203,11 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
       }
 
       setStepIndex(nextStepIndex);
-      
+
       setRun(true);
       setIsPaused(false);
     }
-  }, [tutorialProgress.phases, currentWizardStep]);
+  }, [tutorialProgress.phases, currentWizardStep, ensureJoyrideRuntime]);
 
   const stopTour = useCallback(() => {
     setSteps([]);
@@ -196,6 +228,10 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
   }, []);
 
   const resumeTour = useCallback(async () => {
+    const runtime = await ensureJoyrideRuntime();
+    if (!runtime) {
+      return;
+    }
     // Re-load steps to ensure they are fresh and correctly targeted
     if (activeTour) {
       const { steps: loadedSteps } = await loadTour(activeTour);
@@ -205,9 +241,12 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
     setIsPaused(false);
     setPauseReason(null);
     missingTargetRef.current = null;
-  }, [activeTour]);
+  }, [activeTour, ensureJoyrideRuntime]);
 
   const handleJoyrideCallback = useCallback((data: CallBackProps) => {
+    const runtime = joyrideRuntimeRef.current;
+    if (!runtime) return;
+    const { STATUS, ACTIONS, EVENTS } = runtime;
     const { status, type, index, action } = data;
 
     if (status === STATUS.FINISHED || status === STATUS.SKIPPED) {
@@ -404,7 +443,8 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
     }}>
       {children}
       <TutorialProgressWidget />
-      {steps.length > 0 && run && (() => {
+      {steps.length > 0 && run && joyrideRuntime && (() => {
+        const Joyride = joyrideRuntime.default;
         const tourOptions = getTourOptions(activeTour || '');
         return (
           <Joyride

--- a/src/components/TutorialProvider/useTutorialAutoScroll.ts
+++ b/src/components/TutorialProvider/useTutorialAutoScroll.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { Step } from 'react-joyride';
+import type { Step } from 'react-joyride';
 
 export function useTutorialAutoScroll(
   run: boolean,

--- a/src/components/WorldListScreen/WorldListScreen.tsx
+++ b/src/components/WorldListScreen/WorldListScreen.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import dynamic from 'next/dynamic';
 import { useWorldStore } from '@/state/worldStore';
 import WorldList from '@/components/WorldList/WorldList';
-import { WorldTable } from '@/components/world/WorldTable';
 import {
   WorldViewToggle,
   WorldViewMode,
@@ -19,6 +19,16 @@ import {
   ErrorType,
 } from '@/lib/utils/errorUtils';
 import { readString, writeString } from '@/lib/utils/browserStorage';
+
+// WorldTable pulls @tanstack/react-table but only renders in table view; the
+// list defaults to grid, so load it on demand (issue #1357).
+const WorldTable = dynamic(
+  () =>
+    import('@/components/world/WorldTable').then((m) => ({
+      default: m.WorldTable,
+    })),
+  { ssr: false }
+);
 
 interface WorldListScreenProps {
   /** Callback to pass the view toggle component to parent for header placement */


### PR DESCRIPTION
## Description
Every route was downloading code most visits never use — the whole `lucide-react` icon barrel, the guided-tour runtime, the full game-session screen, the table views, and the dev panel. This loads those on demand instead, so the initial download shrinks (biggest payoff on the dashboard and list pages).

What changed:
- **`next.config.ts`** — added `experimental: { optimizePackageImports: ['lucide-react'] }`. No import-site changes; Next rewrites them at build so a cold start ships only the icons used.
- **`react-joyride`** — now loads on first tour start. `TutorialProvider` lives in the root layout, and joyride's `STATUS`/`ACTIONS`/`EVENTS` enums live in the same single ~67KB bundle as the tour engine, so a static import would drag the runtime onto every page. The provider loads the module on demand (`ensureJoyrideRuntime`) and reads the enums off it. Honors the `react-joyride@3.0.0-7` pin — no version bump.
- **`GameSession`** — loads via `next/dynamic(..., { ssr: false })` on both play routes (`/play` and `/worlds/[id]/play`), reusing each page's existing loading placeholder.
- **`CharacterTable`, `WorldTable`, `GenerateCharacterDialog`** — load via `next/dynamic(..., { ssr: false })`; all three are behind a view toggle or a click.
- **`ClientOnlyDevTools`** — loads `DevToolsPanel` via `next/dynamic` so the devtools module graph stays out of the production bundle. The `NODE_ENV === 'development'` render guard is unchanged.

## Related Issue
Refs #1357 (won't auto-close on a merge to `develop` — will close manually).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
This is a logic-preserving bundle/config change, not a new feature, so it wasn't built test-first. No behavior changed, so no new behavior needed new tests.
- [ ] Tests written before implementation (N/A — perf refactor)
- [ ] All new code is tested (N/A — no new logic)
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — performance/bundle hygiene from the Vercel `react-best-practices` audit (Tier 1).

## Component Development
- [ ] Storybook stories created/updated (N/A — no component API or markup changed)
- [ ] Components developed in isolation first (N/A)
- [x] Visual consistency verified (no visual change — same loading placeholders, same rendered output)

## Implementation Notes
- The only non-mechanical bit is joyride. Wrapping just `<Joyride>` in `next/dynamic` wouldn't have deferred anything, because the `STATUS`/`ACTIONS`/`EVENTS` value imports sit in the same single-file bundle and would keep pulling the runtime in. So the provider loads the module imperatively on first `startTour`/`resumeTour` and sources the enums from it. The callback reads them off a ref; render uses the loaded default export.
- `GenerateCharacterDialog` is rendered unconditionally (with `isOpen`), so it's kept always-rendered and only code-split (it's a Radix dialog — gating its mount would change close behavior). The chunk-split still pulls it out of the page's entry bundle.
- Two `worlds/[id]/play` page tests now `await screen.findByTestId(...)` for the GameSession mock, since it loads asynchronously under `next/dynamic`. Same assertions, just awaited — no behavior change.

## Screenshots
N/A — no UI change.

## Code Review Summary (if applicable)
N/A.

## Quality Checks
- [x] Linting passed (`npm run lint`, `lint:css`, `lint:layout-usage`, `lint:ds-canon`)
- [x] Type checking passed (`npm run type-check`)
- [ ] Security audit passed (not run — no dependency or sink changes)
- [x] No console.log statements in production code
- [x] No unhandled promises (`ensureJoyrideRuntime` catches and logs load failure)

## Testing Instructions
- `npm run type-check`, `npm run lint`, and the Jest suite all pass locally; `npx next build` compiles cleanly with `optimizePackageImports` enabled and `skott:check` holds the cycle baseline at 17.
- Manual three-stage check: start a tour (joyride loads on demand and runs), toggle a worlds/characters list to table view (table loads and works), open the generate-character dialog (loads and opens), and confirm devtools still appear in dev mode.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic (the joyride deferral rationale is documented inline)
- [ ] Documentation updated (if required) (N/A)
- [x] No new warnings generated
- [x] Accessibility considerations addressed (no markup/ARIA change)
