### PR TITLE
feat(devtools): decision console + creation-flow inspector (#212/#213)

### DIFF
--- a/src/components/devtools/DecisionConsoleSection/DecisionConsoleSection.css
+++ b/src/components/devtools/DecisionConsoleSection/DecisionConsoleSection.css
@@ -1,0 +1,89 @@
+/**
+ * DecisionConsoleSection (dev-only) styles. Token-driven.
+ */
+.devtools-decision-console {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  font-size: 0.8125rem;
+}
+
+.devtools-decision-console-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.devtools-decision-console-controls .form-input,
+.devtools-decision-console-controls .form-select {
+  flex: 1 1 10rem;
+  font-size: 0.8125rem;
+}
+
+.devtools-decision-console-patterns {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.devtools-decision-console-pattern-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.devtools-decision-console-pattern-strength {
+  margin-left: auto;
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.devtools-decision-console-meta {
+  color: var(--color-text-muted);
+}
+
+.devtools-decision-console-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.devtools-decision-console-entry {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-canvas);
+}
+
+.devtools-decision-console-entry-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.devtools-decision-console-entry-time {
+  margin-left: auto;
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.devtools-decision-console-entry-prompt {
+  margin: 0;
+  font-weight: 600;
+}
+
+.devtools-decision-console-entry-choice {
+  margin: 0;
+  color: var(--color-text-secondary);
+}
+
+.devtools-decision-console-empty {
+  margin: 0;
+  color: var(--color-text-muted);
+}

--- a/src/components/devtools/DecisionConsoleSection/DecisionConsoleSection.tsx
+++ b/src/components/devtools/DecisionConsoleSection/DecisionConsoleSection.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select } from '@/components/ui/select';
+import { CollapsibleSection } from '@/components/ui/CollapsibleSection';
+import { JsonViewer } from '../JsonViewer';
+import { DevToolsSection } from '../shared/DevToolsSection';
+import { buildDecisionSnapshot } from '../shared/decisionSnapshot';
+import type { PlayerDecision } from '@/types/personalization.types';
+import './DecisionConsoleSection.css';
+
+const ALL = 'all';
+
+const formatTimestamp = (iso: string): string => {
+  const parsed = new Date(iso);
+  return Number.isNaN(parsed.getTime()) ? iso : parsed.toLocaleString();
+};
+
+const matchesSearch = (decision: PlayerDecision, query: string): boolean => {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return true;
+  return (
+    decision.prompt.toLowerCase().includes(needle) ||
+    decision.choiceText.toLowerCase().includes(needle)
+  );
+};
+
+/**
+ * DecisionConsoleSection (#212, epic #1302)
+ *
+ * Searchable, read-only console over the playerDecisionTracker records:
+ * filter by text/choice type/world, inspect full metadata per record, view
+ * the aggregate choice-pattern analysis, and export the filtered set as JSON.
+ * Reads point-in-time snapshots (Refresh re-reads); never mutates tracker
+ * or store state.
+ */
+export const DecisionConsoleSection = () => {
+  const [snapshot, setSnapshot] = useState(() => buildDecisionSnapshot());
+  const [searchText, setSearchText] = useState('');
+  const [choiceTypeFilter, setChoiceTypeFilter] = useState(ALL);
+  const [worldFilter, setWorldFilter] = useState(ALL);
+
+  const { trackerDecisions, patterns } = snapshot;
+
+  const choiceTypes = useMemo(
+    () => [...new Set(trackerDecisions.map((decision) => decision.choiceType))].sort(),
+    [trackerDecisions]
+  );
+  const worldIds = useMemo(
+    () => [...new Set(trackerDecisions.map((decision) => decision.worldId))].sort(),
+    [trackerDecisions]
+  );
+
+  const filteredDecisions = useMemo(
+    () =>
+      trackerDecisions.filter(
+        (decision) =>
+          matchesSearch(decision, searchText) &&
+          (choiceTypeFilter === ALL || decision.choiceType === choiceTypeFilter) &&
+          (worldFilter === ALL || decision.worldId === worldFilter)
+      ),
+    [trackerDecisions, searchText, choiceTypeFilter, worldFilter]
+  );
+
+  const handleRefresh = () => {
+    setSnapshot(buildDecisionSnapshot());
+  };
+
+  const handleExport = () => {
+    const blob = new Blob([JSON.stringify(filteredDecisions, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `narraitor-decisions-${new Date().toISOString().replace(/[:.]/g, '-')}.json`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="devtools-decision-console" data-testid="devtools-decision-console-section">
+      <div className="devtools-decision-console-controls">
+        <Input
+          type="search"
+          placeholder="Search prompt or choice text"
+          aria-label="Search decisions"
+          value={searchText}
+          onChange={(event) => setSearchText(event.target.value)}
+          data-testid="decision-console-search"
+        />
+        <Select
+          aria-label="Filter by choice type"
+          value={choiceTypeFilter}
+          onChange={(event) => setChoiceTypeFilter(event.target.value)}
+          data-testid="decision-console-choice-type-filter"
+        >
+          <option value={ALL}>All choice types</option>
+          {choiceTypes.map((choiceType) => (
+            <option key={choiceType} value={choiceType}>
+              {choiceType}
+            </option>
+          ))}
+        </Select>
+        <Select
+          aria-label="Filter by world"
+          value={worldFilter}
+          onChange={(event) => setWorldFilter(event.target.value)}
+          data-testid="decision-console-world-filter"
+        >
+          <option value={ALL}>All worlds</option>
+          {worldIds.map((worldId) => (
+            <option key={worldId} value={worldId}>
+              {worldId}
+            </option>
+          ))}
+        </Select>
+        <Button variant="ghost" size="sm" onClick={handleRefresh} data-testid="decision-console-refresh">
+          Refresh
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleExport}
+          disabled={filteredDecisions.length === 0}
+          data-testid="decision-console-export"
+        >
+          Export JSON
+        </Button>
+      </div>
+
+      <DevToolsSection title="Choice patterns">
+        {trackerDecisions.length === 0 ? (
+          <p className="devtools-decision-console-empty">No decisions tracked yet.</p>
+        ) : (
+          <div className="devtools-decision-console-patterns" data-testid="decision-console-patterns">
+            <div className="devtools-decision-console-pattern-badges">
+              {patterns.dominantChoiceTypes.map((choiceType, index) => (
+                <Badge
+                  key={choiceType}
+                  variant={index === 0 ? 'info-static' : 'outline-static'}
+                  size="sm"
+                >
+                  {choiceType} ({patterns.choiceDistribution[choiceType]})
+                </Badge>
+              ))}
+            </div>
+            <span className="devtools-decision-console-pattern-strength">
+              Pattern strength {Math.round(patterns.patternStrength)}%
+            </span>
+          </div>
+        )}
+      </DevToolsSection>
+
+      <div className="devtools-decision-console-meta">
+        Showing {filteredDecisions.length} of {trackerDecisions.length} tracked decisions
+      </div>
+
+      <div className="devtools-decision-console-list">
+        {trackerDecisions.length === 0 ? (
+          <p className="devtools-decision-console-empty">
+            Play a session and make choices to populate the tracker, then hit Refresh.
+          </p>
+        ) : filteredDecisions.length === 0 ? (
+          <p className="devtools-decision-console-empty">No decisions match the current filters.</p>
+        ) : (
+          filteredDecisions.map((decision) => (
+            <div
+              key={decision.id}
+              className="devtools-decision-console-entry"
+              data-testid={`decision-console-entry-${decision.id}`}
+            >
+              <div className="devtools-decision-console-entry-head">
+                <Badge variant="outline-static" size="sm">
+                  {decision.choiceType}
+                </Badge>
+                <span className="devtools-decision-console-entry-time">
+                  {formatTimestamp(decision.timestamp)}
+                </span>
+              </div>
+              <p className="devtools-decision-console-entry-prompt">{decision.prompt}</p>
+              <p className="devtools-decision-console-entry-choice">→ {decision.choiceText}</p>
+              <CollapsibleSection title="Metadata" initialCollapsed={true}>
+                <JsonViewer data={decision} />
+              </CollapsibleSection>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/devtools/DecisionConsoleSection/__tests__/DecisionConsoleSection.test.tsx
+++ b/src/components/devtools/DecisionConsoleSection/__tests__/DecisionConsoleSection.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DecisionConsoleSection } from '../DecisionConsoleSection';
+
+const trackerDecisions = [
+  {
+    id: 'pd-1',
+    prompt: 'A guard blocks the gate',
+    choiceText: 'Bribe the guard',
+    choiceType: 'chaotic',
+    timestamp: '2026-06-09T10:00:00.000Z',
+    sessionId: 'session-1',
+    worldId: 'world-1',
+    context: {},
+  },
+  {
+    id: 'pd-2',
+    prompt: 'The merchant offers a deal',
+    choiceText: 'Negotiate a fair price',
+    choiceType: 'diplomatic',
+    timestamp: '2026-06-09T11:00:00.000Z',
+    sessionId: 'session-1',
+    worldId: 'world-2',
+    context: {},
+  },
+];
+
+jest.mock('@/lib/ai/playerDecisionTracker', () => ({
+  playerDecisionTracker: {
+    getAllDecisions: () => trackerDecisions,
+    analyzeChoicePatterns: () => ({
+      dominantChoiceTypes: ['chaotic', 'diplomatic'],
+      choiceDistribution: { chaotic: 1, diplomatic: 1 },
+      patternStrength: 50,
+    }),
+  },
+}));
+
+jest.mock('@/state/narrativeStore', () => {
+  const state = { decisions: {}, sessionDecisions: {}, segments: {} };
+  return { useNarrativeStore: Object.assign(() => state, { getState: () => state }) };
+});
+
+jest.mock('@/components/ui/CollapsibleSection', () => ({
+  CollapsibleSection: ({ title, children }: { title: string; children: React.ReactNode }) => (
+    <div data-testid="collapsible-section">{title}{children}</div>
+  ),
+}));
+
+jest.mock('../../JsonViewer', () => ({
+  JsonViewer: ({ data }: { data: unknown }) => (
+    <pre data-testid="json-viewer">{JSON.stringify(data)}</pre>
+  ),
+}));
+
+describe('DecisionConsoleSection', () => {
+  it('renders tracked decisions with pattern analysis', () => {
+    render(<DecisionConsoleSection />);
+
+    expect(screen.getByTestId('devtools-decision-console-section')).toBeInTheDocument();
+    expect(screen.getByText('A guard blocks the gate')).toBeInTheDocument();
+    expect(screen.getByText('The merchant offers a deal')).toBeInTheDocument();
+    expect(screen.getByTestId('decision-console-patterns')).toBeInTheDocument();
+    expect(screen.getByText(/Pattern strength 50%/)).toBeInTheDocument();
+  });
+
+  it('filters decisions by search text', () => {
+    render(<DecisionConsoleSection />);
+
+    fireEvent.change(screen.getByTestId('decision-console-search'), {
+      target: { value: 'merchant' },
+    });
+
+    expect(screen.getByText('The merchant offers a deal')).toBeInTheDocument();
+    expect(screen.queryByText('A guard blocks the gate')).not.toBeInTheDocument();
+    expect(screen.getByText(/Showing 1 of 2/)).toBeInTheDocument();
+  });
+
+  it('filters decisions by world', () => {
+    render(<DecisionConsoleSection />);
+
+    fireEvent.change(screen.getByTestId('decision-console-world-filter'), {
+      target: { value: 'world-1' },
+    });
+
+    expect(screen.getByText('A guard blocks the gate')).toBeInTheDocument();
+    expect(screen.queryByText('The merchant offers a deal')).not.toBeInTheDocument();
+  });
+
+  it('exports the filtered decisions as a JSON download', () => {
+    const createObjectURL = jest.fn(() => 'blob:mock');
+    const revokeObjectURL = jest.fn();
+    Object.assign(URL, { createObjectURL, revokeObjectURL });
+    const clickSpy = jest
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {});
+
+    render(<DecisionConsoleSection />);
+    fireEvent.click(screen.getByTestId('decision-console-export'));
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock');
+
+    clickSpy.mockRestore();
+  });
+});

--- a/src/components/devtools/DecisionConsoleSection/index.ts
+++ b/src/components/devtools/DecisionConsoleSection/index.ts
@@ -1,0 +1,1 @@
+export { DecisionConsoleSection } from './DecisionConsoleSection';

--- a/src/components/devtools/DecisionFlowSection/DecisionFlowSection.css
+++ b/src/components/devtools/DecisionFlowSection/DecisionFlowSection.css
@@ -1,0 +1,141 @@
+/**
+ * DecisionFlowSection (dev-only) styles. Token-driven.
+ */
+.devtools-decision-flow {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  font-size: 0.8125rem;
+}
+
+.devtools-decision-flow-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.devtools-decision-flow-controls .form-select {
+  flex: 1 1 12rem;
+  font-size: 0.8125rem;
+}
+
+.devtools-decision-flow-traces {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.devtools-decision-flow-trace {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-canvas);
+}
+
+.devtools-decision-flow-trace-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.devtools-decision-flow-trace-time {
+  margin-left: auto;
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.devtools-decision-flow-step,
+.devtools-decision-flow-segment,
+.devtools-decision-flow-tracker,
+.devtools-decision-flow-debug {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.devtools-decision-flow-segment,
+.devtools-decision-flow-tracker {
+  flex-flow: row wrap;
+  align-items: center;
+}
+
+.devtools-decision-flow-segment-content {
+  flex-basis: 100%;
+  margin: 0;
+  color: var(--color-text-secondary);
+}
+
+.devtools-decision-flow-step-label {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-secondary);
+}
+
+.devtools-decision-flow-prompt-text {
+  margin: 0;
+  font-weight: 600;
+}
+
+.devtools-decision-flow-options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.devtools-decision-flow-option {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.devtools-decision-flow-option.is-selected {
+  border-color: var(--color-accent);
+  background: var(--color-surface);
+}
+
+.devtools-decision-flow-option-hint {
+  flex-basis: 100%;
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+.devtools-decision-flow-tracker > span {
+  color: var(--color-text-muted);
+}
+
+.devtools-decision-flow-debug-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-1);
+  color: var(--color-text-muted);
+}
+
+.devtools-decision-flow-prompt {
+  margin: 0;
+  padding: var(--space-2);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-size: 0.75rem;
+}
+
+.devtools-decision-flow-empty {
+  margin: 0;
+  color: var(--color-text-muted);
+}

--- a/src/components/devtools/DecisionFlowSection/DecisionFlowSection.tsx
+++ b/src/components/devtools/DecisionFlowSection/DecisionFlowSection.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Select } from '@/components/ui/select';
+import { buildDecisionSnapshot } from '../shared/decisionSnapshot';
+import { DecisionTrace } from './DecisionTrace';
+import type { Decision } from '@/types/narrative.types';
+import './DecisionFlowSection.css';
+
+/**
+ * DecisionFlowSection (#213, epic #1302)
+ *
+ * Read-only trace of how each decision was created, presented, selected, and
+ * recorded: origin segment → AI-generated options (alignment/custom-input) →
+ * player selection → playerDecisionTracker record → outcome segment, plus the
+ * segment-level prompt debug info when "Show Prompts" capture was on. Choice
+ * generation prompts themselves aren't retained by the pipeline, so the trace
+ * covers what state actually stores. Snapshots on demand; never mutates.
+ */
+export const DecisionFlowSection = () => {
+  const [snapshot, setSnapshot] = useState(() => buildDecisionSnapshot());
+  const sessionIds = useMemo(
+    () =>
+      Object.keys(snapshot.sessionDecisions).filter(
+        (sessionId) => (snapshot.sessionDecisions[sessionId] || []).length > 0
+      ),
+    [snapshot.sessionDecisions]
+  );
+  const [selectedSessionId, setSelectedSessionId] = useState(
+    () => sessionIds[sessionIds.length - 1] || ''
+  );
+
+  const activeSessionId = sessionIds.includes(selectedSessionId)
+    ? selectedSessionId
+    : sessionIds[sessionIds.length - 1] || '';
+
+  const decisions = useMemo(() => {
+    const decisionIds = snapshot.sessionDecisions[activeSessionId] || [];
+    return decisionIds
+      .map((decisionId) => snapshot.storeDecisions[decisionId])
+      .filter((decision): decision is Decision => Boolean(decision))
+      .reverse();
+  }, [snapshot, activeSessionId]);
+
+  const handleRefresh = () => {
+    setSnapshot(buildDecisionSnapshot());
+  };
+
+  return (
+    <div className="devtools-decision-flow" data-testid="devtools-decision-flow-section">
+      <div className="devtools-decision-flow-controls">
+        <Select
+          aria-label="Select session"
+          value={activeSessionId}
+          onChange={(event) => setSelectedSessionId(event.target.value)}
+          data-testid="decision-flow-session-select"
+        >
+          {sessionIds.length === 0 ? (
+            <option value="">No sessions with decisions</option>
+          ) : (
+            sessionIds.map((sessionId) => (
+              <option key={sessionId} value={sessionId}>
+                {sessionId} ({(snapshot.sessionDecisions[sessionId] || []).length})
+              </option>
+            ))
+          )}
+        </Select>
+        <Button variant="ghost" size="sm" onClick={handleRefresh} data-testid="decision-flow-refresh">
+          Refresh
+        </Button>
+      </div>
+
+      {decisions.length === 0 ? (
+        <p className="devtools-decision-flow-empty">
+          No decisions in the narrative store yet. Play a session to a choice point, then hit
+          Refresh.
+        </p>
+      ) : (
+        <div className="devtools-decision-flow-traces">
+          {decisions.map((decision) => (
+            <DecisionTrace
+              key={decision.id}
+              decision={decision}
+              sessionId={activeSessionId}
+              snapshot={snapshot}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/devtools/DecisionFlowSection/DecisionTrace.tsx
+++ b/src/components/devtools/DecisionFlowSection/DecisionTrace.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import React from 'react';
+import { clsx } from 'clsx';
+import { Badge } from '@/components/ui/badge';
+import { CollapsibleSection } from '@/components/ui/CollapsibleSection';
+import { JsonViewer } from '../JsonViewer';
+import { normalizeForTrackerMatch } from '../shared/decisionSnapshot';
+import type { DecisionInspectorSnapshot } from '../shared/decisionSnapshot';
+import type { Decision, NarrativeSegment, DecisionWeight } from '@/types/narrative.types';
+import type { PlayerDecision } from '@/types/personalization.types';
+
+const WEIGHT_BADGE_VARIANTS: Record<DecisionWeight, 'outline-static' | 'warning-static' | 'destructive-static'> = {
+  minor: 'outline-static',
+  major: 'warning-static',
+  critical: 'destructive-static',
+};
+
+const excerpt = (text: string, maxLength: number = 160): string =>
+  text.length > maxLength ? `${text.slice(0, maxLength)}…` : text;
+
+const formatDate = (value: Date | string | undefined): string => {
+  if (!value) return 'not selected yet';
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? String(value) : parsed.toLocaleString();
+};
+
+/**
+ * Finds the tracker record for a decision: same session, and the sanitized
+ * selected-option text the tracker persisted matches the option chosen here.
+ */
+const findTrackerRecord = (
+  decision: Decision,
+  sessionId: string,
+  trackerDecisions: PlayerDecision[]
+): PlayerDecision | undefined => {
+  const selectedOption = decision.options.find(
+    (option) => option.id === decision.selectedOptionId
+  );
+  if (!selectedOption) return undefined;
+
+  const selectedText = normalizeForTrackerMatch(
+    selectedOption.customText || selectedOption.text,
+    300
+  );
+  return trackerDecisions.find(
+    (record) => record.sessionId === sessionId && record.choiceText === selectedText
+  );
+};
+
+const SegmentExcerpt = ({ label, segment }: { label: string; segment: NarrativeSegment }) => (
+  <div className="devtools-decision-flow-segment">
+    <span className="devtools-decision-flow-step-label">{label}</span>
+    <Badge variant="outline-static" size="sm">
+      {segment.type}
+    </Badge>
+    {segment.metadata.decisionOutcome && (
+      <Badge variant="info-static" size="sm">
+        {segment.metadata.decisionOutcome}
+      </Badge>
+    )}
+    <p className="devtools-decision-flow-segment-content">{excerpt(segment.content)}</p>
+  </div>
+);
+
+const PromptDebugBlock = ({ segment }: { segment: NarrativeSegment }) => {
+  const debugInfo = segment.metadata.debugInfo;
+  if (!debugInfo) {
+    return (
+      <p className="devtools-decision-flow-empty">
+        No prompt debug info on this segment. Enable &quot;Show Prompts&quot; in the DevTools
+        header before generating to capture it.
+      </p>
+    );
+  }
+
+  return (
+    <div className="devtools-decision-flow-debug" data-testid="decision-flow-debug-info">
+      <div className="devtools-decision-flow-debug-meta">
+        <Badge variant="outline-static" size="sm">
+          {debugInfo.templateName}
+        </Badge>
+        <span>{debugInfo.modelUsed}</span>
+        {debugInfo.tokenUsage && (
+          <span>
+            {debugInfo.tokenUsage.promptTokens} prompt / {debugInfo.tokenUsage.completionTokens}{' '}
+            completion tokens
+          </span>
+        )}
+      </div>
+      <CollapsibleSection title="Full prompt" initialCollapsed={true}>
+        <pre className="devtools-decision-flow-prompt">{debugInfo.fullPrompt}</pre>
+      </CollapsibleSection>
+      <CollapsibleSection title="Prompt context detail" initialCollapsed={true}>
+        <JsonViewer data={debugInfo} />
+      </CollapsibleSection>
+    </div>
+  );
+};
+
+/**
+ * One decision's creation trace: origin segment, generated options, the
+ * player's selection, the tracker record it produced, the narrative outcome
+ * segment(s), and prompt debug info when capture was on. Pure presentation
+ * over a read-only snapshot.
+ */
+export const DecisionTrace = ({
+  decision,
+  sessionId,
+  snapshot,
+}: {
+  decision: Decision;
+  sessionId: string;
+  snapshot: DecisionInspectorSnapshot;
+}) => {
+  const originSegment = decision.narrativeSegmentId
+    ? snapshot.segments[decision.narrativeSegmentId]
+    : undefined;
+  const outcomeSegments = Object.values(snapshot.segments).filter(
+    (segment) => segment.metadata.causedByDecisionId === decision.id
+  );
+  const trackerRecord = findTrackerRecord(decision, sessionId, snapshot.trackerDecisions);
+  const debugSegment =
+    outcomeSegments.find((segment) => segment.metadata.debugInfo) ||
+    (originSegment?.metadata.debugInfo ? originSegment : undefined);
+
+  return (
+    <div className="devtools-decision-flow-trace" data-testid={`decision-flow-trace-${decision.id}`}>
+      <div className="devtools-decision-flow-trace-head">
+        {decision.decisionWeight && (
+          <Badge variant={WEIGHT_BADGE_VARIANTS[decision.decisionWeight]} size="sm">
+            {decision.decisionWeight}
+          </Badge>
+        )}
+        <span className="devtools-decision-flow-trace-time">{formatDate(decision.selectedAt)}</span>
+      </div>
+
+      {originSegment && <SegmentExcerpt label="Presented after" segment={originSegment} />}
+
+      <div className="devtools-decision-flow-step">
+        <span className="devtools-decision-flow-step-label">Decision prompt</span>
+        <p className="devtools-decision-flow-prompt-text">{decision.prompt}</p>
+      </div>
+
+      <div className="devtools-decision-flow-step">
+        <span className="devtools-decision-flow-step-label">Generated options</span>
+        <ul className="devtools-decision-flow-options">
+          {decision.options.map((option) => {
+            const isSelected = option.id === decision.selectedOptionId;
+            return (
+              <li
+                key={option.id}
+                className={clsx('devtools-decision-flow-option', isSelected && 'is-selected')}
+                data-testid={`decision-flow-option-${option.id}`}
+                data-selected={isSelected || undefined}
+              >
+                <span className="devtools-decision-flow-option-text">
+                  {option.isCustomInput ? option.customText || option.text : option.text}
+                </span>
+                {option.alignment && (
+                  <Badge variant="outline-static" size="sm">
+                    {option.alignment}
+                  </Badge>
+                )}
+                {option.isCustomInput && (
+                  <Badge variant="secondary-static" size="sm">
+                    custom input
+                  </Badge>
+                )}
+                {isSelected && (
+                  <Badge variant="success-static" size="sm">
+                    selected
+                  </Badge>
+                )}
+                {option.hint && (
+                  <span className="devtools-decision-flow-option-hint">{option.hint}</span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+
+      <div className="devtools-decision-flow-step">
+        <span className="devtools-decision-flow-step-label">Recorded in tracker</span>
+        {trackerRecord ? (
+          <div className="devtools-decision-flow-tracker" data-testid="decision-flow-tracker-record">
+            <Badge variant="info-static" size="sm">
+              {trackerRecord.choiceType}
+            </Badge>
+            <span>{formatDate(trackerRecord.timestamp)}</span>
+            <CollapsibleSection title="Tracker record" initialCollapsed={true}>
+              <JsonViewer data={trackerRecord} />
+            </CollapsibleSection>
+          </div>
+        ) : (
+          <p className="devtools-decision-flow-empty">
+            {decision.selectedOptionId
+              ? 'No matching tracker record found for this selection.'
+              : 'Awaiting player selection — nothing recorded yet.'}
+          </p>
+        )}
+      </div>
+
+      {outcomeSegments.map((segment) => (
+        <SegmentExcerpt key={segment.id} label="Narrative outcome" segment={segment} />
+      ))}
+
+      <div className="devtools-decision-flow-step">
+        <span className="devtools-decision-flow-step-label">Prompt debug info</span>
+        {debugSegment ? (
+          <PromptDebugBlock segment={debugSegment} />
+        ) : (
+          <p className="devtools-decision-flow-empty">
+            No prompt debug info captured for this decision&apos;s segments. Enable &quot;Show
+            Prompts&quot; in the DevTools header before generating to capture it.
+          </p>
+        )}
+      </div>
+
+      <CollapsibleSection title="Raw decision object" initialCollapsed={true}>
+        <JsonViewer data={decision} />
+      </CollapsibleSection>
+    </div>
+  );
+};

--- a/src/components/devtools/DecisionFlowSection/DecisionTrace.tsx
+++ b/src/components/devtools/DecisionFlowSection/DecisionTrace.tsx
@@ -27,7 +27,12 @@ const formatDate = (value: Date | string | undefined): string => {
 
 /**
  * Finds the tracker record for a decision: same session, and the sanitized
- * selected-option text the tracker persisted matches the option chosen here.
+ * prompt + selected-option text both match what the tracker persisted. The
+ * store records `decision.prompt` (sanitized to 500) and `selectedOption.text`
+ * (sanitized to 300), so matching on both disambiguates same-session decisions
+ * that happen to share a choice text but differ in prompt — without the prompt
+ * discriminator, `find` would return the newest record (tracker stores
+ * newest-first) for every such decision.
  */
 const findTrackerRecord = (
   decision: Decision,
@@ -43,8 +48,12 @@ const findTrackerRecord = (
     selectedOption.customText || selectedOption.text,
     300
   );
+  const selectedPrompt = normalizeForTrackerMatch(decision.prompt, 500);
   return trackerDecisions.find(
-    (record) => record.sessionId === sessionId && record.choiceText === selectedText
+    (record) =>
+      record.sessionId === sessionId &&
+      record.choiceText === selectedText &&
+      normalizeForTrackerMatch(record.prompt, 500) === selectedPrompt
   );
 };
 

--- a/src/components/devtools/DecisionFlowSection/__tests__/DecisionFlowSection.test.tsx
+++ b/src/components/devtools/DecisionFlowSection/__tests__/DecisionFlowSection.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { DecisionFlowSection } from '../DecisionFlowSection';
+
+jest.mock('@/state/narrativeStore', () => {
+  const decision = {
+    id: 'decision-1',
+    prompt: 'A guard blocks the gate',
+    options: [
+      { id: 'option-1', text: 'Bribe the guard', alignment: 'chaotic' },
+      { id: 'option-2', text: 'Ask politely', alignment: 'lawful', hint: 'Low risk' },
+    ],
+    selectedOptionId: 'option-1',
+    selectedAt: new Date('2026-06-09T10:00:00.000Z'),
+    decisionWeight: 'major',
+    narrativeSegmentId: 'segment-1',
+  };
+  const state = {
+    decisions: { 'decision-1': decision },
+    sessionDecisions: { 'session-1': ['decision-1'] },
+    segments: {
+      'segment-1': {
+        id: 'segment-1',
+        content: 'You approach the city gate at dusk.',
+        type: 'scene',
+        metadata: { tags: [] },
+        timestamp: new Date('2026-06-09T09:59:00.000Z'),
+      },
+      'segment-2': {
+        id: 'segment-2',
+        content: 'The guard pockets the coin and waves you through.',
+        type: 'action',
+        metadata: {
+          tags: [],
+          causedByDecisionId: 'decision-1',
+          decisionOutcome: 'success',
+          debugInfo: {
+            fullPrompt: 'FULL PROMPT TEXT',
+            templateName: 'Scene Template',
+            modelUsed: 'gemini-2.5-flash',
+            generatedAt: new Date('2026-06-09T10:00:05.000Z'),
+          },
+        },
+        timestamp: new Date('2026-06-09T10:00:05.000Z'),
+      },
+    },
+  };
+  return { useNarrativeStore: Object.assign(() => state, { getState: () => state }) };
+});
+
+jest.mock('@/lib/ai/playerDecisionTracker', () => ({
+  playerDecisionTracker: {
+    getAllDecisions: () => [
+      {
+        id: 'pd-1',
+        prompt: 'A guard blocks the gate',
+        choiceText: 'Bribe the guard',
+        choiceType: 'chaotic',
+        timestamp: '2026-06-09T10:00:00.000Z',
+        sessionId: 'session-1',
+        worldId: 'world-1',
+        context: {},
+      },
+    ],
+    analyzeChoicePatterns: () => ({
+      dominantChoiceTypes: ['chaotic'],
+      choiceDistribution: { chaotic: 1 },
+      patternStrength: 100,
+    }),
+  },
+}));
+
+jest.mock('@/components/ui/CollapsibleSection', () => ({
+  CollapsibleSection: ({ title, children }: { title: string; children: React.ReactNode }) => (
+    <div data-testid="collapsible-section">{title}{children}</div>
+  ),
+}));
+
+jest.mock('../../JsonViewer', () => ({
+  JsonViewer: ({ data }: { data: unknown }) => (
+    <pre data-testid="json-viewer">{JSON.stringify(data)}</pre>
+  ),
+}));
+
+describe('DecisionFlowSection', () => {
+  it('renders the decision trace with its options', () => {
+    render(<DecisionFlowSection />);
+
+    expect(screen.getByTestId('devtools-decision-flow-section')).toBeInTheDocument();
+    expect(screen.getByTestId('decision-flow-trace-decision-1')).toBeInTheDocument();
+    expect(screen.getByText('A guard blocks the gate')).toBeInTheDocument();
+    expect(screen.getByText('Bribe the guard')).toBeInTheDocument();
+    expect(screen.getByText('Ask politely')).toBeInTheDocument();
+  });
+
+  it('marks the selected option and links the tracker record', () => {
+    render(<DecisionFlowSection />);
+
+    expect(screen.getByTestId('decision-flow-option-option-1')).toHaveAttribute(
+      'data-selected',
+      'true'
+    );
+    expect(screen.getByTestId('decision-flow-option-option-2')).not.toHaveAttribute(
+      'data-selected'
+    );
+    expect(screen.getByTestId('decision-flow-tracker-record')).toBeInTheDocument();
+  });
+
+  it('shows the outcome segment and its prompt debug info', () => {
+    render(<DecisionFlowSection />);
+
+    expect(screen.getByText(/waves you through/)).toBeInTheDocument();
+    expect(screen.getByTestId('decision-flow-debug-info')).toBeInTheDocument();
+    expect(screen.getByText('Scene Template')).toBeInTheDocument();
+    expect(screen.getByText('FULL PROMPT TEXT')).toBeInTheDocument();
+  });
+});

--- a/src/components/devtools/DecisionFlowSection/__tests__/DecisionFlowSection.test.tsx
+++ b/src/components/devtools/DecisionFlowSection/__tests__/DecisionFlowSection.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { DecisionFlowSection } from '../DecisionFlowSection';
 
 jest.mock('@/state/narrativeStore', () => {
@@ -15,9 +15,20 @@ jest.mock('@/state/narrativeStore', () => {
     decisionWeight: 'major',
     narrativeSegmentId: 'segment-1',
   };
+  // Same session, same selected choice text as decision-1, but a different
+  // prompt — the case that cross-links to the newest tracker record without a
+  // prompt discriminator.
+  const sameTextDecision = {
+    id: 'decision-2',
+    prompt: 'A toll collector demands payment',
+    options: [{ id: 'option-3', text: 'Bribe the guard', alignment: 'chaotic' }],
+    selectedOptionId: 'option-3',
+    selectedAt: new Date('2026-06-09T11:00:00.000Z'),
+    decisionWeight: 'minor',
+  };
   const state = {
-    decisions: { 'decision-1': decision },
-    sessionDecisions: { 'session-1': ['decision-1'] },
+    decisions: { 'decision-1': decision, 'decision-2': sameTextDecision },
+    sessionDecisions: { 'session-1': ['decision-1', 'decision-2'] },
     segments: {
       'segment-1': {
         id: 'segment-1',
@@ -50,7 +61,19 @@ jest.mock('@/state/narrativeStore', () => {
 
 jest.mock('@/lib/ai/playerDecisionTracker', () => ({
   playerDecisionTracker: {
+    // Newest-first, as the tracker unshifts. Both records share choiceText
+    // 'Bribe the guard' but differ in prompt.
     getAllDecisions: () => [
+      {
+        id: 'pd-2',
+        prompt: 'A toll collector demands payment',
+        choiceText: 'Bribe the guard',
+        choiceType: 'aggressive',
+        timestamp: '2026-06-09T11:00:00.000Z',
+        sessionId: 'session-1',
+        worldId: 'world-1',
+        context: {},
+      },
       {
         id: 'pd-1',
         prompt: 'A guard blocks the gate',
@@ -64,8 +87,8 @@ jest.mock('@/lib/ai/playerDecisionTracker', () => ({
     ],
     analyzeChoicePatterns: () => ({
       dominantChoiceTypes: ['chaotic'],
-      choiceDistribution: { chaotic: 1 },
-      patternStrength: 100,
+      choiceDistribution: { chaotic: 1, aggressive: 1 },
+      patternStrength: 50,
     }),
   },
 }));
@@ -87,10 +110,11 @@ describe('DecisionFlowSection', () => {
     render(<DecisionFlowSection />);
 
     expect(screen.getByTestId('devtools-decision-flow-section')).toBeInTheDocument();
-    expect(screen.getByTestId('decision-flow-trace-decision-1')).toBeInTheDocument();
-    expect(screen.getByText('A guard blocks the gate')).toBeInTheDocument();
-    expect(screen.getByText('Bribe the guard')).toBeInTheDocument();
-    expect(screen.getByText('Ask politely')).toBeInTheDocument();
+    const trace = screen.getByTestId('decision-flow-trace-decision-1');
+    expect(trace).toBeInTheDocument();
+    expect(within(trace).getByText('A guard blocks the gate')).toBeInTheDocument();
+    expect(within(trace).getByText('Bribe the guard')).toBeInTheDocument();
+    expect(within(trace).getByText('Ask politely')).toBeInTheDocument();
   });
 
   it('marks the selected option and links the tracker record', () => {
@@ -103,7 +127,8 @@ describe('DecisionFlowSection', () => {
     expect(screen.getByTestId('decision-flow-option-option-2')).not.toHaveAttribute(
       'data-selected'
     );
-    expect(screen.getByTestId('decision-flow-tracker-record')).toBeInTheDocument();
+    const trace = screen.getByTestId('decision-flow-trace-decision-1');
+    expect(within(trace).getByTestId('decision-flow-tracker-record')).toBeInTheDocument();
   });
 
   it('shows the outcome segment and its prompt debug info', () => {
@@ -113,5 +138,18 @@ describe('DecisionFlowSection', () => {
     expect(screen.getByTestId('decision-flow-debug-info')).toBeInTheDocument();
     expect(screen.getByText('Scene Template')).toBeInTheDocument();
     expect(screen.getByText('FULL PROMPT TEXT')).toBeInTheDocument();
+  });
+
+  it('matches the tracker record by prompt, not just choice text', () => {
+    render(<DecisionFlowSection />);
+
+    // decision-1 ("A guard blocks the gate") and decision-2 ("A toll collector
+    // demands payment") both selected "Bribe the guard". Matching on choice
+    // text alone would link decision-1 to the newest record (aggressive);
+    // the prompt discriminator keeps it on its own record (chaotic).
+    const trace1 = screen.getByTestId('decision-flow-trace-decision-1');
+    const record1 = within(trace1).getByTestId('decision-flow-tracker-record');
+    expect(within(record1).getByText('chaotic')).toBeInTheDocument();
+    expect(within(record1).queryByText('aggressive')).not.toBeInTheDocument();
   });
 });

--- a/src/components/devtools/DecisionFlowSection/index.ts
+++ b/src/components/devtools/DecisionFlowSection/index.ts
@@ -1,0 +1,1 @@
+export { DecisionFlowSection } from './DecisionFlowSection';

--- a/src/components/devtools/DevToolsPanel/DevToolsPanel.tsx
+++ b/src/components/devtools/DevToolsPanel/DevToolsPanel.tsx
@@ -12,6 +12,8 @@ import { LoreManagementSection } from '../LoreManagementSection';
 import { TokenBudgetPanel } from '../TokenBudgetPanel';
 import { AIMockingSection } from '../AIMockingSection';
 import { ErrorSection } from '../ErrorSection';
+import { DecisionConsoleSection } from '../DecisionConsoleSection';
+import { DecisionFlowSection } from '../DecisionFlowSection';
 import { DevToolsSection } from '../shared/DevToolsSection';
 import { SectionVisibilityControls } from '../SectionVisibilityControls';
 import { DevToolsSection as SectionId } from '@/lib/devtools/sectionVisibilityStorage';
@@ -160,6 +162,27 @@ export const DevToolsPanel = () => {
                 <div className="devtools-panel-group">
                   <h3 className="devtools-panel-group-title">State Management</h3>
                   <StateSection defaultCollapsed={true} />
+                </div>
+              )}
+
+              {/* Decisions Group - only show if any child sections are visible */}
+              {(isSectionVisible(SectionId.DECISION_CONSOLE) ||
+                isSectionVisible(SectionId.DECISION_FLOW)) && (
+                <div className="devtools-panel-group">
+                  <h3 className="devtools-panel-group-title">Decisions</h3>
+                  <div className="devtools-panel-subgroup">
+                    {isSectionVisible(SectionId.DECISION_CONSOLE) && (
+                      <CollapsibleSection title="Decision Console" initialCollapsed={true}>
+                        <DecisionConsoleSection />
+                      </CollapsibleSection>
+                    )}
+
+                    {isSectionVisible(SectionId.DECISION_FLOW) && (
+                      <CollapsibleSection title="Decision Creation Flow" initialCollapsed={true}>
+                        <DecisionFlowSection />
+                      </CollapsibleSection>
+                    )}
+                  </div>
                 </div>
               )}
 

--- a/src/components/devtools/SectionVisibilityControls/SectionVisibilityControls.tsx
+++ b/src/components/devtools/SectionVisibilityControls/SectionVisibilityControls.tsx
@@ -18,6 +18,8 @@ const SECTION_INFO = {
   [DevToolsSection.ENDING_IMAGE_DEBUG]: 'Ending Image Debug',
   [DevToolsSection.CONSISTENCY_VALIDATION]: 'Consistency Validation',
   [DevToolsSection.LORE_MANAGEMENT]: 'Lore Management',
+  [DevToolsSection.DECISION_CONSOLE]: 'Decision Console',
+  [DevToolsSection.DECISION_FLOW]: 'Decision Creation Flow',
 } as const;
 
 /**
@@ -31,6 +33,8 @@ const SECTION_TEST_IDS = {
   [DevToolsSection.ENDING_IMAGE_DEBUG]: 'toggle-ending-image-debug',
   [DevToolsSection.CONSISTENCY_VALIDATION]: 'toggle-consistency-validation',
   [DevToolsSection.LORE_MANAGEMENT]: 'toggle-lore-management',
+  [DevToolsSection.DECISION_CONSOLE]: 'toggle-decision-console',
+  [DevToolsSection.DECISION_FLOW]: 'toggle-decision-flow',
 } as const;
 
 /**

--- a/src/components/devtools/shared/decisionSnapshot.ts
+++ b/src/components/devtools/shared/decisionSnapshot.ts
@@ -1,0 +1,55 @@
+/**
+ * Read-only snapshot of decision and prompt-debug state for the DevTools
+ * decision inspectors (#212/#213). Reads the playerDecisionTracker singleton
+ * and the narrative store via getState() — a deliberate point-in-time snapshot
+ * (refreshed on demand), never a live subscription, and never a mutation.
+ */
+
+import { playerDecisionTracker } from '@/lib/ai/playerDecisionTracker';
+import { useNarrativeStore } from '@/state/narrativeStore';
+import type { PlayerDecision, ChoiceTypePreference } from '@/types/personalization.types';
+import type { Decision, NarrativeSegment } from '@/types/narrative.types';
+import type { EntityID } from '@/types/common.types';
+
+interface DecisionPatternSummary {
+  dominantChoiceTypes: ChoiceTypePreference[];
+  choiceDistribution: Record<ChoiceTypePreference, number>;
+  patternStrength: number;
+}
+
+export interface DecisionInspectorSnapshot {
+  /** Tracker records, newest first (the tracker unshifts on record). */
+  trackerDecisions: PlayerDecision[];
+  /** Choice-pattern analysis over the tracker records. */
+  patterns: DecisionPatternSummary;
+  /** Structured decisions from the narrative store, by ID. */
+  storeDecisions: Record<EntityID, Decision>;
+  /** Decision IDs grouped by session, in creation order. */
+  sessionDecisions: Record<EntityID, EntityID[]>;
+  /** Narrative segments by ID (carry causedByDecisionId + prompt debugInfo). */
+  segments: Record<EntityID, NarrativeSegment>;
+}
+
+export function buildDecisionSnapshot(): DecisionInspectorSnapshot {
+  const narrativeState = useNarrativeStore.getState();
+  const trackerDecisions = playerDecisionTracker.getAllDecisions();
+
+  return {
+    trackerDecisions,
+    patterns: playerDecisionTracker.analyzeChoicePatterns(trackerDecisions),
+    storeDecisions: narrativeState.decisions,
+    sessionDecisions: narrativeState.sessionDecisions,
+    segments: narrativeState.segments,
+  };
+}
+
+/**
+ * Mirrors the tracker's sanitizeString so store-side text can be matched
+ * against the sanitized copies the tracker persists.
+ */
+export function normalizeForTrackerMatch(text: string, maxLength: number = 500): string {
+  return text
+    .replace(/[<>'"&]/g, '')
+    .substring(0, maxLength)
+    .trim();
+}

--- a/src/lib/devtools/sectionVisibilityStorage.ts
+++ b/src/lib/devtools/sectionVisibilityStorage.ts
@@ -23,7 +23,9 @@ export enum DevToolsSection {
   CONSISTENCY_VALIDATION = 'consistencyValidation',
   LORE_MANAGEMENT = 'loreManagement',
   ERROR_SECTION = 'errorSection',
-  TOKEN_BUDGET = 'tokenBudget'
+  TOKEN_BUDGET = 'tokenBudget',
+  DECISION_CONSOLE = 'decisionConsole',
+  DECISION_FLOW = 'decisionFlow'
 }
 
 /**
@@ -45,6 +47,8 @@ export const DEFAULT_SECTION_VISIBILITY: SectionVisibility = {
   [DevToolsSection.LORE_MANAGEMENT]: true,
   [DevToolsSection.ERROR_SECTION]: true,
   [DevToolsSection.TOKEN_BUDGET]: true,
+  [DevToolsSection.DECISION_CONSOLE]: true,
+  [DevToolsSection.DECISION_FLOW]: true,
 };
 
 /**

--- a/src/stories/03-organisms/devtools/sections/DecisionConsoleSection.stories.tsx
+++ b/src/stories/03-organisms/devtools/sections/DecisionConsoleSection.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DecisionConsoleSection } from '@/components/devtools/DecisionConsoleSection';
+import { playerDecisionTracker } from '@/lib/ai/playerDecisionTracker';
+import type { ChoiceTypePreference } from '@/types/personalization.types';
+
+const meta: Meta<typeof DecisionConsoleSection> = {
+  title: '03-Organisms/devtools/sections/DecisionConsoleSection',
+  component: DecisionConsoleSection,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Read-only DevTools console over the playerDecisionTracker records: search, filter by choice type or world, inspect full metadata, view choice-pattern analysis, and export the filtered set as JSON.'
+      }
+    }
+  },
+  tags: ['autodocs']
+};
+
+export default meta;
+type Story = StoryObj<typeof DecisionConsoleSection>;
+
+const seedTracker = (
+  decisions: Array<{
+    prompt: string;
+    choiceText: string;
+    choiceType: ChoiceTypePreference;
+    worldId?: string;
+    location?: string;
+  }>
+) => {
+  playerDecisionTracker.clearDecisions();
+  decisions.forEach((decision) => {
+    playerDecisionTracker.recordDecision(
+      decision.prompt,
+      decision.choiceText,
+      decision.choiceType,
+      'storybook-session',
+      decision.worldId || 'storybook-world',
+      decision.location ? { location: decision.location } : undefined
+    );
+  });
+};
+
+export const Empty: Story = {
+  name: 'Empty State',
+  render: () => {
+    playerDecisionTracker.clearDecisions();
+    return <DecisionConsoleSection />;
+  }
+};
+
+export const WithDecisions: Story = {
+  name: 'With Tracked Decisions',
+  render: () => {
+    seedTracker([
+      {
+        prompt: 'A guard blocks the gate and demands papers',
+        choiceText: 'Slip him a few coins',
+        choiceType: 'chaotic',
+        location: 'City gate'
+      },
+      {
+        prompt: 'The merchant offers a suspiciously good deal',
+        choiceText: 'Negotiate a fair price instead',
+        choiceType: 'diplomatic',
+        location: 'Market square'
+      },
+      {
+        prompt: 'A stranger asks for help carrying supplies',
+        choiceText: 'Offer to carry the heavier crates',
+        choiceType: 'helpful',
+        worldId: 'storybook-world-2',
+        location: 'Docks'
+      },
+      {
+        prompt: 'Bandits demand your coin purse',
+        choiceText: 'Draw your blade',
+        choiceType: 'aggressive',
+        worldId: 'storybook-world-2',
+        location: 'Forest road'
+      }
+    ]);
+    return <DecisionConsoleSection />;
+  }
+};

--- a/src/stories/03-organisms/devtools/sections/DecisionFlowSection.stories.tsx
+++ b/src/stories/03-organisms/devtools/sections/DecisionFlowSection.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DecisionFlowSection } from '@/components/devtools/DecisionFlowSection';
+import { useNarrativeStore } from '@/state/narrativeStore';
+import { playerDecisionTracker } from '@/lib/ai/playerDecisionTracker';
+import type { Decision, NarrativeSegment } from '@/types/narrative.types';
+
+const meta: Meta<typeof DecisionFlowSection> = {
+  title: '03-Organisms/devtools/sections/DecisionFlowSection',
+  component: DecisionFlowSection,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Read-only DevTools trace of decision creation: origin segment, AI-generated options with alignments, the player selection, the tracker record, the narrative outcome, and segment-level prompt debug info when capture was on.'
+      }
+    }
+  },
+  tags: ['autodocs']
+};
+
+export default meta;
+type Story = StoryObj<typeof DecisionFlowSection>;
+
+const SESSION_ID = 'storybook-session';
+
+const decision: Decision = {
+  id: 'storybook-decision-1',
+  prompt: 'A guard blocks the gate and demands papers',
+  options: [
+    { id: 'option-1', text: 'Slip him a few coins', alignment: 'chaotic' },
+    { id: 'option-2', text: 'Present forged documents', alignment: 'neutral', hint: 'Risky if inspected' },
+    { id: 'option-3', text: 'Ask politely for an exception', alignment: 'lawful' }
+  ],
+  selectedOptionId: 'option-1',
+  selectedAt: new Date(),
+  decisionWeight: 'major',
+  narrativeSegmentId: 'storybook-segment-1'
+};
+
+const originSegment: NarrativeSegment = {
+  id: 'storybook-segment-1',
+  sessionId: SESSION_ID,
+  content: 'You approach the city gate at dusk. A bored guard straightens up and blocks your path.',
+  type: 'scene',
+  metadata: { tags: [] },
+  timestamp: new Date(),
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString()
+};
+
+const outcomeSegment: NarrativeSegment = {
+  id: 'storybook-segment-2',
+  sessionId: SESSION_ID,
+  content: 'The guard pockets the coins with practiced ease and waves you through without a second glance.',
+  type: 'action',
+  metadata: {
+    tags: [],
+    causedByDecisionId: 'storybook-decision-1',
+    decisionOutcome: 'success',
+    debugInfo: {
+      fullPrompt:
+        'Continue the narrative. The player chose: "Slip him a few coins" at the city gate. Tone: tense. Recent decisions: none.',
+      templateName: 'Scene Template',
+      modelUsed: 'gemini-2.5-flash',
+      tokenUsage: { promptTokens: 412, completionTokens: 96, totalTokens: 508 },
+      generatedAt: new Date()
+    }
+  },
+  timestamp: new Date(),
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString()
+};
+
+const seedStores = () => {
+  playerDecisionTracker.clearDecisions();
+  playerDecisionTracker.recordDecision(
+    decision.prompt,
+    'Slip him a few coins',
+    'chaotic',
+    SESSION_ID,
+    'storybook-world',
+    { location: 'City gate' }
+  );
+  useNarrativeStore.setState({
+    decisions: { [decision.id]: decision },
+    sessionDecisions: { [SESSION_ID]: [decision.id] },
+    segments: {
+      [originSegment.id]: originSegment,
+      [outcomeSegment.id]: outcomeSegment
+    }
+  });
+};
+
+export const Empty: Story = {
+  name: 'Empty State',
+  render: () => {
+    useNarrativeStore.setState({ decisions: {}, sessionDecisions: {}, segments: {} });
+    return <DecisionFlowSection />;
+  }
+};
+
+export const WithDecisionTrace: Story = {
+  name: 'With Decision Trace',
+  render: () => {
+    seedStores();
+    return <DecisionFlowSection />;
+  }
+};


### PR DESCRIPTION
## Description
Ships the last two unshipped stories bundled into epic #1302: a searchable decision console (#212) and a decision-creation visualization (#213). Both land as new section folders under `src/components/devtools/`, siblings to the existing `StateSection`/`AITestingPanel` pattern, in a new "Decisions" group in the panel's left column.

- **DecisionConsoleSection** (#212) — read-only console over `playerDecisionTracker` records: text search across prompt/choice, choice-type and world filters, per-entry metadata via `JsonViewer`, choice-pattern summary (`analyzeChoicePatterns`), and JSON export of the currently filtered set.
- **DecisionFlowSection** (#213) — per-session creation trace: the segment the decision was presented after, the generated options (alignment badges, hints, custom-input marker, selected highlight), selection timestamp/weight, the matching tracker record, outcome segments (`causedByDecisionId` + `decisionOutcome`), and segment-level prompt debug info (template, model, token usage, collapsible full prompt) when "Show Prompts" capture is on.

Both sections read getState()-style snapshots with a manual Refresh — deliberately not live subscriptions — through a shared `decisionSnapshot.ts` helper. Nothing here edits `narrativeStore.ts`, `selectDecisionOption`, `extractWorldStateImpacts`, `StateSection.tsx`, or any play-session UI, so this stays clear of the consequence-spine refactor. The #1340 hygiene slice is explicitly out of scope.

## Related Issue
Refs #212, #213 — both already closed as bundled into epic #1302; this delivers their "Remaining work" bullets there. Not using `Closes` (they're closed, and it wouldn't fire on a develop merge anyway).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Implementation and tests were written together in one pass (not strictly test-first); both new suites are MVP-level per project convention.

## User Stories Addressed
- #212 — Debug decision tracking with searchable development console
- #213 — Visualize decision creation process through developer debugging tools

## Component Development
- [x] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

Stories for both sections under `03-Organisms/devtools/sections/`; visual check done live against the dev server (DS1 light), token-only CSS.

## Implementation Notes
- **Scope limits, on purpose:** choice-generation prompts and raw AI responses are discarded after parsing in `choiceGenerator`, so they're not observable read-only — the #213 trace covers what state retains. #212's "enable/disable tracking" AC is also skipped: it would mean modifying the tracker/selection path, which this PR deliberately doesn't touch. If either gap matters later it needs a small capture seam first, as a separate issue.
- Tracker records don't store a decision ID, so the flow section matches them by sessionId + the same string sanitization the tracker applies (`normalizeForTrackerMatch`).
- Registration touches: `sectionVisibilityStorage.ts` (two enum entries + defaults), `SectionVisibilityControls` (labels/test IDs), `DevToolsPanel` (new "Decisions" group).
- Pre-existing nit, not addressed here: the "Sections (n/m)" counter in the visibility dropdown counts stored visibility keys against `SECTION_INFO` labels, which were already out of sync before this change (#1340 territory).

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

`type-check`, `lint`, `lint:css`, `knip`, `skott:check` (cycles hold at baseline 17), and the full Jest suite (348 suites / 2403 tests) all pass locally.

## Testing Instructions
1. `npm run dev`, open any page, expand the DevTools panel.
2. Under "Decisions", expand "Decision Console" and "Decision Creation Flow".
3. Quick Setup a world/character, play to a choice point at `/dev/game-session`, pick an option, then hit Refresh in both sections.
4. Console: search/filter the records, expand Metadata, click Export JSON.
5. Flow: pick the session, confirm the trace shows options with the selected one highlighted, the tracker record, and the outcome segment. Toggle "Show Prompts" before generating to see the prompt debug block.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
