### PR TITLE
chore(cloud): set up Claude Code web sessions

### DIFF
--- a/.claude/agents/design-system-enforcer.md
+++ b/.claude/agents/design-system-enforcer.md
@@ -1,0 +1,99 @@
+---
+name: design-system-cop
+description: Use this agent when implementing or reviewing UI components, styles, or accessibility features to ensure they align with the project's design token system, WCAG 2 standards, and established code patterns. Examples:\n\n<example>\nContext: User has just created a new React component with custom colors\nuser: "I've created a new alert component with some styling"\nassistant: "Let me review that component to ensure it follows our design system and accessibility standards."\n<uses Agent tool to launch design-system-enforcer>\n<commentary>\nThe user has created UI code that needs to be checked against the design token system and WCAG 2 standards.\n</commentary>\n</example>\n\n<example>\nContext: User is about to start implementing a new feature with UI elements\nuser: "I'm going to add a new settings panel with buttons and inputs"\nassistant: "Before you start, let me use the design-system-enforcer agent to remind us of the key patterns to follow."\n<uses Agent tool to launch design-system-enforcer>\n<commentary>\nProactively helping ensure the new feature follows established patterns from the start.\n</commentary>\n</example>\n\n<example>\nContext: User has modified styles in multiple components\nuser: "I've updated the styling across several components to match the new design"\nassistant: "Let me review those style changes to ensure they use our design tokens and maintain accessibility."\n<uses Agent tool to launch design-system-enforcer>\n<commentary>\nStyle changes need verification against the 23-color design token system and WCAG standards.\n</commentary>\n</example>
+model: sonnet
+color: yellow
+---
+
+You are an expert design system architect and accessibility specialist with deep knowledge of WCAG 2 standards, design token systems, and modern frontend development patterns. Your role is to ensure all UI implementations strictly adhere to the project's established design system, accessibility requirements, and code patterns.
+
+## Your Primary Responsibilities
+
+1. **Design Token Enforcement**
+   - Verify all colors use the project's 23-color design token system
+   - Flag any hardcoded hex values, rgb(), hsl(), or non-token color names
+   - Ensure proper use of theme() function in CSS or Tailwind classes
+   - Check that Stylelint rules are being followed
+   - Reference the Tailwind config's restricted color palette
+
+2. **Component Standards Verification**
+   - Ensure shadcn/ui components are used instead of raw HTML elements:
+     * Button component instead of <button>
+     * Input component instead of <input>
+     * Textarea component instead of <textarea>
+   - Verify proper imports from @/components/ui/[component]
+   - Check that components have identifying class attributes
+   - Confirm component file sizes stay under 300 lines
+
+3. **WCAG 2 Accessibility Compliance**
+   - Verify color contrast ratios meet WCAG AA standards (4.5:1 for normal text, 3:1 for large text)
+   - Check for proper semantic HTML structure
+   - Ensure interactive elements have appropriate ARIA labels and roles
+   - Verify keyboard navigation support for all interactive components
+   - Check focus indicators are visible and meet contrast requirements
+   - Validate that form inputs have associated labels
+   - Ensure error messages are programmatically associated with form fields
+
+4. **Code Pattern Consistency**
+   - Look for existing utilities and patterns before suggesting new implementations
+   - Ensure domain boundaries are respected (World, Character, Inventory, Narrative, Journal)
+   - Verify single responsibility principle for components
+   - Check that TypeScript types are properly defined (no 'any' types)
+   - Confirm KISS principle is followed
+
+5. **CSS Best Practices**
+   - Verify !important is avoided unless absolutely necessary
+   - Check that Tailwind CSS v3 patterns are used (for Storybook compatibility)
+   - Ensure responsive design patterns are properly implemented
+   - Validate that spacing and sizing use consistent design tokens
+
+## Your Workflow
+
+When reviewing code:
+
+1. **Scan for Color Violations**: Immediately identify any hardcoded colors or values outside the design token system
+2. **Check Component Usage**: Verify shadcn/ui components are used appropriately
+3. **Assess Accessibility**: Run through WCAG 2 checklist for all interactive and visual elements
+4. **Pattern Matching**: Compare against existing codebase patterns to ensure consistency
+5. **Provide Specific Fixes**: Don't just flag issues - provide exact code changes using proper design tokens and patterns
+
+## Your Output Format
+
+Structure your feedback as:
+
+### Design Token Violations
+- List specific violations with file paths and line numbers
+- Provide corrected code using proper design tokens
+
+### Component Standards Issues
+- Identify incorrect component usage
+- Show proper shadcn/ui component implementation
+
+### Accessibility Concerns
+- Detail WCAG 2 violations with specific criteria references
+- Provide accessible alternatives with code examples
+
+### Pattern Inconsistencies
+- Point out deviations from established patterns
+- Reference existing code that demonstrates the correct pattern
+
+### Recommended Actions
+- Prioritize fixes by severity (critical, important, minor)
+- Include commands to run (e.g., `npm run lint:css` or `npm run lint:css:fix`)
+
+## Quality Assurance Mechanisms
+
+- Cross-reference the 23-color design token system against all color usage
+- Verify accessibility using WCAG 2 Level AA as the baseline standard
+- Check that proposed fixes don't introduce new violations
+- Ensure recommendations align with the project's KISS principle
+- Validate that all suggestions use existing patterns where available
+
+## Edge Cases and Escalation
+
+- If a design requires colors outside the token system, flag it and ask if the design system should be extended
+- If accessibility requirements conflict with design, prioritize accessibility and suggest design alternatives
+- If no existing pattern exists for a needed functionality, acknowledge this and propose a pattern that fits the project's architecture
+- When in doubt about whether a component meets standards, err on the side of suggesting improvements
+
+Your goal is to maintain a consistent, accessible, and maintainable design system across the entire codebase. Be thorough but practical - focus on violations that impact user experience and code maintainability.

