### PR TITLE
feat(narrative): runtime continuity guardrail for generated segments (#409/#412)

### DIFF
--- a/src/components/devtools/ConsistencyValidationSection/ConsistencyValidationSection.tsx
+++ b/src/components/devtools/ConsistencyValidationSection/ConsistencyValidationSection.tsx
@@ -3,11 +3,25 @@
 import React, { useState, useMemo } from 'react';
 import { useLoreStore } from '@/state/loreStore';
 import { useWorldStore } from '@/state/worldStore';
+import { useContinuityStore } from '@/state/continuityStore';
 import { generateConsistencyInstructions } from '@/lib/ai/consistencyInstructions';
 import { buildLoreContext } from '@/lib/lore/loreContext';
 import { JsonViewer } from '@/components/devtools/JsonViewer';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Select } from '@/components/ui/select';
+import { CollapsibleSection } from '@/components/ui/CollapsibleSection';
 import { DevToolsSection } from '@/components/devtools/shared/DevToolsSection';
+import type { ContinuityStatus } from '@/types/continuity.types';
+
+const CONTINUITY_BADGE_VARIANTS: Record<
+  ContinuityStatus,
+  'success-static' | 'info-static' | 'warning-static'
+> = {
+  clean: 'success-static',
+  corrected: 'info-static',
+  flagged: 'warning-static',
+};
 
 /**
  * Consistency Validation Debug Section
@@ -45,6 +59,7 @@ export const ConsistencyValidationSection = () => {
   const [selectedWorldId, setSelectedWorldId] = useState<string>('');
   const { facts, getFacts } = useLoreStore();
   const { worlds } = useWorldStore();
+  const { results: continuityResults, clear: clearContinuityResults } = useContinuityStore();
 
   // Get available world IDs from lore facts
   const availableWorldIds = useMemo(() => {
@@ -91,6 +106,60 @@ export const ConsistencyValidationSection = () => {
 
   return (
     <div>
+      {/* Runtime continuity guardrail results (#409/#412) */}
+      <DevToolsSection title="Runtime Validation" className="devtools-continuity-validation">
+        <div data-testid="devtools-continuity-validation">
+          {continuityResults.length === 0 ? (
+            <p className="devtools-continuity-validation-empty">
+              No segments validated yet this session.
+            </p>
+          ) : (
+            <>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={clearContinuityResults}
+                data-testid="continuity-validation-clear"
+              >
+                Clear
+              </Button>
+              {[...continuityResults].reverse().map((result) => (
+                <div
+                  key={result.id}
+                  className="devtools-continuity-validation-entry"
+                  data-testid={`continuity-validation-result-${result.id}`}
+                >
+                  <div>
+                    <Badge variant={CONTINUITY_BADGE_VARIANTS[result.status]} size="sm">
+                      {result.status}
+                    </Badge>{' '}
+                    <span>{new Date(result.timestamp).toLocaleTimeString()}</span>
+                    {' — '}
+                    <span>
+                      detection {result.detectionMs}ms
+                      {result.correctionMs !== undefined
+                        ? `, correction ${result.correctionMs}ms`
+                        : ''}
+                    </span>
+                  </div>
+                  {result.issues.length > 0 && (
+                    <div>
+                      Issues:{' '}
+                      {result.issues
+                        .map((issue) => `${issue.entity} (${issue.type})`)
+                        .join(', ')}
+                    </div>
+                  )}
+                  <CollapsibleSection title="Details" initialCollapsed={true}>
+                    <JsonViewer data={result} />
+                  </CollapsibleSection>
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+      </DevToolsSection>
+
       {/* World Selection */}
       <DevToolsSection>
         <label>

--- a/src/lib/ai/__tests__/narrativeGenerator.continuity.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.continuity.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Integration tests for the runtime continuity guardrail (#409/#412).
+ *
+ * Seeds a contradiction — an NPC whose trust was tanked via the consequence
+ * path — and proves the guardrail catches a warm portrayal of her in the
+ * generated segment and corrects it before it would reach the player.
+ */
+
+import { NarrativeGenerator } from '../narrativeGenerator';
+import { CONTINUITY_CORRECTION_HEADER } from '@/lib/lore/continuityGuardrail';
+import { useContinuityStore } from '@/state/continuityStore';
+import { useWorldStore } from '@/state/worldStore';
+import { useNPCStore } from '@/state/npcStore';
+import { useLoreStore } from '@/state/loreStore';
+import { extractStructuredLore } from '../structuredLoreExtractor';
+import { setupDecisionConsequencesMocks } from './narrativeGenerator.decisionConsequences.testHelpers';
+import type { AIClient } from '../types';
+import type { NarrativeGenerationRequest } from '@/types/narrative.types';
+
+// Mock the store modules (same set as the sibling decision-consequences tests)
+jest.mock('@/state/worldStore', () => ({
+  useWorldStore: {
+    getState: jest.fn()
+  }
+}));
+jest.mock('@/state/characterStore', () => ({
+  useCharacterStore: {
+    getState: jest.fn()
+  }
+}));
+jest.mock('@/state/aiContextStore', () => ({
+  useAiContextStore: {
+    getState: jest.fn()
+  }
+}));
+jest.mock('@/state/inventoryStore', () => ({
+  useInventoryStore: {
+    getState: jest.fn()
+  }
+}));
+jest.mock('@/state/npcStore', () => ({
+  useNPCStore: {
+    getState: jest.fn()
+  }
+}));
+jest.mock('../playerDecisionTracker');
+jest.mock('../../promptTemplates/narrativeTemplateManager', () => ({
+  getNarrativeTemplate: jest.fn()
+}));
+jest.mock('../loreContextHelper', () => ({
+  getLoreContextForPrompt: jest.fn(),
+  checkAndRecordLoreMentions: jest.fn()
+}));
+jest.mock('../structuredLoreExtractor', () => ({
+  extractStructuredLore: jest.fn()
+}));
+jest.mock('../toneSettingsGuidance', () => ({
+  getDetailedToneInstructions: jest.fn()
+}));
+jest.mock('@/state/loreStore', () => ({
+  useLoreStore: {
+    getState: jest.fn()
+  }
+}));
+
+const mockWorld = {
+  id: 'world-1',
+  name: 'Test World',
+  genre: 'fantasy',
+  description: 'A magical realm',
+  attributes: [],
+  skills: [],
+  derivedStats: [],
+  settings: {
+    maxAttributes: 6,
+    maxSkills: 10,
+    attributePointPool: 30,
+    skillPointPool: 50,
+  },
+  toneSettings: {
+    contentRating: 'teen' as const,
+    narrativeStyle: 'balanced' as const,
+    languageComplexity: 'moderate' as const,
+  },
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+};
+
+const miraFact = {
+  id: 'fact-mira',
+  category: 'characters' as const,
+  key: 'world-1:character_mira',
+  value: 'Mira - a wary herbalist',
+  aliases: ['the herbalist'],
+  source: 'narrative' as const,
+  worldId: 'world-1',
+  visibility: 'world-shared' as const,
+  metadata: { description: 'A wary herbalist who keeps to herself.' },
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+};
+
+const CONTRADICTORY_PROSE =
+  'Mira beams at you and embraces you warmly, delighted to see her old friend again.';
+const CORRECTED_PROSE =
+  'Mira watches you from behind the counter, her expression closed, one hand resting near the door latch.';
+const CLEAN_PROSE =
+  'Mira eyes you warily and gestures toward the shelf without a word.';
+
+interface RoutedClient extends AIClient {
+  generateContent: jest.Mock;
+}
+
+/**
+ * Routes by prompt content rather than call order because generateSegment
+ * makes additional internal AI calls (metadata analysis, language
+ * complexity) that must not consume queued responses.
+ */
+const createRoutedClient = (
+  narrativeContent: string,
+  correctionContent: string
+): RoutedClient => ({
+  generateContent: jest.fn(async (prompt: string) => {
+    if (prompt.includes(CONTINUITY_CORRECTION_HEADER)) {
+      return {
+        content: correctionContent,
+        finishReason: 'STOP',
+        promptTokens: 10,
+        completionTokens: 10,
+      };
+    }
+    return {
+      content: narrativeContent,
+      finishReason: 'STOP',
+      promptTokens: 100,
+      completionTokens: 200,
+    };
+  }),
+});
+
+const correctionPromptsOf = (client: RoutedClient): string[] =>
+  client.generateContent.mock.calls
+    .map(([prompt]: [string]) => prompt)
+    .filter((prompt: string) => prompt.includes(CONTINUITY_CORRECTION_HEADER));
+
+const request: NarrativeGenerationRequest = {
+  worldId: 'world-1',
+  sessionId: 'session-1',
+  characterIds: ['char-1'],
+};
+
+describe('NarrativeGenerator - continuity guardrail', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useContinuityStore.getState().clear();
+
+    setupDecisionConsequencesMocks([]);
+
+    // Seed the contradiction source: Mira's trust was tanked by a recent
+    // decision (worldStore.npcRelationships is what the consequence path
+    // writes to).
+    (useWorldStore.getState as jest.Mock).mockImplementation(() => ({
+      worlds: { 'world-1': mockWorld },
+      worldStates: {},
+      currentWorldId: 'world-1',
+      error: null,
+      loading: false,
+      getWorldState: jest.fn(() => ({
+        npcRelationships: {
+          'npc-mira': {
+            trust: 5,
+            sentiment: -80,
+            lastInteraction: '2025-01-01T00:00:00.000Z',
+            sessionId: 'session-1',
+          },
+        },
+      })),
+    }));
+
+    (useNPCStore.getState as jest.Mock).mockImplementation(() => ({
+      getNPCsByWorld: jest
+        .fn()
+        .mockReturnValue([{ id: 'npc-mira', name: 'Mira', worldId: 'world-1' }]),
+      getById: jest.fn(),
+      createNPC: jest.fn(),
+      updateNPC: jest.fn(),
+    }));
+
+    (useLoreStore.getState as jest.Mock).mockReturnValue({
+      getFacts: jest.fn().mockReturnValue([miraFact]),
+      getLoreContext: jest.fn().mockReturnValue({ factIds: [] }),
+      recordLoreMentions: jest.fn(),
+      recordLoreUsage: jest.fn(),
+      addStructuredLore: jest.fn(),
+    });
+  });
+
+  it('catches a seeded contradiction (tanked trust written as warm) and corrects it', async () => {
+    const client = createRoutedClient(CONTRADICTORY_PROSE, CORRECTED_PROSE);
+    const generator = new NarrativeGenerator(client);
+
+    const result = await generator.generateSegment(request);
+
+    // The contradictory draft never reaches the caller; the corrected prose does.
+    expect(result.content).toBe(CORRECTED_PROSE);
+
+    // Exactly one corrective AI call, naming the offending NPC.
+    const correctionPrompts = correctionPromptsOf(client);
+    expect(correctionPrompts).toHaveLength(1);
+    expect(correctionPrompts[0]).toContain('Mira');
+    expect(correctionPrompts[0]).toContain('embraces you warmly');
+
+    // Segment metadata records the outcome for persistence via addSegment.
+    expect(result.metadata.continuity).toEqual({
+      status: 'corrected',
+      issues: [{ type: 'relationship-tone', entity: 'Mira' }],
+    });
+
+    // Lore extraction ran on the corrected prose, not the contradicted draft.
+    expect(extractStructuredLore).toHaveBeenCalledWith(
+      CORRECTED_PROSE,
+      expect.anything()
+    );
+
+    // DevTools feed got the full validation record.
+    const recorded = useContinuityStore.getState().results;
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0]).toMatchObject({
+      status: 'corrected',
+      worldId: 'world-1',
+      sessionId: 'session-1',
+    });
+    expect(recorded[0].issues[0]).toMatchObject({
+      type: 'relationship-tone',
+      entity: 'Mira',
+    });
+    expect(typeof recorded[0].detectionMs).toBe('number');
+    expect(typeof recorded[0].correctionMs).toBe('number');
+
+    // Prevention layer: the generation prompt itself carries the expectations.
+    const narrativePrompt = client.generateContent.mock.calls[0][0];
+    expect(narrativePrompt).toContain('CONTINUITY REQUIREMENTS');
+    expect(narrativePrompt).toContain('Mira');
+  });
+
+  it('makes no correction call for a clean segment', async () => {
+    const client = createRoutedClient(CLEAN_PROSE, CORRECTED_PROSE);
+    const generator = new NarrativeGenerator(client);
+
+    const result = await generator.generateSegment(request);
+
+    expect(correctionPromptsOf(client)).toHaveLength(0);
+    expect(result.metadata.continuity).toEqual({ status: 'clean' });
+
+    const recorded = useContinuityStore.getState().results;
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].status).toBe('clean');
+  });
+
+  it('flags the segment but keeps the original when correction does not improve it', async () => {
+    const client = createRoutedClient(CONTRADICTORY_PROSE, CONTRADICTORY_PROSE);
+    const generator = new NarrativeGenerator(client);
+
+    const result = await generator.generateSegment(request);
+
+    expect(result.content).toContain('embraces you warmly');
+    expect(result.metadata.continuity?.status).toBe('flagged');
+
+    const recorded = useContinuityStore.getState().results;
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].status).toBe('flagged');
+    expect(recorded[0].remainingIssues).toHaveLength(1);
+  });
+});

