### PR TITLE
feat(analytics): cookieless Vercel Web Analytics launch funnel (#1367)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@tanstack/react-table": "^8.21.3",
+        "@vercel/analytics": "^2.0.1",
         "clsx": "^2.1.1",
         "csv-parse": "^5.6.0",
         "fastest-levenshtein": "^1.0.16",
@@ -5023,7 +5024,7 @@
       "version": "1.56.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
       "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.56.1"
@@ -7047,6 +7048,7 @@
     },
     "node_modules/@types/react": {
       "version": "19.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -7054,7 +7056,7 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -7591,6 +7593,48 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "2.0.5",
@@ -9995,6 +10039,7 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/csv-parse": {
@@ -16278,7 +16323,7 @@
       "version": "1.56.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
       "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.56.1"
@@ -16297,7 +16342,7 @@
       "version": "1.56.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
       "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -16308,6 +16353,7 @@
     },
     "node_modules/playwright/node_modules/fsevents": {
       "version": "2.3.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@tanstack/react-table": "^8.21.3",
+    "@vercel/analytics": "^2.0.1",
     "clsx": "^2.1.1",
     "csv-parse": "^5.6.0",
     "fastest-levenshtein": "^1.0.16",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,6 +31,8 @@ import { ToastProvider, Toaster } from '@/components/ui/toast';
 import { TutorialProvider } from '@/components/TutorialProvider';
 import { ThemeProvider } from '@/lib/theme';
 import { THEME_INIT_SCRIPT } from '@/lib/theme/themeInitScript';
+import { Analytics } from '@vercel/analytics/next';
+import { FunnelAnalytics } from '@/components/analytics/FunnelAnalytics';
 
 /* DS1 fonts (preloaded - default theme) */
 const lora = Lora({
@@ -149,6 +151,8 @@ export default function RootLayout({ children }: RootLayoutProps) {
             </DevToolsProvider>
           </NavigationLoadingProvider>
         </ThemeProvider>
+        <FunnelAnalytics />
+        <Analytics />
       </body>
     </html>
   );

--- a/src/components/analytics/FunnelAnalytics.tsx
+++ b/src/components/analytics/FunnelAnalytics.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+import { getSurfaceMode } from '@/lib/routing/surfaceMode';
+import { trackFunnelStep } from '@/lib/analytics/trackFunnelStep';
+
+const VISITED_KEY = 'narraitor-visited';
+
+/**
+ * FunnelAnalytics — fires the named, anonymous funnel-step conversion events
+ * (#1367). Page views come for free from <Analytics />; this adds the
+ * conversion signals that page views alone do not cleanly capture:
+ *   - landing       — first touch on the public landing page
+ *   - session-started — entering a play (manuscript) route
+ *   - return-visit  — a visitor coming back (one localStorage flag, no identity)
+ *
+ * Renders nothing. All events are funnel-step names only — see trackFunnelStep
+ * for the hard "no user content" constraint.
+ */
+export function FunnelAnalytics() {
+  const pathname = usePathname();
+
+  // Return-visit: fired once per browser, on the first mount of a visitor who
+  // has been here before. The flag is a single boolean — no identity, no content.
+  useEffect(() => {
+    try {
+      if (localStorage.getItem(VISITED_KEY)) {
+        trackFunnelStep('return-visit');
+      } else {
+        localStorage.setItem(VISITED_KEY, '1');
+      }
+    } catch {
+      // localStorage blocked (private mode / strict settings) — skip silently.
+    }
+  }, []);
+
+  // Route-based funnel steps.
+  useEffect(() => {
+    if (!pathname) return;
+    if (pathname === '/welcome') {
+      trackFunnelStep('landing');
+    } else if (getSurfaceMode(pathname) === 'manuscript') {
+      trackFunnelStep('session-started');
+    }
+  }, [pathname]);
+
+  return null;
+}

--- a/src/lib/analytics/__tests__/trackFunnelStep.test.ts
+++ b/src/lib/analytics/__tests__/trackFunnelStep.test.ts
@@ -1,0 +1,39 @@
+import { trackFunnelStep } from '../trackFunnelStep';
+import { track } from '@vercel/analytics';
+import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
+
+jest.mock('@vercel/analytics', () => ({ track: jest.fn() }));
+jest.mock('@/lib/utils/isPlaywrightEnv', () => ({ isPlaywrightEnv: jest.fn() }));
+
+const mockTrack = track as jest.Mock;
+const mockIsPlaywright = isPlaywrightEnv as jest.Mock;
+
+/**
+ * MVP coverage for the analytics funnel helper (#1367). The tests pin the
+ * hard privacy constraint that keeps the privacy note (#1366) true: only the
+ * funnel-step name ever leaves the browser, and nothing fires under Playwright.
+ */
+describe('trackFunnelStep (#1367)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsPlaywright.mockReturnValue(false);
+  });
+
+  it('sends only the funnel-step name — never a content-bearing payload', () => {
+    trackFunnelStep('session-started');
+
+    expect(mockTrack).toHaveBeenCalledTimes(1);
+    expect(mockTrack).toHaveBeenCalledWith('session-started');
+    // Exactly one argument: there is no props object that could carry world
+    // names, prompts, or any other user content.
+    expect(mockTrack.mock.calls[0]).toHaveLength(1);
+  });
+
+  it('no-ops under Playwright so the E2E/visual suite stays deterministic', () => {
+    mockIsPlaywright.mockReturnValue(true);
+
+    trackFunnelStep('landing');
+
+    expect(mockTrack).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/analytics/trackFunnelStep.ts
+++ b/src/lib/analytics/trackFunnelStep.ts
@@ -1,0 +1,27 @@
+import { track } from '@vercel/analytics';
+import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
+
+/**
+ * The funnel steps we measure. Names only — this union is the entire
+ * vocabulary that ever leaves the browser.
+ */
+type FunnelStep = 'landing' | 'session-started' | 'return-visit';
+
+/**
+ * Fire an anonymous funnel-step event to Vercel Web Analytics.
+ *
+ * Hard privacy constraint (#1366 / #1367): the ONLY thing sent is the fixed
+ * step name from the FunnelStep union — never world names, character names,
+ * prompts, or story text. The signature deliberately takes no free-form
+ * payload, so there is no way for caller content to leak into analytics.
+ *
+ * No-ops outside the browser and under Playwright — the latter reuses
+ * isPlaywrightEnv so the E2E/visual suite stays quiet and deterministic.
+ * (Page views are captured automatically by <Analytics />; this is only for
+ * the named conversion steps.)
+ */
+export function trackFunnelStep(step: FunnelStep): void {
+  if (typeof window === 'undefined') return;
+  if (isPlaywrightEnv()) return;
+  track(step);
+}


### PR DESCRIPTION
## Description

So a first public release doesn't launch blind on whether strangers actually get through first-play — measured anonymously, without cookies, accounts, or any personal data. Adds Vercel Web Analytics (the app already deploys on Vercel, so it's the lowest-friction, privacy-clean option).

This is the lowest-stakes item in the v1.0 set (#1320) — a should-have at launch, not a hard blocker. It's distinct from the token-budget observability (#930) in DevTools, which is dev-facing AI-cost instrumentation, not a product funnel.

## Related Issue

Closes #1367

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed

As the maintainer, I can see — anonymously — whether people who land on the site get through first-play and where they drop off, so launch isn't flying blind.

## Implementation Notes

- `@vercel/analytics` added; `<Analytics />` mounted in the root layout. Page views come for free, which already covers the funnel routes (`/welcome`, then `/worlds/create`, then a play route).
- `trackFunnelStep` helper fires the named conversion steps. **Hard privacy constraint:** the signature takes no free-form payload — only the fixed step name from a 3-member union (`landing` / `session-started` / `return-visit`) ever leaves the browser. No world names, character names, prompts, or story text, ever. This is what keeps the #1366 privacy note true and keeps it cookieless (no consent banner).
- It no-ops outside the browser and under Playwright (reuses the existing `isPlaywrightEnv`, **not** broadened — that flag also gates render-path AI), so the E2E/visual suite stays deterministic.
- `FunnelAnalytics` (renders nothing) fires route-based steps: `landing` on `/welcome`, `session-started` on a play route (reuses `getSurfaceMode`, no duplicated route logic), and `return-visit` from a single localStorage boolean (no identity).
- **Dependency note:** `@vercel/analytics` needs `--legacy-peer-deps` to *install* (a phantom optional `@remix-run/react` peer that isn't actually in the tree). Verified that plain `npm ci` against the committed lockfile succeeds — exactly what CI runs — so no `.npmrc` change and no CI impact.
- **Scope/follow-up:** the explicit `world-created` conversion event (in the creation wizard) is a thin follow-up — the `/worlds/create` page view covers that funnel step for now, and core flows are left untouched.

## Quality Checks
- [x] Linting passed (eslint)
- [x] Type checking passed (tsc --noEmit)
- [x] Knip (no unused code/deps)
- [ ] Security audit passed (CodeQL runs in CI)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

1. `npm run dev`; the app loads normally (Analytics is a no-op outside production).
2. `npx jest src/lib/analytics` — 2 tests: only the step name is sent (single argument, no payload), and nothing fires under Playwright.
3. In production on Vercel, the Analytics dashboard shows page views plus the `landing` / `session-started` / `return-visit` custom events — no cookies, no personal data.

## Checklist
- [x] Code follows the project's coding standards
