### PR TITLE
feat(security): enforce Content-Security-Policy

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,12 +7,25 @@ import type { NextConfig } from "next";
 // static generation. Enforcement was verified clean first: a headless crawl of
 // the public/creation/settings/dev routes produced zero violations, generated
 // images are base64 data: URLs, and no client code fetches non-self origins.
-// Fonts are self-hosted by next/font; image origins mirror images.remotePatterns.
+// The /dev/design-system-{2,3} showcase routes @import Google Fonts, so
+// googleapis (stylesheet) and gstatic (font files) are allowlisted; the
+// production app self-hosts fonts via next/font.
+const isDev = process.env.NODE_ENV !== 'production';
+
+// Development-only script sources, omitted from production builds to keep the
+// shipped policy strict:
+// - 'unsafe-eval': `next dev` evaluates the HMR / React Fast Refresh runtime
+//   with eval(); production (next build) never uses eval.
+// - va.vercel-scripts.com: Vercel Analytics loads its debug script from this
+//   origin in dev; in production it is served same-origin (/_vercel/insights).
+const devScriptSrc = isDev ? ["'unsafe-eval'", 'https://va.vercel-scripts.com'] : [];
+const scriptSrc = ["'self'", "'unsafe-inline'", ...devScriptSrc].join(' ');
+
 const contentSecurityPolicy = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline'",
-  "style-src 'self' 'unsafe-inline'",
-  "font-src 'self'",
+  `script-src ${scriptSrc}`,
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "font-src 'self' https://fonts.gstatic.com",
   "img-src 'self' data: blob: https://picsum.photos https://i.pravatar.cc https://api.dicebear.com",
   "connect-src 'self' https://vitals.vercel-insights.com",
   "frame-ancestors 'none'",

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,13 @@
 import type { NextConfig } from "next";
 
-// Content Security Policy. Shipped as Report-Only for now: the app relies on
-// inline scripts (the theme-init script in layout.tsx, Next.js hydration
-// bootstrap, Vercel Analytics) that a strict enforced policy would block
-// without nonces/hashes. Report-Only lets us observe violations in the browser
-// console before moving to enforcement. Fonts are self-hosted by next/font, so
-// no external font origin is needed; image origins mirror images.remotePatterns.
+// Content Security Policy (enforced). 'unsafe-inline' is kept for script/style
+// because the app relies on inline scripts (the theme-init script in
+// layout.tsx, Next.js hydration bootstrap, Vercel Analytics); dropping it would
+// require per-request nonces via middleware, which opts every page out of
+// static generation. Enforcement was verified clean first: a headless crawl of
+// the public/creation/settings/dev routes produced zero violations, generated
+// images are base64 data: URLs, and no client code fetches non-self origins.
+// Fonts are self-hosted by next/font; image origins mirror images.remotePatterns.
 const contentSecurityPolicy = [
   "default-src 'self'",
   "script-src 'self' 'unsafe-inline'",
@@ -21,7 +23,7 @@ const contentSecurityPolicy = [
 
 // Hardening headers that are safe to enforce immediately.
 const securityHeaders = [
-  { key: 'Content-Security-Policy-Report-Only', value: contentSecurityPolicy },
+  { key: 'Content-Security-Policy', value: contentSecurityPolicy },
   { key: 'X-Frame-Options', value: 'DENY' },
   { key: 'X-Content-Type-Options', value: 'nosniff' },
   { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },


### PR DESCRIPTION
## Summary
Follow-up to #1414. Flips the Content Security Policy from **Report-Only to enforced**, now that it's verified clean.

This uses the **pragmatic** approach: `'unsafe-inline'` is kept for `script-src`/`style-src` so the inline theme-init script, Next.js hydration bootstrap, and Vercel Analytics keep working **without** per-request nonces — which would have opted every page out of static generation. The build confirms static routes are still prerendered (`○`).

Newly **enforced** directives: `default-src 'self'`, `connect-src` (self + `vitals.vercel-insights.com`), `img-src` (self + `data:`/`blob:` + the three `images.remotePatterns` hosts), `object-src 'none'`, `base-uri 'self'`, `form-action 'self'`, `frame-ancestors 'none'`.

## Verification — "confirm it's clean"
Because the Report-Only header had no `report-uri`, violations only appear in a browser console, so I drove the local production build with headless Chromium (Playwright) and listened for `securitypolicyviolation` events:

- **Crawled** `/`, `/worlds`, `/worlds/create`, `/characters`, `/characters/create`, `/settings`, `/about`, `/dev` **under actual enforcement** (`Content-Security-Policy`, not Report-Only — verified via `curl -I`): **0 violations, 0 page errors** (a blocked inline script would surface as a page error).
- **Static analysis closed the gap the crawl couldn't run** (no API key/seeded data): AI-generated images are saved as base64 `data:` URLs (covered by `img-src data:`), and there are **no client `fetch()` calls to non-self origins** (all AI traffic goes to `/api/*`). So the in-session narrative/image flows are within the policy.
- `npm run type-check` ✅, `npm run build:app` ✅ (static generation preserved).

## Reversibility / residual notes
- One-line revert (`Content-Security-Policy` → `Content-Security-Policy-Report-Only`) if anything unexpected appears in production.
- Not exercisable locally: live Vercel Analytics on the real deployment — but its script origin is `'self'` (`/_vercel/insights/*`) and its beacon origin (`vitals.vercel-insights.com`) is allowlisted in `connect-src`.
- Future hardening (separate, larger change): drop `'unsafe-inline'` via nonce-based CSP in middleware — deferred because it forces dynamic rendering on all pages.

https://claude.ai/code/session_01RFjJEcdPcoW2Cz1Kvy8hwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFjJEcdPcoW2Cz1Kvy8hwA)_