### PR TITLE
perf(game-session): scope unscoped Zustand subscriptions + passive scroll listeners

### DIFF
--- a/src/components/GameSession/ActiveGameSession.tsx
+++ b/src/components/GameSession/ActiveGameSession.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { World } from '@/types/world.types';
 import { NarrativeController } from '@/components/Narrative/NarrativeController';
 import { Decision, NarrativeSegment } from '@/types/narrative.types';
@@ -122,8 +123,18 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
   );
   const characterSkills = character?.skills ?? [];
   
-  // Get narrative store for ending functionality
-  const { currentEnding, isGeneratingEnding, generateEnding, isSessionEnded } = useNarrativeStore();
+  // Get narrative store for ending functionality. Scope to just the ending
+  // slice (via useShallow) so the game shell doesn't re-render on every
+  // narrative-store write — segments stream in continuously during play.
+  const { currentEnding, isGeneratingEnding, generateEnding, isSessionEnded } =
+    useNarrativeStore(
+      useShallow((state) => ({
+        currentEnding: state.currentEnding,
+        isGeneratingEnding: state.isGeneratingEnding,
+        generateEnding: state.generateEnding,
+        isSessionEnded: state.isSessionEnded,
+      }))
+    );
 
   // Reactively track segment count using a stable snapshot to avoid infinite loops.
   // Selecting derived arrays from Zustand can cause non-cached snapshots.

--- a/src/components/GameSession/CharacterSnapshot.tsx
+++ b/src/components/GameSession/CharacterSnapshot.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Character } from '@/state/characterStore';
 import { useWorldStore } from '@/state/worldStore';