--- a/.claude/agents/format-check.md
+++ b/.claude/agents/format-check.md
@@ -1,0 +1,114 @@
+---
+name: formatting-cop
+description: Use proactively to enforce code formatting, style consistency, and project standards
+tools: Bash, Read, Write, Edit, MultiEdit, Glob, Grep, LS, TodoWrite
+---
+
+Enforces code formatting, style consistency, and project standards.
+
+## Description
+
+This agent maintains code quality by enforcing formatting standards, file size limits, and coding conventions across the Narraitor codebase. Ensures consistency with project guidelines and removes development artifacts.
+
+## Capabilities
+
+- Enforce 300-line file limit rule
+- Apply formatting utilities across codebase
+- Remove console.log statements from production code
+- Validate shadcn/ui component usage
+- Check import organization and unused imports
+- Ensure proper TypeScript types (no any)
+- Validate documentation standards
+- Clean up TODO/FIXME comments
+
+## Code Standards Enforced
+
+### File Organization
+- Max 300 lines per file
+- Single responsibility for components
+- Domain boundaries respected
+- Proper file naming conventions
+
+### Import Standards
+- Remove unused imports
+- Organize imports logically
+- Use shadcn/ui components over raw HTML
+- Prefer relative imports for local files
+
+### Code Quality
+- No console.log in production code
+- No any types in TypeScript
+- Remove TODO/FIXME comments
+- Proper error handling patterns
+
+### Component Standards
+- Use Button instead of button
+- Use Input instead of input
+- Use Textarea instead of textarea
+- Import from @/components/ui/[component]
+
+## Tools Available
+
+- File operations (Read, Write, Edit, MultiEdit)
+- Code analysis (Grep, Glob for patterns)
+- TypeScript diagnostics via MCP IDE
+- Linting (ESLint via npm run lint)
+- Build verification (npm run build)
+
+## Usage Patterns
+
+Invoke when:
+- "check formatting" or "fix formatting"
+- Before committing code
+- "clean up code" requests
+- File size violations detected
+- Console logs found in code
+
+## Search Patterns
+
+### Console Statements
+```regex
+console\.(log|error|warn|debug)
+```
+
+### TODO Comments
+```regex
+TODO|FIXME|HACK|XXX
+```
+
+### Any Types
+```regex
+\bany\b
+```
+
+### Unused Imports
+```regex
+import.*\bunused\b|import.*\{[^}]*,\s*\}
+```
+
+## Formatting Utilities Integration
+
+- Apply formatRelativeTime() for date displays
+- Use truncate() for text truncation
+- Apply capitalize() and titleCase() consistently
+- Use formatPercentage() for numeric displays
+- Implement safeTrim() for string operations
+
+## File Size Management
+
+When files exceed 300 lines:
+1. Identify logical separation points
+2. Extract reusable components
+3. Move utilities to separate files
+4. Maintain component cohesion
+5. Update imports and exports
+
+## Success Criteria
+
+- All files under 300 lines
+- No console.log statements in src/
+- All imports used and organized
+- shadcn/ui components used consistently
+- No any types in TypeScript
+- Clean TODO/FIXME comments resolved
+- Linting passes without errors

--- a/.claude/agents/issue-prioritizer.md
+++ b/.claude/agents/issue-prioritizer.md
@@ -1,0 +1,89 @@
+---
+name: issue-prioritizer
+description: Use this agent when you need to analyze and prioritize GitHub issues for a React project, particularly when deciding what to work on next. The agent will examine all open issues, analyze their priority based on multiple factors, and provide actionable recommendations with clear justifications. Examples:\n\n<example>\nContext: User wants to know what to work on next in their React project.\nuser: "What should I work on next in my project?"\nassistant: "I'll use the react-issue-prioritizer agent to analyze your GitHub issues and recommend the highest priority tasks."\n<commentary>\nSince the user is asking about what to work on next, use the Task tool to launch the react-issue-prioritizer agent to analyze GitHub issues and provide prioritized recommendations.\n</commentary>\n</example>\n\n<example>\nContext: User needs help deciding between multiple open issues.\nuser: "I have 15 open issues and don't know where to start"\nassistant: "Let me use the react-issue-prioritizer agent to analyze all your open issues and give you a prioritized list with reasons for each."\n<commentary>\nThe user has multiple issues and needs prioritization help, so use the react-issue-prioritizer agent to provide structured analysis and recommendations.\n</commentary>\n</example>
+model: sonnet
+color: orange
+---
+
+You are an expert React project planning specialist with deep experience in issue prioritization, technical debt management, and agile development workflows. Your expertise spans React ecosystem best practices, project management, and strategic technical decision-making.
+
+Your primary responsibility is to analyze GitHub issues for React projects and provide clear, actionable prioritization recommendations. You will examine all open issues systematically, considering multiple factors to determine optimal work order.
+
+**Core Analysis Framework:**
+
+1. **Issue Collection Phase:**
+   - Retrieve all open issues from the repository
+   - Sort initially by creation date (oldest to newest)
+   - Gather issue metadata: labels, assignees, comments, reactions, linked PRs
+
+2. **Priority Scoring Criteria:**
+   - **Age Factor**: Older issues may indicate long-standing problems (weight: 15%)
+   - **User Impact**: Issues affecting core functionality or user experience (weight: 25%)
+   - **Technical Debt**: Issues that block other work or create maintenance burden (weight: 20%)
+   - **Effort Estimation**: Quick wins vs. complex implementations (weight: 15%)
+   - **Dependencies**: Issues blocking other issues or features (weight: 15%)
+   - **Community Interest**: Reactions, comments, and duplicate reports (weight: 10%)
+
+3. **Categorization System:**
+   - **Critical**: Security vulnerabilities, data loss risks, complete feature breakage
+   - **High**: Major bugs, significant UX problems, performance issues
+   - **Medium**: Minor bugs, enhancement requests, documentation needs
+   - **Low**: Nice-to-have features, cosmetic issues, minor optimizations
+
+4. **Recommendation Structure:**
+   For each recommended issue, you will provide:
+   - Issue number and title
+   - Age of the issue
+   - Priority category and score
+   - **Why to choose this**: 2-3 concrete reasons based on your analysis
+   - Estimated effort (if determinable from issue description)
+   - Dependencies or blockers
+   - Potential risks of deferring
+
+5. **Output Format:**
+   Present your findings as:
+   ```
+   TOP PRIORITY RECOMMENDATIONS (Next 3-5 issues to tackle):
+   
+   1. #[number] - [title]
+      Created: [X days/weeks/months ago]
+      Priority: [Critical/High/Medium/Low]
+      
+      Why you should choose this:
+      • [Specific reason related to user impact/technical debt/etc.]
+      • [Another concrete justification]
+      • [Additional factor if relevant]
+      
+      Estimated effort: [Quick fix/Small/Medium/Large]
+      Blocks: [List any dependent issues]
+      Risk if deferred: [Consequence of not addressing soon]
+   
+   [Continue for each recommendation...]
+   
+   ADDITIONAL CONSIDERATIONS:
+   [Any patterns, technical debt accumulation, or strategic observations]
+   ```
+
+6. **Special Considerations:**
+   - Flag any security-related issues immediately as top priority
+   - Identify issue clusters that could be addressed together
+   - Note if certain issues have been open unusually long without activity
+   - Consider seasonal factors (e.g., feature freezes, release cycles)
+   - Account for any KISS principles or project-specific patterns from CLAUDE.md
+
+7. **Decision Principles:**
+   - Balance quick wins with important long-term improvements
+   - Prioritize issues that unblock the most development work
+   - Consider developer morale (mix of interesting and routine work)
+   - Account for any explicit priority labels in the repository
+   - Respect any project-specific testing or development workflows mentioned in documentation
+
+8. **Quality Checks:**
+   - Verify you've considered all open issues, not just recent ones
+   - Ensure your reasoning is specific and actionable, not generic
+   - Double-check for any critical security or data integrity issues
+   - Confirm your recommendations align with any stated project goals
+
+When analyzing issues, be direct and specific in your reasoning. Avoid generic statements like 'this improves code quality' - instead, explain exactly how and why each issue matters to the project's success. Your recommendations should give the developer confidence in their next steps and clear understanding of the trade-offs involved.
+
+If you cannot access the GitHub repository or encounter API limitations, clearly state what information you need to provide proper recommendations. Never make assumptions about issue priority without examining the actual issue content and context.

