### PR TITLE
fix(devtools): correct section-visibility dropdown count + list all sections

### DIFF
--- a/src/components/devtools/SectionVisibilityControls/SectionVisibilityControls.tsx
+++ b/src/components/devtools/SectionVisibilityControls/SectionVisibilityControls.tsx
@@ -14,10 +14,13 @@ const SECTION_INFO = {
   [DevToolsSection.STATE_SECTION]: 'State Section',
   [DevToolsSection.TEST_DATA_GENERATOR]: 'Test Data Generator',
   [DevToolsSection.AI_TESTING]: 'AI Testing Panel',
+  [DevToolsSection.AI_MOCKING]: 'AI Mocking',
   [DevToolsSection.PORTRAIT_DEBUG]: 'Portrait Debug',
   [DevToolsSection.ENDING_IMAGE_DEBUG]: 'Ending Image Debug',
   [DevToolsSection.CONSISTENCY_VALIDATION]: 'Consistency Validation',
   [DevToolsSection.LORE_MANAGEMENT]: 'Lore Management',
+  [DevToolsSection.ERROR_SECTION]: 'Error Tracking',
+  [DevToolsSection.TOKEN_BUDGET]: 'Token Budget',
   [DevToolsSection.DECISION_CONSOLE]: 'Decision Console',
   [DevToolsSection.DECISION_FLOW]: 'Decision Creation Flow',
 } as const;
@@ -29,10 +32,13 @@ const SECTION_TEST_IDS = {
   [DevToolsSection.STATE_SECTION]: 'toggle-state-section',
   [DevToolsSection.TEST_DATA_GENERATOR]: 'toggle-test-data-generator',
   [DevToolsSection.AI_TESTING]: 'toggle-ai-testing',
+  [DevToolsSection.AI_MOCKING]: 'toggle-ai-mocking',
   [DevToolsSection.PORTRAIT_DEBUG]: 'toggle-portrait-debug',
   [DevToolsSection.ENDING_IMAGE_DEBUG]: 'toggle-ending-image-debug',
   [DevToolsSection.CONSISTENCY_VALIDATION]: 'toggle-consistency-validation',
   [DevToolsSection.LORE_MANAGEMENT]: 'toggle-lore-management',
+  [DevToolsSection.ERROR_SECTION]: 'toggle-error-section',
+  [DevToolsSection.TOKEN_BUDGET]: 'toggle-token-budget',
   [DevToolsSection.DECISION_CONSOLE]: 'toggle-decision-console',
   [DevToolsSection.DECISION_FLOW]: 'toggle-decision-flow',
 } as const;
@@ -45,15 +51,20 @@ const SECTION_TEST_IDS = {
  */
 export const SectionVisibilityControls = () => {
   const {
-    sectionVisibility,
     toggleSectionVisibility,
     setSectionVisibility,
     isSectionVisible,
   } = useDevTools();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
-  const visibleCount = Object.values(sectionVisibility).filter(Boolean).length;
-  const totalCount = Object.keys(SECTION_INFO).length;
+  // Count over the same universe the dropdown lists (SECTION_INFO), using the
+  // same resolver the per-row checkmarks use, so numerator and denominator can't
+  // diverge from stale keys in the persisted visibility map.
+  const sectionIds = Object.keys(SECTION_INFO);
+  const totalCount = sectionIds.length;
+  const visibleCount = sectionIds.filter(
+    (sectionId) => isSectionVisible?.(sectionId) ?? true
+  ).length;
 
   const handleShowAll = () => {
     const allVisible = Object.keys(SECTION_INFO).reduce(

--- a/src/lib/devtools/sectionVisibilityStorage.ts
+++ b/src/lib/devtools/sectionVisibilityStorage.ts
@@ -41,6 +41,7 @@ export const DEFAULT_SECTION_VISIBILITY: SectionVisibility = {
   [DevToolsSection.STATE_SECTION]: true,
   [DevToolsSection.TEST_DATA_GENERATOR]: true,
   [DevToolsSection.AI_TESTING]: true,
+  [DevToolsSection.AI_MOCKING]: true,
   [DevToolsSection.PORTRAIT_DEBUG]: true,
   [DevToolsSection.ENDING_IMAGE_DEBUG]: true,
   [DevToolsSection.CONSISTENCY_VALIDATION]: true,


### PR DESCRIPTION
## Description

The DevTools section-visibility dropdown showed a nonsense count like "Sections (11/9)". Two different universes were being counted: `visibleCount` tallied every key in the persisted `sectionVisibility` map (all `DevToolsSection` enum entries, including stale keys from localStorage), while `totalCount` only counted the keys of the local `SECTION_INFO` label map. On top of that, `SECTION_INFO` was missing entries for `AI_MOCKING`, `ERROR_SECTION`, and `TOKEN_BUDGET` — so those three sections were un-hideable from the dropdown entirely.

The fix makes the dropdown's universe consistent:

- Both `visibleCount` and `totalCount` now derive from `SECTION_INFO` keys, using the same `isSectionVisible` resolver the per-row checkmarks already use. Numerator and denominator can't diverge anymore, regardless of what stale keys sit in localStorage.
- Added the three missing `SECTION_INFO` labels (`AI Mocking`, `Error Tracking`, `Token Budget`) and matching `SECTION_TEST_IDS`, so all ten enum sections are listed and toggleable.
- Seeded `AI_MOCKING` in `DEFAULT_SECTION_VISIBILITY` (the only enum section absent from the defaults), so the newly-listed row doesn't trip the "unknown section" `console.warn` on every render and counts as visible by default.

## Related Issue

Panel hygiene, #1340-adjacent (epic #1302). No dedicated issue; not auto-closing anything.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## TDD Compliance
- [ ] Tests written before implementation
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Existing `sectionVisibilityStorage` and `DevToolsContext` suites pass (9/9). There's no test on `SectionVisibilityControls` and none assert the dropdown count, so nothing needed updating — adding a test for a dev-only panel badge would be over-coverage per the project's KISS testing stance.

## Implementation Notes

The count is now a derived value over a single source of truth (`SECTION_INFO`), which is the actual root fix — listing the three missing sections alone wouldn't have protected the count against stale persisted keys.

## Quality Checks
- [x] Linting passed (eslint clean on both touched files)
- [x] Type checking passed (the two pre-existing `@vercel/analytics` tsc errors are an unrelated worktree dependency gap, not from this change)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

1. Open the app in dev, toggle the DevTools panel open.
2. Click the "Sections (N/N)" dropdown — the count should read 10/10 on a fresh state, and all ten sections (including AI Mocking, Error Tracking, Token Budget) should be listed and toggleable.
3. Hide a couple of sections; the count decrements to match, and stays consistent across reloads.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected
- [x] Self-review of code performed
- [x] No new warnings generated
- [x] Accessibility considerations addressed (toggles keep `role="menuitemcheckbox"` + `aria-checked`/`aria-label`)