### PR TITLE
feat(landing): free public landing page for 1.0 launch (#1365)

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -76,7 +76,7 @@
         }
       },
       {
-        "files": ["src/app/workshop.css", "src/app/dashboard.css", "src/app/wizard.css", "src/app/about.css"],
+        "files": ["src/app/workshop.css", "src/app/dashboard.css", "src/app/wizard.css", "src/app/about.css", "src/app/landing.css"],
         "rules": {
           "function-allowed-list": ["hsl", "hsla", "var", "calc", "theme", "translateY", "translateX", "translate", "scale", "rotate", "linear-gradient", "radial-gradient", "color-mix", "clamp", "cubic-bezier", "brightness", "blur", "repeat", "minmax"],
           "function-disallowed-list": [],

--- a/src/app/landing.css
+++ b/src/app/landing.css
@@ -1,0 +1,460 @@
+/* ═══════════════════════════════════════════════════════════════
+   Landing Surface
+   Styles for /welcome and the <Landing /> component — the free public
+   front door. All values use design tokens for theme-awareness. The
+   composition is intentionally bolder than the About surface (large
+   display hero, a stepped grid, a distinct "how it's free" band) so it
+   reads as a front door, not a centered template. Per-theme structural
+   treatments mirror about.css:
+   DS1 = drafting-table (drafting grid, hairline rules, mono uppercase labels)
+   DS2 = editorial (large serif display, airy rhythm, soft surfaces)
+   DS3 = mechanical manuscript (dot-grid, corner-bracket cards, mono labels)
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ─── Base layout (token-driven, theme-agnostic) ─── */
+
+.component-landing {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(var(--space-8), 6vw, 5rem);
+  width: 100%;
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: var(--space-8) var(--space-4);
+}
+
+@media (width >= 1024px) {
+  .component-landing {
+    padding: var(--space-8) var(--space-6);
+  }
+}
+
+/* ─── Hero ─── */
+
+.component-landing-hero {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  max-width: 760px;
+}
+
+.component-landing-eyebrow {
+  margin: 0;
+  font-family: var(--font-system);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+}
+
+/* Scoped (.component-landing prefix) to outrank the default-surface h1
+   baseline in workshop.css (.app-surface-default h1) — the hero title is
+   deliberately a large display heading, not the 2rem surface default. */
+.component-landing .component-landing-title {
+  margin: 0;
+  font-family: var(--font-narrative);
+  font-size: clamp(2.5rem, 7vw, 4.5rem);
+  font-weight: 600;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  color: var(--color-text-primary);
+}
+
+.component-landing-lead {
+  margin: 0;
+  font-family: var(--font-interface);
+  font-size: 1.25rem;
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+}
+
+.component-landing-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-4);
+  margin-top: var(--space-2);
+}
+
+.component-landing-cta {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-3) var(--space-6);
+  font-family: var(--font-interface);
+  font-size: 1.0625rem;
+  font-weight: 600;
+  color: var(--color-text-inverse);
+  background: var(--color-accent);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  transition: background-color 120ms ease;
+}
+
+.component-landing-cta:hover {
+  background: var(--color-accent-hover);
+}
+
+.component-landing-cta:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.component-landing-cta-secondary {
+  font-family: var(--font-interface);
+  font-size: 1.0625rem;
+  font-weight: 500;
+  color: var(--color-text-primary);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.component-landing-cta-secondary:hover {
+  color: var(--color-accent);
+}
+
+.component-landing-cta-secondary:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* ─── Shared section title ─── */
+
+.component-landing-section-title {
+  margin: 0 0 var(--space-5);
+  font-family: var(--font-interface);
+  font-size: 1.375rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--color-text-primary);
+}
+
+/* ─── Steps ─── */
+
+.component-landing-step-list {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-4);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+@media (width < 768px) {
+  .component-landing-step-list {
+    grid-template-columns: 1fr;
+  }
+}
+
+.component-landing-step {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-5);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.component-landing-step-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  font-family: var(--font-system);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+  border-radius: var(--radius-full);
+}
+
+.component-landing-step-title {
+  margin: 0;
+  font-family: var(--font-interface);
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.component-landing-step-description {
+  margin: 0;
+  font-family: var(--font-interface);
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  color: var(--color-text-secondary);
+}
+
+/* ─── "How it's free" honest band ─── */
+
+.component-landing-note {
+  padding: var(--space-6);
+  background: var(--color-accent-soft);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+}
+
+@media (width >= 1024px) {
+  .component-landing-note {
+    padding: var(--space-8);
+  }
+}
+
+.component-landing-note-list {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-5);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+@media (width < 768px) {
+  .component-landing-note-list {
+    grid-template-columns: 1fr;
+  }
+}
+
+.component-landing-note-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.component-landing-note-title {
+  margin: 0;
+  font-family: var(--font-interface);
+  font-size: 1.0625rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.component-landing-note-description {
+  margin: 0;
+  font-family: var(--font-interface);
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  color: var(--color-text-secondary);
+}
+
+/* ─── Footer links ─── */
+
+.component-landing-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-5);
+  padding-top: var(--space-5);
+  border-top: 1px solid var(--color-border);
+}
+
+.component-landing-footer-link {
+  font-family: var(--font-interface);
+  font-size: 0.9375rem;
+  color: var(--color-text-secondary);
+  text-decoration: none;
+}
+
+.component-landing-footer-link:hover {
+  color: var(--color-accent);
+}
+
+.component-landing-footer-link:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   DS1 — "The Drafting Table"
+   Faint drafting grid, hairline rules, mono uppercase labels, sharp
+   radius, a bold sans display title. Structural, architectural.
+   ═══════════════════════════════════════════════════════════════ */
+
+[data-theme="ds1"] .component-landing {
+  background-color: var(--color-canvas);
+  background-image:
+    linear-gradient(
+      to right,
+      color-mix(in srgb, var(--color-border-strong) 35%, transparent) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      to bottom,
+      color-mix(in srgb, var(--color-border-strong) 35%, transparent) 1px,
+      transparent 1px
+    );
+  background-size: 24px 24px;
+  background-repeat: repeat;
+}
+
+[data-theme="ds1"] .component-landing-title {
+  font-family: var(--font-interface);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+[data-theme="ds1"] .component-landing-section-title {
+  font-family: var(--font-system);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid var(--color-border-strong);
+}
+
+[data-theme="ds1"] .component-landing-cta,
+[data-theme="ds1"] .component-landing-step {
+  border-radius: var(--radius-sm);
+}
+
+[data-theme="ds1"] .component-landing-step-number {
+  border-radius: var(--radius-sm);
+  background: transparent;
+  border: 1px solid var(--color-border-strong);
+}
+
+[data-theme="ds1"] .component-landing-note {
+  border-radius: var(--radius-sm);
+  border-color: var(--color-border-strong);
+  background: transparent;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   DS2 — "Warm Earth" editorial
+   Large serif display, generous whitespace, soft surfaces, no
+   pattern. Magazine cover energy.
+   ═══════════════════════════════════════════════════════════════ */
+
+[data-theme="ds2"] .component-landing {
+  gap: clamp(var(--space-8), 7vw, 6rem);
+}
+
+[data-theme="ds2"] .component-landing-title {
+  font-weight: 500;
+  letter-spacing: -0.025em;
+}
+
+[data-theme="ds2"] .component-landing-lead {
+  font-family: var(--font-narrative);
+  font-size: 1.5rem;
+  line-height: 1.5;
+}
+
+[data-theme="ds2"] .component-landing-section-title {
+  font-family: var(--font-narrative);
+  font-size: clamp(1.625rem, 3vw, 2.125rem);
+  font-weight: 400;
+  letter-spacing: -0.01em;
+}
+
+[data-theme="ds2"] .component-landing-step {
+  border: none;
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-hover);
+  padding: var(--space-6);
+}
+
+[data-theme="ds2"] .component-landing-step-description {
+  font-family: var(--font-narrative);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+[data-theme="ds2"] .component-landing-note {
+  border: none;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   DS3 — "Mechanical Manuscript"
+   Dot-grid field, mono labels with a dot bullet, corner-bracket step
+   cards, compact rhythm, mono prose.
+   ═══════════════════════════════════════════════════════════════ */
+
+[data-theme="ds3"] .component-landing {
+  gap: clamp(var(--space-6), 5vw, 3.5rem);
+  background-image: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--color-text-primary) 14%, transparent) 1px,
+    transparent 1px
+  );
+  background-size: 24px 24px;
+  background-repeat: repeat;
+}
+
+[data-theme="ds3"] .component-landing-eyebrow {
+  color: var(--color-text-secondary);
+}
+
+[data-theme="ds3"] .component-landing-lead {
+  font-family: var(--font-narrative);
+  font-size: 1.1875rem;
+  line-height: 1.55;
+}
+
+[data-theme="ds3"] .component-landing-section-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-system);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+}
+
+[data-theme="ds3"] .component-landing-section-title::before {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-full);
+  background: var(--color-accent);
+  flex-shrink: 0;
+}
+
+[data-theme="ds3"] .component-landing-step {
+  position: relative;
+  border: none;
+  background: var(--color-surface);
+}
+
+/* Corner brackets — top-left + bottom-right L-marks in accent. */
+[data-theme="ds3"] .component-landing-step::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 10px;
+  height: 10px;
+  border-top: 1px solid var(--color-accent);
+  border-left: 1px solid var(--color-accent);
+  pointer-events: none;
+}
+
+[data-theme="ds3"] .component-landing-step::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 10px;
+  height: 10px;
+  border-right: 1px solid var(--color-accent);
+  border-bottom: 1px solid var(--color-accent);
+  pointer-events: none;
+}
+
+[data-theme="ds3"] .component-landing-step-number {
+  border-radius: var(--radius-sm);
+}
+
+[data-theme="ds3"] .component-landing-step-description,
+[data-theme="ds3"] .component-landing-note-description {
+  font-family: var(--font-system);
+  font-size: 0.875rem;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,6 +15,7 @@ import './workshop.css';
 import './wizard.css';
 import './dashboard.css';
 import './about.css';
+import './landing.css';
 import './badge.css';
 import './character-display.css';
 import '@/lib/theme/themes/_shared-tokens.css';

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+import { Landing } from '@/components/Landing';
+
+export const metadata: Metadata = {
+  title: 'Narraitor — a solo narrative RPG in any world you imagine',
+  description:
+    'Build a world, create a character, and play a story that adapts to your choices. Free, runs in your browser, your data stays on your device.',
+};
+
+export default function WelcomePage() {
+  return <Landing />;
+}

--- a/src/components/Landing/Landing.tsx
+++ b/src/components/Landing/Landing.tsx
@@ -104,7 +104,7 @@ export default function Landing() {
         </ul>
       </section>
 
-      <footer className="component-landing-footer" aria-label="Site information">
+      <nav className="component-landing-footer" aria-label="Site information">
         <Link href="/about" className="component-landing-footer-link">
           About
         </Link>
@@ -114,7 +114,7 @@ export default function Landing() {
         <Link href="/terms" className="component-landing-footer-link">
           Terms
         </Link>
-      </footer>
+      </nav>
     </main>
   );
 }

--- a/src/components/Landing/Landing.tsx
+++ b/src/components/Landing/Landing.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import Link from 'next/link';
+
+/**
+ * Landing — the free public front door for a first-time visitor (#1365).
+ * Token-driven server component. Per-theme structural treatment lives in
+ * src/app/landing.css under [data-theme="dsN"] .component-landing* selectors
+ * (mirrors the About/dashboard pattern):
+ *   DS1 = drafting-table (drafting grid, hairline rules, mono uppercase labels)
+ *   DS2 = editorial (serif display, airy rhythm, soft surfaces)
+ *   DS3 = mechanical manuscript (dot-grid, corner-bracket cards, mono labels)
+ *
+ * Outcome-framed copy — it leads with what you do, not the machinery.
+ */
+
+const STEPS: { title: string; description: string }[] = [
+  {
+    title: 'Build a world',
+    description:
+      'Describe a setting — a noir city, a space opera, Middle Earth, the beaches of Normandy. Real or invented, the world is yours.',
+  },
+  {
+    title: 'Create a character',
+    description:
+      'Decide who you play: their traits, their history, what they are after. The story leans on the details you give it.',
+  },
+  {
+    title: 'Play the story',
+    description:
+      'Make choices and watch the story bend around them. No two playthroughs unfold the same way.',
+  },
+];
+
+const PROMISES: { title: string; description: string }[] = [
+  {
+    title: 'Free to play',
+    description:
+      'It runs on your own provider key, set up once — so you are never footing the bill for anyone else.',
+  },
+  {
+    title: 'Runs in your browser',
+    description:
+      'Your worlds, characters, and saves stay on your device. Export them any time for a backup.',
+  },
+  {
+    title: 'No accounts',
+    description:
+      'Nothing to sign up for, no profile, no email. Just open it and start.',
+  },
+];
+
+export default function Landing() {
+  return (
+    <main className="component-landing">
+      <section className="component-landing-hero" aria-labelledby="landing-hero-heading">
+        <p className="component-landing-eyebrow">A solo narrative RPG</p>
+        <h1 id="landing-hero-heading" className="component-landing-title">
+          Play a story in any world you can imagine
+        </h1>
+        <p className="component-landing-lead">
+          Build a world, create a character, and make the choices that shape an
+          adventure that adapts to you. Free, in your browser, and yours to keep.
+        </p>
+        <div className="component-landing-actions">
+          <Link href="/worlds/create" className="component-landing-cta">
+            Start your story
+          </Link>
+          <Link href="/about" className="component-landing-cta-secondary">
+            How it works
+          </Link>
+        </div>
+      </section>
+
+      <section className="component-landing-steps" aria-labelledby="landing-steps-heading">
+        <h2 id="landing-steps-heading" className="component-landing-section-title">
+          How a story comes together
+        </h2>
+        <ol className="component-landing-step-list">
+          {STEPS.map((step, index) => (
+            <li key={step.title} className="component-landing-step">
+              <span className="component-landing-step-number" aria-hidden="true">
+                {index + 1}
+              </span>
+              <h3 className="component-landing-step-title">{step.title}</h3>
+              <p className="component-landing-step-description">{step.description}</p>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <section className="component-landing-note" aria-labelledby="landing-note-heading">
+        <h2 id="landing-note-heading" className="component-landing-section-title">
+          Straight about how it works
+        </h2>
+        <ul className="component-landing-note-list">
+          {PROMISES.map((promise) => (
+            <li key={promise.title} className="component-landing-note-item">
+              <h3 className="component-landing-note-title">{promise.title}</h3>
+              <p className="component-landing-note-description">
+                {promise.description}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <footer className="component-landing-footer" aria-label="Site information">
+        <Link href="/about" className="component-landing-footer-link">
+          About
+        </Link>
+        <Link href="/privacy" className="component-landing-footer-link">
+          Privacy
+        </Link>
+        <Link href="/terms" className="component-landing-footer-link">
+          Terms
+        </Link>
+      </footer>
+    </main>
+  );
+}

--- a/src/components/Landing/__tests__/Landing.test.tsx
+++ b/src/components/Landing/__tests__/Landing.test.tsx
@@ -39,7 +39,7 @@ describe('Landing page (#1365)', () => {
   it('exposes footer links to about, privacy, and terms', () => {
     render(<WelcomePage />);
 
-    const footer = screen.getByRole('contentinfo', { name: /site information/i });
+    const footer = screen.getByRole('navigation', { name: /site information/i });
     expect(within(footer).getByRole('link', { name: /about/i })).toHaveAttribute(
       'href',
       '/about'

--- a/src/components/Landing/__tests__/Landing.test.tsx
+++ b/src/components/Landing/__tests__/Landing.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import WelcomePage from '@/app/welcome/page';
+
+/**
+ * MVP coverage for the free public landing page (#1365). Tests map to the
+ * acceptance criteria: a plain-language front door with a clear primary CTA
+ * into the existing world-creation flow, an honest "how it's free" note, and
+ * footer links out to About / Privacy / Terms.
+ */
+
+describe('Landing page (#1365)', () => {
+  it('renders an outcome-framed hero with a primary CTA into world creation', () => {
+    render(<WelcomePage />);
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /play a story in any world/i,
+      })
+    ).toBeInTheDocument();
+
+    const cta = screen.getByRole('link', { name: /start your story/i });
+    expect(cta).toHaveAttribute('href', '/worlds/create');
+  });
+
+  it('states the honest "free / local / no accounts" promises', () => {
+    render(<WelcomePage />);
+
+    expect(screen.getByText(/free to play/i)).toBeInTheDocument();
+    expect(screen.getByText(/runs in your browser/i)).toBeInTheDocument();
+    expect(screen.getByText(/your own provider key/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/stay on your device/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/no accounts/i)).toBeInTheDocument();
+  });
+
+  it('exposes footer links to about, privacy, and terms', () => {
+    render(<WelcomePage />);
+
+    const footer = screen.getByRole('contentinfo', { name: /site information/i });
+    expect(within(footer).getByRole('link', { name: /about/i })).toHaveAttribute(
+      'href',
+      '/about'
+    );
+    expect(within(footer).getByRole('link', { name: /privacy/i })).toHaveAttribute(
+      'href',
+      '/privacy'
+    );
+    expect(within(footer).getByRole('link', { name: /terms/i })).toHaveAttribute(
+      'href',
+      '/terms'
+    );
+  });
+});

--- a/src/components/Landing/index.ts
+++ b/src/components/Landing/index.ts
@@ -1,0 +1,1 @@
+export { default as Landing } from './Landing';


### PR DESCRIPTION
## Description

A plain-language front door for a first-time visitor. Today `/` renders the dashboard (built for returning users) and About is reference content — neither is an inviting first-touch with a clear way in. This adds a dedicated `/welcome` surface: an outcome-framed hero (it leads with what you do, not the machinery), a clear primary CTA into world creation, a short honest "free / runs in your browser / your data stays local / bring your own key" band, and footer links.

The composition is deliberately bolder than the About page (large display hero, a stepped grid, a distinct "how it's free" band) so it reads as a front door rather than a centered template — but it's all built within the design system, no bespoke marketing CSS.

Part of the re-scoped v1.0 free-launch gate (#1320), alongside the legal-lite pages (#1366).

## Related Issue

Closes #1365

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed

A first-time visitor lands on a page that explains, in plain language, what Narraitor is and gives them one obvious way in (create a world) — without wading through the dashboard or reference docs.

## Component Development
- [ ] Storybook stories created/updated
- [x] Components developed in isolation first
- [x] Visual consistency verified

Verified live across DS1/DS2/DS3 with bdg (computed styles + screenshots): DS1 drafting-table (drafting-grid field, bold sans display title, hairline section rules, bordered number badges), DS2 warm editorial (large Crimson Pro serif display, soft-surface cards, airy rhythm), DS3 mechanical manuscript (dot-grid field, Newsreader serif display, corner-bracket step cards, mono labels with a dot bullet).

## Implementation Notes

- New `/welcome` route resolves to the default surface and renders a token-driven `Landing` server component. Per-theme structural treatment lives in `src/app/landing.css` under `[data-theme="dsN"] .component-landing*`, mirroring the established About/dashboard pattern. Only existing tokens; no new tokens, no Tailwind.
- The hero title selector is scoped (`.component-landing .component-landing-title`) to outrank the default-surface `h1` baseline (`.app-surface-default h1` in `workshop.css`, specificity 0,1,1) — otherwise the hero would render at the 2rem surface default instead of as the intended large display heading. Comment in the CSS explains why.
- `.stylelintrc.json`: added `src/app/landing.css` to the page-surface override group (allows `clamp()`, same as about/dashboard/wizard/workshop).
- Copy is outcome-framed and keeps "AI" out of the headline/CTA; the BYO-key mechanism is mentioned plainly in the honest band, with About/Privacy carrying the fuller explanation.
- Scope note: `/welcome` is a standalone reachable route (the shareable front-door URL). Routing first-time visitors to it from `/` (vs. the returning-user dashboard) is a separate product/routing call with home-page visual-baseline implications — left as a follow-up, out of scope here.
- No committed Playwright visual baseline in this PR: a brand-new visual spec needs baselines that match the macOS CI runner, and locally-generated ones routinely drift. Cross-theme rendering is verified with bdg instead; a regression spec that adopts baselines from a CI run is a sensible follow-up. All new selectors are scoped to `.component-landing*` and the route is new, so no existing baseline is affected.

## Quality Checks
- [x] Linting passed (eslint + stylelint)
- [x] Type checking passed (tsc --noEmit)
- [ ] Security audit passed (CodeQL runs in CI)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

1. `npm run dev`, visit `/welcome`.
2. Switch design system (DS1/DS2/DS3) — each renders with its own structural treatment; the hero is a large display title in each.
3. "Start your story" goes to `/worlds/create`; "How it works" and the footer reach About / Privacy / Terms.
4. `npx jest src/components/Landing` — 3 tests covering hero, CTA target, promises, and reachability.

## Checklist
- [x] Code follows the project's coding standards