### PR TITLE
ci: enforce dependency-cruiser in the lint job

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -217,7 +217,10 @@ module.exports = {
         'from.pathNot re of the not-to-dev-dep rule in the dependency-cruiser configuration',
       from: {
         path: '^(src)',
-        pathNot: '[.](?:spec|test)[.](?:js|mjs|cjs|jsx|ts|mts|cts|tsx)$'
+        pathNot: [
+          '[.](?:spec|test)[.](?:js|mjs|cjs|jsx|ts|mts|cts|tsx)$',
+          '[.]stories[.](?:js|mjs|cjs|jsx|ts|mts|cts|tsx)$'
+        ]
       },
       to: {
         dependencyTypes: [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,8 @@ jobs:
         run: npm run lint:layout-usage
       - name: Enforce design-system canon (living style guide)
         run: npm run lint:ds-canon
+      - name: Enforce dependency boundaries (no new cycles or dev-dep leaks)
+        run: npm run deps:validate
 
   knip:
     name: Knip (unused code)


### PR DESCRIPTION
## What
Wires `deps:validate` (dependency-cruiser) into the CI lint job, so new circular deps, dev-dep leaks, and domain-boundary violations fail the build instead of drifting in.

First it exempts `.stories.` files from the `not-to-dev-dep` rule — Storybook stories legitimately import `@storybook/test` (a dev dep), which was the only thing keeping the gate red. After that `deps:validate` is green locally (8 non-failing `no-circular` warnings remain).

## Why
The script already lived in `package.json` but no workflow ever called it — nothing stopped a new cycle or a prod-code dev-dep import from landing. This makes it a ratchet that locks in the recent narrativeStore / src-state refactor's architecture.

Overlaps slightly with the existing `skott-cycles` job on cycle detection, but adds the domain-boundary rules (`state-no-component-imports`, `utils-no-state-imports`, ...) and dev-dep enforcement that skott doesn't cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