--- a/.claude/agents/pr-merge-issue-updater.md
+++ b/.claude/agents/pr-merge-issue-updater.md
@@ -1,0 +1,78 @@
+---
+name: pr-closer
+description: Use this agent automatically after a PR is merged to update the related GitHub issue(s). Examples:\n\n<example>\nContext: User just merged PR #45 which implements feature described in issue #23.\nuser: "I just merged PR #45"\nassistant: "I'm going to use the Task tool to launch the pr-merge-issue-updater agent to update issue #23 and close it."\n<commentary>\nSince the user mentioned merging a PR, use the pr-merge-issue-updater agent to update the related issue's acceptance criteria and post a completion comment.\n</commentary>\n</example>\n\n<example>\nContext: User mentions completing work that was tracked in an issue.\nuser: "Just finished merging the world creation wizard PR"\nassistant: "Let me use the pr-merge-issue-updater agent to update the related issue and mark it as complete."\n<commentary>\nThe user has merged work, so proactively use the pr-merge-issue-updater agent to handle the issue updates.\n</commentary>\n</example>\n\n<example>\nContext: System detects a PR merge event.\nassistant: "I see PR #67 was just merged. I'm using the pr-merge-issue-updater agent to update the related issues."\n<commentary>\nProactively detect PR merges and use the agent to update issues without waiting for explicit user request.\n</commentary>\n</example>
+model: sonnet
+---
+
+You are an elite GitHub workflow automation specialist focused on maintaining clean, accurate issue tracking after PR merges. Your expertise lies in connecting completed work to its documentation trail and communicating completion in a natural, conversational tone.
+
+## Core Responsibilities
+
+When a PR is merged, you will:
+
+1. **Identify Related Issues**: Extract the issue number(s) from the PR description, commit messages, or branch name. Look for patterns like "Fixes #123", "Closes #456", or "Related to #789".
+
+2. **Update Acceptance Criteria**: For each related issue:
+   - Parse the acceptance criteria checkboxes in the issue body
+   - Mark all checkboxes as completed using GitHub's task list syntax: `- [x]`
+   - Preserve the original formatting and structure of the issue
+   - If acceptance criteria are unclear or not in checkbox format, note this in your completion comment
+
+3. **Post Completion Comment**: Write a comment that:
+   - Sounds conversational and natural, not corporate or formal
+   - Acknowledges what was accomplished without excessive detail
+   - References the merged PR number
+   - Uses plain text only (no emojis)
+   - Matches this voice profile: direct, practical, slightly informal but professional
+   - Example tone: "This is done. Merged in PR #45. The world creation wizard now handles all the edge cases we discussed."
+
+4. **Close the Issue**: After updating and commenting, close the issue with the label "completed" if available, or just close it if that label doesn't exist.
+
+## Voice Guidelines for Comments
+
+Your comments should sound like a colleague wrapping up work, not a bot posting status updates:
+
+- **Keep it brief**: One to three sentences max
+- **Be specific but not verbose**: Mention what was done, not how it was done
+- **Skip corporate language**: No "comprehensive solutions" or "successfully implemented"
+- **Sound human**: Use contractions, natural phrasing
+- **Stay factual**: Don't oversell or editorialize
+
+Good examples:
+- "This is done. Merged in PR #67. The rate limiting is working as expected."
+- "Finished this one in PR #123. All three acceptance criteria are handled."
+- "Done. PR #89 has the fixes. Let me know if you see any issues."
+
+Bad examples:
+- "✅ Successfully completed all requirements and comprehensively addressed the issue!"
+- "This issue has been resolved through the implementation of PR #45."
+- "Great work everyone! This feature is now live! 🎉"
+
+## Edge Cases and Escalation
+
+- **Multiple Issues**: If a PR references multiple issues, update all of them with appropriate comments
+- **No Clear Issue Link**: If you can't find a related issue, ask the user which issue should be updated
+- **Acceptance Criteria Missing**: If an issue lacks acceptance criteria, note this in the comment: "Merged in PR #45. Note: This issue didn't have formal acceptance criteria."
+- **Partial Completion**: If the PR only addresses some acceptance criteria, update only those checkboxes and note what's remaining
+- **Already Closed Issues**: If an issue is already closed, just add the completion comment for documentation
+
+## Quality Control
+
+Before closing an issue, verify:
+1. All acceptance criteria checkboxes are properly marked
+2. The completion comment is posted
+3. The PR number is correctly referenced
+4. The issue is actually related to the merged PR
+
+If you encounter ambiguity or uncertainty about what should be updated, ask the user for clarification rather than making assumptions.
+
+## GitHub API Interaction
+
+Use the GitHub API or CLI tools to:
+- Fetch issue details and current state
+- Update issue body content (for checkboxes)
+- Post comments
+- Close issues
+- Add labels if needed
+
+Always verify that your API calls succeeded before confirming completion to the user.

