### PR TITLE
fix(ui): mobile header overflow, settings breadcrumb + import polish

### DIFF
--- a/src/app/workshop.css
+++ b/src/app/workshop.css
@@ -926,6 +926,13 @@
     display: none;
   }
 
+  /* Drop the secondary help icon on mobile too (alongside breadcrumbs + recent)
+     so the "Workshop" title and the primary CTA no longer collide under
+     space-between at narrow widths (<= ~415px). */
+  .workshop-context-header .tutorial-menu {
+    display: none;
+  }
+
   .workshop-workspace-main {
     min-height: calc(100vh - 3.5rem);
   }
@@ -1028,6 +1035,17 @@
   display: flex;
   align-items: center;
   gap: var(--space-3);
+}
+
+/* Below the hamburger breakpoint the mobile drawer owns Theme/Tutorial/Recent,
+   the world switcher, and the primary CTA, so the inline actions cluster is
+   redundant and its intrinsic width overflows narrow viewports. Hide it there;
+   the drawer carries everything (ThemeMenu added there for parity). Placed
+   after the base rule so equal-specificity source order keeps display:none. */
+@media (width <= 768px) {
+  .header-nav-actions {
+    display: none;
+  }
 }
 
 /* Brand lockup: icon + serif wordmark, no link underline. */

--- a/src/components/Navigation/MobileNavigationMenu.tsx
+++ b/src/components/Navigation/MobileNavigationMenu.tsx
@@ -7,6 +7,7 @@ import { LogoIcon, LogoText } from '@/components/ui/Logo';
 import { Button } from '@/components/ui/button';
 import { getGenreLabel } from '@/lib/constants/genres';
 import { TutorialMenu } from './TutorialMenu';
+import { ThemeMenu } from './ThemeMenu';
 import { X, Globe, User, Settings, Check, Play, Plus } from 'lucide-react';
 
 const SWIPE_THRESHOLD = 100;