+import { useShallow } from 'zustand/react/shallow';
 import { CharacterPortrait } from '@/components/CharacterPortrait';
 
 interface CharacterSnapshotProps {
@@ -8,7 +9,9 @@ interface CharacterSnapshotProps {
 }
 
 export const CharacterSnapshot: React.FC<CharacterSnapshotProps> = ({ character }) => {
-  const worldStore = useWorldStore();
+  // Scope to the worlds slice so this panel doesn't re-render on unrelated
+  // world-store writes (worldStates churns during play).
+  const worldStore = useWorldStore(useShallow((state) => ({ worlds: state.worlds })));
   const world = worldStore.worlds[character.worldId];
   const normalizedSkills = React.useMemo(() => {
     if (!world) return [];

--- a/src/components/GameSession/CharacterSummary.tsx
+++ b/src/components/GameSession/CharacterSummary.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import Link from 'next/link';
 import { CharacterPortrait } from '@/components/CharacterPortrait';
 import { useWorldStore } from '@/state/worldStore';
+import { useShallow } from 'zustand/react/shallow';
 import { Button } from '@/components/ui/button';
 
 interface CharacterBackground {
@@ -79,7 +80,9 @@ const CharacterSummary: React.FC<CharacterSummaryProps> = ({
   variant = 'default'
 }) => {
   const [isExpanded, setIsExpanded] = useState(variant === 'drawer' ? true : initialExpanded);
-  const worldStore = useWorldStore();
+  // Scope to the worlds slice so this panel doesn't re-render on unrelated
+  // world-store writes (worldStates churns during play).
+  const worldStore = useWorldStore(useShallow((state) => ({ worlds: state.worlds })));
   const world = worldStore.worlds[character.worldId];
 
   const isDrawer = variant === 'drawer';

--- a/src/components/GameSession/EndingScreen.tsx
+++ b/src/components/GameSession/EndingScreen.tsx
@@ -10,6 +10,7 @@ import React, {
   useMemo,
 } from 'react';
 import { useRouter } from 'next/navigation';
+import { useShallow } from 'zustand/react/shallow';
 import { Play } from 'lucide-react';
 import { useNarrativeStore } from '@/state/narrativeStore';
 import { useCharacterStore } from '@/state/characterStore';
@@ -48,8 +49,14 @@ export function EndingScreen() {
     updateCurrentEnding,
   } = useNarrativeStore();
 
-  const { characters } = useCharacterStore();
-  const { worlds } = useWorldStore();
+  // Scope to the entity maps (via useShallow) so the ending screen doesn't
+  // re-render on unrelated character/world-store writes.
+  const { characters } = useCharacterStore(
+    useShallow((state) => ({ characters: state.characters }))
+  );
+  const { worlds } = useWorldStore(
+    useShallow((state) => ({ worlds: state.worlds }))
+  );
 
   // Get story checkpoints for this session (must be called before early returns)
   const worldState = useWorldStore((state) =>

--- a/src/components/GameSession/ManuscriptSessionShell.tsx
+++ b/src/components/GameSession/ManuscriptSessionShell.tsx
@@ -194,7 +194,9 @@ export const ManuscriptSessionShell: React.FC<ManuscriptSessionShellProps> = ({
     mutationObserver.observe(container, { childList: true, subtree: true });
 
     window.addEventListener('resize', syncPosition);
-    window.addEventListener('scroll', syncPosition);
+    // Passive: syncPosition never calls preventDefault, so let the browser
+    // scroll without waiting on this handler (issue #1358).
+    window.addEventListener('scroll', syncPosition, { passive: true });
 
     return () => {
       if (frameId !== null) {

--- a/src/components/GameSession/hooks/useActiveGameSessionEffects.ts
+++ b/src/components/GameSession/hooks/useActiveGameSessionEffects.ts
@@ -184,18 +184,43 @@ export const useActiveGameSessionEffects = ({
 
   // Keep currentDecision synchronized with store updates (supports external generators like item usage)
   useEffect(() => {
+    // Only react when this session's decisions or segments actually change,
+    // rather than on every narrative-store write (segments stream in
+    // token-by-token during play). The body is a pure function of these three
+    // references, so gating on them preserves behavior; the first store event
+    // always runs so the initial sync matches the prior behavior (issue #1358).
+    let initialized = false;
+    let prevDecisionIds: unknown;
+    let prevSegmentIds: unknown;
+    let prevLatestDecision: unknown;
+
     const unsubscribe = useNarrativeStore.subscribe((state) => {
       const decisionIds = state.sessionDecisions[sessionId];
       const ids = decisionIds || [];
       const latestId = ids[ids.length - 1];
+      const latestDecision = latestId ? (state.decisions[latestId] || null) : null;
+      const segmentIds = state.sessionSegments[sessionId];
+
+      if (
+        initialized &&
+        decisionIds === prevDecisionIds &&
+        latestDecision === prevLatestDecision &&
+        segmentIds === prevSegmentIds
+      ) {
+        return;
+      }
+      initialized = true;
+      prevDecisionIds = decisionIds;
+      prevLatestDecision = latestDecision;
+      prevSegmentIds = segmentIds;
+
       if (latestId) {
-        const latest = state.decisions[latestId] || null;
-        setCurrentDecision(latest);
+        setCurrentDecision(latestDecision);
         setIsGeneratingChoices(false);
       } else {
         setCurrentDecision(null);
         // If narrative already exists, surface a loading state while choices regenerate
-        const hasSegments = (state.sessionSegments[sessionId]?.length ?? 0) > 0;
+        const hasSegments = (segmentIds?.length ?? 0) > 0;
         if (hasSegments) {
           setIsGeneratingChoices(true);
         }

--- a/src/components/GameSession/hooks/useGameSessionState.ts
+++ b/src/components/GameSession/hooks/useGameSessionState.ts
@@ -86,6 +86,14 @@ export const useGameSessionState = ({
   );
   const actualSessionState = useSessionStore(
     useShallow((state) => ({
+      // savedSessions is part of the slice (not just the actions) because the
+      // savedSession memo below derives from getSavedSession(savedSessions). If
+      // IndexedDB hydration populates saved sessions after the world/character
+      // ids are already stable, the resume prompt still needs to refresh — so we
+      // subscribe to it. It changes far less often than the streaming session
+      // fields (status/playerChoices/currentSceneId), which is where the
+      // mid-stream re-render churn we're avoiding actually comes from.
+      savedSessions: state.savedSessions,
       initializeSession: state.initializeSession,
       selectChoice: state.selectChoice,
       endSession: state.endSession,

--- a/src/components/GameSession/hooks/useGameSessionState.ts
+++ b/src/components/GameSession/hooks/useGameSessionState.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState, useRef, useMemo, useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useWorldStore } from '@/state/worldStore';
 import { useSessionStore } from '@/state/sessionStore';
 import { useCharacterStore, type Character } from '@/state/characterStore';
@@ -76,9 +77,29 @@ export const useGameSessionState = ({
   // Local state for error handling
   const [error, setError] = useState<Error | null>(null);
   
-  const actualWorldState = useWorldStore();
-  const actualSessionState = useSessionStore();
-  const actualCharacterState = useCharacterStore();
+  // Scope each store subscription to the slice this hook actually uses, so the
+  // game session doesn't re-render on every unrelated store write during play.
+  // Session state itself is consumed via the dedicated subscription below; here
+  // we only need its (stable) action methods (issue #1358).
+  const actualWorldState = useWorldStore(
+    useShallow((state) => ({ worlds: state.worlds }))
+  );
+  const actualSessionState = useSessionStore(
+    useShallow((state) => ({
+      initializeSession: state.initializeSession,
+      selectChoice: state.selectChoice,
+      endSession: state.endSession,
+      getSavedSession: state.getSavedSession,
+      resumeSavedSession: state.resumeSavedSession,
+    }))
+  );
+  const actualCharacterState = useCharacterStore(
+    useShallow((state) => ({
+      characters: state.characters,
+      currentCharacterId: state.currentCharacterId,
+      setCurrentCharacter: state.setCurrentCharacter,
+    }))
+  );
   
   // Check if world exists - only on client-side
   const worldExists = useMemo(() => {

--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -79,9 +79,6 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
     []
   );
 
-  // Access character and world stores for skill evaluation
-  const characters = useCharacterStore((state) => state.characters);
-  const worlds = useWorldStore((state) => state.worlds);
   const npcIds = useNPCStore(
     useCallback((state) => state.worldNpcs[worldId] ?? EMPTY_NPC_IDS, [worldId])
   );
@@ -601,8 +598,14 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
 
       // Evaluate skill requirements (rolls, tags, outcome, per-roll toasts, and
       // the parent onSkillCheckPerformed notification are handled in the helper)
-      const character = characterId ? characters[characterId] : undefined;
-      const world = worlds[worldId];
+      // Read characters/worlds at call time via getState() rather than
+      // subscribing — they're only needed here inside this async handler, so a
+      // store subscription would re-render the controller on every character/
+      // world write for no benefit (issue #1358).
+      const character = characterId
+        ? useCharacterStore.getState().characters[characterId]
+        : undefined;
+      const world = useWorldStore.getState().worlds[worldId];
       const { skillCheckTags, rollResults, decisionOutcome } =
         evaluateDecisionSkillChecks({
           selectedOption,

--- a/src/components/Narrative/NarrativeHistory.tsx
+++ b/src/components/Narrative/NarrativeHistory.tsx
@@ -257,7 +257,9 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
       const viewport = scrollAreaRef.current.querySelector('[data-radix-scroll-area-viewport]') as HTMLDivElement;
       if (viewport) {
         scrollViewportRef.current = viewport;
-        viewport.addEventListener('scroll', handleScroll);
+        // Passive: handleScroll only reads scroll position (no preventDefault),
+        // so mark it passive to avoid blocking scroll (issue #1358).
+        viewport.addEventListener('scroll', handleScroll, { passive: true });
 
         // ResizeObserver: anchor scroll to bottom during content growth
         const contentEl = scrollContentRef.current;

--- a/src/components/Narrative/NarrativeHistoryManager.tsx
+++ b/src/components/Narrative/NarrativeHistoryManager.tsx
@@ -51,10 +51,20 @@ export const NarrativeHistoryManager: React.FC<NarrativeHistoryManagerProps> = (
     
     // Load initial segments
     loadSegments();
-    
-    // Subscribe to store updates
-    const unsubscribe = useNarrativeStore.subscribe(loadSegments);
-    
+
+    // Only re-run the dedup/sort when THIS session's segment list actually
+    // changes, instead of on every narrative-store write. Segments stream in
+    // token-by-token during play (each a store write), and addSegment replaces
+    // sessionSegments[sessionId] with a new array, so a reference check catches
+    // every add/remove for this session (issue #1358).
+    let prevSegmentIds = useNarrativeStore.getState().sessionSegments[sessionId];
+    const unsubscribe = useNarrativeStore.subscribe((state) => {
+      const nextSegmentIds = state.sessionSegments[sessionId];
+      if (nextSegmentIds === prevSegmentIds) return;
+      prevSegmentIds = nextSegmentIds;
+      loadSegments();
+    });
+
     // Cleanup on unmount
     return () => {
       unsubscribe();


### PR DESCRIPTION
## Description
During an active story the AI narrative streams in token by token, and the narrative store is written on every segment commit. Some game-session components subscribed to an entire store (or to the raw store with no selector), so they re-rendered or re-ran their work on every one of those writes. This narrows those subscriptions to the slice each consumer actually reads — fewer re-renders mid-stream, identical output.

**Confirmed sites**
- `ActiveGameSession` — the selectorless `useNarrativeStore()` destructure now selects just the ending slice via `useShallow`.
- `NarrativeHistoryManager` — the raw `useNarrativeStore.subscribe(loadSegments)` now reference-checks `sessionSegments[sessionId]` before re-running its O(n) dedup/sort, so it reacts to segment add/remove for this session instead of every store write. (`addSegment` replaces that array, and `updateSegment` is unused in production, so a reference check catches every real change.)
- `useGameSessionState` — the three selectorless store hooks now select their used slices via `useShallow`. Session state is consumed through the hook's dedicated `subscribe` below, so here it only needs the stable action methods.

**Verify-then-fix sites** (each confirmed against the code before editing)
- `useActiveGameSessionEffects` — the raw decision-sync subscribe now gates on this session's decision ids / latest decision / segment ids. The listener body is a pure function of those three, and the first store event always runs so the initial sync is unchanged.
- `NarrativeController` — `characters`/`worlds` are only read inside the async generate handler, so they're read via `getState()` instead of subscribed.
- `CharacterSnapshot` / `CharacterSummary` / `EndingScreen` — the selectorless world/character reads now select the relevant entity map via `useShallow`.

Two scroll listeners (`ManuscriptSessionShell`, `NarrativeHistory`) are marked `{ passive: true }` — neither handler calls `preventDefault`.

## Related Issue
Refs #1358 (won't auto-close on a merge to `develop` — will close manually).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
Logic-preserving re-render optimization, not a new feature — no behavior changed, so no new tests were needed. The existing GameSession + Narrative suites guard the behavior.
- [ ] Tests written before implementation (N/A — perf refactor)
- [ ] All new code is tested (N/A — no new logic)
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — game-session re-render hot path, from the Vercel `react-best-practices` audit (Tier 2).

## Component Development
- [ ] Storybook stories created/updated (N/A — no component API or markup changed)
- [ ] Components developed in isolation first (N/A)
- [x] Visual consistency verified (no visual change — subscription scoping only)

## Implementation Notes
- `narrativeStore` uses `persist`, not `subscribeWithSelector`, so the `subscribe(selector, listener, opts)` overload isn't available. The two raw-subscribe sites use a manual reference check instead, which is equivalent for the references that matter.
- For `CharacterSnapshot`/`CharacterSummary`/`EndingScreen` I scoped to the relevant store *field* (the `worlds`/`characters` map) rather than the single entity by id. The existing unit-test mocks for these return a fixed object and ignore the selector, so a by-id selector would have broken them; field-scoping keeps the tests and behavior intact while still avoiding re-renders on unrelated `worldStates` churn. Narrowing further to the individual entity is a reasonable follow-up if those mocks are updated to apply selectors.
- `useShallow` (already used in `JournalPage`/`ManuscriptDrawerPanels`) keeps the object-returning selectors referentially stable, which is what avoids the non-cached-snapshot loop the existing comment in `ActiveGameSession` warns about.

## Screenshots
N/A — no UI change.

## Quality Checks
- [x] Linting passed (`npm run lint`, `lint:css`, `lint:layout-usage`, `lint:ds-canon`)
- [x] Type checking passed (`npm run type-check`)
- [ ] Security audit passed (not run — no dependency or sink changes)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
- `npm run type-check`, `npm run lint`, and `jest` for `src/components/GameSession` + `src/components/Narrative` (40 suites / 235 tests) all pass locally; `skott:check` holds the cycle baseline at 17.
- Manual three-stage check: play a session and confirm narrative streams, choices appear, the scene/character panels update, and an ending still renders — all unchanged, just with fewer redundant re-renders mid-stream.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic (each scoped subscription explains why)
- [ ] Documentation updated (if required) (N/A)
- [x] No new warnings generated
- [x] Accessibility considerations addressed (no markup/ARIA change)