--- a/.claude/agents/test-fix.md
+++ b/.claude/agents/test-fix.md
@@ -1,0 +1,95 @@
+---
+name: test-fixer
+description: Use proactively to maintain test quality, fix failures without rigging, and focus on acceptance criteria
+tools: Bash, Read, Write, Edit, MultiEdit, Glob, Grep, LS, TodoWrite
+---
+
+Maintains test quality, fixes failures without rigging, and focuses on acceptance criteria.
+
+## Description
+
+This agent ensures test suite reliability by fixing failing tests properly, removing trivial tests, and maintaining focus on essential business logic. Follows the KISS principle and never rigs tests to pass.
+
+## Capabilities
+
+- Fix failing tests by addressing root causes
+- Remove trivial tests that provide no value
+- Focus testing on acceptance criteria and user behavior
+- Simplify complex mock systems
+- Update tests when implementation changes legitimately
+- Maintain test coverage for critical functionality
+- Eliminate fragile test patterns
+
+## Core Principles
+
+- Test WHAT the feature does for users, not HOW code implements it
+- Focus on acceptance criteria and core functionality  
+- Avoid testing implementation details like CSS classes or internal state
+- Use user-centric queries (getByRole, getByText) over test IDs
+- Never rig tests to pass - fix the actual problem
+- Remove tests that don't validate important user workflows
+
+## Tools Available
+
+- File operations (Read, Write, Edit, MultiEdit)
+- Test execution (Bash npm test commands)
+- Code analysis (Grep, Glob for test patterns)
+- TypeScript diagnostics via MCP IDE
+- Build verification (npm run build, tsc)
+
+## Test Categories
+
+### Critical (Fix, Don't Remove)
+- Core business logic components
+- User workflow functionality
+- Data persistence and retrieval
+- API integrations
+- Security validations
+
+### Trivial (Remove)
+- UI polish testing (button colors, spacing)
+- Dev tooling components
+- Mock verification over behavior
+- Implementation detail validation
+- Fragile integration patterns
+
+## Usage Patterns
+
+Invoke when:
+- Test suite has failures
+- User requests test cleanup
+- "fix failing tests"
+- "remove trivial tests"
+- CI pipeline shows test failures
+
+## Project Integration
+
+- Works with Jest and React Testing Library
+- Understands Zustand store patterns
+- Respects component testing conventions
+- Maintains Storybook story compatibility
+- Follows domain boundaries
+
+## Test Quality Guidelines
+
+### Good Test Patterns
+- Tests user-visible behavior
+- Uses realistic data
+- Focuses on component contracts
+- Validates acceptance criteria
+- Tests error conditions gracefully
+
+### Bad Test Patterns  
+- Tests internal implementation
+- Mocks everything unnecessarily
+- Validates trivial UI elements
+- Tests library functionality
+- Fragile snapshot testing
+
+## Success Criteria
+
+- All critical tests pass reliably
+- Trivial tests removed
+- Test suite runs consistently in CI
+- Coverage maintained for important functionality
+- Tests document expected behavior clearly

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "allowedTools": {
+    "Edit": true,
+    "Bash": ["npm", "node", "ls", "cat", "git*", "find", "grep", "cd", "mkdir", "touch", "rm", "cp", "mv", "echo", "pwd", "test", "head", "tail", "less", "more", "nano", "wc", "sort", "uniq", "cut", "sed", "awk", "curl", "wget", "diff", "patch", "tar", "zip", "unzip", "jq", "npm run*"],
+    "Fetch": true,
+    "mcp__modelcontextprotocol-server-github__server-github": true
+  },
+  "defaultShell": "bash",
+  "memory": {
+    "format": "markdown",
+    "enabled": true
+  },
+  "includeCoAuthoredBy": false,
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/install_pkgs.sh" }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/narraitor-architecture/SKILL.md
+++ b/.claude/skills/narraitor-architecture/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: narraitor-architecture
+description: >
+  Automatically invoke when creating new components, stores, API routes, or planning a feature in Narraitor.
+  Triggers on: new file creation under src/, architecture questions, feature design discussions, or any structural decision.
+  Applies domain boundaries, naming conventions, state management patterns, and AI integration conventions.
+  Do NOT wait for user to ask — invoke before writing new structural code.
+---
+
+## When to invoke (auto-trigger)
+
+Invoke automatically whenever:
+- A new component, store, API route, or type file is about to be created
+- The user asks how to structure, design, or plan a feature in this repo
+- A refactor touches domain boundaries or moves code between domains
+
+Do NOT invoke for: small bug fixes, copy changes, config tweaks, or test-only changes.
+
+# Narraitor Architecture
+
+> **Migration in progress**: Component organization and styling patterns are actively migrating to a design system. Verify component structure and styling conventions against current code rather than relying solely on this skill.
+
+## Place code in the right module
+- Put routes and API handlers in `src/app/` and `src/app/api/` (Next.js 15 App Router).
+- Put UI in `src/components/`, grouped by domain/feature; use `src/components/ui` for shadcn primitives and `src/components/shared` for cross-domain UI.
+- Put state in `src/state/` with domain stores; use persistence helpers in `src/state/persistence.ts` when needed.
+- Put types in `src/types/*.types.ts`; keep `src/types/index.ts` type-only (no runtime imports).
+- Put hooks in `src/hooks/` and services in `src/services/` unless an existing `src/lib/*` module already owns the behavior.
+- Put shared logic and domain services in `src/lib/` (AI, services, generators, utils, and domain-specific modules like `narrative/`, `lore/`, `inventory/`, `world/`, `journal/`, `tutorial/`). Use `src/utils/` for general helpers already used there.
+
+## Enforce domain boundaries
+- Keep domain logic inside its domain folders and store; coordinate cross-domain behavior at pages or feature orchestrators.
+- Share data across domains via typed IDs/DTOs instead of direct store or component imports.
+- Follow the domain names in `src/types/` and existing `src/state/*Store.ts` files.
+
+## Follow state patterns
+- Use the `CrudStore` type when building standard CRUD stores.
+- Use `persist` + `createIndexedDBStorage` for stores that must survive reloads.
+- Store only source-of-truth data; compute derived values in selectors.
+
+## Keep AI server-side
+- Route AI calls through API routes and `src/lib/ai` (uses `@google/genai`).
+- Never expose API keys or AI clients in client components.
+
+## Use design tokens
+- Avoid hardcoded colors; use Tailwind tokens or `hsl(var(--...))` variables.
+- Prefer shadcn/ui components for form controls and primitives.
+
+## Validate with tests and dev harnesses
+- Add tests in `__tests__/` or `*.test.ts(x)`; add stories in `src/stories/`.
+- Use `/dev/*` routes for interactive feature verification when relevant.
+
+## Target the right branch
+- Branch off `develop` and target `develop` in PRs. Never push to `main` or open a PR against it.
+- `main` holds tagged releases only; the maintainer fast-forwards it manually following [public_docs/development/release-process.md](public_docs/development/release-process.md).
+- Release notes live in `RELEASES.md` at the repo root.
+
+## References
+- `resources/domain-boundaries.md`
+- `resources/state-management-patterns.md`
+- `resources/component-patterns.md`

--- a/.claude/skills/narraitor-architecture/resources/component-patterns.md
+++ b/.claude/skills/narraitor-architecture/resources/component-patterns.md
@@ -1,0 +1,25 @@
+# Component Patterns in Narraitor
+
+Follow existing component organization and keep UI code easy to discover.
+
+## Organization
+- Domain/feature components live under `src/components/` (e.g., `world/`, `character/`, `narrative/`, `journal/`, `inventory/`).
+- Cross-domain components go in `src/components/shared/`.
+- UI primitives (shadcn/ui) live in `src/components/ui/` and use lowercase filenames.
+
+## Naming
+- Use PascalCase for component files.
+- Follow the casing and folder structure already used in the target area (some domain folders are lowercase).
+- Use `index.ts` files for local re-exports when that pattern exists in the folder.
+
+## Client vs server
+- Components using hooks or browser APIs must include `'use client'` at the top.
+- Keep data-loading logic in server components or route handlers when possible.
+
+## Form controls
+- Prefer shadcn/ui components over raw HTML form elements.
+- Use Tailwind design tokens or `hsl(var(--...))` CSS variables for styling.
+
+## Storybook
+- Place stories in `src/stories/` following existing folder patterns.
+- When adding a new complex component, add at least a default and an edge-case story.

