### PR TITLE
feat(legal): lightweight privacy note + terms for 1.0 launch (#1366)

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -76,7 +76,7 @@
         }
       },
       {
-        "files": ["src/app/workshop.css", "src/app/dashboard.css", "src/app/wizard.css", "src/app/about.css"],
+        "files": ["src/app/workshop.css", "src/app/dashboard.css", "src/app/wizard.css", "src/app/about.css", "src/app/legal.css"],
         "rules": {
           "function-allowed-list": ["hsl", "hsla", "var", "calc", "theme", "translateY", "translateX", "translate", "scale", "rotate", "linear-gradient", "radial-gradient", "color-mix", "clamp", "cubic-bezier", "brightness", "blur", "repeat", "minmax"],
           "function-disallowed-list": [],

--- a/src/app/about.css
+++ b/src/app/about.css
@@ -193,6 +193,45 @@
   outline-offset: 2px;
 }
 
+/* ─── Footer links (Privacy / Terms) ───
+   Rendered as a sibling of .component-about so the About visual baselines
+   (which screenshot the .component-about locator) stay unchanged; it self-
+   centers to the same measure. */
+
+.component-about-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-5);
+  width: 100%;
+  max-width: 860px;
+  margin: 0 auto;
+  padding: var(--space-5) var(--space-4);
+  border-top: 1px solid var(--color-border);
+}
+
+@media (width >= 1024px) {
+  .component-about-footer {
+    padding: var(--space-5) var(--space-6);
+  }
+}
+
+.component-about-footer-link {
+  font-family: var(--font-interface);
+  font-size: 0.9375rem;
+  color: var(--color-text-secondary);
+  text-decoration: none;
+}
+
+.component-about-footer-link:hover {
+  color: var(--color-accent);
+}
+
+.component-about-footer-link:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
 /* ═══════════════════════════════════════════════════════════════
    DS1 — "The Drafting Table"
    Archival / drafting: sharp radius, hairline rules between

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,6 +15,7 @@ import './workshop.css';
 import './wizard.css';
 import './dashboard.css';
 import './about.css';
+import './legal.css';
 import './badge.css';
 import './character-display.css';
 import '@/lib/theme/themes/_shared-tokens.css';

--- a/src/app/legal.css
+++ b/src/app/legal.css
@@ -1,0 +1,259 @@
+/* ═══════════════════════════════════════════════════════════════
+   Legal Surface
+   Styles for /privacy and /terms and the <LegalPage /> component.
+   All values use design tokens for theme-awareness. Per-theme
+   structural treatments mirror about.css, but tuned for dense text:
+   readability comes first, so there are no full-page background
+   patterns — differentiation lives in the hero, section titles,
+   and rhythm.
+   DS1 = drafting-table (hairline section rules, mono uppercase labels)
+   DS2 = editorial (serif prose, airy rhythm)
+   DS3 = mechanical manuscript (mono labels with a dot bullet, compact)
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ─── Base layout (token-driven, theme-agnostic) ─── */
+
+.component-legal {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: var(--space-6) var(--space-4);
+}
+
+@media (width >= 1024px) {
+  .component-legal {
+    padding: var(--space-8) var(--space-6);
+  }
+}
+
+/* ─── Hero ─── */
+
+.component-legal-hero {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.component-legal-eyebrow {
+  margin: 0;
+  font-family: var(--font-system);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.component-legal-title {
+  margin: 0;
+  font-family: var(--font-narrative);
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  font-weight: 600;
+  line-height: 1.15;
+  color: var(--color-text-primary);
+}
+
+.component-legal-lead {
+  margin: 0;
+  font-family: var(--font-interface);
+  font-size: 1.0625rem;
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+}
+
+.component-legal-updated {
+  margin: 0;
+  font-family: var(--font-system);
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+}
+
+/* ─── Section ─── */
+
+.component-legal-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.component-legal-section-title {
+  margin: 0;
+  font-family: var(--font-interface);
+  font-size: 1.1875rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--color-text-primary);
+}
+
+.component-legal-prose {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.component-legal-prose p {
+  margin: 0;
+  font-family: var(--font-interface);
+  font-size: 1rem;
+  line-height: 1.65;
+  color: var(--color-text-secondary);
+}
+
+.component-legal-prose a {
+  color: var(--color-accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.component-legal-prose a:hover {
+  color: var(--color-accent-hover);
+}
+
+.component-legal-prose a:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* ─── Footer links ─── */
+
+.component-legal-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-5);
+  padding-top: var(--space-5);
+  border-top: 1px solid var(--color-border);
+}
+
+.component-legal-footer-link {
+  font-family: var(--font-interface);
+  font-size: 0.9375rem;
+  color: var(--color-text-secondary);
+  text-decoration: none;
+}
+
+.component-legal-footer-link:hover {
+  color: var(--color-accent);
+}
+
+.component-legal-footer-link:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   DS1 — "The Drafting Table"
+   Hairline rules between sections, mono uppercase section labels,
+   tight rhythm, sharp footer rule.
+   ═══════════════════════════════════════════════════════════════ */
+
+[data-theme="ds1"] .component-legal {
+  gap: 0;
+}
+
+[data-theme="ds1"] .component-legal-hero {
+  padding-bottom: var(--space-6);
+  border-bottom: 1px solid var(--color-border-strong);
+}
+
+[data-theme="ds1"] .component-legal-section {
+  padding: var(--space-6) 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+[data-theme="ds1"] .component-legal-title {
+  font-family: var(--font-interface);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+[data-theme="ds1"] .component-legal-section-title {
+  font-family: var(--font-system);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+[data-theme="ds1"] .component-legal-footer {
+  padding-top: var(--space-6);
+  border-top-color: var(--color-border-strong);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   DS2 — "Warm Earth" editorial
+   Serif prose, generous whitespace, large serif section titles.
+   ═══════════════════════════════════════════════════════════════ */
+
+[data-theme="ds2"] .component-legal {
+  gap: clamp(var(--space-8), 5vw, 3.5rem);
+}
+
+[data-theme="ds2"] .component-legal-lead {
+  font-family: var(--font-narrative);
+  font-size: 1.25rem;
+  line-height: 1.55;
+}
+
+[data-theme="ds2"] .component-legal-section-title {
+  font-family: var(--font-narrative);
+  font-size: clamp(1.375rem, 2.5vw, 1.75rem);
+  font-weight: 400;
+  letter-spacing: -0.01em;
+}
+
+[data-theme="ds2"] .component-legal-prose p {
+  font-family: var(--font-narrative);
+  font-size: 1.125rem;
+  line-height: 1.7;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   DS3 — "Mechanical Manuscript"
+   Compact: mono uppercase section labels with a dot bullet, mono
+   prose, tighter rhythm.
+   ═══════════════════════════════════════════════════════════════ */
+
+[data-theme="ds3"] .component-legal {
+  gap: var(--space-6);
+}
+
+[data-theme="ds3"] .component-legal-section-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-system);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+}
+
+[data-theme="ds3"] .component-legal-section-title::before {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-full);
+  background: var(--color-accent);
+  flex-shrink: 0;
+}
+
+[data-theme="ds3"] .component-legal-lead {
+  font-family: var(--font-narrative);
+  font-size: 1.125rem;
+  line-height: 1.55;
+}
+
+[data-theme="ds3"] .component-legal-prose p {
+  font-family: var(--font-system);
+  font-size: 0.9375rem;
+  line-height: 1.6;
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from 'next';
+import { LegalPage, LegalSection } from '@/components/Legal';
+
+export const metadata: Metadata = {
+  title: 'Privacy — Narraitor',
+  description:
+    'How Narraitor handles your data: your worlds and characters stay in your browser, prompts go to the provider that generates the story, and usage measurement is anonymous and cookieless.',
+};
+
+export default function PrivacyPage() {
+  return (
+    <LegalPage
+      title="Privacy"
+      lead="The short, honest version: your stories live in your browser, and the only thing that leaves it is the prompt sent off to generate the next part of the story."
+      updated="June 2026"
+    >
+      <LegalSection id="privacy-data" heading="Where your data lives">
+        <p>
+          Your worlds, characters, and saved stories are stored locally in your
+          browser, on the device you&apos;re using. They aren&apos;t uploaded to a
+          server — there isn&apos;t one holding your stuff.
+        </p>
+        <p>
+          From Settings you can export everything to a file and import it back —
+          that&apos;s your backup, and it&apos;s the only copy that leaves your
+          device, when you choose to make it. Clearing your browser data for this
+          site erases everything, so keep an export of anything you&apos;d be sad
+          to lose.
+        </p>
+      </LegalSection>
+
+      <LegalSection id="privacy-prompts" heading="What leaves your browser">
+        <p>
+          To write the story and generate images, the app sends your prompts — the
+          world and character details you create, and the choices you make — to the
+          provider that does the generating. By default that&apos;s Google Gemini;
+          if you&apos;ve set up your own provider key, it goes to whichever provider
+          you chose instead.
+        </p>
+        <p>
+          What that provider does with what you send is governed by their terms, not
+          ours. The practical upshot: treat a prompt like anything you&apos;d paste
+          into a third-party service, and don&apos;t put passwords, secrets, or real
+          personal data you&apos;d rather not share into it.
+        </p>
+      </LegalSection>
+
+      <LegalSection id="privacy-accounts" heading="No accounts">
+        <p>
+          There&apos;s no sign-up, no login, no profile. The app doesn&apos;t know
+          who you are, and nothing ties your stories to an identity.
+        </p>
+      </LegalSection>
+
+      <LegalSection id="privacy-analytics" heading="Usage measurement">
+        <p>
+          Usage is measured with Vercel Web Analytics: anonymous, cookieless counting
+          of page views and a few funnel steps — did someone land on the site, create
+          a world, start a session, come back. Because it&apos;s cookieless,
+          there&apos;s no consent banner to click through.
+        </p>
+        <p>
+          No personal data, and nothing derived from your content — world names,
+          character names, prompts, story text — is ever sent to it. It exists to
+          answer one question: does the first-play flow actually work for someone new.
+        </p>
+      </LegalSection>
+
+      <LegalSection id="privacy-changes" heading="If this changes">
+        <p>
+          This note matches how the app works today: local-first, no accounts. If
+          that ever changes — accounts, server-side saves, syncing across devices —
+          this note changes with it, and the change shows up right here.
+        </p>
+      </LegalSection>
+    </LegalPage>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,77 @@
+import type { Metadata } from 'next';
+import { LegalPage, LegalSection } from '@/components/Legal';
+
+export const metadata: Metadata = {
+  title: 'Terms — Narraitor',
+  description:
+    'Plain-language terms for Narraitor: a free, creative-fiction tool provided as-is, with no warranty. Your stories are yours.',
+};
+
+export default function TermsPage() {
+  return (
+    <LegalPage
+      title="Terms"
+      lead="Plain-language terms for a free, creative-fiction tool. No fine print designed to trip you up — just what you can expect, and what's on you."
+      updated="June 2026"
+    >
+      <LegalSection id="terms-what" heading="What this is">
+        <p>
+          Narraitor is a free, creative-fiction tool and a personal, open-source
+          project. It&apos;s for building and playing your own stories. By using it,
+          you&apos;re agreeing to the plain-language terms below.
+        </p>
+      </LegalSection>
+
+      <LegalSection id="terms-warranty" heading="Provided as-is, no warranty">
+        <p>
+          It comes with no warranty of any kind. It might have bugs, it might be
+          unavailable, and the story and images it generates are produced by a model
+          — they can be wrong, strange, repetitive, or just not what you asked for.
+          Use it at your own risk.
+        </p>
+      </LegalSection>
+
+      <LegalSection id="terms-responsibility" heading="Your part of the deal">
+        <p>
+          Don&apos;t paste secrets or real personal data into prompts — see the{' '}
+          <a href="/privacy">privacy note</a> for why. You&apos;re responsible for
+          what you create and how you use it.
+        </p>
+        <p>
+          If you&apos;re using your own provider key, you&apos;re also bound by that
+          provider&apos;s terms, and any usage costs billed to that key are yours.
+        </p>
+      </LegalSection>
+
+      <LegalSection id="terms-ownership" heading="Your stories are yours">
+        <p>
+          The app doesn&apos;t claim your stories, and because they live in your
+          browser, the project never sees them. The code itself is open-source under
+          the license in its repository.
+        </p>
+      </LegalSection>
+
+      <LegalSection id="terms-availability" heading="It can change or go away">
+        <p>
+          This is a hobby release. Features can change, and there&apos;s no guarantee
+          it&apos;ll stay online or keep working. Your local data is yours to export
+          and keep, so back up anything you&apos;d be sad to lose.
+        </p>
+      </LegalSection>
+
+      <LegalSection id="terms-questions" heading="Questions">
+        <p>
+          It&apos;s open-source — read the code, or file an issue on{' '}
+          <a
+            href="https://github.com/jerseycheese/Narraitor"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            GitHub
+          </a>
+          .
+        </p>
+      </LegalSection>
+    </LegalPage>
+  );
+}

--- a/src/components/About/About.tsx
+++ b/src/components/About/About.tsx
@@ -120,14 +120,14 @@ export default function About() {
         </section>
       </main>
 
-      <footer className="component-about-footer" aria-label="Site information">
+      <nav className="component-about-footer" aria-label="Site information">
         <Link href="/privacy" className="component-about-footer-link">
           Privacy
         </Link>
         <Link href="/terms" className="component-about-footer-link">
           Terms
         </Link>
-      </footer>
+      </nav>
     </>
   );
 }

--- a/src/components/About/About.tsx
+++ b/src/components/About/About.tsx
@@ -27,96 +27,107 @@ const STEPS: { title: string; description: string }[] = [
 
 export default function About() {
   return (
-    <main className="component-about">
-      <section className="component-about-hero" aria-labelledby="about-hero-heading">
-        <h1 id="about-hero-heading" className="component-about-title">
-          About Narraitor
-        </h1>
-        <p className="component-about-lead">
-          Narraitor is a narrative RPG you play on your own, in any world you can
-          describe. Pick a setting, create a character, and make the choices that
-          steer the story — one that adapts to you as you go.
-        </p>
-      </section>
-
-      <section className="component-about-section" aria-labelledby="about-what-heading">
-        <h2 id="about-what-heading" className="component-about-section-title">
-          What it is
-        </h2>
-        <div className="component-about-prose">
-          <p>
-            It is a solo role-playing experience for any world — fictional or
-            real. Want to walk the streets of a rain-soaked detective city, command
-            a starship at the edge of known space, or live a quiet story somewhere
-            entirely of your own making? You set the stage, and the choices you make
-            shape where the story goes.
+    <>
+      <main className="component-about">
+        <section className="component-about-hero" aria-labelledby="about-hero-heading">
+          <h1 id="about-hero-heading" className="component-about-title">
+            About Narraitor
+          </h1>
+          <p className="component-about-lead">
+            Narraitor is a narrative RPG you play on your own, in any world you can
+            describe. Pick a setting, create a character, and make the choices that
+            steer the story — one that adapts to you as you go.
           </p>
-          <p>
-            There is no fixed script. Every decision matters, and the narrative
-            bends around the path you take.
-          </p>
-        </div>
-      </section>
+        </section>
 
-      <section className="component-about-section" aria-labelledby="about-how-heading">
-        <h2 id="about-how-heading" className="component-about-section-title">
-          How it works
-        </h2>
-        <ol className="component-about-steps">
-          {STEPS.map((step, index) => (
-            <li key={step.title} className="component-about-step">
-              <span className="component-about-step-number" aria-hidden="true">
-                {index + 1}
-              </span>
-              <h3 className="component-about-step-title">{step.title}</h3>
-              <p className="component-about-step-description">{step.description}</p>
-            </li>
-          ))}
-        </ol>
-      </section>
+        <section className="component-about-section" aria-labelledby="about-what-heading">
+          <h2 id="about-what-heading" className="component-about-section-title">
+            What it is
+          </h2>
+          <div className="component-about-prose">
+            <p>
+              It is a solo role-playing experience for any world — fictional or
+              real. Want to walk the streets of a rain-soaked detective city,
+              command a starship at the edge of known space, or live a quiet story
+              somewhere entirely of your own making? You set the stage, and the
+              choices you make shape where the story goes.
+            </p>
+            <p>
+              There is no fixed script. Every decision matters, and the narrative
+              bends around the path you take.
+            </p>
+          </div>
+        </section>
 
-      <section className="component-about-section" aria-labelledby="about-privacy-heading">
-        <h2 id="about-privacy-heading" className="component-about-section-title">
-          Your stories stay with you
-        </h2>
-        <div className="component-about-prose">
-          <p>
-            Your worlds, characters, and saved stories live right in your
-            browser — kept on your own device, with no account to sign up for.
-            Come back any time and pick up where you left off.
-          </p>
-        </div>
-      </section>
+        <section className="component-about-section" aria-labelledby="about-how-heading">
+          <h2 id="about-how-heading" className="component-about-section-title">
+            How it works
+          </h2>
+          <ol className="component-about-steps">
+            {STEPS.map((step, index) => (
+              <li key={step.title} className="component-about-step">
+                <span className="component-about-step-number" aria-hidden="true">
+                  {index + 1}
+                </span>
+                <h3 className="component-about-step-title">{step.title}</h3>
+                <p className="component-about-step-description">{step.description}</p>
+              </li>
+            ))}
+          </ol>
+        </section>
 
-      <section className="component-about-section" aria-labelledby="about-credit-heading">
-        <h2 id="about-credit-heading" className="component-about-section-title">
-          Who made it
-        </h2>
-        <div className="component-about-prose component-about-credit">
-          <p>
-            Narraitor was created by Jack as a personal project, and it is
-            open-source. You can read the code, file an issue, or help shape where
-            it goes next on{' '}
-            <a
-              href="https://github.com/jerseycheese/Narraitor"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              GitHub
-            </a>
-            .
-          </p>
-        </div>
-      </section>
+        <section className="component-about-section" aria-labelledby="about-privacy-heading">
+          <h2 id="about-privacy-heading" className="component-about-section-title">
+            Your stories stay with you
+          </h2>
+          <div className="component-about-prose">
+            <p>
+              Your worlds, characters, and saved stories live right in your
+              browser — kept on your own device, with no account to sign up for.
+              Come back any time and pick up where you left off.
+            </p>
+          </div>
+        </section>
 
-      <section className="component-about-cta" aria-labelledby="about-cta-heading">
-        <h2 id="about-cta-heading" className="component-about-section-title">
-          Ready to begin?
-        </h2>
-        <Link href="/worlds" className="component-about-cta-link">
-          Create your first world
+        <section className="component-about-section" aria-labelledby="about-credit-heading">
+          <h2 id="about-credit-heading" className="component-about-section-title">
+            Who made it
+          </h2>
+          <div className="component-about-prose component-about-credit">
+            <p>
+              Narraitor was created by Jack as a personal project, and it is
+              open-source. You can read the code, file an issue, or help shape where
+              it goes next on{' '}
+              <a
+                href="https://github.com/jerseycheese/Narraitor"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                GitHub
+              </a>
+              .
+            </p>
+          </div>
+        </section>
+
+        <section className="component-about-cta" aria-labelledby="about-cta-heading">
+          <h2 id="about-cta-heading" className="component-about-section-title">
+            Ready to begin?
+          </h2>
+          <Link href="/worlds" className="component-about-cta-link">
+            Create your first world
+          </Link>
+        </section>
+      </main>
+
+      <footer className="component-about-footer" aria-label="Site information">
+        <Link href="/privacy" className="component-about-footer-link">
+          Privacy
         </Link>
-      </section>
-    </main>
+        <Link href="/terms" className="component-about-footer-link">
+          Terms
+        </Link>
+      </footer>
+    </>
   );
 }

--- a/src/components/Legal/LegalPage.tsx
+++ b/src/components/Legal/LegalPage.tsx
@@ -33,7 +33,7 @@ export function LegalPage({ title, lead, updated, children }: LegalPageProps) {
 
       {children}
 
-      <footer className="component-legal-footer" aria-label="More information">
+      <nav className="component-legal-footer" aria-label="More information">
         <Link href="/about" className="component-legal-footer-link">
           About
         </Link>
@@ -43,7 +43,7 @@ export function LegalPage({ title, lead, updated, children }: LegalPageProps) {
         <Link href="/terms" className="component-legal-footer-link">
           Terms
         </Link>
-      </footer>
+      </nav>
     </main>
   );
 }

--- a/src/components/Legal/LegalPage.tsx
+++ b/src/components/Legal/LegalPage.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import Link from 'next/link';
+
+/**
+ * LegalPage — shared layout for the lightweight privacy/terms surfaces (#1366).
+ * Token-driven server component. Per-theme structural treatment lives in
+ * src/app/legal.css under [data-theme="dsN"] .component-legal* selectors
+ * (mirrors the About/dashboard pattern):
+ *   DS1 = drafting-table (hairline section rules, mono uppercase labels)
+ *   DS2 = editorial (serif prose, airy rhythm)
+ *   DS3 = mechanical manuscript (mono labels with a dot bullet, compact)
+ */
+
+interface LegalPageProps {
+  /** Document title, e.g. "Privacy" */
+  title: string;
+  /** One-line plain-language summary under the title */
+  lead: string;
+  /** Human month/year the document was last revised, e.g. "June 2026" */
+  updated: string;
+  children: React.ReactNode;
+}
+
+export function LegalPage({ title, lead, updated, children }: LegalPageProps) {
+  return (
+    <main className="component-legal">
+      <header className="component-legal-hero">
+        <p className="component-legal-eyebrow">Narraitor</p>
+        <h1 className="component-legal-title">{title}</h1>
+        <p className="component-legal-lead">{lead}</p>
+        <p className="component-legal-updated">Last updated {updated}</p>
+      </header>
+
+      {children}
+
+      <footer className="component-legal-footer" aria-label="More information">
+        <Link href="/about" className="component-legal-footer-link">
+          About
+        </Link>
+        <Link href="/privacy" className="component-legal-footer-link">
+          Privacy
+        </Link>
+        <Link href="/terms" className="component-legal-footer-link">
+          Terms
+        </Link>
+      </footer>
+    </main>
+  );
+}
+
+interface LegalSectionProps {
+  /** Unique id, wired to the heading for aria-labelledby */
+  id: string;
+  heading: string;
+  children: React.ReactNode;
+}
+
+export function LegalSection({ id, heading, children }: LegalSectionProps) {
+  return (
+    <section className="component-legal-section" aria-labelledby={id}>
+      <h2 id={id} className="component-legal-section-title">
+        {heading}
+      </h2>
+      <div className="component-legal-prose">{children}</div>
+    </section>
+  );
+}

--- a/src/components/Legal/__tests__/legalPages.test.tsx
+++ b/src/components/Legal/__tests__/legalPages.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import PrivacyPage from '@/app/privacy/page';
+import TermsPage from '@/app/terms/page';
+import About from '@/components/About';
+
+/**
+ * MVP coverage for the lightweight privacy/terms surfaces (#1366).
+ * Tests map to the acceptance criteria: the copy states how the app actually
+ * works (local data, prompts leave the browser, no accounts, cookieless
+ * analytics; use-at-your-own-risk terms), and the pages are reachable from
+ * each other via the shared footer.
+ */
+
+describe('Privacy page (#1366)', () => {
+  it('states the local-data model and that prompts go to the provider', () => {
+    render(<PrivacyPage />);
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: /privacy/i })
+    ).toBeInTheDocument();
+    // Local-first storage
+    expect(screen.getByText(/stored locally in your browser/i)).toBeInTheDocument();
+    // Export/import backup
+    expect(screen.getByText(/export everything to a file/i)).toBeInTheDocument();
+    // Prompts leave the browser for the AI provider
+    expect(
+      screen.getByText(/sends your prompts.*to the provider that does the generating/i)
+    ).toBeInTheDocument();
+    // No accounts
+    expect(screen.getByText(/no sign-up, no login, no profile/i)).toBeInTheDocument();
+    // Cookieless analytics, no content-derived data
+    expect(screen.getByText(/anonymous, cookieless/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/nothing derived from your content/i)
+    ).toBeInTheDocument();
+  });
+});
+
+describe('Terms page (#1366)', () => {
+  it('states no-warranty and the do-not-paste-secrets responsibility', () => {
+    render(<TermsPage />);
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: /terms/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/no warranty of any kind/i)).toBeInTheDocument();
+    expect(screen.getByText(/use it at your own risk/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/don't paste secrets or real personal data/i)
+    ).toBeInTheDocument();
+  });
+});
+
+describe('Legal pages are reachable (#1366)', () => {
+  it('exposes footer links to privacy, terms, and about', () => {
+    render(<PrivacyPage />);
+
+    const footer = screen.getByRole('contentinfo', { name: /more information/i });
+    expect(within(footer).getByRole('link', { name: /privacy/i })).toHaveAttribute(
+      'href',
+      '/privacy'
+    );
+    expect(within(footer).getByRole('link', { name: /terms/i })).toHaveAttribute(
+      'href',
+      '/terms'
+    );
+    expect(within(footer).getByRole('link', { name: /about/i })).toHaveAttribute(
+      'href',
+      '/about'
+    );
+  });
+
+  it('exposes privacy and terms links from the About page', () => {
+    render(<About />);
+
+    const footer = screen.getByRole('contentinfo', { name: /site information/i });
+    expect(within(footer).getByRole('link', { name: /privacy/i })).toHaveAttribute(
+      'href',
+      '/privacy'
+    );
+    expect(within(footer).getByRole('link', { name: /terms/i })).toHaveAttribute(
+      'href',
+      '/terms'
+    );
+  });
+});

--- a/src/components/Legal/__tests__/legalPages.test.tsx
+++ b/src/components/Legal/__tests__/legalPages.test.tsx
@@ -56,7 +56,7 @@ describe('Legal pages are reachable (#1366)', () => {
   it('exposes footer links to privacy, terms, and about', () => {
     render(<PrivacyPage />);
 
-    const footer = screen.getByRole('contentinfo', { name: /more information/i });
+    const footer = screen.getByRole('navigation', { name: /more information/i });
     expect(within(footer).getByRole('link', { name: /privacy/i })).toHaveAttribute(
       'href',
       '/privacy'
@@ -74,7 +74,7 @@ describe('Legal pages are reachable (#1366)', () => {
   it('exposes privacy and terms links from the About page', () => {
     render(<About />);
 
-    const footer = screen.getByRole('contentinfo', { name: /site information/i });
+    const footer = screen.getByRole('navigation', { name: /site information/i });
     expect(within(footer).getByRole('link', { name: /privacy/i })).toHaveAttribute(
       'href',
       '/privacy'

--- a/src/components/Legal/index.ts
+++ b/src/components/Legal/index.ts
@@ -1,0 +1,1 @@
+export { LegalPage, LegalSection } from './LegalPage';


### PR DESCRIPTION
## Description

Two short, plain-language pages — `/privacy` and `/terms` — sized for what the app actually is: a free, local-first, single-player tool. The privacy note is honest about the only two things worth being upfront on (your stories live in your browser; prompts leave it for the AI provider), and the terms are basic use-at-your-own-risk wording. Deliberately not the full GDPR/SaaS legal machinery — that stays on the commercialization track (#495), which assumes accounts and server-side data that don't exist.

Part of the re-scoped v1.0 free-launch gate (#1320). One of the two remaining hard blockers alongside the landing page (#1365).

## Related Issue

Closes #1366

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed

A first-time visitor (and anyone checking before they play) can see, in plain language, where their data goes and what they're agreeing to — reachable from the About page and from each legal page.

## Component Development
- [ ] Storybook stories created/updated
- [x] Components developed in isolation first
- [x] Visual consistency verified

Verified live across DS1/DS2/DS3 with bdg (computed styles + screenshots): DS1 drafting-table (hairline section rules, uppercase mono labels), DS2 warm editorial (serif prose, airy rhythm), DS3 mechanical manuscript (mono labels with a dot bullet, compact).

## Implementation Notes

- New `/privacy` and `/terms` routes resolve to the default surface. Both compose a shared, token-driven `LegalPage` component; per-theme structural treatment lives in `src/app/legal.css` under `[data-theme="dsN"] .component-legal*`, mirroring the established About/dashboard pattern. No bespoke CSS, no off-system tokens, no Tailwind.
- Reachability: the legal pages cross-link (About / Privacy / Terms), and the About page gets a small footer with Privacy/Terms links. That footer renders as a **sibling** of `.component-about` on purpose — the About visual spec screenshots the `.component-about` locator, so keeping the footer outside it leaves those baselines byte-identical (no baseline churn, no visual-diff risk in CI).
- `.stylelintrc.json`: added `src/app/legal.css` to the page-surface override group (so `clamp()` is allowed, same as about/dashboard/wizard/workshop).
- The analytics paragraph in the privacy note describes the cookieless Vercel Web Analytics posture wired up in #1367. If #1367 slips past launch, that paragraph is the one line to reconcile — recommend merging #1367 first or together.

## Quality Checks
- [x] Linting passed (eslint + stylelint)
- [x] Type checking passed (tsc --noEmit)
- [ ] Security audit passed (CodeQL runs in CI)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

1. `npm run dev`, visit `/privacy` and `/terms`.
2. Switch design system (DS1/DS2/DS3) — each renders with its own structural treatment, text stays readable.
3. From `/about`, the footer links reach Privacy and Terms; the legal pages link back to About and to each other.
4. `npx jest src/components/Legal` — 4 tests covering the copy claims and reachability.

## Checklist
- [x] Code follows the project's coding standards