### PR TITLE
fix(state): make session-journal event wiring idempotent

### DIFF
--- a/src/lib/state/__tests__/storePubSub.test.ts
+++ b/src/lib/state/__tests__/storePubSub.test.ts
@@ -1,0 +1,108 @@
+/**
+ * StoreEventBus: subscribeOnce idempotency + emit error isolation.
+ *
+ * These guard the wiring contract that session journal entries depend on —
+ * a handler registered once even under repeat module evaluation, and a
+ * throwing subscriber that doesn't take down its siblings or the emitter.
+ */
+import { storeEvents } from '../storePubSub';
+
+// Reach a fresh bus instance to model jest's per-file module reset / a fresh
+// app runtime, without depending on the shared singleton's accumulated state.
+type BusCtor = new () => typeof storeEvents;
+const FreshBus = (storeEvents as unknown as { constructor: BusCtor }).constructor;
+const makeBus = () => new FreshBus();
+
+describe('StoreEventBus.subscribeOnce', () => {
+  it('registers a handler the first time a key is seen', async () => {
+    const bus = makeBus();
+    const handler = jest.fn();
+
+    bus.subscribeOnce('evt', handler, 'key-a');
+    await bus.emit('evt', { value: 1 });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({ value: 1 });
+  });
+
+  it('does not stack a duplicate handler for a repeated key', async () => {
+    const bus = makeBus();
+    const handler = jest.fn();
+
+    bus.subscribeOnce('evt', handler, 'key-a');
+    bus.subscribeOnce('evt', handler, 'key-a'); // HMR / double-import
+    bus.subscribeOnce('evt', jest.fn(), 'key-a'); // even a different callback
+    await bus.emit('evt', {});
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers distinct keys independently', async () => {
+    const bus = makeBus();
+    const a = jest.fn();
+    const b = jest.fn();
+
+    bus.subscribeOnce('evt', a, 'key-a');
+    bus.subscribeOnce('evt', b, 'key-b');
+    await bus.emit('evt', {});
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-registers the same key on a fresh bus instance', async () => {
+    // The trap a globalThis flag would fall into: jest gives each test file a
+    // fresh bus (module reset), so the dedup state must live on the instance.
+    const first = makeBus();
+    const handlerA = jest.fn();
+    first.subscribeOnce('evt', handlerA, 'shared-key');
+
+    const second = makeBus();
+    const handlerB = jest.fn();
+    second.subscribeOnce('evt', handlerB, 'shared-key');
+    await second.emit('evt', {});
+
+    expect(handlerB).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows re-subscription after unsubscribe', async () => {
+    const bus = makeBus();
+    const handler = jest.fn();
+
+    const sub = bus.subscribeOnce('evt', handler, 'key-a');
+    sub.unsubscribe();
+    bus.subscribeOnce('evt', handler, 'key-a');
+    await bus.emit('evt', {});
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('StoreEventBus.emit error isolation', () => {
+  it('runs every handler even when one throws, and resolves', async () => {
+    const bus = makeBus();
+    const before = jest.fn();
+    const after = jest.fn();
+    bus.subscribe('evt', before);
+    bus.subscribe('evt', () => {
+      throw new Error('handler boom');
+    });
+    bus.subscribe('evt', after);
+
+    await expect(bus.emit('evt', {})).resolves.toBeUndefined();
+    expect(before).toHaveBeenCalledTimes(1);
+    expect(after).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows an async handler rejection without rejecting emit', async () => {
+    const bus = makeBus();
+    const sibling = jest.fn();
+    bus.subscribe('evt', async () => {
+      throw new Error('async boom');
+    });
+    bus.subscribe('evt', sibling);
+
+    await expect(bus.emit('evt', {})).resolves.toBeUndefined();
+    expect(sibling).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/state/storePubSub.ts
+++ b/src/lib/state/storePubSub.ts
@@ -18,6 +18,13 @@ interface EventSubscription {
 
 class StoreEventBus {
   private subscribers = new Map<string, Set<EventCallback>>();
+  // Keys of subscriptions registered via subscribeOnce, so repeat calls with
+  // the same key (HMR re-evaluation, a stray double import) don't stack
+  // duplicate handlers. Tracked per bus instance — NOT on a module global or
+  // globalThis — so a fresh bus (jest resets modules per test file) starts
+  // with an empty set and re-registers correctly, while a re-evaluated wiring
+  // module hitting the same live bus is deduped.
+  private onceKeys = new Set<string>();
 
   subscribe<T = unknown>(event: string, callback: EventCallback<T>): EventSubscription {
     if (!this.subscribers.has(event)) {
@@ -35,6 +42,32 @@ class StoreEventBus {
             this.subscribers.delete(event);
           }
         }
+      },
+    };
+  }
+
+  /**
+   * Idempotent subscribe: registers the callback only the first time this
+   * `key` is seen on this bus instance. Use for app-lifetime wiring that may
+   * be evaluated more than once (HMR, re-imported side-effect modules), where
+   * a duplicate handler would be harmful — e.g. writing a session journal
+   * entry twice. Returns a no-op subscription on repeat calls.
+   */
+  subscribeOnce<T = unknown>(
+    event: string,
+    callback: EventCallback<T>,
+    key: string
+  ): EventSubscription {
+    if (this.onceKeys.has(key)) {
+      return { unsubscribe: () => {} };
+    }
+    this.onceKeys.add(key);
+
+    const subscription = this.subscribe(event, callback);
+    return {
+      unsubscribe: () => {
+        this.onceKeys.delete(key);
+        subscription.unsubscribe();
       },
     };
   }

--- a/src/state/__tests__/storeEventWiring.integration.test.ts
+++ b/src/state/__tests__/storeEventWiring.integration.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Full session-lifecycle through the REAL event wiring (#1406 follow-up).
+ *
+ * Imports the wiring once, then drives sessionStore.initializeSession /
+ * endSession and asserts the composed result: exactly one journal entry per
+ * boundary (no double-registration), the forced-fresh path clears inventory,
+ * a new session clears its own stale narrative while preserving others, and a
+ * throwing subscriber doesn't abort initializeSession.
+ */
+import '@/state/storeEventWiring';
+import { useSessionStore } from '@/state/sessionStore';
+import { useJournalStore } from '@/state/journalStore';
+import { useNarrativeStore } from '@/state/narrativeStore';
+import { useInventoryStore } from '@/state/inventoryStore';
+import {
+  storeEvents,
+  StoreEventTypes,
+  type SessionStartedEvent,
+} from '@/lib/state/storePubSub';
+import type { NarrativeSegment } from '@/types/narrative.types';
+import type { InventoryItem } from '@/types/inventory.types';
+
+const ensureInventoryHydrated = async (): Promise<void> => {
+  const persistApi = (useInventoryStore as unknown as {
+    persist?: {
+      hasHydrated?: () => boolean;
+      onFinishHydration?: (cb: () => void) => () => void;
+      rehydrate?: () => Promise<void> | void;
+    };
+  }).persist;
+  if (persistApi?.hasHydrated?.()) return;
+  await new Promise<void>((resolve) => {
+    persistApi?.onFinishHydration?.(() => resolve());
+    void persistApi?.rehydrate?.();
+  });
+};
+
+const seedInventoryItem = (characterId: string, itemId: string): void => {
+  const item = { id: itemId, name: 'Seeded Blade', quantity: 1, stackable: false } as unknown as InventoryItem;
+  useInventoryStore.setState((state) => ({
+    items: { ...state.items, [itemId]: item },
+    entities: { ...state.entities, [itemId]: item },
+    characterInventories: {
+      ...state.characterInventories,
+      [characterId]: [...(state.characterInventories[characterId] ?? []), itemId],
+    },
+  }));
+};
+
+const seedNarrativeForSession = (sessionId: string): void => {
+  const segment = {
+    id: `seg-${sessionId}`,
+    sessionId,
+    worldId: 'world-1',
+    content: 'Stale prologue',
+    type: 'scene',
+    metadata: { tags: [] },
+    timestamp: new Date(),
+    createdAt: new Date().toISOString(),
+  } as unknown as NarrativeSegment;
+  useNarrativeStore.setState((state) => ({
+    segments: { ...state.segments, [segment.id]: segment },
+    sessionSegments: { ...state.sessionSegments, [sessionId]: [segment.id] },
+  }));
+};
+
+const countEntries = (sessionId: string, type: string): number =>
+  useJournalStore
+    .getState()
+    .getSessionEntries(sessionId)
+    .filter((entry) => entry.type === type).length;
+
+const resetStores = () => {
+  useJournalStore.setState({ entries: {}, sessionEntries: {} });
+  useNarrativeStore.setState({ segments: {}, sessionSegments: {}, decisions: {}, sessionDecisions: {}, currentEnding: null });
+  useInventoryStore.setState({ items: {}, entities: {}, characterInventories: {} });
+  useSessionStore.setState({
+    id: null,
+    status: 'initializing',
+    worldId: null,
+    characterId: null,
+    savedSessions: {},
+    sessionLifecycle: {},
+    error: null,
+  });
+};
+
+describe('session lifecycle through real store wiring', () => {
+  beforeEach(async () => {
+    await ensureInventoryHydrated();
+    resetStores();
+  });
+
+  it('produces exactly one start and one end journal entry across the lifecycle', async () => {
+    await useSessionStore.getState().initializeSession('world-1', 'char-hero');
+    const sessionId = useSessionStore.getState().id as string;
+
+    expect(useSessionStore.getState().status).toBe('active');
+    expect(countEntries(sessionId, 'session_start')).toBe(1);
+
+    await useSessionStore.getState().endSession();
+
+    expect(countEntries(sessionId, 'session_end')).toBe(1);
+    // The start entry isn't duplicated by the end flow.
+    expect(countEntries(sessionId, 'session_start')).toBe(1);
+  });
+
+  it('clears the character inventory on a forced-fresh init', async () => {
+    seedInventoryItem('char-hero', 'item-1');
+    expect(useInventoryStore.getState().getCharacterItems('char-hero')).toHaveLength(1);
+
+    await useSessionStore.getState().initializeSession('world-1', 'char-hero', undefined, true);
+
+    expect(useInventoryStore.getState().getCharacterItems('char-hero')).toHaveLength(0);
+  });
+
+  it('clears the new session’s stale narrative but preserves unrelated sessions', async () => {
+    seedNarrativeForSession('other-session');
+
+    await useSessionStore.getState().initializeSession('world-1', 'char-hero');
+    const sessionId = useSessionStore.getState().id as string;
+    // Stale data happened to share the freshly-generated id (defensive clear).
+    seedNarrativeForSession(sessionId);
+    await storeEvents.emit(StoreEventTypes.SESSION_FRESH_START, {
+      sessionId,
+      worldId: 'world-1',
+      characterId: 'char-hero',
+      isNewSession: true,
+      isForcedFresh: false,
+    });
+
+    expect(useNarrativeStore.getState().getSessionSegments(sessionId)).toHaveLength(0);
+    expect(useNarrativeStore.getState().getSessionSegments('other-session')).toHaveLength(1);
+  });
+
+  it('completes initializeSession even if a SESSION_STARTED subscriber throws', async () => {
+    const rogue = storeEvents.subscribe<SessionStartedEvent>(StoreEventTypes.SESSION_STARTED, () => {
+      throw new Error('rogue subscriber');
+    });
+
+    try {
+      await expect(useSessionStore.getState().initializeSession('world-1', 'char-hero')).resolves.toBeUndefined();
+    } finally {
+      rogue.unsubscribe();
+    }
+
+    const sessionId = useSessionStore.getState().id as string;
+    expect(useSessionStore.getState().status).toBe('active');
+    // The real journal handler still ran despite the rogue sibling throwing.
+    expect(countEntries(sessionId, 'session_start')).toBe(1);
+  });
+});

--- a/src/state/storeEventWiring.ts
+++ b/src/state/storeEventWiring.ts
@@ -23,5 +23,18 @@ import {
 } from '@/lib/state/storePubSub';
 import { handleSessionStarted, handleSessionEnded } from '@/lib/session/sessionJournalEntries';
 
-storeEvents.subscribe<SessionStartedEvent>(StoreEventTypes.SESSION_STARTED, handleSessionStarted);
-storeEvents.subscribe<SessionEndedEvent>(StoreEventTypes.SESSION_ENDED, handleSessionEnded);
+// subscribeOnce (keyed, deduped per bus instance) so a re-evaluated module —
+// HMR in dev, or this side-effect import being pulled in more than once —
+// can't stack duplicate journal handlers and write a session_start/end entry
+// twice. The store-tail subscriptions in narrativeStore/inventoryStore stay on
+// plain subscribe: their handlers only clear data, so a double-fire is a no-op.
+storeEvents.subscribeOnce<SessionStartedEvent>(
+  StoreEventTypes.SESSION_STARTED,
+  handleSessionStarted,
+  'session-journal:started'
+);
+storeEvents.subscribeOnce<SessionEndedEvent>(
+  StoreEventTypes.SESSION_ENDED,
+  handleSessionEnded,
+  'session-journal:ended'
+);


### PR DESCRIPTION
## Description

Follow-up to #1406, addressing the actionable core of the Codex review on that PR: the session-journal event wiring wasn't idempotent under module re-evaluation.

`storeEventWiring.ts` registered the `SESSION_STARTED`/`SESSION_ENDED` journal handlers with a bare `storeEvents.subscribe` at module top level. It works today because the module mounts once via the root layout — but if it's ever evaluated twice (HMR in dev, or a future app-shell refactor that re-imports it), the handlers stack and a session logs duplicate `session_start`/`session_end` journal entries.

**The fix:** a new `StoreEventBus.subscribeOnce(event, callback, key)` that registers a handler only the first time a `key` is seen on the bus instance. The journal handlers now use it.

**Why instance-keyed, not a globalThis guard** (Codex suggested a module-level guard): a module-level flag dies on the exact HMR re-evaluation it's meant to survive, and a `globalThis` flag breaks jest — jest hands each test file a fresh bus (module reset) but keeps `globalThis`, so the flag would report "already wired" and skip subscription against an empty bus, silently breaking every test after the first. Keying the dedup set to the bus *instance* handles both: a fresh bus re-registers correctly, a re-evaluated wiring module against a live bus is deduped.

**Scope — only the journal handlers are guarded.** The distinction is the harm gradient, not symmetry: `SESSION_STARTED/ENDED` write journal entries (a double-fire is a visible duplicate), while the `SESSION_FRESH_START` clears and the pre-existing `WORLD_DELETED`/`CHARACTER_DELETED` cascade subscriptions are idempotent by nature (clearing twice is a no-op). Guarding the harmless ones for symmetry would only leave the cascade subs as a new asymmetry.

The other Codex points went unaddressed, on purpose: the PR-splitting / baseline-sequencing suggestions are process taste (#1406 was already committed in that order with the baseline as its own commit), and the "preserve previous failure behavior" concern was based on a misread — the old inline code also swallowed those failures and continued; the PR documented the changed swallow point.

## Related Issue

Follow-up to #1406 / #468 (both already merged). No issue to close.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

`subscribeOnce` dedup (repeat key → one handler, distinct keys independent, fresh-instance re-registration — the jest trap), `emit` error isolation (a throwing handler doesn't take down its siblings or reject `emit`), and a full `init → forced-fresh → end` lifecycle through the real wiring asserting exactly one entry per boundary, inventory reset on forced-fresh, stale-narrative clear, and that a throwing `SESSION_STARTED` subscriber doesn't abort `initializeSession`.

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

`npm test` (2,449 pass, +11 here). The idempotency-specific run: `npx jest storePubSub storeEventWiring.integration`.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] No new warnings generated