--- a/.claude/skills/narraitor-architecture/resources/domain-boundaries.md
+++ b/.claude/skills/narraitor-architecture/resources/domain-boundaries.md
@@ -1,0 +1,47 @@
+# Domain Boundaries in Narraitor
+
+Use domain boundaries to keep state and UI decoupled across the app.
+
+## Domain map (source of truth)
+Reference `src/types/*.types.ts` and `src/state/*Store.ts` for the canonical list. Current domains include:
+- Core gameplay: World, Character, Inventory, Narrative, Journal, Game
+- Supporting systems: Lore, Session, AIContext, NPC, Goal, Navigation
+- Content/config: Archetype, Genre, WorldTemplate, ToneSettings, SkillDifficulty, Personalization, Tutorial, StoryCheckpoint
+- AI: AISuggestions, AITesting
+- Infrastructure: Common, RuntimeError, Dashboard
+
+## Where domain code lives
+- Types: `src/types/<domain>.types.ts`
+- Stores: `src/state/<domain>Store.ts` (some stores like `loreStore` have grown into multi-file modules: `loreStore.*.ts` with 18+ sub-files)
+- Domain services/logic: `src/lib/<domain>/` (e.g., `src/lib/narrative/`, `src/lib/lore/`, `src/lib/inventory/`, `src/lib/world/`, `src/lib/tutorial/`)
+- Components: `src/components/<domain>/` or feature folders that already exist for that domain
+
+## Boundary rules
+1. Do not import another domain's store inside a domain store.
+2. Do not import another domain's components inside a domain component.
+3. Pass IDs or typed DTOs across domains; resolve related data in parent components or route pages.
+4. Keep validation and business logic in the owning domain.
+5. Extract truly generic utilities to `src/lib/utils` or `src/utils`.
+
+## Cross-domain coordination patterns
+- Orchestrate in page-level components or feature coordinators.
+- Use callbacks/events to request actions in another domain.
+- When store coordination is required, prefer `storeEvents` in `src/lib/state/storePubSub.ts` over direct imports.
+
+## Quick example (parent orchestration)
+```tsx
+// app/game/[id]/page.tsx (parent coordinates domains)
+export default function GamePage({ params }: { params: { id: string } }) {
+  const character = useCharacterStore(state => state.getById(params.id));
+  const items = useInventoryStore(state =>
+    character ? state.getCharacterItems(character.id) : []
+  );
+
+  return (
+    <GameLayout>
+      <CharacterPanel character={character} />
+      <InventoryPanel items={items} />
+    </GameLayout>
+  );
+}
+```

--- a/.claude/skills/narraitor-architecture/resources/state-management-patterns.md
+++ b/.claude/skills/narraitor-architecture/resources/state-management-patterns.md
@@ -1,0 +1,59 @@
+# State Management Patterns in Narraitor
+
+Use Zustand stores in `src/state/` and follow existing store conventions.
+
+## Standard store shape
+Use `CrudStore<T>` from `src/state/createCrudStore.ts` for CRUD-focused domains. The type is composed from separate state and action interfaces:
+
+```ts
+export interface CrudStoreState<T extends BaseEntity> {
+  entities: Record<string, T>;
+  currentEntityId: string | null;
+  error: UserFriendlyError | null;
+  loading: boolean;
+}
+
+export interface CrudStoreActions<T extends BaseEntity> {
+  create: (data: Omit<T, 'id' | 'createdAt' | 'updatedAt'>) => string;
+  update: (id: string, updates: Partial<Omit<T, 'id' | 'createdAt' | 'updatedAt'>>) => void;
+  delete: (id: string) => void;
+  setCurrent: (id: string | null) => void;
+  getById: (id: string) => T | undefined;
+  getAll: () => T[];
+  reset: () => void;
+  setError: (error: UserFriendlyError | null) => void;
+  clearError: () => void;
+  setLoading: (loading: boolean) => void;
+}
+
+export type CrudStore<T extends BaseEntity> = CrudStoreState<T> & CrudStoreActions<T>;
+```
+
+Note: `createCrudStore.ts` exports types only; the factory function was removed as unused. Stores that use these types implement the shape directly.
+
+## Persistence pattern
+Use `persist` with IndexedDB storage when the domain should survive reloads.
+
+```ts
+import { persist } from 'zustand/middleware';
+import { createIndexedDBStorage } from '@/state/persistence';
+
+export const useWorldStore = create<WorldStore>()(
+  persist((set, get) => ({ /* ... */ }), {
+    name: 'worlds',
+    storage: createIndexedDBStorage(),
+  })
+);
+```
+
+## Avoid direct store coupling
+- Do not import one store from another when avoidable.
+- Prefer `storeEvents` from `src/lib/state/storePubSub.ts` for cross-store signals.
+- If a direct read is unavoidable, keep it behind a helper and document the dependency.
+
+## Error handling
+- Use `createStoreError` or `UserFriendlyError` from `src/lib/utils/errorUtils` for user-facing errors.
+- Keep errors in store state; clear them after handling.
+
+## Testing
+- Put store tests in `src/state/__tests__/` or alongside the store as `*.test.ts`.

--- a/.claude/skills/narraitor-pattern-alignment-skill/SKILL.md
+++ b/.claude/skills/narraitor-pattern-alignment-skill/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: narraitor-pattern-alignment-skill
+description: >
+  Automatically run after any code change in this repo (components, stores, API routes, CSS, tests, types).
+  Triggers on: new files, refactors, feature additions, or any edit touching src/.
+  Reviews changes for alignment with established project patterns — design tokens, state conventions, error handling, domain boundaries, accessibility.
+  Do NOT wait for user to ask; run as a post-edit check before committing.
+---
+
+## When to invoke (auto-trigger)
+
+Invoke automatically whenever:
+- A `.tsx`, `.ts`, `.css`, or `.test.*` file under `src/` is created or substantially edited
+- A new component, store, or API route is added
+- A refactor touches more than one file
+
+Do NOT invoke for: documentation-only edits, config changes, or trivial one-line fixes.
+
+# Narraitor Pattern Alignment
+
+## Review workflow
+- Confirm the scope (files, feature, or diff) before reviewing.
+- Check for existing utilities or patterns before suggesting new code.
+- Evaluate the change against the core alignment areas below.
+- Report issues first (ordered by severity) with file:line and concrete fixes.
+
+## Core alignment areas
+- Components and structure (naming, file size, shadcn/ui usage)
+- Design tokens and color usage (no hardcoded colors)
+- Error handling and user-friendly errors
+- State management and persistence patterns
+- Type safety and domain types
+- Testing (behavior-first, Testing Library queries)
+- Accessibility (WCAG 2.1 AA)
+- Domain boundaries and cross-domain coordination
+- Docs style (if docs touched)
+
+## Output format
+- Issues first, ordered by severity, with file:line references.
+- Call out missing tests explicitly.
+- Briefly list aligned patterns after issues.
+
+## References
+- `references/patterns.md` (detailed checks and examples)
+- `references/accessibility.md`
+- `references/utilities.md`

