### PR TITLE
feat(ai): route AI calls through the player's provider key (#893)

### DIFF
--- a/src/app/api/ai/analyze-world/route.ts
+++ b/src/app/api/ai/analyze-world/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { resolveApiKey } from '@/lib/ai/resolveApiKey';
 import { analyzeWorldDescription } from '@/lib/ai/worldAnalyzer';
 import Logger from '@/lib/utils/logger';
 
@@ -25,7 +26,7 @@ export async function POST(request: NextRequest) {
     logger.debug('analyze-world API', 'Analyzing world description...');
 
     // Analyze the world description using the AI service
-    const analysis = await analyzeWorldDescription(body.description);
+    const analysis = await analyzeWorldDescription(body.description, resolveApiKey(request));
     
     logger.debug('analyze-world API', 'Analysis completed successfully');
 

--- a/src/app/api/ai/generate-template/route.ts
+++ b/src/app/api/ai/generate-template/route.ts
@@ -3,6 +3,7 @@ import { generateWorldTemplate } from '@/lib/ai/templateGenerator';
 import { TemplateGenerationContext } from '@/lib/ai/templatePrompts';
 import { GeminiClient } from '@/lib/ai/geminiClient';
 import { getAIConfig, getGenerationConfig, getSafetySettings } from '@/lib/ai/config';
+import { resolveApiKey } from '@/lib/ai/resolveApiKey';
 import Logger from '@/lib/utils/logger';
 import { TEMPLATE_GENERATION_TIMEOUT_MS } from '@/lib/constants/timeouts';
 
@@ -58,7 +59,7 @@ export async function POST(request: NextRequest) {
     // Generate the template using the secure server-side client with timeout
     const aiConfig = getAIConfig();
     const client = new GeminiClient({
-      apiKey: aiConfig.geminiApiKey,
+      apiKey: resolveApiKey(request) ?? aiConfig.geminiApiKey,
       modelName: aiConfig.modelName,
       maxRetries: aiConfig.maxRetries,
       timeout: aiConfig.timeout,

--- a/src/app/api/generate-character/route.ts
+++ b/src/app/api/generate-character/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { resolveApiKey } from '@/lib/ai/resolveApiKey';
 import { createAPIErrorResponse } from '@/lib/utils/errorUtils';
 import { generateCharacter } from '@/lib/ai/characterGenerator';
 import { World } from '@/types/world.types';
@@ -41,7 +42,8 @@ export async function POST(request: NextRequest) {
       (Array.isArray(existingNames) ? existingNames : []) as string[],
       suggestedName as string | undefined,
       (characterType as 'original' | 'known' | 'specific') || 'original',
-      typeof concept === 'string' ? concept : undefined
+      typeof concept === 'string' ? concept : undefined,
+      resolveApiKey(request)
     );
 
     return NextResponse.json(generatedCharacter);

--- a/src/app/api/generate-ending-image/route.ts
+++ b/src/app/api/generate-ending-image/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
+import { resolveApiKey } from '@/lib/ai/resolveApiKey';
 import type { StoryEnding } from '@/types/narrative.types';
 import type { World } from '@/types/world.types';
 import type { Character } from '@/types/character.types';
@@ -114,8 +115,9 @@ export async function POST(request: NextRequest) {
     logger.debug('generate-ending-image', 'Starting image generation for ending:', body.ending.id);
 
     try {
-      // Generate image prompt using AI
-      const client = createDefaultGeminiClient();
+      // Generate image prompt using AI (player's BYO key -> env fallback)
+      const apiKey = resolveApiKey(request);
+      const client = createDefaultGeminiClient(apiKey);
       const imagePrompt = generateImagePrompt(body.ending, body.world, body.character, body.recentNarrative);
       
       logger.debug('generate-ending-image', 'Generated image prompt:', imagePrompt);
@@ -149,10 +151,8 @@ export async function POST(request: NextRequest) {
       let aiGenerated = false;
       let placeholder = true;
 
-      // Check if we have Gemini API key for image generation
-      const apiKey = process.env.GEMINI_API_KEY;
-      
-      if (apiKey && apiKey !== 'MOCK_API_KEY') {
+      // Use the key resolved above (player's BYO key -> env fallback).
+      if (apiKey) {
         try {
           logger.debug('generate-ending-image', 'Attempting Gemini image generation');
           

--- a/src/app/api/generate-item-image/route.ts
+++ b/src/app/api/generate-item-image/route.ts
@@ -5,6 +5,7 @@ import Logger from '@/lib/utils/logger';
 import type { InventoryItem } from '@/types/inventory.types';
 import { buildItemPrompt } from '@/lib/ai/itemImageGenerator';
 import { generateImageWithFallback } from '@/lib/api/imageGenerationHelpers';
+import { resolveApiKey } from '@/lib/ai/resolveApiKey';
 
 const logger = new Logger('API');
 
@@ -40,6 +41,7 @@ export async function POST(request: NextRequest) {
     // Use centralized helper for image generation with fallback
     return generateImageWithFallback({
       prompt,
+      apiKey: resolveApiKey(request),
       fallback: {
         variant: 'shapes',
         seed: item.name,

--- a/src/app/api/generate-journal-image/route.ts
+++ b/src/app/api/generate-journal-image/route.ts
@@ -3,6 +3,7 @@ import type { JournalEntry } from '@/types/journal.types';
 import type { World } from '@/types/world.types';
 import Logger from '@/lib/utils/logger';
 import { generateImageWithGemini } from '@/lib/ai/geminiImageGenerator';
+import { resolveApiKey } from '@/lib/ai/resolveApiKey';
 import { getGenreStyleGuidance, getGenreFallbackImage } from '@/lib/utils/genrePromptGuide';
 
 const logger = new Logger('JournalImageAPI');
@@ -60,9 +61,9 @@ export async function POST(request: NextRequest) {
     logger.debug('generate-journal-image', 'Starting image generation');
 
     const imagePrompt = customPrompt || generateImagePrompt(entry, world);
-    const apiKey = process.env.GEMINI_API_KEY;
+    const apiKey = resolveApiKey(request);
 
-    if (!apiKey || apiKey === 'MOCK_API_KEY') {
+    if (!apiKey) {
       logger.debug('generate-journal-image', 'No Gemini API key configured, using fallback');
       return NextResponse.json({
         imageUrl: generateFallbackImage(entry, world),

--- a/src/app/api/generate-portrait/route.ts
+++ b/src/app/api/generate-portrait/route.ts
@@ -6,6 +6,7 @@ import { Character } from '@/types/character.types';
 import { World } from '@/types/world.types';
 import { truncate, getTimestamp } from '@/lib/utils';
 import { generateImageWithGemini } from '@/lib/ai/geminiImageGenerator';
+import { resolveApiKey } from '@/lib/ai/resolveApiKey';
 
 const logger = new Logger('API');
 
@@ -16,7 +17,8 @@ async function buildPortraitPrompt(
   characterName: string,
   physicalDescription: string,
   worldGenre: string,
-  isKnownFigure?: boolean
+  isKnownFigure?: boolean,
+  apiKey?: string | null
 ): Promise<string> {
   try {
     logger.debug(
@@ -37,7 +39,7 @@ async function buildPortraitPrompt(
     ]);
 
     logger.debug('generate-portrait API', 'Creating AI client and generator');
-    const aiClient = createDefaultGeminiClient();
+    const aiClient = createDefaultGeminiClient(apiKey);
 
     // Create a minimal character object for detection
     const mockCharacter: Character = {
@@ -150,7 +152,8 @@ export async function POST(request: NextRequest) {
           characterName,
           physicalDesc,
           worldGenre,
-          isKnownFigure
+          isKnownFigure,
+          resolveApiKey(request)
         );
 
         return NextResponse.json({
@@ -171,7 +174,8 @@ export async function POST(request: NextRequest) {
           characterName,
           physicalDesc,
           worldGenre,
-          isKnownFigure
+          isKnownFigure,
+          resolveApiKey(request)
         );
       }
     } else {
@@ -194,9 +198,9 @@ export async function POST(request: NextRequest) {
       truncate(prompt, 100)
     );
 
-    const apiKey = process.env.GEMINI_API_KEY;
+    const apiKey = resolveApiKey(request);
 
-    if (!apiKey || apiKey === 'MOCK_API_KEY') {
+    if (!apiKey) {
       // Return a mock portrait for development
       const mockPortrait = {
         type: 'ai-generated' as const,

--- a/src/app/api/generate-world-image/route.ts
+++ b/src/app/api/generate-world-image/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
+import { resolveApiKey } from '@/lib/ai/resolveApiKey';
 import type { World } from '@/types/world.types';
 import Logger from '@/lib/utils/logger';
 import { generateAndSaveImageWithGemini } from '@/lib/ai/geminiImageGenerator';
@@ -59,7 +60,8 @@ export async function POST(request: NextRequest) {
 
     try {
       // Use custom prompt if provided, otherwise generate one using AI
-      const client = createDefaultGeminiClient();
+      const apiKey = resolveApiKey(request);
+      const client = createDefaultGeminiClient(apiKey);
       let imagePrompt: string;
       
       if (body.customPrompt) {
@@ -97,10 +99,8 @@ export async function POST(request: NextRequest) {
       let aiGenerated = false;
       let placeholder = true;
 
-      // Check if we have Gemini API key for image generation
-      const apiKey = process.env.GEMINI_API_KEY;
-
-      if (apiKey && apiKey !== 'MOCK_API_KEY') {
+      // Use the key resolved above (player's BYO key -> env fallback).
+      if (apiKey) {
         try {
           logger.debug('generate-world-image', 'Attempting Gemini image generation with model: gemini-2.5-flash-image');
 

--- a/src/app/api/generate-world/route.ts
+++ b/src/app/api/generate-world/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { resolveApiKey } from '@/lib/ai/resolveApiKey';
 import { createAPIErrorResponse } from '@/lib/utils/errorUtils';
 import { generateWorld } from '@/lib/generators/worldGenerator';
 import Logger from '@/lib/utils/logger';
@@ -35,7 +36,7 @@ export async function POST(request: NextRequest) {
       relationship: body.worldRelationship || 'inspired_by',
       existingNames: body.existingNames,
       suggestedName: body.suggestedName
-    });
+    }, resolveApiKey(request));
     
     // Validate generated world structure
     if (!generatedWorld.name || !generatedWorld.description || !generatedWorld.genre) {

--- a/src/app/api/inventory/categorize/__tests__/route.test.ts
+++ b/src/app/api/inventory/categorize/__tests__/route.test.ts
@@ -69,11 +69,15 @@ describe('POST /api/inventory/categorize', () => {
     expect(response.status).toBe(200);
     const data = await response.json();
 
-    // Only valid items are sent to the categorizer.
-    expect(mockCategorize).toHaveBeenCalledWith([
-      { name: 'Iron Sword', description: 'A blade', context: undefined },
-      { name: 'Gold Coins', description: 'Currency', context: undefined },
-    ]);
+    // Only valid items are sent to the categorizer, with the request-resolved
+    // key (null here: no BYO header and the env key is the MOCK sentinel).
+    expect(mockCategorize).toHaveBeenCalledWith(
+      [
+        { name: 'Iron Sword', description: 'A blade', context: undefined },
+        { name: 'Gold Coins', description: 'Currency', context: undefined },
+      ],
+      null
+    );
 
     // Response is full-length and positionally aligned to the input.
     expect(data.results).toHaveLength(3);

--- a/src/app/api/inventory/categorize/route.ts
+++ b/src/app/api/inventory/categorize/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { resolveApiKey } from '@/lib/ai/resolveApiKey';
 import { categorizeInventoryItems } from '@/lib/ai/inventoryCategorizer';
 import type { InventoryCategorizationResult } from '@/lib/ai/inventoryCategorizer';
 import Logger from '@/lib/utils/logger';
@@ -47,7 +48,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const categorizations = await categorizeInventoryItems(validItems);
+    const categorizations = await categorizeInventoryItems(validItems, resolveApiKey(request));
     const classifiedAt = getTimestamp();
 
     // Map each categorization back to its original input slot, then emit a

--- a/src/app/api/inventory/check-similarity/route.ts
+++ b/src/app/api/inventory/check-similarity/route.ts
@@ -3,6 +3,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { GeminiClient } from '@/lib/ai/geminiClient';
 import { getDefaultConfig } from '@/lib/ai/config';
+import { resolveApiKey } from '@/lib/ai/resolveApiKey';
 import Logger from '@/lib/utils/logger';
 
 const logger = new Logger('CheckSimilarityAPI');
@@ -54,7 +55,7 @@ If they're definitely different items, return similar: false.
 
 Response (JSON only):`;
 
-    const config = getDefaultConfig();
+    const config = getDefaultConfig(resolveApiKey(request));
     const client = new GeminiClient(config);
     const response = await client.generateContent(prompt);
 

--- a/src/app/api/lore/check-similarity/route.ts
+++ b/src/app/api/lore/check-similarity/route.ts
@@ -6,6 +6,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { GeminiClient } from '@/lib/ai/geminiClient';
 import { getDefaultConfig } from '@/lib/ai/config';
+import { resolveApiKey } from '@/lib/ai/resolveApiKey';
 import Logger from '@/lib/utils/logger';
 
 const logger = new Logger('CheckLoreSimilarityAPI');
@@ -65,7 +66,7 @@ For uncertain cases, adjust confidence accordingly.
 
 Response (JSON only):`;
 
-    const config = getDefaultConfig();
+    const config = getDefaultConfig(resolveApiKey(request));
     const client = new GeminiClient(config);
     const response = await client.generateContent(prompt);
 

--- a/src/app/api/narrative/ending/route.ts
+++ b/src/app/api/narrative/ending/route.ts
@@ -1,6 +1,7 @@
 // src/app/api/narrative/ending/route.ts
 
 import { NextRequest, NextResponse } from 'next/server';
+import { resolveApiKey } from '@/lib/ai/resolveApiKey';
 import { generateEnding } from '../../../../lib/ai/endingGenerator';
 import { logger } from '../../../../lib/utils/logger';
 import type { EndingGenerationRequest, EndingType, EndingTone } from '../../../../types/narrative.types';
@@ -63,7 +64,7 @@ export async function POST(request: NextRequest) {
     });
 
     // Generate the ending
-    const result = await generateEnding(endingRequest);
+    const result = await generateEnding(endingRequest, resolveApiKey(request));
 
     logger.info('Story ending generated successfully', { 
       sessionId,

--- a/src/app/api/narrative/story-checkpoint/__tests__/route.test.ts
+++ b/src/app/api/narrative/story-checkpoint/__tests__/route.test.ts
@@ -76,7 +76,8 @@ describe('/api/narrative/story-checkpoint', () => {
     expect(response.status).toBe(200);
     expect(data.summary).toBe('Recap');
     expect(mockGenerateStoryCheckpointSummary).toHaveBeenCalledWith(
-      expect.objectContaining({ worldId: 'world-1', sessionId: 'session-1' })
+      expect.objectContaining({ worldId: 'world-1', sessionId: 'session-1' }),
+      null
     );
   });
 

--- a/src/app/api/narrative/story-checkpoint/route.ts
+++ b/src/app/api/narrative/story-checkpoint/route.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
+import { resolveApiKey } from '@/lib/ai/resolveApiKey';
 import { StoryCheckpointRequestBody } from '@/types/story-checkpoint.types';
 import { ToneSettings } from '@/types/tone-settings.types';
 import { generateStoryCheckpointSummary } from '@/lib/ai/storyCheckpointGenerator';
@@ -165,7 +166,7 @@ export async function POST(request: NextRequest) {
       toneSettings: sanitizeToneSettings(rawBody?.toneSettings),
     };
 
-    const summary = await generateStoryCheckpointSummary(payload);
+    const summary = await generateStoryCheckpointSummary(payload, resolveApiKey(request));
     return NextResponse.json(summary);
   } catch (error) {
     logger.error('[story-checkpoint] Failed to generate summary', error);

--- a/src/app/api/narrative/summarize/route.ts
+++ b/src/app/api/narrative/summarize/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
+import { resolveApiKey } from '@/lib/ai/resolveApiKey';
 
 import Logger from '@/lib/utils/logger';
 const logger = new Logger('Summarize');
@@ -25,7 +26,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const geminiClient = createDefaultGeminiClient();
+    const geminiClient = createDefaultGeminiClient(resolveApiKey(request));
     
     const prompt = `${instructions}
 

--- a/src/app/api/narrative/validate-event-significance/route.ts
+++ b/src/app/api/narrative/validate-event-significance/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { resolveApiKey } from '@/lib/ai/resolveApiKey';
 import { validateEventSignificance, ValidationContext } from '@/lib/ai/eventSignificanceValidator';
 
 import Logger from '@/lib/utils/logger';
@@ -23,7 +24,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const result = await validateEventSignificance(majorEvent, context);
+    const result = await validateEventSignificance(majorEvent, context, resolveApiKey(request));
 
     return NextResponse.json(result);
   } catch (error) {

--- a/src/app/characters/page.tsx
+++ b/src/app/characters/page.tsx
@@ -29,6 +29,7 @@ import { getGenreLabel } from '@/lib/constants/genres';
 import { GameSessionConfirmationDialog } from '@/components/GameSession/GameSessionConfirmationDialog';
 import type { GeneratedImage } from '@/types/common.types';
 import { generatePortrait } from '@/lib/api/generatePortrait';
+import { aiFetch } from '@/lib/ai/aiFetch';
 
 // CharacterTable pulls @tanstack/react-table but only renders in table view,
 // and the generate dialog only matters once the page is interactive. Load both
@@ -309,7 +310,7 @@ export default function CharactersPage() {
       const nameToUse =
         generationType === 'specific' ? characterName : undefined;
 
-      const response = await fetch('/api/generate-character', {
+      const response = await aiFetch('/api/generate-character', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/src/components/CharacterCreationWizard/components/CharacterSuggestions.tsx
+++ b/src/components/CharacterCreationWizard/components/CharacterSuggestions.tsx
@@ -9,6 +9,7 @@ import { ErrorBlock } from '@/components/shared';
 import { World } from '@/types/world.types';
 import { CharacterCreationData } from '@/hooks/useCharacterCreationWizard';
 import type { GeneratedCharacterData } from '@/lib/ai/characterGenerator';
+import { aiFetch } from '@/lib/ai/aiFetch';
 
 type CardKey = 'description' | 'background' | 'attributes' | 'skills';
 
@@ -58,7 +59,7 @@ export const CharacterSuggestions: React.FC<CharacterSuggestionsProps> = ({
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch('/api/generate-character', {
+      const response = await aiFetch('/api/generate-character', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/src/components/CharacterEditor/CharacterEditor.tsx
+++ b/src/components/CharacterEditor/CharacterEditor.tsx
@@ -13,6 +13,7 @@ import { BasicInfoForm } from './components/BasicInfoForm';
 import { BackgroundForm } from './components/BackgroundForm';
 import { AttributesForm } from './components/AttributesForm';
 import { SkillsForm } from './components/SkillsForm';
+import { aiFetch } from '@/lib/ai/aiFetch';
 
 import Logger from '@/lib/utils/logger';
 const logger = new Logger('CharacterEditor');
@@ -126,7 +127,7 @@ const CharacterEditor: React.FC<CharacterEditorProps> = ({ characterId }) => {
     setGeneratingPortrait(true);
     setPortraitError(null); // Clear previous portrait errors
     try {
-      const response = await fetch('/api/generate-portrait', {
+      const response = await aiFetch('/api/generate-portrait', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/src/components/GameSession/EndingScreen.tsx
+++ b/src/components/GameSession/EndingScreen.tsx
@@ -29,6 +29,7 @@ import Image from 'next/image';
 import { buildStoryFromCheckpoints } from '@/lib/narrative/storyCheckpointHelpers';
 import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
 import { isStorybookEnv } from '@/lib/utils/isStorybookEnv';
+import { aiFetch } from '@/lib/ai/aiFetch';
 
 import Logger from '@/lib/utils/logger';
 const logger = new Logger('EndingScreen');
@@ -121,7 +122,7 @@ export function EndingScreen() {
         .slice(-5)
         .map((segment) => segment.content);
 
-      const response = await fetch('/api/generate-ending-image', {
+      const response = await aiFetch('/api/generate-ending-image', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/components/GameSession/hooks/useActiveGameSessionJournal.ts
+++ b/src/components/GameSession/hooks/useActiveGameSessionJournal.ts
@@ -5,6 +5,7 @@ import { useJournalStore } from '@/state/journalStore';
 import type { Decision, NarrativeSegment } from '@/types/narrative.types';
 import { safeTrim, truncate, getTimestamp } from '@/lib/utils';
 import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
+import { aiFetch } from '@/lib/ai/aiFetch';
 
 import Logger from '@/lib/utils/logger';
 const logger = new Logger('UseActiveGameSessionJournal');
@@ -62,7 +63,7 @@ export const useActiveGameSessionJournal = ({
     }
 
     try {
-      const response = await fetch('/api/narrative/summarize', {
+      const response = await aiFetch('/api/narrative/summarize', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/src/components/GameSession/hooks/useStoryCheckpointManager.ts
+++ b/src/components/GameSession/hooks/useStoryCheckpointManager.ts
@@ -8,6 +8,7 @@ import { StoryCheckpointDecisionPayload, StoryCheckpointResponseBody } from '@/t
 import { generateUniqueId, safeTrim } from '@/lib/utils';
 import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
 import { buildStoryCheckpointPayload } from '@/lib/narrative/storyCheckpointPayload';
+import { aiFetch } from '@/lib/ai/aiFetch';
 
 interface UseStoryCheckpointManagerArgs {
   worldId: string;
@@ -252,7 +253,7 @@ export const useStoryCheckpointManager = ({ worldId, sessionId, characterId }: U
         toneSettings: world?.toneSettings,
       });
 
-      const response = await fetch('/api/narrative/story-checkpoint', {
+      const response = await aiFetch('/api/narrative/story-checkpoint', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),

--- a/src/lib/ai/__tests__/aiFetch.test.ts
+++ b/src/lib/ai/__tests__/aiFetch.test.ts
@@ -1,0 +1,50 @@
+jest.mock('@/state/providerStore', () => ({
+  getActiveProviderKey: jest.fn(),
+}));
+
+import { aiFetch } from '../aiFetch';
+import { getActiveProviderKey } from '@/state/providerStore';
+
+const mockGetKey = getActiveProviderKey as jest.MockedFunction<typeof getActiveProviderKey>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = jest.fn(async () => ({ ok: true })) as unknown as typeof fetch;
+});
+
+function lastFetchHeaders(): Headers {
+  const init = (global.fetch as jest.Mock).mock.calls[0][1];
+  return new Headers(init.headers);
+}
+
+describe('aiFetch', () => {
+  test('attaches the provider key header when a key exists', async () => {
+    mockGetKey.mockResolvedValue('byo-key');
+    await aiFetch('/api/narrative/generate', { method: 'POST' });
+
+    expect(lastFetchHeaders().get('x-provider-api-key')).toBe('byo-key');
+  });
+
+  test('sends no key header when none is configured', async () => {
+    mockGetKey.mockResolvedValue(null);
+    await aiFetch('/api/narrative/generate');
+
+    expect(lastFetchHeaders().has('x-provider-api-key')).toBe(false);
+  });
+
+  test('preserves caller-supplied headers', async () => {
+    mockGetKey.mockResolvedValue('byo-key');
+    await aiFetch('/api/x', { headers: { 'Content-Type': 'application/json' } });
+
+    const headers = lastFetchHeaders();
+    expect(headers.get('content-type')).toBe('application/json');
+    expect(headers.get('x-provider-api-key')).toBe('byo-key');
+  });
+
+  test('falls back to a plain fetch when key lookup throws', async () => {
+    mockGetKey.mockRejectedValue(new Error('decrypt failed'));
+    await aiFetch('/api/x');
+
+    expect(lastFetchHeaders().has('x-provider-api-key')).toBe(false);
+  });
+});

--- a/src/lib/ai/__tests__/resolveApiKey.test.ts
+++ b/src/lib/ai/__tests__/resolveApiKey.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+import { resolveApiKey, PROVIDER_API_KEY_HEADER } from '../resolveApiKey';
+
+const ORIGINAL = process.env.GEMINI_API_KEY;
+
+function requestWithKey(key?: string): NextRequest {
+  const headers: Record<string, string> = {};
+  if (key) headers[PROVIDER_API_KEY_HEADER] = key;
+  return new NextRequest('http://localhost/api/x', { headers });
+}
+
+afterEach(() => {
+  process.env.GEMINI_API_KEY = ORIGINAL;
+});
+
+describe('resolveApiKey', () => {
+  test('prefers the request header over the env key', () => {
+    process.env.GEMINI_API_KEY = 'env-key';
+    expect(resolveApiKey(requestWithKey('byo-key'))).toBe('byo-key');
+  });
+
+  test('falls back to the env key when no header is present', () => {
+    process.env.GEMINI_API_KEY = 'env-key';
+    expect(resolveApiKey(requestWithKey())).toBe('env-key');
+  });
+
+  test('returns null when env is the MOCK sentinel and no header', () => {
+    process.env.GEMINI_API_KEY = 'MOCK_API_KEY';
+    expect(resolveApiKey(requestWithKey())).toBeNull();
+  });
+
+  test('returns null when neither header nor env key is present', () => {
+    delete process.env.GEMINI_API_KEY;
+    expect(resolveApiKey(requestWithKey())).toBeNull();
+  });
+
+  test('header wins even when env is the MOCK sentinel', () => {
+    process.env.GEMINI_API_KEY = 'MOCK_API_KEY';
+    expect(resolveApiKey(requestWithKey('byo-key'))).toBe('byo-key');
+  });
+
+  test('trims surrounding whitespace on the header value', () => {
+    delete process.env.GEMINI_API_KEY;
+    expect(resolveApiKey(requestWithKey('  spaced-key  '))).toBe('spaced-key');
+  });
+
+  test('returns null with no request and no env key', () => {
+    delete process.env.GEMINI_API_KEY;
+    expect(resolveApiKey()).toBeNull();
+  });
+});

--- a/src/lib/ai/aiFetch.ts
+++ b/src/lib/ai/aiFetch.ts
@@ -1,0 +1,25 @@
+// src/lib/ai/aiFetch.ts
+
+import { PROVIDER_API_KEY_HEADER } from './providerKeyHeader';
+import { getActiveProviderKey } from '@/state/providerStore';
+
+/**
+ * fetch() wrapper for browser -> our own AI routes.
+ *
+ * Just-in-time pulls the active provider's decrypted key and attaches it as a
+ * header, only when one exists. When there's no configured key, this is a plain
+ * fetch and the server falls back to the env key — so dev, tests, and E2E are
+ * unchanged. The plaintext key lives only in this closure for the duration of
+ * the call; it's never stored or logged.
+ */
+export async function aiFetch(input: string, init: RequestInit = {}): Promise<Response> {
+  const key = await getActiveProviderKey().catch(() => null);
+  // No configured key -> identical to a plain fetch (env fallback applies
+  // server-side). This keeps aiFetch a true drop-in: dev, tests, and E2E behave
+  // exactly as before, and only a configured BYO key adds the header.
+  if (!key) return fetch(input, init);
+
+  const headers = new Headers(init.headers);
+  headers.set(PROVIDER_API_KEY_HEADER, key);
+  return fetch(input, { ...init, headers });
+}

--- a/src/lib/ai/characterGenerator.ts
+++ b/src/lib/ai/characterGenerator.ts
@@ -22,9 +22,10 @@ export async function generateCharacter(
   existingCharacterNames: string[],
   suggestedName?: string,
   generationType?: 'known' | 'original' | 'specific',
-  concept?: string
+  concept?: string,
+  apiKey?: string | null
 ): Promise<GeneratedCharacterData> {
   // Random generation type if not specified
   const effectiveType = generationType ?? (Math.random() < 0.5 ? 'known' : 'original');
-  return generateAICharacter(world, existingCharacterNames, suggestedName, effectiveType, concept);
+  return generateAICharacter(world, existingCharacterNames, suggestedName, effectiveType, concept, apiKey);
 }

--- a/src/lib/ai/clientGeminiClient.ts
+++ b/src/lib/ai/clientGeminiClient.ts
@@ -2,6 +2,7 @@
 
 import { AIClient, AIResponse, AIImageResponse } from './types';
 import { userFriendlyError } from './userFriendlyErrors';
+import { aiFetch } from './aiFetch';
 
 import Logger from '@/lib/utils/logger';
 const logger = new Logger('ClientGeminiClient');
@@ -28,7 +29,7 @@ export class ClientGeminiClient implements AIClient {
       const isChoiceGeneration = this.isChoiceGenerationPrompt(prompt);
       const endpoint = isChoiceGeneration ? '/api/narrative/choices' : '/api/narrative/generate';
       
-      const response = await fetch(`${this.baseUrl}${endpoint}`, {
+      const response = await aiFetch(`${this.baseUrl}${endpoint}`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -94,7 +95,7 @@ export class ClientGeminiClient implements AIClient {
    */
   async generateChoices(prompt: string): Promise<AIResponse> {
     try {
-      const response = await fetch(`${this.baseUrl}/api/narrative/choices`, {
+      const response = await aiFetch(`${this.baseUrl}/api/narrative/choices`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -141,7 +142,7 @@ export class ClientGeminiClient implements AIClient {
    */
   async generateImage(prompt: string): Promise<AIImageResponse> {
     try {
-      const response = await fetch(`${this.baseUrl}/api/generate-portrait`, {
+      const response = await aiFetch(`${this.baseUrl}/api/generate-portrait`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -182,7 +183,7 @@ export class ClientGeminiClient implements AIClient {
   async isAvailable(): Promise<boolean> {
     try {
       // Make a simple request to check if the API is responding
-      const response = await fetch(`${this.baseUrl}/api/narrative/generate`, {
+      const response = await aiFetch(`${this.baseUrl}/api/narrative/generate`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -49,13 +49,16 @@ export const getSafetySettings = (): SafetySetting[] => {
 };
 
 /**
- * Gets default configuration for AI service
+ * Gets default configuration for AI service.
+ * @param apiKeyOverride - the player's bring-your-own key for this request; when
+ *   omitted, falls back to the server env key (today's behavior).
  * @returns Complete AI service configuration
  */
-export const getDefaultConfig = () => {
+export const getDefaultConfig = (apiKeyOverride?: string | null) => {
   const aiConfig = getAIConfig();
   return {
-    apiKey: aiConfig.geminiApiKey,
+    // The player's resolved key (passed by the route) -> server env key.
+    apiKey: apiKeyOverride ?? aiConfig.geminiApiKey,
     modelName: aiConfig.modelName,
     maxRetries: aiConfig.maxRetries,
     timeout: aiConfig.timeout,

--- a/src/lib/ai/defaultGeminiClient.ts
+++ b/src/lib/ai/defaultGeminiClient.ts
@@ -10,8 +10,12 @@ import { getDefaultConfig } from './config';
  * - Browser (client-side): Uses secure proxy
  * - Server-side with API key: Uses real client
  * - Server-side without API key: Uses mock (for local development)
+ *
+ * @param apiKeyOverride - the player's bring-your-own key, resolved from the
+ *   request (see resolveApiKey). When present, the server real client uses it;
+ *   otherwise it falls back to the env key, exactly as before.
  */
-export const createDefaultGeminiClient = () => {
+export const createDefaultGeminiClient = (apiKeyOverride?: string | null) => {
   // In test environment, Jest will automatically use the mock from __mocks__/geminiClient.mock.ts
   if (process.env.NODE_ENV === 'test' || process.env.JEST_WORKER_ID) {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -24,9 +28,14 @@ export const createDefaultGeminiClient = () => {
     return new ClientGeminiClient();
   }
 
-  // Server-side: use real client when API key is available
-  if (process.env.GEMINI_API_KEY && process.env.GEMINI_API_KEY !== 'MOCK_API_KEY') {
-    return new GeminiClient(getDefaultConfig());
+  // Server-side: the player's resolved key (passed by the route) -> env key.
+  const envKey =
+    process.env.GEMINI_API_KEY && process.env.GEMINI_API_KEY !== 'MOCK_API_KEY'
+      ? process.env.GEMINI_API_KEY
+      : null;
+  const effectiveKey = apiKeyOverride ?? envKey;
+  if (effectiveKey) {
+    return new GeminiClient(getDefaultConfig(effectiveKey));
   }
 
   // Server-side fallback: use mock for local development without API key

--- a/src/lib/ai/endingGenerator.ts
+++ b/src/lib/ai/endingGenerator.ts
@@ -127,7 +127,7 @@ function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export async function generateEnding(request: EndingGenerationRequest): Promise<EndingGenerationResult> {
+export async function generateEnding(request: EndingGenerationRequest, apiKey?: string | null): Promise<EndingGenerationResult> {
   try {
     logger.debug('Generating story ending', { request });
 
@@ -166,7 +166,7 @@ export async function generateEnding(request: EndingGenerationRequest): Promise<
     let lastError: Error | null = null;
     for (let i = 0; i <= MAX_RETRIES; i++) {
       try {
-        const client = createDefaultGeminiClient();
+        const client = createDefaultGeminiClient(apiKey);
         const response = await client.generateContent(finalPrompt);
         const result = parseResponse(response.content);
 

--- a/src/lib/ai/eventSignificanceValidator.ts
+++ b/src/lib/ai/eventSignificanceValidator.ts
@@ -34,7 +34,8 @@ export interface ValidationContext {
  */
 export async function validateEventSignificance(
   majorEvent: string,
-  context: ValidationContext = {}
+  context: ValidationContext = {},
+  apiKey?: string | null
 ): Promise<SignificanceValidationResult> {
   const startTime = Date.now();
 
@@ -47,9 +48,9 @@ export async function validateEventSignificance(
     // Build the validation prompt
     const prompt = buildValidationPrompt(majorEvent, context);
 
-    // Call Gemini Flash for validation
-    const apiKey = process.env.GEMINI_API_KEY;
-    if (!apiKey) {
+    // Call Gemini Flash for validation (player's BYO key -> env fallback)
+    const effectiveKey = apiKey ?? process.env.GEMINI_API_KEY;
+    if (!effectiveKey) {
       logger.warn('EventSignificanceValidator', 'GEMINI_API_KEY not found, defaulting to accepting event');
       return {
         isSignificant: true,
@@ -57,7 +58,7 @@ export async function validateEventSignificance(
       };
     }
 
-    const genAI = new GoogleGenAI({ apiKey });
+    const genAI = new GoogleGenAI({ apiKey: effectiveKey });
     const model = getAIConfig().modelName;
 
     const result = await genAI.models.generateContent({

--- a/src/lib/ai/inventoryCategorizer.ts
+++ b/src/lib/ai/inventoryCategorizer.ts
@@ -101,22 +101,24 @@ function parseAIResponse(raw: string): AIResponseShape | null {
 }
 
 async function categorizeInventoryItem(
-  input: CategorizeInventoryItemInput
+  input: CategorizeInventoryItemInput,
+  apiKey?: string | null
 ): Promise<InventoryCategorizationResult> {
   const config = getAIConfig();
+  const effectiveKey = apiKey ?? config.geminiApiKey;
   const baseLogContext = {
     name: input.name,
     description: truncate(input.description ?? '', 100),
   };
 
-  if (!config.geminiApiKey) {
+  if (!effectiveKey) {
     logger.warn('InventoryCategorizer', 'No GEMINI_API_KEY configured, using fallback categorization', baseLogContext);
     return determineFallbackCategory(input.name, input.description);
   }
 
   try {
     const client = new GeminiClient({
-      apiKey: config.geminiApiKey,
+      apiKey: effectiveKey,
       modelName: config.modelName,
       maxRetries: config.maxRetries,
       timeout: config.timeout,
@@ -184,19 +186,21 @@ function parseAIBatchResponse(raw: string): AIBatchEntryShape[] | null {
  * partial or malformed batch response never blocks item acquisition.
  */
 export async function categorizeInventoryItems(
-  inputs: CategorizeInventoryItemInput[]
+  inputs: CategorizeInventoryItemInput[],
+  apiKey?: string | null
 ): Promise<InventoryCategorizationResult[]> {
   if (inputs.length === 0) {
     return [];
   }
 
   if (inputs.length === 1) {
-    return [await categorizeInventoryItem(inputs[0])];
+    return [await categorizeInventoryItem(inputs[0], apiKey)];
   }
 
   const config = getAIConfig();
+  const effectiveKey = apiKey ?? config.geminiApiKey;
 
-  if (!config.geminiApiKey) {
+  if (!effectiveKey) {
     logger.warn(
       'InventoryCategorizer',
       'No GEMINI_API_KEY configured, using fallback categorization for batch',
@@ -207,7 +211,7 @@ export async function categorizeInventoryItems(
 
   try {
     const client = new GeminiClient({
-      apiKey: config.geminiApiKey,
+      apiKey: effectiveKey,
       modelName: config.modelName,
       maxRetries: config.maxRetries,
       timeout: config.timeout,

--- a/src/lib/ai/journalImageGenerator.ts
+++ b/src/lib/ai/journalImageGenerator.ts
@@ -5,6 +5,7 @@ import { World } from '@/types/world.types';
 import { GeneratedImage } from '@/types/common.types';
 import { getTimestamp } from '@/lib/utils';
 import Logger from '@/lib/utils/logger';
+import { aiFetch } from './aiFetch';
 
 const logger = new Logger('JournalImageGenerator');
 
@@ -18,7 +19,7 @@ export async function generateJournalImage(
   customPrompt?: string
 ): Promise<GeneratedImage> {
   try {
-    const response = await fetch('/api/generate-journal-image', {
+    const response = await aiFetch('/api/generate-journal-image', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ entry, world, customPrompt }),

--- a/src/lib/ai/resolveApiKey.ts
+++ b/src/lib/ai/resolveApiKey.ts
@@ -1,0 +1,29 @@
+// src/lib/ai/resolveApiKey.ts
+
+import type { NextRequest } from 'next/server';
+import { PROVIDER_API_KEY_HEADER } from './providerKeyHeader';
+
+export { PROVIDER_API_KEY_HEADER };
+
+/**
+ * Resolve the effective Gemini key for a request.
+ *
+ * Priority: the player's bring-your-own key (sent per request in
+ * PROVIDER_API_KEY_HEADER) -> the server env key as a dev/local fallback. Returns
+ * null when neither is usable, so callers reproduce today's "no key" behavior
+ * exactly (mock client / "API key not configured").
+ *
+ * The MOCK_API_KEY sentinel only gates the env branch — a real player would
+ * never type it. NextRequest is a type-only import, so this module is safe to
+ * pull into the client bundle (for the shared header constant).
+ *
+ * SECURITY: never log the return value or the header.
+ */
+export function resolveApiKey(request?: NextRequest): string | null {
+  const headerKey = request?.headers.get(PROVIDER_API_KEY_HEADER)?.trim();
+  if (headerKey) return headerKey;
+
+  const envKey = process.env.GEMINI_API_KEY;
+  if (!envKey || envKey === 'MOCK_API_KEY') return null;
+  return envKey;
+}

--- a/src/lib/ai/storyCheckpointGenerator.ts
+++ b/src/lib/ai/storyCheckpointGenerator.ts
@@ -146,8 +146,9 @@ const parseResponse = (content: string): StoryCheckpointResponseBody => {
 
 export const generateStoryCheckpointSummary = async (
   payload: StoryCheckpointRequestBody,
+  apiKey?: string | null,
 ): Promise<StoryCheckpointResponseBody> => {
-  const client = createDefaultGeminiClient();
+  const client = createDefaultGeminiClient(apiKey);
   const prompt = buildPrompt(payload);
 
   const response = await client.generateContent(prompt);

--- a/src/lib/ai/worldAnalyzer.ts
+++ b/src/lib/ai/worldAnalyzer.ts
@@ -31,18 +31,19 @@ interface AIAnalysisResponse {
   skills: AISkill[];
 }
 
-export async function analyzeWorldDescription(description: string): Promise<WorldAnalysisResult> {
+export async function analyzeWorldDescription(description: string, apiKey?: string | null): Promise<WorldAnalysisResult> {
   logger.debug('analyzeWorldDescription called with:', truncate(description, 100));
-  
+
   try {
     const config = getAIConfig();
-    logger.debug('Using AI config:', { 
-      modelName: config.modelName, 
+    const effectiveKey = apiKey ?? config.geminiApiKey;
+    logger.debug('Using AI config:', {
+      modelName: config.modelName,
       timeout: config.timeout,
-      hasApiKey: !!config.geminiApiKey 
+      hasApiKey: !!effectiveKey
     });
-    
-    if (!config.geminiApiKey) {
+
+    if (!effectiveKey) {
       logger.error('API key is not configured - check GEMINI_API_KEY environment variable');
       throw new Error('API key is not configured');
     }
@@ -97,7 +98,7 @@ export async function analyzeWorldDescription(description: string): Promise<Worl
     logger.debug('Calling AI service directly...');
     // Call the AI service directly with proper configuration
     const client = new GeminiClient({
-      apiKey: config.geminiApiKey,
+      apiKey: effectiveKey,
       modelName: config.modelName,
       maxRetries: config.maxRetries,
       timeout: config.timeout,

--- a/src/lib/ai/worldAnalyzerClient.ts
+++ b/src/lib/ai/worldAnalyzerClient.ts
@@ -1,6 +1,7 @@
 // Client-side world analyzer that calls the secure API endpoint
 import Logger from '@/lib/utils/logger';
 import { WorldAnalysisResult } from './worldAnalyzer';
+import { aiFetch } from './aiFetch';
 
 const logger = new Logger('WorldAnalyzerClient');
 
@@ -8,7 +9,7 @@ export async function analyzeWorldDescriptionClient(description: string): Promis
   logger.debug('analyzeWorldDescriptionClient called with:', description.substring(0, 50) + '...');
   
   try {
-    const response = await fetch('/api/ai/analyze-world', {
+    const response = await aiFetch('/api/ai/analyze-world', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/lib/ai/worldImageGenerator.ts
+++ b/src/lib/ai/worldImageGenerator.ts
@@ -6,6 +6,7 @@ import { getTimestamp } from '@/lib/utils';
 
 import Logger from '@/lib/utils/logger';
 import { isStorybookEnv } from '@/lib/utils/isStorybookEnv';
+import { aiFetch } from './aiFetch';
 const logger = new Logger('WorldImageGenerator');
 
 function buildPrompt(world: World): string {
@@ -79,7 +80,7 @@ export async function generateWorldImage(world: World, customPrompt?: string): P
       };
     }
 
-    const response = await fetch('/api/generate-world-image', {
+    const response = await aiFetch('/api/generate-world-image', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/lib/api/generatePortrait.ts
+++ b/src/lib/api/generatePortrait.ts
@@ -1,4 +1,5 @@
 import type { GeneratedImage } from '@/types/common.types';
+import { aiFetch } from '@/lib/ai/aiFetch';
 
 export interface PortraitRequest {
   character?: unknown;
@@ -16,7 +17,7 @@ export interface PortraitResponse {
 export async function generatePortrait(
   payload: PortraitRequest
 ): Promise<PortraitResponse> {
-  const response = await fetch('/api/generate-portrait', {
+  const response = await aiFetch('/api/generate-portrait', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),

--- a/src/lib/api/imageGenerationHelpers.ts
+++ b/src/lib/api/imageGenerationHelpers.ts
@@ -33,6 +33,8 @@ interface ImageGenerationConfig {
   loggerContext: string;
   /** Additional fields to include in response */
   responseFields?: Record<string, unknown>;
+  /** Resolved key for this request (player's BYO key); falls back to env when omitted. */
+  apiKey?: string | null;
 }
 
 /**
@@ -86,7 +88,7 @@ function getGeminiApiKey(): string | null {
 export async function generateImageWithFallback(
   config: ImageGenerationConfig
 ): Promise<NextResponse> {
-  const apiKey = getGeminiApiKey();
+  const apiKey = config.apiKey ?? getGeminiApiKey();
 
   // Mock mode - return placeholder immediately
   if (!apiKey) {

--- a/src/lib/api/worldApi.ts
+++ b/src/lib/api/worldApi.ts
@@ -1,4 +1,5 @@
 import { GeneratedWorldData } from '@/lib/generators/worldGenerator';
+import { aiFetch } from '@/lib/ai/aiFetch';
 
 export interface GenerateWorldParams {
   worldReference?: string;
@@ -30,7 +31,7 @@ export const worldApi = {
    * Generate a new world using AI
    */
   async generateWorld(params: GenerateWorldParams): Promise<GeneratedWorldData> {
-    const response = await fetch('/api/generate-world', {
+    const response = await aiFetch('/api/generate-world', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -50,7 +51,7 @@ export const worldApi = {
    * Generate an image for a world
    */
   async generateWorldImage(params: WorldImageParams): Promise<WorldImageResponse> {
-    const response = await fetch('/api/generate-world-image', {
+    const response = await aiFetch('/api/generate-world-image', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/lib/generators/characterGenerator.ts
+++ b/src/lib/generators/characterGenerator.ts
@@ -17,7 +17,7 @@ const logger = new Logger('CharacterGenerator');
 /**
  * Generate character using AI
  */
-async function generateWithAI(options: CharacterGenerationOptions): Promise<GeneratedCharacterData> {
+async function generateWithAI(options: CharacterGenerationOptions, apiKey?: string | null): Promise<GeneratedCharacterData> {
   const { world, existingNames = [], suggestedName, generationType = 'known', concept } = options;
   
   // Validate the world data first
@@ -102,7 +102,7 @@ CRITICAL INSTRUCTIONS:
 
     // Import and use the AI client directly for server-side usage
     const { createDefaultGeminiClient } = await import('@/lib/ai/defaultGeminiClient');
-    const client = createDefaultGeminiClient();
+    const client = createDefaultGeminiClient(apiKey);
     
     // Generate with AI
     const response = await client.generateContent(prompt);
@@ -358,7 +358,8 @@ export async function generateAICharacter(
   existingCharacterNames: string[],
   suggestedName?: string,
   generationType: CharacterGenerationType = 'known',
-  concept?: string
+  concept?: string,
+  apiKey?: string | null
 ): Promise<GeneratedCharacterData> {
   return generateWithAI({
     method: 'ai',
@@ -367,5 +368,5 @@ export async function generateAICharacter(
     suggestedName,
     generationType,
     concept
-  });
+  }, apiKey);
 }

--- a/src/lib/generators/worldGenerator.ts
+++ b/src/lib/generators/worldGenerator.ts
@@ -53,15 +53,15 @@ export interface WorldGenerationOptions {
 /**
  * Unified world generation function
  */
-export async function generateWorld(options: WorldGenerationOptions): Promise<GeneratedWorldData> {
+export async function generateWorld(options: WorldGenerationOptions, apiKey?: string | null): Promise<GeneratedWorldData> {
   // Always use AI generation, but with TV/movie inspiration
-  return generateWithAI(options);
+  return generateWithAI(options, apiKey);
 }
 
 /**
  * Generate world using AI through secure API
  */
-async function generateWithAI(options: WorldGenerationOptions): Promise<GeneratedWorldData> {
+async function generateWithAI(options: WorldGenerationOptions, apiKey?: string | null): Promise<GeneratedWorldData> {
   // Handle different world generation types
   let prompt: string;
   
@@ -232,7 +232,7 @@ Make the world interesting and playable with concepts appropriate to the setting
     try {
       // Import the AI client for server-side usage
       const { createDefaultGeminiClient } = await import('@/lib/ai/defaultGeminiClient');
-      const client = createDefaultGeminiClient();
+      const client = createDefaultGeminiClient(apiKey);
       
       // Add retry context to prompt for subsequent attempts
       const retryPrompt = attempt > 1 

--- a/src/lib/inventory/categorizeInventoryItemClient.ts
+++ b/src/lib/inventory/categorizeInventoryItemClient.ts
@@ -1,5 +1,6 @@
 import type { StandardInventoryCategory } from '@/types/inventory.types';
 import Logger from '@/lib/utils/logger';
+import { aiFetch } from '@/lib/ai/aiFetch';
 
 const logger = new Logger('InventoryCategorizeClient');
 
@@ -30,7 +31,7 @@ export async function categorizeInventoryItemsClient(
     return [];
   }
 
-  const response = await fetch('/api/inventory/categorize', {
+  const response = await aiFetch('/api/inventory/categorize', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/lib/inventory/checkItemSimilarityClient.ts
+++ b/src/lib/inventory/checkItemSimilarityClient.ts
@@ -1,6 +1,7 @@
 // src/lib/inventory/checkItemSimilarityClient.ts
 
 import Logger from '@/lib/utils/logger';
+import { aiFetch } from '@/lib/ai/aiFetch';
 
 const logger = new Logger('ItemSimilarityClient');
 
@@ -22,7 +23,7 @@ export interface CheckItemSimilarityRequest {
 export async function checkItemSimilarityClient(
   payload: CheckItemSimilarityRequest
 ): Promise<ItemSimilarityResponse> {
-  const response = await fetch('/api/inventory/check-similarity', {
+  const response = await aiFetch('/api/inventory/check-similarity', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/lib/lore/checkLoreSimilarityClient.ts
+++ b/src/lib/lore/checkLoreSimilarityClient.ts
@@ -5,6 +5,7 @@
 
 import Logger from '@/lib/utils/logger';
 import type { LoreCategory } from '@/types/lore.types';
+import { aiFetch } from '@/lib/ai/aiFetch';
 
 const logger = new Logger('LoreSimilarityClient');
 
@@ -27,7 +28,7 @@ export interface LoreSimilarityRequest {
 export async function checkLoreSimilarityClient(
   payload: LoreSimilarityRequest
 ): Promise<LoreSimilarityResponse> {
-  const response = await fetch('/api/lore/check-similarity', {
+  const response = await aiFetch('/api/lore/check-similarity', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/lib/narrative/applyWorldStateThreadUpdates.ts
+++ b/src/lib/narrative/applyWorldStateThreadUpdates.ts
@@ -7,6 +7,7 @@ import type {
 } from '@/types/world-state.types';
 import { generateUniqueId, getTimestamp } from '@/lib/utils';
 import { logger } from '@/lib/utils/logger';
+import { aiFetch } from '@/lib/ai/aiFetch';
 import { useWorldStore } from '@/state/worldStore';
 import { useSessionStore } from '@/state/sessionStore';
 
@@ -177,7 +178,7 @@ export async function applyWorldStateThreadUpdates({
         }];
       } else {
         try {
-          const validationResponse = await fetch('/api/narrative/validate-event-significance', {
+          const validationResponse = await aiFetch('/api/narrative/validate-event-significance', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({

--- a/src/lib/services/itemImageService.ts
+++ b/src/lib/services/itemImageService.ts
@@ -6,6 +6,7 @@ import { useCharacterStore } from '@/state/characterStore';
 import { useWorldStore } from '@/state/worldStore';
 import Logger from '@/lib/utils/logger';
 import { ImageRequestCoordinator } from './imageRequestCoordinator';
+import { aiFetch } from '@/lib/ai/aiFetch';
 
 const logger = new Logger('ItemImageService');
 
@@ -67,7 +68,7 @@ class ItemImageService {
     item: { name: string; description?: string; categoryId: string },
     genre?: string
   ): Promise<GeneratedImage> {
-    const response = await fetch('/api/generate-item-image', {
+    const response = await aiFetch('/api/generate-item-image', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ item, genre }),

--- a/src/lib/services/npcPortraitService.ts
+++ b/src/lib/services/npcPortraitService.ts
@@ -5,6 +5,7 @@ import { useNPCStore } from '@/state/npcStore';
 import { useWorldStore } from '@/state/worldStore';
 import Logger from '@/lib/utils/logger';
 import { ImageRequestCoordinator } from './imageRequestCoordinator';
+import { aiFetch } from '@/lib/ai/aiFetch';
 
 const logger = new Logger('NPCPortraitService');
 
@@ -59,7 +60,7 @@ class NPCPortraitService {
       genre: world.genre,
     });
 
-    const response = await fetch('/api/generate-portrait', {
+    const response = await aiFetch('/api/generate-portrait', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),

--- a/src/state/narrativeStore.ts
+++ b/src/state/narrativeStore.ts
@@ -13,6 +13,7 @@ import { logger } from '../lib/utils/logger';
 import { normalizeText, NORM_DESC } from '../lib/utils/textNormalization';
 import { playerDecisionTracker } from '../lib/ai/playerDecisionTracker';
 import { applyWorldStateThreadUpdates } from '../lib/narrative/applyWorldStateThreadUpdates';
+import { aiFetch } from '@/lib/ai/aiFetch';
 import { createIndexedDBStorage } from './persistence';
 import {
   NPCRelationshipUpdate,
@@ -919,7 +920,7 @@ export const useNarrativeStore = create<NarrativeStore>()(
       journalEntries = allJournalEntries.slice(-5); // Last 5 journal entries only
 
       // Route through server API to keep AI usage server-side and enable test mocking
-      const response = await fetch('/api/narrative/ending', {
+      const response = await aiFetch('/api/narrative/ending', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -3,6 +3,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { globalRateLimiter, RateLimiter, type RateLimitResult } from './rateLimiter';
 import { getAIConfig } from '../lib/ai/config';
+import { resolveApiKey } from '../lib/ai/resolveApiKey';
 import { createAPIErrorResponse } from '../lib/utils/errorUtils';
 
 import Logger from '@/lib/utils/logger';
@@ -77,19 +78,6 @@ async function validateAIRequest(request: NextRequest): Promise<{
   } catch {
     return null;
   }
-}
-
-/**
- * Get and validate API key
- */
-function validateAPIKey(): string | null {
-  const apiKey = process.env.GEMINI_API_KEY;
-  
-  if (!apiKey || apiKey === 'MOCK_API_KEY') {
-    return null;
-  }
-  
-  return apiKey;
 }
 
 /**
@@ -238,8 +226,8 @@ export async function processGeminiTextRequest(
       );
     }
 
-    // Validate API key
-    const apiKey = validateAPIKey();
+    // Resolve the effective key: the player's BYO key (header) -> env fallback.
+    const apiKey = resolveApiKey(request);
     if (!apiKey) {
       return createAPIErrorResponse(
         new Error('Service configuration error: API key not configured'),


### PR DESCRIPTION
## Description

The last piece of bring-your-own-key (and the risky one): every AI call now uses the **player's** provider key when one is configured, falling back to the server `GEMINI_API_KEY` so dev, tests, and E2E are unchanged. Behavior is byte-for-byte identical when no key is present — this is a refactor, not a behavior change. Builds on #1371 (storage + UI).

Two small seams instead of hand-editing ~40 call sites:
- **`resolveApiKey(request)`** — server-side: reads the `x-provider-api-key` header, falls back to the env key. Used for the one call, never logged or persisted.
- **`aiFetch(input, init)`** — browser wrapper that JIT-pulls the active provider key and attaches the header. A true drop-in: with no configured key it's a plain `fetch`, so existing callers and their tests are unaffected.

## Related Issue

Closes #893

(Note: "Closes" doesn't auto-close on a merge to `develop` — I'll close it manually after merge.)

## Type of Change
- [ ] Bug fix
- [x] New feature (BYO-key routing) — non-breaking
- [x] Refactoring (key resolution centralized; identical behavior with no key)
- [ ] Breaking change
- [x] Test addition or improvement

## TDD Compliance
- [x] All new code is tested (resolveApiKey 7 cases, aiFetch 4 cases)
- [x] All tests pass locally (340 suites / 2384 tests)
- [x] Test coverage maintained or improved

## User Stories Addressed

**#893** — As a developer, I need AI calls migrated to use the player's provider so Gemini keeps working while players can bring their own key.

## Implementation Notes

Plumbed at the factory/config layer so callers inherit it:
- `getDefaultConfig` / `createDefaultGeminiClient` gained an optional key override (defaults preserve today's behavior).
- **Text** (`generate`/`choices`): resolve directly in `processGeminiTextRequest`; the old `validateAPIKey` folded into `resolveApiKey`.
- **Shallow** routes (summarize, the four image routes, item-image via a config field, inventory/lore check-similarity, generate-template): resolve in-handler and pass the key down.
- **Deep** generators (character/world/ending/story-checkpoint) and inline-client leaves (categorize/analyze-world/event-significance): take an optional `apiKey` threaded from the route.
- **19 browser call sites** (`ClientGeminiClient` + direct fetches) switched to `aiFetch`.

Safety settings, retries, rate limiting, and image generation are untouched. The IP-based rate limiter stays as-is on purpose (keying it on the user's key would add a leak/fingerprint surface).

**On AsyncLocalStorage:** I first tried a request-scoped ALS context so deep callers could inherit the key with zero threading. It pulled `node:async_hooks` into the client bundle (via the isomorphic `defaultGeminiClient`) and broke the build, so I switched to explicit threading. No implicit context; everything is followable by parameter.

**Scope:** this is the minimal BYO-key plumbing for the free 1.0 release. The full provider-interface restructure from #890 (moving files under `providers/gemini/`, a `GeminiProvider` class, `safetyStrategy.ts`) stays post-1.0 under epic #878 — so a few of #893's literal acceptance items (file moves, the provider class) are intentionally **not** done here. Flagging that honestly.

## Quality Checks
- [x] Linting passed (eslint on the changed AI surface)
- [x] Type checking passed
- [ ] Security audit (CodeQL runs in CI — relevant here for log-injection; the key is never logged)
- [x] No console.log in production code
- [x] No unhandled promises

## Testing Instructions

1. **Unit**: full suite — `340 suites / 2384 tests` pass. New: `src/lib/ai/__tests__/resolveApiKey.test.ts`, `aiFetch.test.ts`.
2. **Live smoke (curl, not Playwright — render-path gen is gated under isPlaywrightEnv)**: with a dev server (no `GEMINI_API_KEY` in its env), a bogus key in the header proves the BYO path end-to-end:
   ```
   curl -X POST :PORT/api/narrative/generate \
     -H 'x-provider-api-key: AIza-bogus' \
     -H 'Content-Type: application/json' \
     -d '{"prompt":"one sentence","config":{"maxTokens":64}}'
   ```
   → reaches Google, returns `400 API_KEY_INVALID` ("API key not valid"). The key appears in neither the response nor the server logs. No header → env fallback (here: not-configured error).
3. `verify-fresh-session` and the visual suite mock the routes / use the env fallback (no header), so they're unchanged — no `isPlaywrightEnv` changes were needed.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected
- [x] Self-review performed
- [x] Comments added for the seams and the threading rationale
- [ ] Documentation updated (none needed)
- [x] No new warnings generated
- [x] Accessibility considerations addressed (n/a — no UI changes)
