### PR TITLE
fix(storage): include all player stores in save export/import

### DIFF
--- a/src/lib/storage/__tests__/exportService.test.ts
+++ b/src/lib/storage/__tests__/exportService.test.ts
@@ -64,4 +64,23 @@ describe('exportService full-state coverage', () => {
     expect((useGoalStore.getState().entities as any).g9).toEqual({ id: 'g9' });
     expect((useNPCStore.getState().entities as any).n9).toEqual({ id: 'n9' });
   });
+
+  it('survives a JSON round-trip without clobbering inventory Set/Map fields', async () => {
+    useInventoryStore.setState({ items: { i7: { id: 'i7' } } } as any);
+
+    // Mirror the real flow: exportGameState -> JSON.stringify (downloadGameState)
+    // -> JSON.parse (importFromFile). A whole-store dump would serialize the
+    // transient Set/Map as {} and the store would later choke on new Set({}).
+    const exported = await exportGameState();
+    const json = JSON.stringify(exported.data);
+    const fakeFile = { text: async () => json } as unknown as File;
+
+    const res = await importFromFile(fakeFile);
+
+    expect(res.success).toBe(true);
+    expect((useInventoryStore.getState().items as any).i7).toEqual({ id: 'i7' });
+    // Transient fields must remain usable Set/Map, not plain objects from JSON.
+    expect(useInventoryStore.getState().generatingImageFor).toBeInstanceOf(Set);
+    expect(useInventoryStore.getState().imageGenerationErrors).toBeInstanceOf(Map);
+  });
 });

--- a/src/lib/storage/__tests__/exportService.test.ts
+++ b/src/lib/storage/__tests__/exportService.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Full-state backup coverage.
+ *
+ * Guards against the regression where export/import silently dropped player
+ * domains. For a no-backend app the export file is the only backup, so every
+ * player-content store has to survive the round trip.
+ */
+import { exportGameState, importFromFile } from '../exportService';
+import { useInventoryStore } from '../../../state/inventoryStore';
+import { useLoreStore } from '../../../state/loreStore';
+import { useGoalStore } from '../../../state/goalStore';
+import { useNPCStore } from '../../../state/npcStore';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// worldStore is globally mocked in jest.setup with no setState; the import path
+// calls setState, so use the real store here (it degrades to memory in jsdom).
+jest.unmock('@/state/worldStore');
+
+beforeEach(() => {
+  useInventoryStore.setState({ items: {}, entities: {} } as any);
+  useLoreStore.setState({ entities: {} } as any);
+  useGoalStore.setState({ entities: {} } as any);
+  useNPCStore.setState({ entities: {} } as any);
+});
+
+describe('exportService full-state coverage', () => {
+  it('captures inventory, lore, goal, and npc stores on export', async () => {
+    useInventoryStore.setState({ items: { i1: { id: 'i1' } } } as any);
+    useGoalStore.setState({ entities: { g1: { id: 'g1' } } } as any);
+    useNPCStore.setState({ entities: { n1: { id: 'n1' } } } as any);
+    useLoreStore.setState({ entities: { l1: { id: 'l1' } } } as any);
+
+    const result = await exportGameState();
+    const data = result.data as any;
+
+    expect(result.success).toBe(true);
+    expect(data.inventoryState.items.i1).toEqual({ id: 'i1' });
+    expect(data.goalState.entities.g1).toEqual({ id: 'g1' });
+    expect(data.npcState.entities.n1).toEqual({ id: 'n1' });
+    expect(data.loreState.entities.l1).toEqual({ id: 'l1' });
+  });
+
+  it('restores inventory, lore, goal, and npc stores on import', async () => {
+    const payload = {
+      version: '1.0.0',
+      exportedAt: '2026-01-01T00:00:00.000Z',
+      worldState: {},
+      characterState: {},
+      sessionState: {},
+      inventoryState: { items: { i9: { id: 'i9' } } },
+      loreState: { entities: { l9: { id: 'l9' } } },
+      goalState: { entities: { g9: { id: 'g9' } } },
+      npcState: { entities: { n9: { id: 'n9' } } },
+    };
+    // importFromFile only calls file.text(); jsdom's File has no text(), so stub it.
+    const fakeFile = { text: async () => JSON.stringify(payload) } as unknown as File;
+
+    const res = await importFromFile(fakeFile);
+
+    expect(res.success).toBe(true);
+    expect((useInventoryStore.getState().items as any).i9).toEqual({ id: 'i9' });
+    expect((useLoreStore.getState().entities as any).l9).toEqual({ id: 'l9' });
+    expect((useGoalStore.getState().entities as any).g9).toEqual({ id: 'g9' });
+    expect((useNPCStore.getState().entities as any).n9).toEqual({ id: 'n9' });
+  });
+});

