### PR TITLE
fix(design-system): showcase dark mode + Storybook story hygiene

### DIFF
--- a/src/app/dev/design-system-2/design-system-2.css
+++ b/src/app/dev/design-system-2/design-system-2.css
@@ -446,12 +446,17 @@
 
 .ds2-palette-band {
   flex: 1;
+  /* Allow bands to shrink below their nowrap label width; without this,
+     min-width:auto lets 8 labels sum past the strip and spill the band
+     ~133px past the viewport (clipped, not scrolled, by .ds2 overflow-x). */
+  min-width: 0;
   position: relative;
   transition: flex 0.4s cubic-bezier(0.19, 1, 0.22, 1);
   cursor: default;
   display: flex;
   align-items: flex-end;
   padding: var(--space-2);
+  overflow: hidden;
 }
 
 .ds2-palette-band:hover {

--- a/src/app/dev/design-system/_ui/ComponentShowcase.tsx
+++ b/src/app/dev/design-system/_ui/ComponentShowcase.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { clsx } from 'clsx';
 import { Search, Info, AlertTriangle, CheckCircle2, Bell } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -38,6 +39,7 @@ import { DataTable } from '@/components/ui/data-table';
 import { CollapsibleSection } from '@/components/ui/CollapsibleSection';
 import type { ColumnDef } from '@tanstack/react-table';
 import type { DSTheme } from './DSToggle';
+import { useResolvedDark } from './useResolvedDark';
 import './component-showcase.css';
 
 const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
@@ -101,9 +103,14 @@ export function ComponentShowcase({ theme }: { theme: DSTheme }) {
   const [tracking, setTracking] = useState('investigate');
   const [spoilers, setSpoilers] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
+  const isDark = useResolvedDark();
 
   return (
-    <div className="ds-components" data-theme={theme} data-testid="ds-components">
+    <div
+      className={clsx('ds-components', isDark && 'dark')}
+      data-theme={theme}
+      data-testid="ds-components"
+    >
       {/* Buttons */}
       <section className="dsc-group" aria-label="Button primitive">
         <h3 className="dsc-group-title">Button</h3>

--- a/src/app/dev/design-system/_ui/OverlayShowcase.tsx
+++ b/src/app/dev/design-system/_ui/OverlayShowcase.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { useState } from 'react';
+import { clsx } from 'clsx';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { SimpleModal } from '@/components/shared/SimpleModal';
 import { PreviewModal } from '@/components/shared/PreviewModal/PreviewModal';
 import type { DSTheme } from './DSToggle';
+import { useResolvedDark } from './useResolvedDark';
 // Showcase layout classes (dso-group/dso-row/dso-preview) live in the shared
 // component showcase stylesheet. The modals themselves are styled in production
 // (dialog.css), not here.
@@ -26,9 +28,14 @@ import './component-showcase.css';
 export function OverlayShowcase({ theme }: { theme: DSTheme }) {
   const [simpleOpen, setSimpleOpen] = useState(false);
   const [previewOpen, setPreviewOpen] = useState(false);
+  const isDark = useResolvedDark();
 
   return (
-    <div className="ds-overlay" data-theme={theme} data-testid="ds-overlay">
+    <div
+      className={clsx('ds-overlay', isDark && 'dark')}
+      data-theme={theme}
+      data-testid="ds-overlay"
+    >
       {/* SimpleModal — the app's standard modal wrapper */}
       <section className="dso-group" aria-label="SimpleModal composition">
         <h3 className="dso-group-title">SimpleModal</h3>

--- a/src/app/dev/design-system/_ui/SessionShowcase.tsx
+++ b/src/app/dev/design-system/_ui/SessionShowcase.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { clsx } from 'clsx';
 import { Button } from '@/components/ui/button';
 import { ManuscriptSessionShell } from '@/components/GameSession/ManuscriptSessionShell';
 import { ManuscriptFloatingHud } from '@/components/GameSession/ManuscriptFloatingHud';
@@ -13,6 +14,7 @@ import { useNPCStore } from '@/state/npcStore';
 import type { NPC } from '@/types/npc.types';
 import type { Decision, NarrativeSegment } from '@/types/narrative.types';
 import type { DSTheme } from './DSToggle';
+import { useResolvedDark } from './useResolvedDark';
 // Showcase layout classes (dso-group/dso-row) live in the shared component
 // showcase stylesheet. The session surface itself is styled in production
 // (manuscript-session.css), not here.
@@ -206,6 +208,7 @@ export function SessionShowcase({
   const [open, setOpen] = useState(defaultOpen);
   const [isCharacterOpen, setIsCharacterOpen] = useState(false);
   const characterButtonRef = useRef<HTMLButtonElement>(null);
+  const isDark = useResolvedDark();
 
   // Seed demo NPCs so the real SceneStatus resolves participant names (the
   // canon path: SceneStatus reads npcStore). Idempotent, demo-only ids.
@@ -225,7 +228,11 @@ export function SessionShowcase({
   const latestSegment = DEMO_SEGMENTS[DEMO_SEGMENTS.length - 1];
 
   return (
-    <div className="ds-session" data-theme={theme} data-testid="ds-session">
+    <div
+      className={clsx('ds-session', isDark && 'dark')}
+      data-theme={theme}
+      data-testid="ds-session"
+    >
       {showLauncher && (
         <section className="dso-group" aria-label="Game session composition">
           <h3 className="dso-group-title">Game Session</h3>

--- a/src/app/dev/design-system/_ui/useResolvedDark.ts
+++ b/src/app/dev/design-system/_ui/useResolvedDark.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Tracks whether the page is currently in dark mode by mirroring the `.dark`
+ * class on <html> (issue: DS showcase dark-mode bug).
+ *
+ * The design-system showcase wrappers (`.ds-components`, `.ds-overlay`,
+ * `.ds-session`) re-scope `data-theme` onto a local <div>. The theme token CSS
+ * scopes its dark overrides to the same element — `[data-theme="dsX"].dark` —
+ * so a wrapper that carries `data-theme` but not `.dark` never picks up the
+ * dark tokens, even though <html> is dark. These wrappers use this hook to also
+ * carry `.dark` so the dark overrides compose inside the forced subtree.
+ *
+ * We read `.dark` off <html> rather than `useTheme().resolvedColorScheme`
+ * because the standalone DS pages have their own local Light/Dark toggle that
+ * mutates `document.documentElement.classList` directly (bypassing the
+ * ThemeProvider). `<html>.dark` is the one signal every writer converges on —
+ * the global ThemeProvider effect, system-preference changes, and the page's
+ * own toggle button. A MutationObserver on the class attribute catches them all
+ * reactively while the page stays open.
+ */
+export function useResolvedDark(): boolean {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const sync = () => setIsDark(root.classList.contains('dark'));
+
+    sync();
+
+    const observer = new MutationObserver(sync);
+    observer.observe(root, { attributes: true, attributeFilter: ['class'] });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return isDark;
+}

--- a/src/stories/01-atoms/forms/inputs/Checkbox.stories.tsx
+++ b/src/stories/01-atoms/forms/inputs/Checkbox.stories.tsx
@@ -30,12 +30,14 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     checked: false,
+    label: 'Enable option',
   },
 };
 
 export const Checked: Story = {
   args: {
     checked: true,
+    label: 'Enable option',
   },
 };
 

--- a/src/stories/01-atoms/forms/inputs/Input.stories.tsx
+++ b/src/stories/01-atoms/forms/inputs/Input.stories.tsx
@@ -38,6 +38,7 @@ type Story = StoryObj<typeof Input>;
 export const Default: Story = {
   args: {
     placeholder: 'Enter your name',
+    'aria-label': 'Name',
   },
 };
 
@@ -76,6 +77,7 @@ export const Disabled: Story = {
     placeholder: 'Disabled input',
     disabled: true,
     value: 'This input is disabled',
+    'aria-label': 'Disabled field',
   },
 };
 
@@ -83,20 +85,20 @@ export const Types: Story = {
   render: () => (
     <div>
       <div>
-        <Label>Text Input</Label>
-        <Input type="text" placeholder="Enter text" />
+        <Label htmlFor="text-input">Text Input</Label>
+        <Input id="text-input" type="text" placeholder="Enter text" />
       </div>
       <div>
-        <Label>Email Input</Label>
-        <Input type="email" placeholder="Enter email" />
+        <Label htmlFor="email-input">Email Input</Label>
+        <Input id="email-input" type="email" placeholder="Enter email" />
       </div>
       <div>
-        <Label>Password Input</Label>
-        <Input type="password" placeholder="Enter password" />
+        <Label htmlFor="password-input">Password Input</Label>
+        <Input id="password-input" type="password" placeholder="Enter password" />
       </div>
       <div>
-        <Label>Number Input</Label>
-        <Input type="number" placeholder="Enter number" />
+        <Label htmlFor="number-input">Number Input</Label>
+        <Input id="number-input" type="number" placeholder="Enter number" />
       </div>
     </div>
   ),

--- a/src/stories/01-atoms/forms/inputs/RadioGroup.stories.tsx
+++ b/src/stories/01-atoms/forms/inputs/RadioGroup.stories.tsx
@@ -106,7 +106,7 @@ const WorldTypeExampleComponent = (args: React.ComponentProps<typeof RadioGroup>
         onValueChange={setValue}
         name="world-type-radio"
       >
-        <div>
+        <label>
           <RadioGroupItem value="original" />
           <div>
             <div>Original World</div>
@@ -114,8 +114,8 @@ const WorldTypeExampleComponent = (args: React.ComponentProps<typeof RadioGroup>
               Generate a completely original world with unique settings and themes
             </div>
           </div>
-        </div>
-        <div>
+        </label>
+        <label>
           <RadioGroupItem value="inspired_by" />
           <div>
             <div>Inspired By</div>
@@ -123,8 +123,8 @@ const WorldTypeExampleComponent = (args: React.ComponentProps<typeof RadioGroup>
               Generate an original world inspired by an existing fictional universe
             </div>
           </div>
-        </div>
-        <div>
+        </label>
+        <label>
           <RadioGroupItem value="set_within" />
           <div>
             <div>Set Within</div>
@@ -132,7 +132,7 @@ const WorldTypeExampleComponent = (args: React.ComponentProps<typeof RadioGroup>
               Generate a world directly within an existing fictional universe
             </div>
           </div>
-        </div>
+        </label>
       </RadioGroup>
     </div>
   );

--- a/src/stories/02-molecules/ui-components/DataTable.stories.tsx
+++ b/src/stories/02-molecules/ui-components/DataTable.stories.tsx
@@ -68,7 +68,7 @@ interface DataTableProps {
 }
 
 const meta: Meta<DataTableProps> = {
-  title: '02-molecules/ui-components/DataTable',
+  title: '02-Molecules/ui-components/DataTable',
   component: DataTable,
   parameters: {
     layout: 'padded',

--- a/src/stories/04-templates/layouts/WorldListScreen.stories.tsx
+++ b/src/stories/04-templates/layouts/WorldListScreen.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
 import WorldListScreen from '@/components/WorldListScreen/WorldListScreen';
 import { useWorldStore } from '@/state/worldStore';
 import { World } from '@/types/world.types';
@@ -62,6 +63,11 @@ const meta: Meta<typeof WorldListScreen> = {
   component: WorldListScreen,
   parameters: {
     layout: 'padded',
+  },
+  args: {
+    // Explicit spy so Storybook 8 doesn't treat this on* prop as an implicit
+    // action arg, which crashes the render (the component calls it on mount).
+    onViewToggleRender: fn(),
   },
   tags: ['autodocs'],
   decorators: [


### PR DESCRIPTION
## Description
Visual-crawl follow-ups on the design-system showcase and Storybook — all on dev/showcase/story surfaces, **none user-facing**:
- **Showcase dark mode was broken across DS1/2/3.** The showcase wrappers re-scope `data-theme` onto a local div, but the theme CSS scopes dark overrides as `[data-theme="dsX"].dark` (same element), so a wrapper carrying `data-theme` but no `.dark` kept light-mode tokens — charcoal text on the dark canvas. A `useResolvedDark` hook + `.dark` on each wrapper makes the override compose.
- **WorldListScreen story** crashed on Storybook 8's implicit-action guard — added an explicit `fn()` for `onViewToggleRender`.
- **DataTable story title** was mis-cased (`02-molecules` -> `02-Molecules`), which split it into a stray sidebar group.
- **DS2 palette band** overflowed the viewport (~133px) — `min-width:0` + `overflow:hidden` on the band.
- **Isolated form stories** (Input/Checkbox/RadioGroup) had unlabelled controls — added accessible names.

## Related Issue
<!-- n/a — these came out of a visual-QA crawl (reported, not separately filed). -->

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation <!-- dev/showcase fixes, not TDD-driven -->
- [x] All new code is tested <!-- existing component/story coverage; full suite green -->
- [x] All tests pass locally <!-- 346 suites / 2396 tests -->
- [x] Test coverage maintained or improved

## Component Development
- [x] Storybook stories created/updated <!-- the story fixes are themselves story changes -->
- [x] Components developed in isolation first
- [x] Visual consistency verified <!-- bdg: DS1/2/3 dark labels now legible; palette band within bounds -->

## Implementation Notes
- The dark-mode root cause is composition: `ForceTheme` sets `data-theme` on `<html>` (which already has `.dark`), but the inner showcase wrappers re-declare `data-theme` to scope the theme locally and weren't carrying `.dark`. The hook reads `<html>.dark` (not `resolvedColorScheme`) because the standalone DS pages have their own light/dark toggle that mutates `documentElement` directly.
- No production code touched — only `/dev/design-system*` showcase components and Storybook stories. The base UI components are unchanged.

## Quality Checks
- [x] Linting passed (eslint + stylelint)
- [x] Type checking passed
- [ ] Security audit passed <!-- n/a -->
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm run dev` -> `/dev/design-system/ds1` (and `ds2`/`ds3`), toggle Dark: the component-catalog labels render light on the dark canvas (were invisible before). At 1280px the DS2 palette band stays within the viewport.
2. `npm run storybook` -> `04-Templates/layouts/WorldListScreen` renders (was an error page); `02-Molecules/.../DataTable` groups under `02-Molecules`; the Input/Checkbox/RadioGroup stories' controls have accessible names.
3. `npm test` — full suite green.

## Checklist
- [x] Code follows the project's coding standards (tokens, no Tailwind, no `!important`)
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic <!-- useResolvedDark is documented -->
- [ ] Documentation updated (if required) <!-- n/a -->
- [x] No new warnings generated
- [x] Accessibility considerations addressed <!-- story labels + dark-mode legibility -->