@@ -123,7 +124,8 @@ export const MobileNavigationMenu = React.memo(function MobileNavigationMenu({
           <LogoText size="sm" className="app-wordmark" />
         </div>
         <div className="mobile-nav-header-actions">
-          {/* Tutorial menu for mobile feature parity with desktop */}
+          {/* Appearance + tutorial menus for mobile parity with the desktop header */}
+          <ThemeMenu />
           <TutorialMenu />
           <Button
             onClick={onClose}

--- a/src/components/Navigation/TutorialMenu.tsx
+++ b/src/components/Navigation/TutorialMenu.tsx
@@ -53,7 +53,7 @@ export function TutorialMenu() {
   };
 
   return (
-    <div ref={dropdownRef}>
+    <div ref={dropdownRef} className="tutorial-menu">
       <Button
         onClick={() => setIsOpen(!isOpen)}
         variant="ghost"

--- a/src/components/Navigation/__tests__/MobileNavigationMenu.test.tsx
+++ b/src/components/Navigation/__tests__/MobileNavigationMenu.test.tsx
@@ -22,8 +22,12 @@ jest.mock('../TutorialMenu', () => ({
   TutorialMenu: () => <div data-testid="tutorial-menu">Tutorials</div>,
 }));
 
+jest.mock('../ThemeMenu', () => ({
+  ThemeMenu: () => <div data-testid="theme-menu">Appearance</div>,
+}));
+
 describe('MobileNavigationMenu', () => {
-  it('shows tutorial menu when mobile menu is open', () => {
+  it('shows appearance and tutorial menus when mobile menu is open', () => {
     render(
       <MobileNavigationMenu
         isOpen={true}
@@ -32,6 +36,7 @@ describe('MobileNavigationMenu', () => {
       />
     );
 
+    expect(screen.getByTestId('theme-menu')).toBeInTheDocument();
     expect(screen.getByTestId('tutorial-menu')).toBeInTheDocument();
   });
 });

--- a/src/components/shared/ExportImportControls.tsx
+++ b/src/components/shared/ExportImportControls.tsx
@@ -111,9 +111,8 @@ export function ExportImportControls({ className = '' }: ExportImportControlsPro
         </Button>
 
         <div className="settings-export-import-files">
-          <label htmlFor="import-file" >
-            Import Game Data
-          </label>
+          {/* Visually hidden: the styled Button below is the trigger (clicks this
+              via ref). Kept in the DOM with an aria-label for assistive tech. */}
           <input
             id="import-file"
             ref={fileInputRef}
@@ -121,7 +120,7 @@ export function ExportImportControls({ className = '' }: ExportImportControlsPro
             accept=".json"
             onChange={handleFileChange}
             disabled={isLoading}
-
+            className="sr-only"
             aria-label="Import game data from file"
           />
           <Button

--- a/src/utils/__tests__/routeUtils.test.ts
+++ b/src/utils/__tests__/routeUtils.test.ts
@@ -1,0 +1,29 @@
+import { buildBreadcrumbSegments } from '../routeUtils';
+
+describe('buildBreadcrumbSegments', () => {
+  const worlds = { 'world-1': { id: 'world-1', name: 'Eldoria' } };
+  const characters = {};
+
+  it('returns no segments on the worlds home route', () => {
+    expect(buildBreadcrumbSegments('/worlds', worlds, characters, null)).toEqual([]);
+  });
+
+  it('builds Worlds > <world name> for a world detail route', () => {
+    const segs = buildBreadcrumbSegments('/worlds/world-1', worlds, characters, 'world-1');
+    expect(segs.map((s) => s.label)).toEqual(['Worlds', 'Eldoria']);
+  });
+
+  it('adds a Settings segment on /settings', () => {
+    const segs = buildBreadcrumbSegments('/settings', worlds, characters, null);
+    expect(segs.map((s) => s.label)).toEqual(['Worlds', 'Settings']);
+    expect(segs[segs.length - 1]).toMatchObject({ label: 'Settings', isCurrentPage: true });
+  });
+
+  it('adds Settings > Providers on /settings/providers', () => {
+    const segs = buildBreadcrumbSegments('/settings/providers', worlds, characters, null);
+    expect(segs.map((s) => s.label)).toEqual(['Worlds', 'Settings', 'Providers']);
+    expect(segs[segs.length - 1]).toMatchObject({ label: 'Providers', isCurrentPage: true });
+    // The parent Settings crumb should not be marked current
+    expect(segs.find((s) => s.label === 'Settings')?.isCurrentPage).toBe(false);
+  });
+});

--- a/src/utils/routeUtils.ts
+++ b/src/utils/routeUtils.ts
@@ -132,6 +132,23 @@ export function buildBreadcrumbSegments(
       });
     }
   }
-  
+
+  // Handle settings routes (Worlds stays the home crumb, as for every page)
+  if (pathname.startsWith('/settings')) {
+    segments.push({
+      label: 'Settings',
+      href: '/settings',
+      isCurrentPage: pathname === '/settings'
+    });
+
+    if (pathname.startsWith('/settings/providers')) {
+      segments.push({
+        label: 'Providers',
+        href: '/settings/providers',
+        isCurrentPage: pathname === '/settings/providers'
+      });
+    }
+  }
+
   return segments;
 }


### PR DESCRIPTION
## Description

Four fixes from the 2026-06-08 visual crawl, all live-verified at 375/400px and desktop:

- **Header overflow on mobile** (#1395): the inline `.header-nav-actions` cluster (Appearance/Tutorial/Recent menus, world switcher, CTA) never collapsed under the hamburger, so it overflowed ~95px at 375px. Hidden at `<=768px`; `ThemeMenu` moved into the mobile drawer for parity since the drawer already carried the rest.
- **Workshop header overlap** (#1396): at `<=415px` the help icon overlapped the "Workshop" title. Hidden on mobile alongside the already-hidden breadcrumbs/recent. Gave `TutorialMenu` a `.tutorial-menu` class to target it (it had no identifying class).
- **Settings breadcrumb** (#1397): `/settings` showed only "Worlds". Added a `/settings` branch to `buildBreadcrumbSegments`, so it reads "Worlds > Settings" / "Worlds > Settings > Providers".
- **Settings import control** (#1398): the raw native file input ("Choose File") was visible next to a duplicate "Import Game Data" label. Hid the input with the existing `.sr-only`; the styled button is the sole trigger.

## Related Issue
Closes #1395, #1396, #1397, #1398

(These won't auto-close on merge to `develop` — closing manually after merge.)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## TDD Compliance
- [ ] Tests written before implementation
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Added a `buildBreadcrumbSegments` unit test (the function had none) and extended the `MobileNavigationMenu` test for the drawer's Appearance menu. The CSS changes are verified live (computed widths/overlap) rather than unit-tested.

## Implementation Notes

- The header fix is gated behind `@media (width <= 768px)`, placed *after* the base `.header-nav-actions` rule so equal-specificity source order keeps `display:none` (placing it before let the base `display:flex` win).
- The mobile drawer now includes `ThemeMenu` so Appearance stays reachable on phones (the drawer already had Tutorial, nav, world switch, and the CTA).
- Desktop rendering is untouched: F1/F2 are mobile-only media rules. F3/F4 affect the settings page at all widths.

## Screenshots

Before/after, verified live via the dev server:

- **F1 @375px** - before: `.header-nav-actions` right edge 471px, scrollWidth 470 (~95px overflow), CTA clipped. After: actions `display:none`, scrollWidth 375, overflow 0 (hamburger + brand only).
- **F2 @400px** - before: title right 136px vs help-icon left 117px (~18px overlap). After: help icon hidden, ~8px gap, no overlap.
- **F3** - `/settings`: "Worlds" -> "Worlds > Settings"; `/settings/providers` -> "Worlds > Settings > Providers".
- **F4** - `/settings` import: raw "Choose File" + duplicate label -> single styled "Import Game Data" button (input now 1x1 sr-only).

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [x] No console.log statements in production code
- [x] No unhandled promises

`npm run type-check`, eslint (changed files), and stylelint (workshop.css) all clean.

## Testing Instructions

1. `/` at 375px: header shows only hamburger + brand, no horizontal scroll; open the drawer and confirm Appearance + Tutorial menus are present.
2. `/settings` at `<=415px`: no overlap between "Workshop" and the CTA; the help icon is hidden.
3. `/settings` and `/settings/providers`: the breadcrumb includes the Settings segment.
4. `/settings` -> Data Management: one "Import Game Data" button, no raw "Choose File".

## Checklist
- [x] Code follows the project's coding standards
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] No new warnings generated
- [x] Accessibility considerations addressed

Note on visual baselines: F1/F2 are mobile-only media rules (desktop baselines unaffected); F3/F4 change the settings page. Adopt any visual-regression diffs from the macOS-CI artifact per the usual process (E2E is non-blocking).