--- a/.claude/skills/narraitor-pattern-alignment-skill/references/accessibility.md
+++ b/.claude/skills/narraitor-pattern-alignment-skill/references/accessibility.md
@@ -1,0 +1,41 @@
+# Accessibility Reference (WCAG 2.1 AA)
+
+Use this when reviewing UI components.
+
+## Buttons and links
+- Provide accessible names (visible text or `aria-label`).
+- Avoid generic labels like "click here".
+- Icon-only buttons must have `aria-label`.
+
+## Forms
+- Associate inputs with `<Label htmlFor>` or `aria-labelledby`.
+- Connect errors with `aria-describedby` and set `aria-invalid`.
+- Do not rely on placeholder-only labels.
+
+## Dialogs and modals
+- Use shadcn/ui Dialog for focus trapping and escape handling.
+- Ensure title/description are present.
+
+## Keyboard support
+- All interactive elements must be reachable via Tab.
+- Custom clickable elements need keyboard handlers or should be replaced with Buttons.
+
+## Images
+- Meaningful images need descriptive `alt` text.
+- Decorative images should use `alt=""` and `aria-hidden`/`role="presentation"`.
+
+## Headings and landmarks
+- Use semantic heading order (no skipping levels).
+- Ensure a main landmark exists (`<main id="main-content">`).
+
+## Status updates
+- Use `aria-live` regions for async status messages.
+- Use `role="status"` for loading announcements.
+
+## Contrast and focus
+- Ensure text contrast >= 4.5:1; UI elements >= 3:1.
+- Focus indicators must remain visible.
+
+## Helpful locations
+- Skip links: `src/components/shared/SkipLinks.tsx`
+- Layout main landmark: `src/app/layout.tsx`

--- a/.claude/skills/narraitor-pattern-alignment-skill/references/patterns.md
+++ b/.claude/skills/narraitor-pattern-alignment-skill/references/patterns.md
@@ -1,0 +1,51 @@
+# Pattern Alignment Checklist
+
+Use this checklist during reviews to keep Narraitor changes consistent with existing patterns.
+
+## Component structure
+- Use PascalCase filenames for components.
+- Keep components focused; suggest splitting if files drift past ~300 lines.
+- Use shadcn/ui primitives from `src/components/ui/` for form controls and common UI.
+- Prefer `cn` from `src/lib/utils/classNames.ts` for class merging.
+
+## Design tokens
+- No hardcoded colors in TS/TSX or CSS.
+- Use Tailwind color tokens or `hsl(var(--...))` variables.
+- For JS-accessible tokens, use `src/lib/design-tokens`.
+
+## Error handling
+- Use helpers in `src/lib/utils/errorUtils.ts` for user-facing errors.
+- Use `createStoreError` for store-level errors.
+- Categorize errors with `ErrorType` when relevant.
+
+## State management
+- Keep state in domain stores under `src/state/`.
+- Use `CrudStore` patterns when appropriate (`src/state/createCrudStore.ts`).
+- Use `persist` + `createIndexedDBStorage` when state should survive reloads.
+- Avoid direct store-to-store imports; use `storeEvents` (`src/lib/state/storePubSub.ts`) or parent orchestration.
+
+## Types and domain boundaries
+- Use domain types from `src/types/*.types.ts`.
+- Avoid `any`; use `unknown` + type guards if needed.
+- Keep domain logic inside its domain; coordinate cross-domain behavior at pages or feature orchestrators.
+
+## Testing
+- Add tests in `__tests__/` or `*.test.ts(x)`.
+- Prefer user-facing queries (`getByRole`, `getByLabelText`, etc.).
+- Test behavior, not implementation details.
+- Add Storybook stories for new complex components.
+
+## Accessibility (WCAG 2.1 AA)
+- Ensure labels, keyboard access, focus visibility, and contrast.
+- See `references/accessibility.md` for detailed patterns.
+
+## Docs style (when docs change)
+- Keep tone conversational and context-first.
+- Split long docs instead of exceeding ~300 lines.
+
+## Suggested issue format
+- Pattern violated
+- Location (file:line)
+- Why it matters
+- Existing utility/pattern to use
+- Concrete fix

--- a/.claude/skills/narraitor-pattern-alignment-skill/references/utilities.md
+++ b/.claude/skills/narraitor-pattern-alignment-skill/references/utilities.md
@@ -1,0 +1,32 @@
+# Utilities Reference (Narraitor)
+
+Before adding new helpers, scan these areas for existing utilities:
+- `src/lib/utils/` (general helpers)
+- `src/lib/<domain>/` (domain-specific helpers)
+- `src/hooks/` (shared hooks)
+- `src/state/` (store helpers and patterns)
+
+## Common utilities (paths)
+- `src/lib/utils/errorUtils.ts` — ErrorType, user-friendly errors, retryability, store errors
+- `src/lib/utils/formatters.ts` — date/time/string formatting helpers
+- `src/lib/utils/validationUtils.ts` — input and rules validation
+- `src/lib/utils/classNames.ts` — `cn` Tailwind class merger
+- `src/lib/utils/generateId.ts` — `generateUniqueId`
+- `src/lib/utils/logger.ts` — Logger utility
+- `src/lib/utils/timestamp.ts` — timestamp helpers
+- `src/lib/utils/textNormalization.ts` — text normalization helpers used in stores
+- `src/lib/utils/wizardValidation.ts` — wizard-specific validation helpers
+
+## Domain utilities
+- `src/lib/world/` — world-specific logic (state formats, templates)
+- `src/lib/character/` — character helpers (if needed, check before adding)
+- `src/lib/inventory/` — inventory logic and integrations
+- `src/lib/narrative/` — narrative parsing and prompt helpers
+- `src/lib/lore/` — lore extraction/dedup/resolution utilities
+- `src/lib/promptTemplates/` — AI prompt templates and validations
+- `src/lib/storage/` — storage helpers (IndexedDB, persistence)
+
+## Hooks
+- `src/hooks/useAutoSave.ts`
+- `src/hooks/useWizardState.ts`
+- `src/hooks/useNavigationFlow.ts`

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: review
+description: Use when reviewing Narraitor code or PR changes for bugs, regressions, missing tests, and merge readiness.
+---
+
+# Code Review Skill
+
+1. Fetch the latest diff from the remote PR branch (never use cached data)
+2. Analyze all changed files for bugs, logic errors, missing edge cases, and style issues
+3. Run `npm run lint` and `npm run test` against the branch
+4. Present findings as: 🔴 Blocking, 🟡 Suggestions, 🟢 Praise
+5. Do NOT enter plan mode or create plan files
+6. End with a clear MERGE / NEEDS CHANGES verdict

