### PR TITLE
test(ds-canon): span session surfaces with layout-invariant assertions (#1325)

### DIFF
--- a/.ds-canon-baseline.json
+++ b/.ds-canon-baseline.json
@@ -1,10 +1,14 @@
 {
-  "comment": "Design-system canon guard (scripts/verify-ds-canon.cjs, npm run lint:ds-canon). The living style guide (src/app/dev/design-system*) must render REAL production components as canon, with styling defined in production so it flows downstream — the app must never be the canon source. Two checks: (1) skinning — the guide must not re-skin a real primitive with guide-local classes; (2) coverage — every src/components/ui/* primitive must be represented in the guide. Both fail only on NEW violations; existing ones are grandfathered below with tracking issues. Shrink these lists as canon work proceeds. Mirrors the .skott-baseline.json pattern.",
+  "comment": "Design-system canon guard (scripts/verify-ds-canon.cjs, npm run lint:ds-canon). The living style guide (src/app/dev/design-system*) must render REAL production components as canon, with styling defined in production so it flows downstream — the app must never be the canon source. Three checks: (1) skinning — the guide must not re-skin a real primitive with guide-local classes; (2) coverage — every src/components/ui/* primitive must be represented in the guide; (3) storybook — every primitive must also appear in a story under src/stories/** (#1325). All fail only on NEW violations; existing ones are grandfathered below with tracking issues. Shrink these lists as canon work proceeds. Mirrors the .skott-baseline.json pattern.",
   "skinning": [
     "src/app/dev/design-system/_ui/ComponentShowcase.tsx::overlayClassName::dsc-dialog-overlay"
   ],
   "coverageGaps": [],
   "coverageExceptions": {
     "scroll-area": "Behavior/utility wrapper (adds scroll styling around arbitrary content) — no visual variants/states to canonize."
-  }
+  },
+  "storybookGaps": [
+    "dialog",
+    "table"
+  ]
 }

--- a/scripts/verify-ds-canon.cjs
+++ b/scripts/verify-ds-canon.cjs
@@ -29,7 +29,13 @@ const glob = require('glob');
 const ROOT = process.cwd();
 const GUIDE_GLOB = 'src/app/dev/design-system*/**/*.{ts,tsx}';
 const PRIMITIVES_GLOB = 'src/components/ui/*.tsx';
-const STORIES_GLOB = 'src/stories/**/*.stories.tsx';
+// Match Storybook's configured story patterns (.storybook/main.cjs) so a
+// primitive covered by a .stories.{js,jsx,ts} or .mdx story isn't falsely
+// flagged as missing.
+const STORIES_GLOBS = [
+  'src/stories/**/*.stories.{js,jsx,ts,tsx}',
+  'src/stories/**/*.mdx',
+];
 const BASELINE_PATH = path.join(ROOT, '.ds-canon-baseline.json');
 
 // Component-specific styling props — present only on DS primitives, never on raw HTML.
