### PR TITLE
fix(design-system): darken DS1/DS2 success green so Play hits AA

### DIFF
--- a/src/lib/theme/themes/ds1.css
+++ b/src/lib/theme/themes/ds1.css
@@ -51,7 +51,9 @@
   --radius: 0.5rem;
 
   /* Extended semantic tokens */
-  --success: 142 71% 45%;
+
+  /* Darkened from 45% so the filled .button-success (Play) carries white text at WCAG AA: white on #16833E = 4.83:1. See #1387. Dark mode is left to #1379. */
+  --success: 142 71% 30%;
   --success-foreground: 210 40% 98%;
   --success-text: 154 86% 20%;
   --success-background: 142 69% 83%;

--- a/src/lib/theme/themes/ds2.css
+++ b/src/lib/theme/themes/ds2.css
@@ -51,7 +51,9 @@
   --radius: 0.75rem;
 
   /* Extended semantic tokens */
-  --success: 142 71% 45%;
+
+  /* Darkened from 45% so the filled .button-success (Play) carries white text at WCAG AA: white on #16833E = 4.83:1. See #1387. Dark mode is left to #1379. */
+  --success: 142 71% 30%;
   --success-foreground: 210 40% 98%;
   --success-text: 154 86% 20%;
   --success-background: 142 50% 88%;


### PR DESCRIPTION
## Description

The filled green "Play" button — the primary action across the app — had white text on a green that was too light to read at the WCAG AA bar. White on `rgb(33 196 93)` (`#21C45D`) comes out at 2.30:1, well under the 4.5:1 floor for normal text and below even the 3:1 large-text bar.

The fix is a single-token darken. `.button-success` in [globals.css](src/app/globals.css) fills from `--color-success`, which for DS1 and DS2 resolves from `--success: 142 71% 45%`. Dropping that to `142 71% 30%` (`#16833E`) lands white-on-green at 4.83:1 — same vivid hue and saturation, just a deeper green, right in the ballpark of DS3's existing accessible green. DS3 already overrides `--color-success` to its own forest green and was passing at 4.86:1, so it's left untouched.

Two things deliberately left alone: DS3 (already AA) and dark mode. The dark-mode green is #1379's territory — its acceptance criteria already covers solid Play buttons in dark mode, and the fix there is different (it darkens the text, not the accent). This change only touches the light-mode `--success` in DS1/DS2.

Worth noting the token feeds a few other things — success text, the 10% pale tint, the workshop filled badge — but those all either improve with a darker green (better contrast on light surfaces) or don't care (the pale `--success-background/border/muted` tints are separate tokens). Nothing regresses in light mode.

## Related Issue
Closes #1387

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

This is a design-token value change, so there's no unit test to write first — CSS custom-property values aren't covered by the Jest suite, and no existing test asserts on the green. Verification is the computed-contrast check below plus the lint/type-check passes. The full suite still passes locally.

## Implementation Notes

Confirmed the darkened token against the running dev server (not just the math) by injecting a real `.button-success` element under each theme in forced light mode and reading the computed background and text colors:

| Theme (light mode) | Before | After |
| --- | --- | --- |
| DS1 | white on `rgb(33 196 93)` = 2.30:1 (fail) | white on `rgb(22 131 62)` = 4.83:1 (pass) |
| DS2 | white on `rgb(33 196 93)` = 2.30:1 (fail) | white on `rgb(22 131 62)` = 4.83:1 (pass) |
| DS3 | white on `rgb(74 124 89)` = 4.86:1 (pass) | unchanged, 4.86:1 |

Heads up on visual baselines: this changes the rendered color of every filled Play/`success` button, so any visual-regression baseline that frames one (world cards, dashboard, world/character detail) will diff. Most of those overlap the CI-adopted baseline set, so they're best re-adopted from the macOS-CI `e2e-test-failures` artifact rather than regenerated locally — local regen bakes in macOS-vs-Linux pixel differences for that set. The visual job isn't a required check, so it won't block the merge; flagging it so the diffs aren't a surprise.

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

No component changes — this is a token value, and the existing `success` button stories render it automatically.

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

`npm run lint`, `npm run lint:css`, and `npm run type-check` all pass. No dependency changes, so nothing for the security audit.

## Testing Instructions

1. `npm run dev`, open the app in DS1 or DS2 with light mode.
2. Find any filled Play CTA — header "Play", a world card's "Play", `/worlds/[id]` "Play in World", `/characters/[id]` "Play with Character".
3. Check the green fill against the white label with a contrast checker or `bdg` computed styles — it should now read ~4.83:1 instead of 2.30:1.
4. Sanity-check DS3 still looks the same (its green is untouched).

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
