### PR TITLE
fix(visual): serve hero images unoptimized under Playwright (#1346)

### DIFF
--- a/src/components/shared/Hero.tsx
+++ b/src/components/shared/Hero.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Image from 'next/image';
+import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
 
 interface HeroProps {
   /** The title to display over the image */
@@ -72,8 +73,14 @@ export const Hero: React.FC<HeroProps> = ({
           width={800}
           height={400}
 
-          // Use unoptimized for data URLs and tests to avoid Next optimization proxy
-          unoptimized={typeof image.url === 'string' && image.url.startsWith('data:')}
+          // Skip Next's optimization proxy for data URLs and under Playwright.
+          // The on-demand optimizer cold-starts slowly on CI and leaves the
+          // banner blank past the visual-test image wait (#1346); serving the
+          // raw file keeps the banner deterministic in tests.
+          unoptimized={
+            isPlaywrightEnv() ||
+            (typeof image.url === 'string' && image.url.startsWith('data:'))
+          }
         />
       )}
 


### PR DESCRIPTION
## Description

E2E Tests (2) has been red on `develop` (pre-existing, not from recent feature work). The failing specs were `worlds-themes` DS1/DS2, and the root cause turned out to be a recurrence of #1346 rather than plain baseline drift.

The Cyberpunk world's banner is a 648KB static PNG (`/visual-assets/world-cyberpunk.png`) rendered through `next/image`. `Hero.tsx` only set `unoptimized` for `data:` URLs, so this banner went through Next's on-demand optimizer, which cold-starts slowly on CI and leaves the banner blank past the spec's 30s image wait. DS3 only passed because it runs last, once the optimizer is warm. The actuals were byte-identical across all three retries (a persistent blank, not a flake), so adopting them as-is would have baked a broken render in.

The fix: the comment above the `unoptimized` line already says *"Use unoptimized for data URLs **and tests**"* -- but the "and tests" half was never implemented. This wires in `isPlaywrightEnv()` so static-asset banners serve as raw files under Playwright, loading deterministically regardless of optimizer warmth.

## Result

All E2E shards + Tutorial Visual Tests are green on this PR. The banner now renders reliably, and the raw-vs-optimized pixel difference stays within the existing visual-diff tolerance across the suite -- so **no baselines needed re-adopting**. (I'd expected a suite-wide re-adoption going in; turned out the diff was sub-threshold everywhere, so the one-line fix was enough.)

manuscript-layout:54 was a one-off flake in the original report -- it was already passing on develop's latest run, so it's untouched here.

## Related Issue

Recurrence of #1346 (the 30s image wait is no longer enough on cold CI). Not using `Closes` -- #1346 is already closed and the keyword doesn't fire on merges to `develop` anyway.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## TDD Compliance
- [x] All tests pass locally (type-check + WorldCard/Hero unit suites) and on CI (full visual suite)
- [x] Test coverage maintained or improved

Note: this is a visual-regression fix -- the "test" here is the Playwright baseline set, verified against macOS CI.

## Implementation Notes

- `Hero.tsx` is presentational and, in this app, only ever renders an image client-side (all world data is client-side IndexedDB, so the banner paints post-hydration). So calling `isPlaywrightEnv()` in render is hydration-safe -- there's no SSR `<img>` for it to mismatch against.
- Outside Playwright, behavior is unchanged: production still uses the optimizer.

## Quality Checks
- [x] Linting passed (only a pre-existing unused-arg warning, not from this change)
- [x] Type checking passed
- [x] No console.log statements in production code

## Testing Instructions

1. `npm run type-check` and `npx jest src/components/WorldCard src/components/shared/Hero` -- green.
2. Visual: macOS CI E2E (1)/(2) + Tutorial Visual Tests are green on this PR. Verify against the CI run, not a local visual run (local Chromium renders banners differently).

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] No new warnings generated
- [x] Accessibility considerations addressed (alt text unchanged)