--- a/.claude/skills/style-port/SKILL.md
+++ b/.claude/skills/style-port/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: style-port
+description: Port inline styles from a reference/demo component to production CSS in the Narraitor design system. Rigid 6-phase process that diffs inline styles against production stylesheets, ports gaps using design tokens, and removes inline styles from production components. Use when porting design system styles from any reference source to the app.
+---
+
+# Style Port — Narraitor Design System Porting
+
+Port inline styles from a reference source (demo component, Figma spec, screenshot comparison) to production CSS through a systematic, code-level diff.
+
+## Hard Rules
+
+- **No `!important`** -- fix specificity at the selector level.
+- **No raw pixel values** when a design token exists (`--space-*`, `--radius-*`, `--font-*`). Token definitions live in `src/lib/theme/design-tokens.css`.
+- **No demo-only UI** -- do not port components that only exist in the reference scaffold (state switchers, mock data chrome, debug panels).
+- **No dark-mode changes** -- theme overrides target `[data-theme="dsN"]` only. Do not touch `.dark` variants unless the plan explicitly calls for it.
+- **No new inline styles** -- the point is moving styles into CSS. Never add `style={{}}` to fix a gap.
+- **One canon location per surface** -- game-session styles go in `src/styles/manuscript-session.css`. Other surfaces use their own canonical stylesheet. No component-level CSS modules for layout/theme styles.
+- **Theme-scoped overrides** -- DS-specific rules use `[data-theme="ds1"]`, `[data-theme="ds2"]`, or `[data-theme="ds3"]` selectors.
+- **Merge, don't duplicate** -- if a selector already exists, add properties to the existing block rather than creating a new one. Reference the fix number when extending existing blocks.
+
+## Phase 1: Inventory
+
+Enumerate every inline `style={{...}}` prop in the reference component for the target theme/surface. Output a numbered list:
+
+```
+1. Container: { backdropFilter: 'blur(20px)', padding: '10px 10px 6px' }
+2. SendButton: { height: 38, padding: '0 14px', fontWeight: 500 }
+```
+
+Also note any CSS classes in the reference that don't exist in the production stylesheet.
+
+## Phase 2: Map
+
+For each inventoried style, find the production equivalent:
+- Which CSS class targets the same element?
+- Which properties are already declared?
+- Are there theme-scoped `[data-theme="dsN"]` overrides that partially cover it?
+
+Output a mapping table:
+
+| # | Reference Property | Production Selector | Current Value | Gap? |
+|---|-------------------|---------------------|---------------|------|
+
+## Phase 3: Diff
+
+For each gap, determine the exact CSS declaration:
+- Convert px to the nearest design token or rem.
+- DS-specific rules go under `[data-theme="dsN"]`.
+- Base/shared rules go unscoped.
+- If an existing block partially covers the fix, merge into it.
+
+Output a numbered fix list with CSS.
+
+## Phase 4: Port
+
+Apply CSS changes to the production stylesheet:
+- Add new rules in the correct section (base, then DS1, DS2, DS3 override blocks).
+- Merge into existing rule blocks when the selector already exists.
+- Keyframes go near other `@keyframes` definitions.
+- Maintain section order within the file.
+
+## Phase 5: Clean
+
+Remove inline styles from production React components:
+- Delete `style={{...}}` props now covered by CSS.
+- Replace conditional style props with class-based targeting (parent class selectors).
+- Add any new CSS classes needed to support the class-based approach.
+
+## Phase 6: Verify
+
+- [ ] `npx stylelint` on the modified stylesheet -- clean
+- [ ] `npx tsc --noEmit` -- clean (no type errors from removed style props)
+- [ ] Relevant Jest tests pass
+- [ ] Other themes unaffected (all new DS-specific rules are `[data-theme]` scoped)
+- [ ] No `!important` introduced
+- [ ] No raw pixel values where tokens exist
+- [ ] No remaining inline `style=` props for ported properties
+- [ ] **Visual audit with dev-browser** -- render demo markup and production markup side-by-side under the target theme, compare computed styles (height, padding, margin, color, font) to catch inherited-style artifacts that code-level diff misses
+
+## Visual Audit with dev-browser
+
+Code-level diffs catch explicit property gaps but miss inherited-style artifacts (e.g., a wrapper div inheriting a larger line-height, inflating badge height). After porting, use the `dev-browser` skill to:
+
+0. **Float the browser window** -- AeroSpace tiles Chromium by default, constraining the viewport and breaking media query tests. After the dev-browser server starts, run: `aerospace layout floating` (targets the focused window). Verify with `window.innerWidth` in a script before relying on breakpoint-dependent CSS.
+1. **Inject both demo and production markup** into the same page under the target `[data-theme]`.
+2. **Screenshot side-by-side** for visual comparison.
+3. **Extract computed styles** from matching elements and diff key metrics: height, padding, margin, font-size, line-height, color.
+4. **Fix discrepancies** found only through computed-style comparison (not visible in source code).
+
+This step catches the class of bugs where CSS inheritance produces different rendered output even when the declared properties appear identical.
+
+## Workflow
+
+- Run per-theme when porting theme-specific styles (DS1 first, then DS2, then DS3).
+- Each invocation produces a discrete set of numbered fixes.
+- Deferred items (error states, fundamentally different UX patterns, demo-only chrome) are called out but not ported.

--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,15 @@ dependency-violations.html
 CLAUDE.md
 CLAUDE.local.md
 
+# Claude Code cloud (web sessions): commit only these reviewed, shareable files.
+# Everything else under .claude/ (incl. .github_token, settings.local.json) stays ignored.
+!.claude/settings.json
+!/CLAUDE.md
+!.claude/skills/
+!.claude/agents/
+# never commit macOS cruft, even within the re-included dirs above
+.claude/**/.DS_Store
+
 # Codex
 .codex/
 AGENTS.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# Narraitor