@@ -122,7 +128,9 @@ for (const name of primitives) {
 // src/components/ui/* primitive must appear in a story under src/stories/**, or
 // Storybook silently drifts from the guide + the app. Mirrors Check 2: scan
 // story files for `@/components/ui/<name>` imports.
-const storyFiles = glob.sync(STORIES_GLOB, { cwd: ROOT, absolute: true, nodir: true });
+const storyFiles = STORIES_GLOBS.flatMap((g) =>
+  glob.sync(g, { cwd: ROOT, absolute: true, nodir: true }),
+);
 const storyImports = new Set();
 for (const file of storyFiles) {
   let content;

--- a/scripts/verify-ds-canon.cjs
+++ b/scripts/verify-ds-canon.cjs
@@ -13,6 +13,9 @@
 //   2. Full coverage — every production primitive (src/components/ui/*) must be
 //      represented in the living style guide. If the app uses a primitive the guide
 //      doesn't render, the app has become the canon source. (#1317)
+//   3. Storybook coverage — every production primitive must also appear in a story
+//      under `src/stories/**`, so Storybook stays a real canon surface and doesn't
+//      silently drift from the guide and the app. (#1325)
 //
 // Existing violations are grandfathered in `.ds-canon-baseline.json` (mirrors the
 // .skott-baseline.json pattern). The guard fails only on NEW violations, so it
@@ -26,6 +29,7 @@ const glob = require('glob');
 const ROOT = process.cwd();
 const GUIDE_GLOB = 'src/app/dev/design-system*/**/*.{ts,tsx}';
 const PRIMITIVES_GLOB = 'src/components/ui/*.tsx';
+const STORIES_GLOB = 'src/stories/**/*.stories.tsx';
 const BASELINE_PATH = path.join(ROOT, '.ds-canon-baseline.json');
 
 // Component-specific styling props — present only on DS primitives, never on raw HTML.
@@ -59,6 +63,7 @@ const baselineSkinCounts = {};
 for (const k of baseline.skinning || []) baselineSkinCounts[k] = (baselineSkinCounts[k] || 0) + 1;
 const baselineCoverage = new Set(baseline.coverageGaps || []);
 const coverageExceptions = baseline.coverageExceptions || {};
+const baselineStorybook = new Set(baseline.storybookGaps || []);
 
 const guideFiles = glob.sync(GUIDE_GLOB, { cwd: ROOT, absolute: true, nodir: true });
 
@@ -112,6 +117,29 @@ for (const name of primitives) {
   coverageViolations.push(name);
 }
 
+// --- Check 3: Storybook coverage --------------------------------------------
+// Storybook is a real canon surface for the primitives (#1325). Every
+// src/components/ui/* primitive must appear in a story under src/stories/**, or
+// Storybook silently drifts from the guide + the app. Mirrors Check 2: scan
+// story files for `@/components/ui/<name>` imports.
+const storyFiles = glob.sync(STORIES_GLOB, { cwd: ROOT, absolute: true, nodir: true });
+const storyImports = new Set();
+for (const file of storyFiles) {
+  let content;
+  try { content = fs.readFileSync(file, 'utf8'); } catch { continue; }
+  importRe.lastIndex = 0;
+  let m;
+  while ((m = importRe.exec(content)) !== null) storyImports.add(m[1]);
+}
+
+const storybookViolations = [];
+for (const name of primitives) {
+  if (storyImports.has(name)) continue;            // has a story
+  if (coverageExceptions[name]) continue;          // documented non-visual exception
+  if (baselineStorybook.has(name)) continue;       // grandfathered gap (tracked)
+  storybookViolations.push(name);
+}
+
 // --- Report ------------------------------------------------------------------
 let failed = false;
 
@@ -131,12 +159,21 @@ if (coverageViolations.length > 0) {
   console.error('\nIf it is a non-visual behavior/utility wrapper, add it to "coverageExceptions" in .ds-canon-baseline.json with a reason.');
 }
 
+if (storybookViolations.length > 0) {
+  failed = true;
+  console.error('Canon violation — production primitive(s) without a Storybook story:');
+  console.error('Every src/components/ui/* primitive must appear in a story under src/stories/**, or Storybook drifts from canon.\n');
+  for (const name of storybookViolations) console.error(` - ${name} (src/components/ui/${name}.tsx) — add a story under src/stories/**`);
+  console.error('\nIf it is a non-visual behavior/utility wrapper, add it to "coverageExceptions" in .ds-canon-baseline.json with a reason.');
+}
+
 if (failed) {
-  console.error('\nSee #1276 (canon flows downstream), #1316, #1317.');
+  console.error('\nSee #1276 (canon flows downstream), #1316, #1317, #1325.');
   process.exit(1);
 }
 
 const skinN = (baseline.skinning || []).length;
 const gapN = baselineCoverage.size;
+const sbN = baselineStorybook.size;
 const excN = Object.keys(coverageExceptions).length;
-console.log(`DS canon OK — ${primitives.length} primitives checked (${gapN} grandfathered coverage gap(s), ${excN} exception(s)); ${skinN} grandfathered skin(s) within baseline.`);
+console.log(`DS canon OK — ${primitives.length} primitives checked (${gapN} grandfathered guide gap(s), ${sbN} grandfathered storybook gap(s), ${excN} exception(s)); ${skinN} grandfathered skin(s) within baseline.`);

--- a/tests/visual/design-system-session.spec.ts
+++ b/tests/visual/design-system-session.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { waitForContentStable } from './utils/wait-helpers';
+import { readSessionStageLayout } from './utils/manuscript-helpers';
 
 /**
  * Design-system session showcase visual regression (issue #1276).
@@ -47,6 +48,24 @@ test.describe('Design system session showcase', () => {
       await page.addStyleTag({ content: '.ds-toggle { display: none; }' });
       // Let the DS1 rail/panel geometry sync settle before capture.
       await page.waitForTimeout(1200);
+
+      // #1325: assert the composed stage lays out as intended on the CANON
+      // surface too, so showcase drift trips an invariant — not only the pixel
+      // baseline below (a baseline bakes in a pre-existing bug; an invariant
+      // catches it). Same contract the production play route asserts.
+      const geo = await readSessionStageLayout(page);
+      expect(geo, 'expected composed session-stage nodes in the showcase').not.toBeNull();
+      if (geo) {
+        if (id === 'ds1') {
+          // DS1: three-column stage, scene status as a rail left of the column.
+          expect(geo.trackCount).toBe(3);
+          expect(geo.railLeft).toBeLessThan(geo.mainLeft);
+        } else {
+          // DS2/DS3: single-column stage, scene status stacked above the column.
+          expect(geo.trackCount).toBe(1);
+          expect(geo.railTop).toBeLessThan(geo.mainTop);
+        }
+      }
 
       await expect(shell).toHaveScreenshot(`ds-session-${id}.png`);
     });

--- a/tests/visual/session-themes.spec.ts
+++ b/tests/visual/session-themes.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from '@playwright/test';
 import { seedTestData } from './utils/seedTestData';
 import { mockApiEndpoints } from './utils/mockApi';
 import { hideDynamicContent, waitForContentStable } from './utils/wait-helpers';
+import { readSessionStageLayout } from './utils/manuscript-helpers';
 
 /**
  * Game-session theme differentiation (#1225 + #986).
@@ -48,25 +49,6 @@ const setupSession = async (page: Page, theme: ThemeId): Promise<void> => {
   await page.evaluate(() => document.fonts.ready);
 };
 
-const sceneStatusGeometry = (page: Page) =>
-  page.evaluate(() => {
-    const rail = document.querySelector('.manuscript-characters-rail');
-    const main = document.querySelector('.manuscript-main-content');
-    const shell = document.querySelector('.manuscript-viewport-shell');
-    if (!rail || !main || !shell) return null;
-    const r = rail.getBoundingClientRect();
-    const m = main.getBoundingClientRect();
-    return {
-      railLeft: Math.round(r.left),
-      railRight: Math.round(r.right),
-      railTop: Math.round(r.top),
-      railBottom: Math.round(r.bottom),
-      mainLeft: Math.round(m.left),
-      mainTop: Math.round(m.top),
-      shellBg: window.getComputedStyle(shell).backgroundImage,
-    };
-  });
-
 test.describe('Game session theme differentiation', () => {
   for (const theme of THEMES) {
     test(`${theme} desktop: scene status renders and is themed`, async ({ page }) => {
@@ -79,13 +61,25 @@ test.describe('Game session theme differentiation', () => {
       await expect(sceneStatus.getByText('Characters Present')).toBeVisible();
       await expect(sceneStatus.getByText('Location')).toBeVisible();
 
-      const geo = await sceneStatusGeometry(page);
+      const geo = await readSessionStageLayout(page);
       expect(geo).not.toBeNull();
       if (!geo) throw new Error('expected session layout nodes');
 
+      // #1325: layout-invariant assertions for the composed session stage, per
+      // theme. These catch intended-layout drift (like the DS2/DS3 grid split
+      // fixed in PR #1324) regardless of any screenshot baseline — a baseline
+      // bakes in whatever production renders first, so it can't flag a
+      // pre-existing structural bug; an invariant can.
       if (theme === 'ds1') {
-        // DS1: scene status sits as a side rail to the left of the reading column.
+        // DS1: three-column stage with scene status as a rail LEFT of the column.
+        expect(geo.trackCount).toBe(3);
         expect(geo.railLeft).toBeLessThan(geo.mainLeft);
+      } else {
+        // DS2/DS3: single-column stage with scene status STACKED ABOVE the
+        // narrative. The #1324 regression left the narrative in grid-column 2,
+        // splitting the stage into a too-wide rail + cramped column instead.
+        expect(geo.trackCount).toBe(1);
+        expect(geo.railTop).toBeLessThan(geo.mainTop);
       }
 
       // DS3 alone paints the mechanical dot grid on the shell.
@@ -107,7 +101,7 @@ test.describe('Game session theme differentiation', () => {
       await expect(sceneStatus.getByText('Characters Present')).toBeVisible();
 
       // On mobile every theme stacks scene status above the narrative.
-      const geo = await sceneStatusGeometry(page);
+      const geo = await readSessionStageLayout(page);
       expect(geo).not.toBeNull();
       if (!geo) throw new Error('expected session layout nodes');
       expect(geo.railTop).toBeLessThanOrEqual(geo.mainTop + 4);

--- a/tests/visual/utils/manuscript-helpers.ts
+++ b/tests/visual/utils/manuscript-helpers.ts
@@ -181,6 +181,60 @@ export const stabilizeForCapture = async (page: Page): Promise<void> => {
   await pause(100);
 };
 
+export interface SessionStageLayout {
+  /** Number of explicit grid tracks on `.manuscript-main-stage` (DS1 = 3, DS2/DS3 = 1). */
+  trackCount: number;
+  gridTemplateColumns: string;
+  railLeft: number;
+  railRight: number;
+  railTop: number;
+  railBottom: number;
+  mainLeft: number;
+  mainTop: number;
+  /** `background-image` of `.manuscript-viewport-shell` (DS3 paints a radial dot grid). */
+  shellBg: string;
+}
+
+/**
+ * Read the composed session-stage layout for layout-invariant assertions (#1325).
+ *
+ * Returns geometry/computed style the deterministic assertions need — grid track
+ * count, the scene-status rail vs narrative-column rects, and the shell
+ * background — so a composed-layout regression (e.g. the DS2/DS3 grid split
+ * fixed in PR #1324) trips a check regardless of any screenshot baseline.
+ *
+ * Returns null when the stage/rail/content nodes are absent (no-rail or skeleton
+ * state) so callers guard explicitly rather than asserting on a partial tree.
+ */
+export const readSessionStageLayout = (
+  page: Page,
+): Promise<SessionStageLayout | null> =>
+  page.evaluate(() => {
+    const stage = document.querySelector('.manuscript-main-stage');
+    const rail = document.querySelector('.manuscript-characters-rail');
+    const main = document.querySelector('.manuscript-main-content');
+    const shell = document.querySelector('.manuscript-viewport-shell');
+    if (!stage || !rail || !main || !shell) return null;
+
+    const railRect = rail.getBoundingClientRect();
+    const mainRect = main.getBoundingClientRect();
+    // Computed grid-template-columns resolves minmax()/fr to space-separated px
+    // values, so the token count is the explicit track count.
+    const cols = window.getComputedStyle(stage).gridTemplateColumns;
+
+    return {
+      trackCount: cols.split(/\s+/).filter(Boolean).length,
+      gridTemplateColumns: cols,
+      railLeft: Math.round(railRect.left),
+      railRight: Math.round(railRect.right),
+      railTop: Math.round(railRect.top),
+      railBottom: Math.round(railRect.bottom),
+      mainLeft: Math.round(mainRect.left),
+      mainTop: Math.round(mainRect.top),
+      shellBg: window.getComputedStyle(shell).backgroundImage,
+    };
+  });
+
 export interface ManuscriptMetricNode {
   selector: string;
   exists: boolean;


### PR DESCRIPTION
## Description

Canon enforcement only watched one surface — the `/dev/design-system` living style guide — so a composed-layout regression could ship across the app, the guide, the dev harness, and Storybook with no check noticing. PR #1324 was the motivating example: DS2/DS3 desktop sessions split into a too-wide scene-status rail + a cramped narrative (the narrative stayed in `grid-column: 2` and was never reset to a single column), and it fell through `ds-guard`, `pattern-alignment`, `verify-ds-canon`, and the `session-themes` spec — surfacing only when a human looked.

This closes the gap with **layout-invariant assertions** (not more screenshots) on the two session surfaces, plus a Storybook-coverage check in the canon guard. The key insight from the issue: a screenshot baseline can't catch this class of bug because it bakes in whatever production renders first — a pre-existing split *becomes* the baseline. An assertion on the intended layout catches it regardless of baseline state.

What changed:
- **`readSessionStageLayout` helper** (`tests/visual/utils/manuscript-helpers.ts`) — one shared geometry reader (grid track count, scene-status rail vs narrative-column rects, shell background) so both specs assert the same contract.
- **Production play route** (`session-themes.spec.ts`) — per-theme desktop invariants: DS1 = three tracks, rail left of the column; DS2/DS3 = one track, scene status stacked above the narrative. Replaces the inline geometry reader; the existing scene-status screenshots stay.
- **Canon guide** (`design-system-session.spec.ts`) — the same invariants asserted before the existing shell screenshot, so the canon surface is governed by an invariant too, not just a pixel baseline.
- **DS-canon guard** (`verify-ds-canon.cjs` + `.ds-canon-baseline.json`) — a third check: every `src/components/ui/*` primitive must appear in a Storybook story under `src/stories/**`. `dialog` + `table` grandfathered; `scroll-area` already excepted.

## Related Issue
Closes #1325

## Type of Change
- [x] Test addition or improvement
- [x] Refactoring (code improvements without changing functionality)

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The deliverable here *is* test/guard coverage. I verified the new guard check actually fires (temporarily un-grandfathering `dialog`/`table` made `lint:ds-canon` fail with the expected message), then restored the baseline.

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A — no components changed. (The guard now *requires* a story for every `ui/*` primitive going forward; current gaps `dialog`/`table` are grandfathered, tracked for a follow-up.)

## Implementation Notes

Maps to the issue's three deliverables:
1. **Layout-invariant assertions per theme (highest value)** — done on both the production play route and the canon guide. DS1 three-column rail-left; DS2/DS3 single-column scene-status-above.
2. **Composed-session visual coverage per theme** — the `design-system-session` baselines (added in PR #1324) are kept; app-side stage regressions are now covered on the production play route by assertion. I deliberately did *not* add a new full-stage production screenshot: the issue's own "Alternatives Considered" rejects baselines-alone as sufficient, and a new full-stage baseline is a fresh cross-platform-flake surface for marginal gain over the assertions + the existing composed shell baselines.
3. **Storybook coverage parity in the guard (optional)** — done.

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

```
# Deterministic guard (no server needed):
npm run lint:ds-canon          # passes; temporarily clearing storybookGaps makes it fail as expected

# Visual specs (server already running on the worktree port):
PLAYWRIGHT_BASE_URL=http://localhost:<port> npx playwright test --project=chromium \
  tests/visual/session-themes.spec.ts tests/visual/design-system-session.spec.ts
```

Locally (macOS): all 6 `session-themes` tests pass (incl. the new DS1/DS2/DS3 desktop invariants) and all 3 `design-system-session` tests pass (one ds3 first-run flake on `scrollIntoViewIfNeeded` cleared on rerun — it's a compile-timing issue before any of the new code). `tsc --noEmit` and `eslint` are clean.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