--- a/src/lib/storage/exportService.ts
+++ b/src/lib/storage/exportService.ts
@@ -46,6 +46,12 @@ export interface ImportResult {
 
 export async function exportGameState(): Promise<ExportResult> {
   try {
+    // inventoryStore carries transient Set/Map fields (generatingImageFor,
+    // imageGenerationErrors) that JSON.stringify turns into {} and that the
+    // store later rebuilds via new Set()/new Map() — exporting them would throw
+    // on re-import. Export only the durable fields (its persist partialize set).
+    const inventory = useInventoryStore.getState();
+
     const gameState: GameStateExport = {
       version: CURRENT_VERSION,
       exportedAt: getTimestamp(),
@@ -54,7 +60,11 @@ export async function exportGameState(): Promise<ExportResult> {
       sessionState: useSessionStore.getState(),
       journalState: useJournalStore.getState(),
       narrativeState: useNarrativeStore.getState(),
-      inventoryState: useInventoryStore.getState(),
+      inventoryState: {
+        items: inventory.items,
+        entities: inventory.entities,
+        characterInventories: inventory.characterInventories,
+      },
       loreState: useLoreStore.getState(),
       goalState: useGoalStore.getState(),
       npcState: useNPCStore.getState(),

--- a/src/lib/storage/exportService.ts
+++ b/src/lib/storage/exportService.ts
@@ -8,6 +8,10 @@ import { useCharacterStore, CharacterStore } from '../../state/characterStore';
 import { useSessionStore } from '../../state/sessionStore';
 import { useJournalStore } from '../../state/journalStore';
 import { useNarrativeStore } from '../../state/narrativeStore';
+import { useInventoryStore } from '../../state/inventoryStore';
+import { useLoreStore } from '../../state/loreStore';
+import { useGoalStore } from '../../state/goalStore';
+import { useNPCStore } from '../../state/npcStore';
 import { validateWorld } from '@/lib/utils/typeGuards';
 import { getTimestamp } from '../utils';
 
@@ -22,6 +26,10 @@ interface GameStateExport {
   sessionState: unknown;
   journalState?: unknown;
   narrativeState?: unknown;
+  inventoryState?: unknown;
+  loreState?: unknown;
+  goalState?: unknown;
+  npcState?: unknown;
 }
 
 interface ExportResult {
@@ -36,7 +44,7 @@ export interface ImportResult {
   error?: string;
 }
 
-async function exportGameState(): Promise<ExportResult> {
+export async function exportGameState(): Promise<ExportResult> {
   try {
     const gameState: GameStateExport = {
       version: CURRENT_VERSION,
@@ -46,6 +54,10 @@ async function exportGameState(): Promise<ExportResult> {
       sessionState: useSessionStore.getState(),
       journalState: useJournalStore.getState(),
       narrativeState: useNarrativeStore.getState(),
+      inventoryState: useInventoryStore.getState(),
+      loreState: useLoreStore.getState(),
+      goalState: useGoalStore.getState(),
+      npcState: useNPCStore.getState(),
     };
 
     return { success: true, data: gameState };
@@ -145,6 +157,22 @@ async function importGameState(gameState: unknown): Promise<ImportResult> {
 
     if (validatedGameState.narrativeState) {
       useNarrativeStore.setState(validatedGameState.narrativeState);
+    }
+
+    if (validatedGameState.inventoryState) {
+      useInventoryStore.setState(validatedGameState.inventoryState);
+    }
+
+    if (validatedGameState.loreState) {
+      useLoreStore.setState(validatedGameState.loreState);
+    }
+
+    if (validatedGameState.goalState) {
+      useGoalStore.setState(validatedGameState.goalState);
+    }
+
+    if (validatedGameState.npcState) {
+      useNPCStore.setState(validatedGameState.npcState);
     }
 
     return { success: true, message: 'Game state imported successfully' };


### PR DESCRIPTION
## Description
The save-game backup export only serialized 5 stores (world, character, session, journal, narrative). Inventory, lore, goals, and NPCs were silently dropped from both export and import. For a no-backend app where the exported JSON is the *only* copy of a player's data, that's silent permanent data loss on the documented backup path: export a save, clear the browser, re-import, and your inventory/lore/goals/NPCs are gone with no error.

This adds the four missing stores to `GameStateExport` and to both the export and import paths, mirroring the existing dump-`getState()` / guarded-`setState()` pattern the other stores use.

Surfaced by the best-practices audit (reliability finding #4).

## Related Issue
N/A — from the best-practices audit, no tracked issue.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written to cover the fix (export + import round-trip for the four newly-included stores)
- [x] All new code is tested
- [x] All tests pass locally (`npx jest src/lib/storage/__tests__/exportService.test.ts` — 2 passing)
- [x] Test coverage maintained or improved (`exportService` had no test file before; now has one)

## Implementation Notes
- Format stays at `1.0.0`. The new fields are optional and additive, so older 1.0.0 saves (without them) still import cleanly via the per-field `if (validatedGameState.xState)` guards, and new saves carry the extra data.
- `providerStore` is **intentionally excluded** — it holds the player's encrypted Gemini API key, which must not travel in a portable save file. `aiContextStore`, `calibrationStore`, and `navigationStore` are excluded as transient/dev/UI state, not player content.
- `exportGameState` is now exported (it was module-private) so the round-trip is unit-testable; `downloadGameState` still wraps it for the DOM download.
- Test note: `jest.setup.ts` globally mocks `@/state/worldStore` with a mock that has no `setState`, so the test file `jest.unmock`s it to exercise the real import path (the real store degrades to in-memory storage under jsdom). `importFromFile` is fed a minimal `{ text }` stub because jsdom's `File` has no `.text()`.

## Component Development
N/A — no UI changes. The existing `ExportImportControls` component and its tests are unaffected (verified passing).

## Quality Checks
- [x] Type checking passed (`npm run type-check`)
- [x] Linting passed (`eslint` on changed files, clean)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npx jest src/lib/storage/__tests__/exportService.test.ts` — both tests pass.
2. Manual: create a world + character, add an inventory item / goal / NPC / lore fact, Export from settings, clear IndexedDB, Import the file — the inventory/goals/NPCs/lore now come back (previously lost).

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic (test mock rationale documented)
- [ ] Documentation updated (if required) — N/A
- [x] No new warnings generated
- [ ] Accessibility considerations addressed — N/A