--- a/src/lib/ai/narrativeGenerator.continuity.ts
+++ b/src/lib/ai/narrativeGenerator.continuity.ts
@@ -1,0 +1,256 @@
+/**
+ * Continuity guardrail wiring for narrative generation (#409/#412).
+ *
+ * Owns the store reads and the single corrective AI call so the pure
+ * detection logic in `lib/lore/continuityGuardrail.ts` stays store-free.
+ * Everything here is fail-open: any error leaves the generated segment
+ * untouched — continuity checking must never block the player.
+ */
+
+import { useWorldStore } from '@/state/worldStore';
+import { useNPCStore } from '@/state/npcStore';
+import { useLoreStore } from '@/state/loreStore';
+import { useContinuityStore } from '@/state/continuityStore';
+import { generateUniqueId } from '@/lib/utils/generateId';
+import { logger } from '@/lib/utils/logger';
+import type { AIClient } from './types';
+import type { EntityID } from '@/types/common.types';
+import type {
+  NarrativeGenerationRequest,
+  NarrativeGenerationResult,
+} from '@/types/narrative.types';
+import type {
+  ContinuityContract,
+  ContinuityRecentDecision,
+  ContinuitySegmentNote,
+  ContinuityValidationResult,
+} from '@/types/continuity.types';
+import {
+  buildContinuityContract,
+  buildContinuityCorrectionPrompt,
+  detectContinuityIssues,
+  formatContinuityExpectations,
+} from '@/lib/lore/continuityGuardrail';
+
+const CORRECTION_TIMEOUT_MS = 8000;
+
+/**
+ * Recent decisions come from the request context (segments already carry
+ * `causedByDecisionText` / `decisionOutcome` from addSegment's decision
+ * linking) rather than a narrativeStore read, which would add a new
+ * lib/ai -> state edge for data the request already has.
+ */
+const collectRecentDecisions = (
+  request: NarrativeGenerationRequest
+): ContinuityRecentDecision[] => {
+  const decisions: ContinuityRecentDecision[] = [];
+  for (const segment of request.narrativeContext?.previousSegments ?? []) {
+    const text = segment?.metadata?.causedByDecisionText;
+    if (text) {
+      decisions.push({ text, outcome: segment.metadata?.decisionOutcome });
+    }
+  }
+  const currentSituation = request.narrativeContext?.currentSituation;
+  if (currentSituation?.startsWith('Player chose')) {
+    decisions.push({ text: currentSituation });
+  }
+  return decisions;
+};
+
+/**
+ * Builds the continuity contract from live stores. Returns null when the
+ * contract would be vacuous (nothing to validate against) or when any store
+ * read fails — a null contract disables the guardrail for this request.
+ */
+export const buildContinuityContractFromStores = (
+  request: NarrativeGenerationRequest
+): ContinuityContract | null => {
+  try {
+    const worldStoreState = useWorldStore.getState();
+    const worldState =
+      typeof worldStoreState.getWorldState === 'function'
+        ? worldStoreState.getWorldState(request.worldId)
+        : undefined;
+    const npcRelationships = worldState?.npcRelationships ?? {};
+
+    const npcNames: Record<EntityID, string> = {};
+    const npcStoreState = useNPCStore.getState();
+    if (typeof npcStoreState.getNPCsByWorld === 'function') {
+      for (const npc of npcStoreState.getNPCsByWorld(request.worldId) ?? []) {
+        if (npc?.id && npc?.name) {
+          npcNames[npc.id] = npc.name;
+        }
+      }
+    }
+
+    const loreStoreState = useLoreStore.getState();
+    const facts =
+      typeof loreStoreState.getFacts === 'function'
+        ? (loreStoreState.getFacts({
+            worldId: request.worldId,
+            sessionId: request.sessionId,
+          }) ?? [])
+        : [];
+
+    const contract = buildContinuityContract({
+      facts,
+      npcRelationships,
+      npcNames,
+      recentDecisions: collectRecentDecisions(request),
+    });
+
+    if (contract.npcs.length === 0 && contract.canonFacts.length === 0) {
+      return null;
+    }
+    return contract;
+  } catch (error) {
+    logger.warn('[ContinuityGuardrail] Failed to build contract', { error });
+    return null;
+  }
+};
+
+/**
+ * Prevention layer: appends the contract's expectations to the generation
+ * prompt so the model is less likely to contradict state in the first place.
+ */
+export const enhancePromptWithContinuityExpectations = (
+  prompt: string,
+  contract: ContinuityContract | null
+): string => {
+  if (!contract) return prompt;
+  const expectations = formatContinuityExpectations(contract);
+  if (!expectations) return prompt;
+  return `${prompt}\n\n${expectations}`;
+};
+
+const raceWithTimeout = async <T>(promise: Promise<T>, ms: number): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error('Continuity correction timed out')),
+          ms
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/**
+ * Push a validation result into the continuity store for the DevTools panel.
+ * Browser + non-production only; failures are swallowed so that observability
+ * never interferes with narrative generation.
+ */
+const publishContinuityResult = (result: ContinuityValidationResult): void => {
+  if (typeof window === 'undefined' || process.env.NODE_ENV === 'production') {
+    return;
+  }
+  try {
+    useContinuityStore.getState().recordResult(result);
+  } catch {
+    // Intentionally ignored — observability must never break generation.
+  }
+};
+
+const withContinuityNote = (
+  result: NarrativeGenerationResult,
+  note: ContinuitySegmentNote
+): NarrativeGenerationResult => ({
+  ...result,
+  metadata: {
+    ...result.metadata,
+    continuity: note,
+  },
+});
+
+/**
+ * Runtime check on the formatted segment prose. Deterministic detection is
+ * the fast path; when an issue is found, one corrective AI call rewrites the
+ * segment, and the corrected text is adopted only if it strictly reduces the
+ * issue count. Otherwise the original ships flagged (visible in DevTools).
+ */
+export const applyContinuityGuardrail = async (options: {
+  result: NarrativeGenerationResult;
+  contract: ContinuityContract | null;
+  client: AIClient;
+  worldId: EntityID;
+  sessionId?: EntityID;
+}): Promise<NarrativeGenerationResult> => {
+  const { result, contract, client, worldId, sessionId } = options;
+  if (!contract || !result.content) {
+    return result;
+  }
+
+  const detectionStart = Date.now();
+  const issues = detectContinuityIssues(result.content, contract);
+  const detectionMs = Date.now() - detectionStart;
+
+  if (issues.length === 0) {
+    publishContinuityResult({
+      id: generateUniqueId('continuity'),
+      worldId,
+      sessionId,
+      status: 'clean',
+      issues: [],
+      detectionMs,
+      timestamp: new Date().toISOString(),
+    });
+    return withContinuityNote(result, { status: 'clean' });
+  }
+
+  const correctionStart = Date.now();
+  let correctedContent: string | null = null;
+  try {
+    const response = await raceWithTimeout(
+      client.generateContent(
+        buildContinuityCorrectionPrompt(result.content, issues, contract)
+      ),
+      CORRECTION_TIMEOUT_MS
+    );
+    correctedContent = response?.content?.trim() || null;
+  } catch (error) {
+    logger.warn('[ContinuityGuardrail] Correction call failed', { error });
+  }
+  const correctionMs = Date.now() - correctionStart;
+
+  const remainingIssues = correctedContent
+    ? detectContinuityIssues(correctedContent, contract)
+    : issues;
+  const corrected =
+    correctedContent !== null && remainingIssues.length < issues.length;
+  const status = corrected ? 'corrected' : 'flagged';
+
+  publishContinuityResult({
+    id: generateUniqueId('continuity'),
+    worldId,
+    sessionId,
+    status,
+    issues,
+    remainingIssues: corrected ? undefined : remainingIssues,
+    detectionMs,
+    correctionMs,
+    timestamp: new Date().toISOString(),
+  });
+
+  logger.info('[ContinuityGuardrail] Contradiction handled', {
+    worldId,
+    sessionId,
+    status,
+    issueCount: issues.length,
+    entities: issues.map((issue) => issue.entity),
+  });
+
+  const finalResult =
+    corrected && correctedContent !== null
+      ? { ...result, content: correctedContent }
+      : result;
+
+  return withContinuityNote(finalResult, {
+    status,
+    issues: issues.map((issue) => ({ type: issue.type, entity: issue.entity })),
+  });
+};

