### PR TITLE
fix(storybook): repair badge, color swatch, and game-session stories

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -19,6 +19,8 @@ import '../src/app/globals.css';
 import '../src/app/workshop.css';
 import '../src/app/wizard.css';
 import '../src/app/dashboard.css';
+import '../src/app/badge.css';
+import '../src/lib/theme/themes/_shared-tokens.css';
 import '../src/lib/theme/themes/ds1.css';
 import '../src/lib/theme/themes/ds2.css';
 import '../src/lib/theme/themes/ds3.css';

--- a/src/stories/00-foundation/DesignSystemShowcase.stories.tsx
+++ b/src/stories/00-foundation/DesignSystemShowcase.stories.tsx
@@ -43,19 +43,32 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 // Color Swatch Component
+//
+// Render the color as a div `background` rather than an SVG `<rect fill>`:
+// a percentage-sized SVG with a square viewBox stretched each swatch to the
+// full page width (~1393px tall), ballooning the showcase to ~27,000px.
 const ColorSwatch = ({ color, name }: { color: string; name: string }) => (
-  <div>
-    <div>
-      <svg
-        width="100%"
-        height="100%"
-        viewBox="0 0 32 32"
-        role="img"
-        aria-label={`${name} swatch`}
-      >
-        <rect x="0" y="0" width="32" height="32" fill={color} />
-      </svg>
-    </div>
+  <div
+    className="ds-color-swatch"
+    style={{
+      display: 'inline-block',
+      verticalAlign: 'top',
+      marginRight: 'var(--space-4)',
+      marginBottom: 'var(--space-3)',
+    }}
+  >
+    <div
+      className="ds-color-swatch-chip"
+      style={{
+        background: color,
+        width: '3rem',
+        height: '3rem',
+        borderRadius: 'var(--radius-md)',
+        border: '1px solid var(--color-border)',
+      }}
+      role="img"
+      aria-label={`${name} swatch`}
+    />
     <div>
       <div>{name}</div>
       <div>{color}</div>
@@ -93,13 +106,21 @@ export const CompleteShowcase: Story = {
           <h3>Primitive Colors</h3>
           <div>
             {Object.entries(primitiveColors).map(([colorName, shades]) =>
-              Object.entries(shades as Record<string, string>).map(
-                ([shade, color]) => (
-                  <ColorSwatch
-                    key={`${colorName}-${shade}`}
-                    color={color}
-                    name={`${colorName}-${shade}`}
-                  />
+              // `white`/`black` are bare strings, not shade maps. Iterating a
+              // string with Object.entries yields its characters ("#", "f", ...),
+              // which rendered junk swatches with an invalid "#" fill — render a
+              // single swatch for them instead.
+              typeof shades === 'string' ? (
+                <ColorSwatch key={colorName} color={shades} name={colorName} />
+              ) : (
+                Object.entries(shades as Record<string, string>).map(
+                  ([shade, color]) => (
+                    <ColorSwatch
+                      key={`${colorName}-${shade}`}
+                      color={color}
+                      name={`${colorName}-${shade}`}
+                    />
+                  )
                 )
               )
             )}

--- a/src/stories/00-foundation/DesignTokens.stories.tsx
+++ b/src/stories/00-foundation/DesignTokens.stories.tsx
@@ -13,13 +13,32 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 // Color Swatch Component
+//
+// Render the color as a div `background` rather than an SVG `<rect fill>`:
+// the percentage-sized SVG with a square viewBox stretched each swatch to the
+// full page width, blowing up the page height.
 const ColorSwatch = ({ color, name, description }: { color: string; name: string; description?: string }) => (
-  <div>
-    <div>
-    <svg width="100%" height="100%" viewBox="0 0 48 48" role="img" aria-label={`${name} swatch`}>
-        <rect x="0" y="0" width="48" height="48" fill={color} />
-      </svg>
-    </div>
+  <div
+    className="ds-color-swatch"
+    style={{
+      display: 'inline-block',
+      verticalAlign: 'top',
+      marginRight: 'var(--space-4)',
+      marginBottom: 'var(--space-3)',
+    }}
+  >
+    <div
+      className="ds-color-swatch-chip"
+      style={{
+        background: color,
+        width: '3rem',
+        height: '3rem',
+        borderRadius: 'var(--radius-md)',
+        border: '1px solid var(--color-border)',
+      }}
+      role="img"
+      aria-label={`${name} swatch`}
+    />
     <div>
       <div>{name}</div>
       <div>{color}</div>
@@ -151,11 +170,18 @@ export const ContextualTokens: Story = {
                 <div>
                   bg: {colors.background} | border: {colors.border}
                 </div>
-                <div>
-                <svg width="100%" height="32" viewBox="0 0 200 32" role="img" aria-label={`${category} example`}>
-                    <rect x="0" y="0" width="200" height="32" fill={colors.background} stroke={colors.border} />
-                  </svg>
-                </div>
+                <div
+                  className="ds-lore-swatch"
+                  style={{
+                    background: colors.background,
+                    border: `1px solid ${colors.border}`,
+                    width: '100%',
+                    height: '32px',
+                    borderRadius: 'var(--radius-sm)',
+                  }}
+                  role="img"
+                  aria-label={`${category} example`}
+                />
               </div>
             ))}
           </div>

--- a/src/stories/05-pages/game-session/ActiveGameSession.stories.tsx
+++ b/src/stories/05-pages/game-session/ActiveGameSession.stories.tsx
@@ -6,6 +6,7 @@ import { NarrativeSegment, Decision } from '@/types/narrative.types';
 import { useNarrativeStore } from '@/state/narrativeStore';
 import { useSessionStore } from '@/state/sessionStore';
 import { useCharacterStore } from '@/state/characterStore';
+import { ToastProvider } from '@/components/ui/toast';
 import { getTimestamp } from '@/lib/utils';
 
 const meta: Meta<typeof ActiveGameSession> = {
@@ -27,6 +28,8 @@ const meta: Meta<typeof ActiveGameSession> = {
     },
   },
   decorators: [
+    // ActiveGameSession's useAutoSave calls useToast, so every story needs a ToastProvider ancestor.
+    (Story) => <ToastProvider><Story /></ToastProvider>,
     (Story) => {
       // Reset stores before each story and clear any endings to prevent endscreen display
       useNarrativeStore.setState({


### PR DESCRIPTION
## Description

Three Storybook-layer fixes from the 2026-06-08 QA crawl. All are story/config changes — no production component logic was touched. Each one I confirmed in a headless Storybook (computed styles + page height + console), then spot-checked visually.

- **Badge rendered as unstyled text.** `preview.tsx` imported the theme CSS but never `badge.css`. Adding it wasn't enough on its own: the badge also leans on `--space-*` and `--radius-full`, which live in `_shared-tokens.css` (imported by `layout.tsx` in the real app but missing from Storybook), so padding and radius were collapsing to `0`. Imported both. Badge now renders with the right background, pill radius (`9999px`), and padding (`8px`).
- **Color swatches rendered black and blew the showcase up to ~27,000px.** Two causes: the swatch SVG used `width/height: 100%` over a square `viewBox`, stretching each swatch to the full page width (~1393px tall each); and the primitive map ran `Object.entries()` over the bare `white`/`black` *strings*, iterating them character-by-character — that's where the invalid `"#"` fill came from. Render swatches as sized `<div>`s (color as `background`) that flow in wrapping rows, and skip the string primitives. Showcase is ~5,500px now and every swatch shows its real color.
- **ActiveGameSession crashed** with `useToast must be used within a ToastProvider` (`useAutoSave` needs it). Wrapped the meta-level decorators in `ToastProvider`; all 5 stories render, and the header shows "SAVED AT…", confirming autosave/toast is live.

## Related Issue
Closes #1389

(PR targets `develop`, so the keyword won't auto-close — I'll close it manually after merge.)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Component Development
- [x] Storybook stories created/updated
- [x] Visual consistency verified

## Implementation Notes
The issue's suggested root cause for the swatches (CSS variables not resolving in SVG `fill`) turned out not to be it — the token values are plain hex. The real culprits were the percentage-sized square SVG and the string-iteration over `white`/`black`. Verified in a headless browser against the worktree's own Storybook on a separate port (the shared 6006 was serving a different worktree).

## Quality Checks
- [x] Linting passed (`npm run lint`)
- [x] Type checking passed (`npm run type-check`)
- [x] No console.log statements in production code

## Testing Instructions
1. `npm run storybook`
2. `01-Atoms/display/Badge → Variants` — colored pills, not plain text.
3. `00-Foundation/Design System Showcase → Complete Design System` — Color System shows real colors; page is a normal length.
4. `00-Foundation/Design Tokens → Primitive Tokens` — swatches render in rows with correct colors.
5. `05-Pages/game-session/ActiveGameSession` — all 5 stories load without the ToastProvider crash.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] No new warnings generated
