### PR TITLE
perf(ai): async hygiene in image API routes (+ open question on prompt-elaboration hop)

### DIFF
--- a/src/app/api/generate-portrait/route.ts
+++ b/src/app/api/generate-portrait/route.ts
@@ -25,11 +25,16 @@ async function buildPortraitPrompt(
       characterName
     );
 
-    // Use only the character detection part, not the full image generation
-    const { buildPortraitPrompt: buildPortraitPromptFn } = await import('@/lib/ai/portraitGenerator');
-    const { createDefaultGeminiClient } = await import(
-      '@/lib/ai/defaultGeminiClient'
-    );
+    // Use only the character detection part, not the full image generation.
+    // These two dynamic imports are independent, so load them in parallel
+    // rather than awaiting one after the other.
+    const [
+      { buildPortraitPrompt: buildPortraitPromptFn },
+      { createDefaultGeminiClient },
+    ] = await Promise.all([
+      import('@/lib/ai/portraitGenerator'),
+      import('@/lib/ai/defaultGeminiClient'),
+    ]);
 
     logger.debug('generate-portrait API', 'Creating AI client and generator');
     const aiClient = createDefaultGeminiClient();

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -3,6 +3,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { globalRateLimiter, RateLimiter, type RateLimitResult } from './rateLimiter';
 import { getAIConfig } from '../lib/ai/config';
+import { createAPIErrorResponse } from '../lib/utils/errorUtils';
 
 import Logger from '@/lib/utils/logger';
 const logger = new Logger('ApiHelpers');
@@ -220,9 +221,6 @@ export async function processGeminiTextRequest(
     temperature = 0.7,
     errorContext = 'Generation'
   } = options;
-
-  // Lazy import to avoid circular dependency
-  const { createAPIErrorResponse } = await import('../lib/utils/errorUtils');
 
   try {
     // Rate limiting


### PR DESCRIPTION
## Description
Two small, **output-preserving** async cleanups in the AI routes, from the Vercel `react-best-practices` audit. Nothing about the generated images or responses changes.

- **`generate-portrait`** — the two independent dynamic imports (`portraitGenerator`, `defaultGeminiClient`) were `await`ed one after the other. Loaded them in parallel with `Promise.all` instead.
- **`apiHelpers` (`processGeminiTextRequest`)** — the error-util import ran on every call via `await import(...)`, even though `createAPIErrorResponse` is only used on error branches. `errorUtils` imports nothing (it's a leaf module), so the "avoid circular dependency" reason the lazy import was guarding against no longer holds — hoisted it to a static module import. `skott` cycle count holds at 17, confirming no cycle was introduced.

## :raising_hand: Open question for you — the real latency win
The bigger win from the audit is **dropping the prompt-elaboration LLM hop** in the two image routes, and I deliberately did **not** touch it — it's a product call.

- `generate-world-image/route.ts:84` and `generate-ending-image/route.ts:124` each run a text-LLM `client.generateContent()` to "elaborate" the image prompt before image generation. That blocks for ~1-3s per image.
- `generateImagePrompt()` already builds a detailed, genre-aware domain prompt, so the elaboration is arguably redundant — feeding `generateImagePrompt()`'s output straight into image generation would cut that latency.
- The tradeoff: the elaborated prompt does change the image slightly, so this is quality-vs-latency, not a free win.

**Entangled with this: the "fail-fast on missing API key" guard reorder** from the issue. In both routes the body validation already sits immediately after the first `await` (`request.json()`), so it's as early as it can be. The API-key *presence* check, though, sits **after** the elaboration hop — so "fail fast on a missing/mock key" can only happen by short-circuiting the elaboration. Doing that changes the no-key fallback response (its `description` currently comes from the elaboration), which is a behavior/output change. So I've folded that reorder into this same decision rather than make it silently.

Two ways forward when you decide:
1. **Drop the elaboration** — feed `generateImagePrompt()` straight to image gen, and move the API-key presence check above it so missing-key requests fall back immediately. (Faster; slight image-output change.)
2. **Keep it** — leave both routes as they are.

Happy to do a follow-up PR for whichever you pick. Parallelizing elaboration + image gen isn't an option — image gen genuinely needs the elaborated string.

## Related Issue
Refs #1359 (won't auto-close on a merge to `develop` — will close manually).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
Logic-preserving async hygiene, not a new feature. The existing `apiHelpers` and `generate-world-image` route suites guard the behavior.
- [ ] Tests written before implementation (N/A — perf refactor)
- [ ] All new code is tested (N/A — no new logic)
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — AI-service async hygiene from the `react-best-practices` audit.

## Component Development
- [ ] Storybook stories created/updated (N/A — server route / util only)
- [ ] Components developed in isolation first (N/A)
- [x] Visual consistency verified (N/A — no UI)

## Implementation Notes
- The portrait change is a pure parallelization of two imports that don't depend on each other — same modules, same subsequent use.
- The `apiHelpers` hoist was verified safe two ways: `errorUtils` has no imports (nothing can cycle back through it), and `skott:check` still reports 17 cycles (the baseline).
- I kept the scope to the unambiguously safe items per the issue. The elaboration hop and its entangled key-check reorder are the open question above.

## Screenshots
N/A — no UI change.

## Quality Checks
- [x] Linting passed (`npm run lint`, `lint:css`)
- [x] Type checking passed (`npm run type-check`)
- [ ] Security audit passed (not run — no dependency or sink changes)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
- `npm run type-check`, `npm run lint`, and `jest` for `src/utils/__tests__/apiHelpers.test.ts` + `src/app/api/generate-world-image/__tests__/route.test.ts` (20 tests) pass locally; `skott:check` holds the cycle baseline at 17.
- Manual: generate a character portrait, a world image, and an ending image — all produce the same results as before, just with the portrait route's two helper imports loaded in parallel.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) (N/A)
- [x] No new warnings generated
- [x] Accessibility considerations addressed (N/A — no UI)