--- a/src/lib/ai/narrativeGenerator.ts
+++ b/src/lib/ai/narrativeGenerator.ts
@@ -54,6 +54,11 @@ import {
 import { formatNarrativeResponse } from './narrativeGenerator.response';
 import { enforceLanguageComplexity } from './narrativeGenerator.languageComplexity';
 import { buildNpcRoster, syncNpcMetadata } from './narrativeGenerator.npc';
+import {
+  applyContinuityGuardrail,
+  buildContinuityContractFromStores,
+  enhancePromptWithContinuityExpectations,
+} from './narrativeGenerator.continuity';
 
 export class NarrativeGenerator {
   private staticContentCache: NarrativeStaticContentCache = {
@@ -135,16 +140,40 @@ export class NarrativeGenerator {
         characterInventory
       );
 
-      const response = await this.geminiClient.generateContent(fullyEnhancedPrompt);
-      recordRequestCalibration(budget, fullyEnhancedPrompt, response);
+      const continuityContract = buildContinuityContractFromStores(request);
+      const finalPrompt = enhancePromptWithContinuityExpectations(
+        fullyEnhancedPrompt,
+        continuityContract
+      );
 
-      if (response.content) {
+      const response = await this.geminiClient.generateContent(finalPrompt);
+      recordRequestCalibration(budget, finalPrompt, response);
+
+      let result = await formatNarrativeResponse(
+        response,
+        inferSegmentType(response.content || ''),
+        this.geminiClient
+      );
+
+      result = await enforceLanguageComplexity(result, toneSettings, this.geminiClient);
+
+      result = await applyContinuityGuardrail({
+        result,
+        contract: continuityContract,
+        client: this.geminiClient,
+        worldId: request.worldId,
+        sessionId: request.sessionId,
+      });
+
+      // Lore extraction runs on the final (possibly corrected) prose so a
+      // contradicted draft never pollutes the lore store.
+      if (result.content) {
         try {
           if (process.env.NODE_ENV !== 'production') {
             logger.info('[NarrativeGenerator] EXTRACTION: Post-segment', {
               worldId: request.worldId,
               sessionId: request.sessionId,
-              contentLength: response.content.length,
+              contentLength: result.content.length,
             });
           }
 
@@ -152,7 +181,7 @@ export class NarrativeGenerator {
             recordUsage: false,
           });
           const structuredLore = await extractStructuredLore(
-            response.content,
+            result.content,
             existingLoreContext
           );
 
@@ -179,14 +208,6 @@ export class NarrativeGenerator {
           logger.error('[NarrativeGenerator] Failed to extract lore:', error);
         }
       }
-
-      let result = await formatNarrativeResponse(
-        response,
-        inferSegmentType(response.content || ''),
-        this.geminiClient
-      );
-
-      result = await enforceLanguageComplexity(result, toneSettings, this.geminiClient);
 
       if (
         (!result.metadata.itemsLost || result.metadata.itemsLost.length === 0) &&
@@ -226,7 +247,7 @@ export class NarrativeGenerator {
         const templateType = 'scene';
 
         const debugInfoContext: DebugInfoContext = {
-          fullPrompt: fullyEnhancedPrompt,
+          fullPrompt: finalPrompt,
           templateName: this.getTemplateName(templateType),
           world,
           toneSettings,
@@ -281,6 +302,8 @@ export class NarrativeGenerator {
     }
   }
 
+  // Deliberately not continuity-guarded: at session start there are no
+  // decisions or NPC relationships to validate against (#409/#412).
   async generateInitialScene(
     worldId: string,
     characterIds: string[],

--- a/src/lib/lore/__tests__/continuityGuardrail.test.ts
+++ b/src/lib/lore/__tests__/continuityGuardrail.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for the pure continuity guardrail module (#409/#412): contract
+ * building, deterministic contradiction detection, and correction prompts.
+ */
+
+import {
+  buildContinuityContract,
+  buildContinuityCorrectionPrompt,
+  detectContinuityIssues,
+  formatContinuityExpectations,
+  CONTINUITY_CORRECTION_HEADER,
+} from '../continuityGuardrail';
+import type { LoreFact } from '@/types/lore.types';
+import type { ContinuityContract } from '@/types/continuity.types';
+import type { NPCRelationshipState } from '@/types/world-state.types';
+
+const makeFact = (overrides: Partial<LoreFact> = {}): LoreFact => ({
+  id: 'fact-mira',
+  category: 'characters',
+  key: 'world-1:character_mira',
+  value: 'Mira - a wary herbalist',
+  aliases: ['the herbalist'],
+  source: 'narrative',
+  worldId: 'world-1',
+  visibility: 'world-shared',
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+const makeRelationship = (
+  trust: number,
+  sentiment: number
+): NPCRelationshipState => ({
+  trust,
+  sentiment,
+  lastInteraction: '2025-01-01T00:00:00.000Z',
+  sessionId: 'session-1',
+});
+
+const buildMiraContract = (trust = 5, sentiment = -80): ContinuityContract =>
+  buildContinuityContract({
+    facts: [makeFact()],
+    npcRelationships: { 'npc-mira': makeRelationship(trust, sentiment) },
+    npcNames: { 'npc-mira': 'Mira' },
+    recentDecisions: [{ text: 'Betray the herbalist', outcome: 'success' }],
+  });
+
+describe('buildContinuityContract', () => {
+  it('joins relationships to lore aliases and derives tone from trust/sentiment', () => {
+    const contract = buildMiraContract();
+
+    expect(contract.npcs).toHaveLength(1);
+    expect(contract.npcs[0]).toMatchObject({
+      npcId: 'npc-mira',
+      name: 'Mira',
+      trust: 5,
+      sentiment: -80,
+      expectedTone: 'hostile',
+    });
+    expect(contract.npcs[0].aliases).toContain('the herbalist');
+    expect(contract.recentDecisions).toEqual([
+      { text: 'Betray the herbalist', outcome: 'success' },
+    ]);
+  });
+
+  it('extracts canon facts for dead entities from fact descriptions', () => {
+    const contract = buildContinuityContract({
+      facts: [
+        makeFact({
+          id: 'fact-tom',
+          key: 'world-1:character_old_tom',
+          value: 'Old Tom - the village elder',
+          aliases: [],
+          metadata: { description: 'Old Tom died defending the bridge.' },
+        }),
+      ],
+      npcRelationships: {},
+      npcNames: {},
+      recentDecisions: [],
+    });
+
+    expect(contract.canonFacts).toHaveLength(1);
+    expect(contract.canonFacts[0]).toMatchObject({
+      entity: 'Old Tom',
+      status: 'dead',
+    });
+  });
+});
+
+describe('detectContinuityIssues', () => {
+  it('flags warm prose about an NPC whose trust was tanked', () => {
+    const issues = detectContinuityIssues(
+      'Mira beams at you and embraces you warmly.',
+      buildMiraContract()
+    );
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ type: 'relationship-tone', entity: 'Mira' });
+    expect(issues[0].excerpt).toContain('embraces you warmly');
+  });
+
+  it('flags warm prose referencing the NPC only by a lore alias', () => {
+    const issues = detectContinuityIssues(
+      'The herbalist hugs you fondly before you leave.',
+      buildMiraContract()
+    );
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].entity).toBe('Mira');
+  });
+
+  it('passes warm prose when the relationship is actually warm', () => {
+    const issues = detectContinuityIssues(
+      'Mira beams at you and embraces you warmly.',
+      buildMiraContract(90, 60)
+    );
+
+    expect(issues).toHaveLength(0);
+  });
+
+  it('respects negation guards', () => {
+    const issues = detectContinuityIssues(
+      'Mira does not smile warmly at you.',
+      buildMiraContract()
+    );
+
+    expect(issues).toHaveLength(0);
+  });
+
+  it('flags a dead entity written as actively present', () => {
+    const contract = buildContinuityContract({
+      facts: [
+        makeFact({
+          id: 'fact-tom',
+          value: 'Old Tom - the village elder',
+          aliases: [],
+          metadata: { description: 'Old Tom died defending the bridge.' },
+        }),
+      ],
+      npcRelationships: {},
+      npcNames: {},
+      recentDecisions: [],
+    });
+
+    expect(
+      detectContinuityIssues('Old Tom greets you at the door.', contract)
+    ).toMatchObject([{ type: 'reversed-fact', entity: 'Old Tom' }]);
+    expect(
+      detectContinuityIssues(
+        'You remember how Old Tom used to greet you.',
+        contract
+      )
+    ).toHaveLength(0);
+  });
+
+  it('returns nothing for empty content', () => {
+    expect(detectContinuityIssues('', buildMiraContract())).toHaveLength(0);
+  });
+});
+
+describe('formatContinuityExpectations', () => {
+  it('formats NPC, canon, and decision constraints', () => {
+    const block = formatContinuityExpectations(buildMiraContract());
+
+    expect(block).toContain('CONTINUITY REQUIREMENTS');
+    expect(block).toContain('Mira');
+    expect(block).toContain('trust 5/100');
+    expect(block).toContain('Betray the herbalist');
+  });
+
+  it('returns an empty string for an empty contract', () => {
+    expect(
+      formatContinuityExpectations({ npcs: [], canonFacts: [], recentDecisions: [] })
+    ).toBe('');
+  });
+});
+
+describe('buildContinuityCorrectionPrompt', () => {
+  it('includes the header, detected issues, constraints, and original prose', () => {
+    const contract = buildMiraContract();
+    const content = 'Mira beams at you and embraces you warmly.';
+    const issues = detectContinuityIssues(content, contract);
+
+    const prompt = buildContinuityCorrectionPrompt(content, issues, contract);
+
+    expect(prompt).toContain(CONTINUITY_CORRECTION_HEADER);
+    expect(prompt).toContain('embraces you warmly');
+    expect(prompt).toContain('CONTINUITY REQUIREMENTS');
+    expect(prompt).toContain(content);
+  });
+});

--- a/src/lib/lore/continuityGuardrail.ts
+++ b/src/lib/lore/continuityGuardrail.ts
@@ -1,0 +1,289 @@
+/**
+ * Continuity Guardrail (#409/#412)
+ *
+ * Pure contradiction detection for generated narrative. Builds a compact
+ * "continuity contract" from established state (lore facts, NPC relationships,
+ * recent decisions) and checks new prose against it deterministically, so the
+ * fast path adds microseconds — an AI correction call only happens when an
+ * issue is detected (per #441's sub-200ms generation-impact constraint).
+ *
+ * Like `loreContext.ts`, this module takes data as parameters and imports no
+ * stores; store reads live in `lib/ai/narrativeGenerator.continuity.ts`.
+ */
+
+import type { LoreFact } from '../../types/lore.types';
+import type { NPCRelationshipState } from '../../types/world-state.types';
+import type { EntityID } from '../../types/common.types';
+import type {
+  ContinuityCanonFact,
+  ContinuityContract,
+  ContinuityIssue,
+  ContinuityNpcExpectation,
+  ContinuityRecentDecision,
+  ContinuityTone,
+} from '../../types/continuity.types';
+
+/** Routes correction responses in tests and marks the call in debug output. */
+export const CONTINUITY_CORRECTION_HEADER = 'CONTINUITY CORRECTION';
+
+const MAX_NPC_EXPECTATIONS = 8;
+const MAX_CANON_FACTS = 10;
+const MAX_RECENT_DECISIONS = 3;
+const MAX_EXCERPT_LENGTH = 240;
+const MIN_TERM_LENGTH = 3;
+
+// Lexicons are deliberately conservative: every false positive costs an AI
+// correction call, so prefer missing a soft contradiction over flagging
+// ordinary prose.
+const DEAD_STATUS = /\b(is dead|died|was killed|slain|deceased)\b/i;
+const DESTROYED_STATUS = /\b(was destroyed|burned down|razed|no longer exists)\b/i;
+const WARMTH_LEXICON =
+  /\b(warmly|embrac(?:e|es|ed|ing)|beam(?:s|ed|ing)|fondly|affectionate(?:ly)?|hug(?:s|ged|ging)?|old friend|dear friend|trusts? you)\b/i;
+const NEGATION_GUARD =
+  /\b(not|never|no longer|coldly|icily|feigned|feigning|pretend(?:s|ed|ing)?|mockingly|sarcastically)\b|n['’]t\b/i;
+const ACTIVE_PRESENCE_LEXICON =
+  /\b(says?|said|speak(?:s|ing)?|spoke|asks?|asked|repl(?:y|ies|ied)|smil(?:e|es|ed|ing)|laugh(?:s|ed|ing)?|walk(?:s|ed|ing)?|arriv(?:e|es|ed|ing)|greet(?:s|ed|ing)?|stands?|stood|nods?|nodded|hands you|waves?|waved)\b/i;
+const MEMORY_GUARD =
+  /\b(remember(?:s|ed|ing)?|recall(?:s|ed|ing)?|memor\w+|ghost(?:s|ly)?|spirit|vision|dream(?:s|ed|t|ing)?|grave\w*|tomb|dead|died|death|haunt\w*|once|used to|echo(?:es)?|portrait|statue)\b/i;
+
+export interface BuildContinuityContractArgs {
+  facts: LoreFact[];
+  npcRelationships: Record<EntityID, NPCRelationshipState>;
+  /** npcId -> display name, from the NPC store roster. */
+  npcNames: Record<EntityID, string>;
+  recentDecisions: ContinuityRecentDecision[];
+}
+
+/**
+ * Derives the tone a segment should give an NPC from relationship numbers.
+ */
+function toneForRelationship(trust: number, sentiment: number): ContinuityTone {
+  if (sentiment <= -50) return 'hostile';
+  if (trust <= 25) return 'guarded';
+  if (trust >= 75 && sentiment >= 50) return 'warm';
+  return 'neutral';
+}
+
+/** Leading entity name, before the first dash/colon (loreContext convention). */
+function parseEntityName(value: string): string {
+  const match = value.match(/^([^-:]+?)(?:\s*[-:]\s*.+)?$/);
+  return (match ? match[1] : value).trim();
+}
+
+function escapeRegExp(term: string): string {
+  return term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function dedupeTerms(terms: Array<string | undefined>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const term of terms) {
+    const trimmed = term?.trim();
+    if (!trimmed || trimmed.length < MIN_TERM_LENGTH) continue;
+    const lower = trimmed.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+export function buildContinuityContract(
+  args: BuildContinuityContractArgs
+): ContinuityContract {
+  const { facts, npcRelationships, npcNames, recentDecisions } = args;
+  const characterFacts = facts.filter((fact) => fact?.category === 'characters');
+
+  const npcs: ContinuityNpcExpectation[] = [];
+  for (const [npcId, relationship] of Object.entries(npcRelationships)) {
+    const name = npcNames[npcId]?.trim();
+    if (!name || !relationship) continue;
+
+    // Lore facts carry names, not npc ids, so the only join is name equality.
+    const matchingFacts = characterFacts.filter((fact) => {
+      const factName = parseEntityName(fact.value).toLowerCase();
+      return (
+        factName === name.toLowerCase() ||
+        (fact.aliases || []).some((alias) => alias.toLowerCase() === name.toLowerCase())
+      );
+    });
+    const aliases = dedupeTerms(
+      matchingFacts.flatMap((fact) => [parseEntityName(fact.value), ...(fact.aliases || [])])
+    ).filter((alias) => alias.toLowerCase() !== name.toLowerCase());
+
+    npcs.push({
+      npcId,
+      name,
+      aliases,
+      trust: relationship.trust,
+      sentiment: relationship.sentiment,
+      expectedTone: toneForRelationship(relationship.trust, relationship.sentiment),
+    });
+  }
+  npcs.sort((a, b) => Math.abs(b.sentiment) - Math.abs(a.sentiment));
+
+  const canonFacts: ContinuityCanonFact[] = [];
+  for (const fact of facts) {
+    if (!fact?.value || !['characters', 'locations', 'events'].includes(fact.category)) {
+      continue;
+    }
+    const text = `${fact.value} ${fact.metadata?.description ?? ''}`;
+    const status = DEAD_STATUS.test(text)
+      ? 'dead'
+      : DESTROYED_STATUS.test(text)
+        ? 'destroyed'
+        : null;
+    if (!status) continue;
+
+    canonFacts.push({
+      entity: parseEntityName(fact.value),
+      aliases: dedupeTerms(fact.aliases || []),
+      status,
+      statement: text.trim(),
+    });
+    if (canonFacts.length >= MAX_CANON_FACTS) break;
+  }
+
+  return {
+    npcs: npcs.slice(0, MAX_NPC_EXPECTATIONS),
+    canonFacts,
+    recentDecisions: recentDecisions.slice(-MAX_RECENT_DECISIONS),
+  };
+}
+
+function findOffendingSentence(
+  sentences: string[],
+  terms: string[],
+  positiveLexicon: RegExp,
+  guardLexicon: RegExp
+): string | null {
+  const termPatterns = terms.map(
+    (term) => new RegExp(`\\b${escapeRegExp(term)}\\b`, 'i')
+  );
+  for (const sentence of sentences) {
+    if (!positiveLexicon.test(sentence) || guardLexicon.test(sentence)) continue;
+    if (termPatterns.some((pattern) => pattern.test(sentence))) {
+      return sentence.trim().slice(0, MAX_EXCERPT_LENGTH);
+    }
+  }
+  return null;
+}
+
+/**
+ * Deterministic fast-path check. Returns at most one issue per NPC / canon
+ * fact so a repeated contradiction doesn't flood the result.
+ */
+export function detectContinuityIssues(
+  content: string,
+  contract: ContinuityContract
+): ContinuityIssue[] {
+  if (!content?.trim()) return [];
+
+  const sentences = content.split(/(?<=[.!?])\s+/);
+  const issues: ContinuityIssue[] = [];
+
+  for (const npc of contract.npcs) {
+    if (npc.expectedTone !== 'hostile' && npc.expectedTone !== 'guarded') continue;
+    const excerpt = findOffendingSentence(
+      sentences,
+      [npc.name, ...npc.aliases],
+      WARMTH_LEXICON,
+      NEGATION_GUARD
+    );
+    if (excerpt) {
+      issues.push({
+        type: 'relationship-tone',
+        entity: npc.name,
+        excerpt,
+        expectation: describeNpcExpectation(npc),
+      });
+    }
+  }
+
+  for (const canon of contract.canonFacts) {
+    const excerpt = findOffendingSentence(
+      sentences,
+      [canon.entity, ...canon.aliases],
+      ACTIVE_PRESENCE_LEXICON,
+      MEMORY_GUARD
+    );
+    if (excerpt) {
+      issues.push({
+        type: 'reversed-fact',
+        entity: canon.entity,
+        excerpt,
+        expectation: describeCanonExpectation(canon),
+      });
+    }
+  }
+
+  return issues;
+}
+
+function describeNpcExpectation(npc: ContinuityNpcExpectation): string {
+  const stance = npc.expectedTone === 'hostile' ? 'is hostile toward' : 'distrusts';
+  return `${npc.name} currently ${stance} the player (trust ${npc.trust}/100, sentiment ${npc.sentiment}). Portray them as ${npc.expectedTone === 'hostile' ? 'hostile or cold' : 'guarded or wary'} — never warm or affectionate.`;
+}
+
+function describeCanonExpectation(canon: ContinuityCanonFact): string {
+  const state = canon.status === 'dead' ? 'is dead' : 'was destroyed';
+  const forbidden = canon.status === 'dead' ? 'alive or present' : 'intact or in use';
+  return `${canon.entity} ${state} (${canon.statement}). Do not write ${canon.status === 'dead' ? 'them' : 'it'} as ${forbidden}.`;
+}
+
+/**
+ * Compact prompt block shared by the prevention layer (appended to the
+ * generation prompt) and the correction prompt. Empty string for an empty
+ * contract so callers can append unconditionally.
+ */
+export function formatContinuityExpectations(contract: ContinuityContract): string {
+  const lines: string[] = [];
+
+  for (const npc of contract.npcs) {
+    if (npc.expectedTone === 'hostile' || npc.expectedTone === 'guarded') {
+      lines.push(`- ${describeNpcExpectation(npc)}`);
+    } else if (npc.expectedTone === 'warm') {
+      lines.push(
+        `- ${npc.name} is friendly toward the player (trust ${npc.trust}/100, sentiment ${npc.sentiment}).`
+      );
+    }
+  }
+  for (const canon of contract.canonFacts) {
+    lines.push(`- ${describeCanonExpectation(canon)}`);
+  }
+  for (const decision of contract.recentDecisions) {
+    const outcome = decision.outcome ? ` (outcome: ${decision.outcome})` : '';
+    lines.push(`- Recent decision: "${decision.text}"${outcome}. Honor its consequences.`);
+  }
+
+  if (lines.length === 0) return '';
+  return `CONTINUITY REQUIREMENTS (do not violate):\n${lines.join('\n')}`;
+}
+
+/**
+ * Prompt for the single corrective AI call: minimal rewrite that honors the
+ * contract while preserving the rest of the segment.
+ */
+export function buildContinuityCorrectionPrompt(
+  content: string,
+  issues: ContinuityIssue[],
+  contract: ContinuityContract
+): string {
+  const issueLines = issues
+    .map((issue) => `- [${issue.type}] ${issue.expectation}\n  Offending text: "${issue.excerpt}"`)
+    .join('\n');
+
+  return `${CONTINUITY_CORRECTION_HEADER}
+
+The narrative segment below contradicts established story state.
+
+Detected contradictions:
+${issueLines}
+
+${formatContinuityExpectations(contract)}
+
+Rewrite the segment with the minimal changes needed to honor every requirement above. Preserve the plot events, point of view, tense, formatting, and approximate length. Return ONLY the corrected narrative prose — no commentary, headings, or JSON.
+
+Original segment:
+${content}`;
+}

--- a/src/state/__tests__/narrativeStore.segments.continuity.test.ts
+++ b/src/state/__tests__/narrativeStore.segments.continuity.test.ts
@@ -1,0 +1,84 @@
+/**
+ * addSegment persists the continuity guardrail note on segment metadata
+ * (#409/#412) — the finalMetadata whitelist must carry it through.
+ */
+
+import { useNarrativeStore } from '../narrativeStore';
+import { useWorldStore } from '../worldStore';
+import { useSessionStore } from '../sessionStore';
+
+describe('addSegment continuity metadata', () => {
+  let worldId: string;
+  const sessionId = 'session-continuity-test';
+
+  beforeEach(() => {
+    jest.useRealTimers();
+    useWorldStore.getState().reset();
+    useNarrativeStore.getState().reset();
+    global.fetch = jest.fn();
+
+    worldId = useWorldStore.getState().createWorld({
+      name: 'Test World',
+      description: 'A test world',
+      genre: 'fantasy',
+      attributes: [],
+      skills: [],
+      settings: {
+        maxAttributes: 5,
+        maxSkills: 5,
+        attributePointPool: 10,
+        skillPointPool: 10,
+      },
+    });
+    useSessionStore.getState().upsertSessionLifecycle({
+      id: sessionId,
+      worldId,
+      characterId: 'char-test',
+      status: 'active',
+      lastActivity: new Date().toISOString(),
+    });
+  });
+
+  afterEach(() => {
+    useNarrativeStore.getState().reset();
+    useWorldStore.getState().reset();
+    jest.restoreAllMocks();
+  });
+
+  it('persists metadata.continuity on the stored segment', () => {
+    const segmentId = useNarrativeStore.getState().addSegment(sessionId, {
+      worldId,
+      content: 'Mira watches you from behind the counter.',
+      type: 'scene',
+      metadata: {
+        tags: [],
+        continuity: {
+          status: 'corrected',
+          issues: [{ type: 'relationship-tone', entity: 'Mira' }],
+        },
+      },
+      timestamp: new Date(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const segment = useNarrativeStore.getState().segments[segmentId];
+    expect(segment.metadata.continuity).toEqual({
+      status: 'corrected',
+      issues: [{ type: 'relationship-tone', entity: 'Mira' }],
+    });
+  });
+
+  it('leaves continuity undefined when not provided', () => {
+    const segmentId = useNarrativeStore.getState().addSegment(sessionId, {
+      worldId,
+      content: 'You step into the quiet shop.',
+      type: 'scene',
+      metadata: { tags: [] },
+      timestamp: new Date(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const segment = useNarrativeStore.getState().segments[segmentId];
+    expect(segment.metadata.continuity).toBeUndefined();
+  });
+});

--- a/src/state/continuityStore.ts
+++ b/src/state/continuityStore.ts
@@ -1,0 +1,33 @@
+import { create } from 'zustand';
+import type { ContinuityValidationResult } from '@/types/continuity.types';
+
+/**
+ * Maximum number of validation results retained for the DevTools panel. This
+ * is ephemeral, dev-only observability data so the history is intentionally
+ * small and never persisted.
+ */
+const MAX_RESULTS = 25;
+
+interface ContinuityState {
+  /** Captured validation results, oldest first. Newest is `results.at(-1)`. */
+  results: ContinuityValidationResult[];
+  /** Record a new result, trimming history to the most recent MAX_RESULTS. */
+  recordResult: (result: ContinuityValidationResult) => void;
+  /** Clear all captured results. */
+  clear: () => void;
+}
+
+/**
+ * Holds continuity-guardrail validation results captured after each narrative
+ * generation so the DevTools ConsistencyValidationSection can show live
+ * detection/correction outcomes (#409/#412). Populated client-side by
+ * `applyContinuityGuardrail` in `narrativeGenerator.continuity.ts`.
+ */
+export const useContinuityStore = create<ContinuityState>((set) => ({
+  results: [],
+  recordResult: (result) =>
+    set((state) => ({
+      results: [...state.results, result].slice(-MAX_RESULTS),
+    })),
+  clear: () => set({ results: [] }),
+}));

--- a/src/state/narrativeStore.segments.ts
+++ b/src/state/narrativeStore.segments.ts
@@ -126,6 +126,7 @@ export const createNarrativeSegmentActions = (
       causedByDecisionId,
       causedByDecisionText,
       decisionOutcome: metadata?.decisionOutcome,
+      continuity: metadata?.continuity,
       debugInfo: metadata?.debugInfo, // Preserve debug info from AI generation
     };
 

--- a/src/types/continuity.types.ts
+++ b/src/types/continuity.types.ts
@@ -1,0 +1,82 @@
+// src/types/continuity.types.ts
+
+import type { EntityID } from './common.types';
+
+/**
+ * Types for the runtime continuity guardrail (#409/#412): deterministic
+ * contradiction detection over generated narrative, with a single corrective
+ * AI call when an issue is found.
+ */
+
+type ContinuityIssueType = 'relationship-tone' | 'reversed-fact';
+
+export type ContinuityStatus = 'clean' | 'corrected' | 'flagged';
+
+export type ContinuityTone = 'hostile' | 'guarded' | 'neutral' | 'warm';
+
+/**
+ * Tone expectation for an NPC, derived from worldStore.npcRelationships and
+ * joined to display names/aliases via npcStore and lore character facts.
+ */
+export interface ContinuityNpcExpectation {
+  npcId: EntityID;
+  name: string;
+  aliases: string[];
+  trust: number;
+  sentiment: number;
+  expectedTone: ContinuityTone;
+}
+
+/**
+ * A lore fact whose status makes certain narrative assertions contradictory
+ * (e.g. a dead character appearing alive).
+ */
+export interface ContinuityCanonFact {
+  entity: string;
+  aliases: string[];
+  status: 'dead' | 'destroyed';
+  statement: string;
+}
+
+export interface ContinuityRecentDecision {
+  text: string;
+  outcome?: string;
+}
+
+/**
+ * Compact, deterministic snapshot of the constraints a new segment must honor.
+ */
+export interface ContinuityContract {
+  npcs: ContinuityNpcExpectation[];
+  canonFacts: ContinuityCanonFact[];
+  recentDecisions: ContinuityRecentDecision[];
+}
+
+export interface ContinuityIssue {
+  type: ContinuityIssueType;
+  entity: string;
+  /** Offending sentence (trimmed). */
+  excerpt: string;
+  /** Human-readable constraint that was violated. */
+  expectation: string;
+}
+
+/** Compact note persisted on the segment (NarrativeMetadata.continuity). */
+export interface ContinuitySegmentNote {
+  status: ContinuityStatus;
+  issues?: Array<{ type: ContinuityIssueType; entity: string }>;
+}
+
+/** Full record for the DevTools feed (continuityStore). */
+export interface ContinuityValidationResult {
+  id: string;
+  worldId: EntityID;
+  sessionId?: EntityID;
+  status: ContinuityStatus;
+  issues: ContinuityIssue[];
+  /** Issues still present after the correction attempt (status === 'flagged'). */
+  remainingIssues?: ContinuityIssue[];
+  detectionMs: number;
+  correctionMs?: number;
+  timestamp: string;
+}

--- a/src/types/narrative.types.ts
+++ b/src/types/narrative.types.ts
@@ -4,6 +4,7 @@ import type { EntityID, TimestampedEntity } from './common.types';
 import type { World } from './world.types';
 import type { Character } from './character.types';
 import type { InventoryAcquisitionMethod, StandardInventoryCategory } from './inventory.types';
+import type { ContinuitySegmentNote } from './continuity.types';
 
 /**
  * Represents a segment of narrative in the game
@@ -269,6 +270,8 @@ export interface NarrativeMetadata {
   causedByDecisionId?: EntityID;
   causedByDecisionText?: string;
   decisionOutcome?: DecisionOutcome;
+  // Continuity guardrail outcome (#409/#412)
+  continuity?: ContinuitySegmentNote;
   // Debug information (dev mode only)
   debugInfo?: PromptDebugInfo;
 }
@@ -375,6 +378,8 @@ export interface NarrativeGenerationResult {
     itemsLost?: LostItemMetadata[];
     // Major event tracking
     majorEvent?: string;
+    // Continuity guardrail outcome (#409/#412)
+    continuity?: ContinuitySegmentNote;
     // Debug information (dev mode only)
     debugInfo?: PromptDebugInfo;
   };


### PR DESCRIPTION
## Description

Generated segments were committed without any check against established state, so contradictions slipped straight through to the player — an NPC whose trust you just tanked could greet you like an old friend, a character established as dead could stroll back in.

This wires a continuity guardrail into the segment pipeline:

- **Contract**: before generation, a compact "continuity contract" is built from worldStore.npcRelationships (trust/sentiment tone bands), lore facts (entity aliases + dead/destroyed canon facts), and recent decisions from the request context.
- **Prevention**: the contract's expectations get appended to the generation prompt ("Mira currently distrusts the player (trust 5/100)... never warm or affectionate"), so the model contradicts less in the first place.
- **Detection**: after formatting, the prose is checked deterministically (sentence-level lexicon matching with negation/memory guards). This is the fast path — microseconds, which is how it stays inside #441's sub-200ms generation-impact constraint.
- **Correction**: only when an issue is found, one corrective AI call rewrites the segment (8s timeout, fail-open). Corrected text is adopted only if it strictly reduces the issue count; otherwise the original ships flagged. The player is never blocked.
- **Observability**: every validation lands in a new Runtime Validation block in the DevTools ConsistencyValidationSection (fed by a small non-persisted `continuityStore`, mirroring the calibrationStore pattern), and each segment persists a `metadata.continuity` note.

One ordering change worth calling out: `extractStructuredLore` moved from before formatting to after the guardrail, so lore is extracted from the final (possibly corrected) prose and a contradicted draft never pollutes the lore store. Its input also improves from the raw response envelope to normalized prose; no existing test asserted on either.

## Related Issue

Addresses #409 (lore validation layer) and #412 (the auto-correction slice — player-facing retcon tools stay out of scope), with framing from #441. Not using `Closes` — both issues have remaining scope, and it wouldn't auto-close on a develop merge anyway.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation (written alongside, not strictly first)
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed

#441: "As a player, I want the game to prevent narrative contradictions so that my story remains coherent and believable."

## Component Development
- [ ] Storybook stories created/updated (no new components — the DevTools block reuses Badge/Button/DevToolsSection/JsonViewer)
- [ ] Components developed in isolation first
- [x] Visual consistency verified (existing DS components only, no new CSS)

## Implementation Notes

- The pure detection logic lives in `src/lib/lore/continuityGuardrail.ts` with zero store imports (same discipline as `loreContext.ts`, keeps the skott baseline at 6). Store reads live in `src/lib/ai/narrativeGenerator.continuity.ts`, following the sibling-module convention.
- Everything is fail-open: contract building wraps all store reads in try/catch and returns null on anything unexpected; a null or vacuous contract makes the guardrail fully inert (no prompt change, no extra AI calls). That's also what keeps the 11 existing generateSegment test suites green untouched.
- Lexicons are deliberately conservative (hostile/guarded NPCs only, strict dead/destroyed patterns, negation and memory guards) since every false positive costs an AI call.
- NPC join: relationships are keyed by npcId, lore facts carry names — the join is case-insensitive name equality between the npcStore roster and character facts (facts don't store npc ids).
- `generateInitialScene` is deliberately not guarded — no decisions or relationships exist at session start.
- Explicitly untouched: `choiceGenerator.parser.ts` and the consequence path (`narrativeStore.decisions.ts` / `worldStateImpacts` / `applyWorldStateThreadUpdates`).

## Quality Checks
- [x] Linting passed (eslint + stylelint)
- [x] Type checking passed
- [ ] Security audit passed (not run — no new dependencies or input surfaces)
- [x] No console.log statements in production code (logger only)
- [x] No unhandled promises

Also green locally: full Jest suite (359 suites / 2473 tests), knip, skott baseline (6), deps:validate, production build.

## Testing Instructions

1. `npx jest continuityGuardrail narrativeGenerator.continuity narrativeStore.segments.continuity` — unit + integration coverage, including the seeded-contradiction acceptance test: Mira's trust tanked to 5/sentiment -80, the AI returns "Mira beams at you and embraces you warmly...", the guardrail detects it, issues one correction call, and the corrected prose is what comes out (with lore extraction running on the corrected text).
2. Manual: play a session, pick choices that tank an NPC's trust, then open DevTools > Consistency Validation > Runtime Validation to watch clean/corrected/flagged results with detection/correction timings.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed (devtools-only UI, existing components)