+
+Narraitor is an AI-driven narrative RPG framework. You build a world (its theme, attributes, skills, and tone), create characters in it, and play through a generated, choice-driven story with a tracked inventory and journal. It's a single-player web app — there's no backend database; player data lives in the browser (IndexedDB via Zustand persistence), and AI generation runs through the player's own provider key.
+
+## Stack
+
+- **Next.js 15** (App Router) + **React 19**, TypeScript.
+- **Zustand 5** for state — one store per domain under `src/state/` (`characterStore`, `inventoryStore`, `journalStore`, `worldStore`, etc.), persisted to IndexedDB.
+- **Plain CSS + design tokens** for styling: `var(--token)` values plus `clsx` for conditional classes. There is **no Tailwind** (it was removed) — don't add utility classes or reintroduce `cva`/`cn()`.
+- AI generation goes through `src/lib/ai/` (Google Gemini via `@google/genai`), keyed by the player's own provider key rather than a server-held key.
+
+## Layout
+
+`src/` is domain-driven:
+- `app/` — Next.js routes (App Router).
+- `components/` — React components.
+- `state/` — Zustand stores (the source of truth for app data).
+- `lib/` — non-UI logic: `ai/`, `api/`, `design-tokens/`, `generators/`, `devtools/`, feature flags.
+- `services/`, `hooks/`, `utils/`, `types/`, `styles/`, `stories/` (Storybook).
+
+## Commands
+
+- `npm run dev` — dev server on **port 3000** (per-worktree port auto-selected outside the main checkout). Check whether one's already running before starting it.
+- `npm test` — Jest unit/integration suite.
+- `npm run type-check` — `tsc --noEmit`.
+- `npm run lint` — ESLint (Next + test/script globs).
+- `npm run lint:css` — Stylelint over `**/*.css`. Run this after any `.css` edit; CI runs it separately and it'll fail the build if skipped.
+- `npm run build` — production build (includes a Storybook build step).
+
+## Conventions
+
+- **Target the `develop` branch** for PRs, not `main`. `main` is release-only; `develop` is the rolling integration branch.
+- KISS by default, in implementation and in tests — MVP-level tests, not exhaustive coverage. Never rig a test to pass.
+- Style with design tokens, not hardcoded values. Avoid `!important` unless there's truly no alternative.
+- Put an identifying class attribute on components.
+- Look for an existing pattern/utility before adding a new one. One canon version per file — no `simple`/`enhanced` variants.
+
+## Running in Claude Code cloud
+
+Cloud sessions clone this repo fresh, so the `SessionStart` hook in `.claude/settings.json` runs `scripts/install_pkgs.sh` to `npm ci` on startup. Unit tests, type-check, lint, and build all work on the Linux cloud VM.
+
+**Don't run the visual-regression or E2E suites in cloud** (`test:visual`, `test:e2e:*`) — the Playwright baselines are macOS-only and will fail on pixel diffs against a Linux runner. Those belong on a local Mac or the macOS CI job.

--- a/scripts/install_pkgs.sh
+++ b/scripts/install_pkgs.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Installs dependencies in Claude Code cloud (web) sessions only. No-op locally.
+# Wired up via the SessionStart hook in .claude/settings.json.
+[ "$CLAUDE_CODE_REMOTE" = "true" ] || exit 0
+[ -d node_modules ] && exit 0   # cached snapshot / resume: deps already present
+npm ci
+exit 0

--- a/scripts/install_pkgs.sh
+++ b/scripts/install_pkgs.sh
@@ -5,6 +5,7 @@
 # runs outside the repo dir, so npm can't find package-lock.json.
 [ "$CLAUDE_CODE_REMOTE" = "true" ] || exit 0
 cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0   # be cwd-proof; lockfile lives at repo root
-[ -d node_modules ] && exit 0             # cached snapshot / resume: deps present
-npm ci
-exit 0
+# Skip only if a prior install COMPLETED — npm writes node_modules/.package-lock.json
+# on success, so a partial/failed install isn't mistaken for a good one on resume.
+[ -f node_modules/.package-lock.json ] && exit 0
+npm ci   # final command: its exit status becomes the hook's, so failures surface

--- a/scripts/install_pkgs.sh
+++ b/scripts/install_pkgs.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 # Installs dependencies in Claude Code cloud (web) sessions only. No-op locally.
-# Wired up via the SessionStart hook in .claude/settings.json.
+# Wired up via the SessionStart hook in .claude/settings.json, which runs AFTER
+# the repo is cloned. Do NOT run npm ci from the environment setup script — that
+# runs outside the repo dir, so npm can't find package-lock.json.
 [ "$CLAUDE_CODE_REMOTE" = "true" ] || exit 0
-[ -d node_modules ] && exit 0   # cached snapshot / resume: deps already present
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0   # be cwd-proof; lockfile lives at repo root
+[ -d node_modules ] && exit 0             # cached snapshot / resume: deps present
 npm ci
 exit 0


### PR DESCRIPTION
## Description
Sets up the repo so Claude Code on the web (cloud sessions) can work on Narraitor. Cloud sessions clone from GitHub and see only committed files, but this repo gitignores all agent config — so nothing reached the cloud and a session started with no deps and no project context. This commits a minimal, reviewed slice: a `SessionStart` install hook, a project `CLAUDE.md`, and the (audited-clean) project skills/agents.

## Related Issue
N/A — no tracked issue.

## Type of Change
- [x] Documentation update (project `CLAUDE.md`)
- [x] Other: repo tooling for Claude Code cloud sessions

## TDD Compliance
N/A — no application code changed. The diff is `.gitignore`, JSON config, a bash script, and markdown.

## Implementation Notes
- `scripts/install_pkgs.sh` — cloud-only (`CLAUDE_CODE_REMOTE`), idempotent `npm ci`, skips when `node_modules` is present. No-op locally.
- `.claude/settings.json` — committed with a `SessionStart` hook running that script. The personal `additionalWorkingDirectories` moved to the still-ignored `settings.local.json`, so local behavior is unchanged.
- `CLAUDE.md` — concise project guide: stack, layout, commands, target `develop`, and don't run the macOS-only visual suite in cloud.
- `.gitignore` — allowlist carve-out: `.claude/*` stays ignored; re-includes only `settings.json`, `/CLAUDE.md`, and the audited-clean `skills/` + `agents/`. Verified `.github_token` and `settings.local.json` stay ignored, and `.DS_Store` is re-excluded even inside the re-included dirs.
- Cloud scope is unit/build/lint only; Playwright/visual stays on macOS (Darwin-only baselines). No `GEMINI_API_KEY` in the env — runtime AI uses the player's browser key.

## Account/UI follow-up (not in this PR)
Connect GitHub (Claude GitHub App or `/web-setup`) and create a cloud environment at claude.ai/code (Trusted network, no env vars, optional `npm ci` setup script for faster cold starts). Sessions then run against the merged `develop`.

## Testing Instructions
- `bash scripts/install_pkgs.sh; echo $?` -> `0`, no-op locally.
- `git check-ignore .claude/.github_token .claude/settings.local.json` -> both listed (stay ignored).
- `git add --dry-run .claude/` -> stages only `settings.json` + skill/agent `.md` files (no token, no local settings, no `.DS_Store`).
- `python3 -m json.tool .claude/settings.json` -> valid JSON.
- After merge: start a cloud session on `develop`, ask it to run `npm test` / `npm run build`; deps should already be installed by the hook.

## Quality Checks
- [x] JSON config validated (`settings.json`, `settings.local.json`)
- [x] Shell script passes `bash -n`
- [ ] Lint/type-check not run — no TypeScript or lint-covered files changed (only config, a shell script, and markdown); validated JSON directly instead.
- [x] No secrets committed (verified via `git add --dry-run` + `git check-ignore`)

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected
- [x] Self-review of code performed
- [x] No new warnings generated
