### PR TITLE
fix(game-session): custom actions only fire generation when registered on a decision (#1427)

### DIFF
--- a/src/components/GameSession/hooks/__tests__/useActiveGameSessionActions.test.ts
+++ b/src/components/GameSession/hooks/__tests__/useActiveGameSessionActions.test.ts
@@ -10,6 +10,7 @@ const mockSessionStoreState = {
 const mockNarrativeStoreState = {
   selectDecisionOption: jest.fn(),
   updateDecision: jest.fn(),
+  getSessionSegments: jest.fn(() => []),
 };
 
 jest.mock('@/state/sessionStore', () => ({
@@ -24,6 +25,24 @@ jest.mock('@/state/narrativeStore', () => ({
     jest.fn(() => mockNarrativeStoreState),
     { getState: jest.fn(() => mockNarrativeStoreState) }
   ),
+}));
+
+jest.mock('@/state/characterStore', () => ({
+  useCharacterStore: Object.assign(
+    jest.fn(),
+    { getState: jest.fn(() => ({ characters: {} })) }
+  ),
+}));
+
+jest.mock('@/state/worldStore', () => ({
+  useWorldStore: Object.assign(
+    jest.fn(),
+    { getState: jest.fn(() => ({ worlds: {} })) }
+  ),
+}));
+
+jest.mock('@/lib/ai/customActionSkillInference', () => ({
+  inferCustomActionSkillChecks: jest.fn(async () => []),
 }));
 
 const buildOptions = (overrides = {}) => ({
@@ -61,11 +80,14 @@ describe('useActiveGameSessionActions', () => {
     expect(mockSessionStoreState.completeTutorialPhase).toHaveBeenCalledWith('firstPlay');
   });
 
-  it('marks first play tutorial as completed after a custom choice', () => {
-    const { result } = renderHook(() => useActiveGameSessionActions(buildOptions()));
+  it('marks first play tutorial as completed after a custom choice', async () => {
+    const decision = { id: 'decision-1', prompt: 'What do you do?', options: [] };
+    const { result } = renderHook(() =>
+      useActiveGameSessionActions(buildOptions({ currentDecision: decision }))
+    );
 
-    act(() => {
-      result.current.handleCustomSubmit('Custom choice');
+    await act(async () => {
+      await result.current.handleCustomSubmit('Custom choice');
     });
 
     expect(mockSessionStoreState.completeTutorialPhase).toHaveBeenCalledWith('firstPlay');
@@ -80,5 +102,48 @@ describe('useActiveGameSessionActions', () => {
     });
 
     expect(mockSessionStoreState.completeTutorialPhase).not.toHaveBeenCalled();
+  });
+
+  describe('handleCustomSubmit — decision guard', () => {
+    it('does nothing when there is no active decision', async () => {
+      const onChoiceSelected = jest.fn();
+      const { result } = renderHook(() =>
+        useActiveGameSessionActions(buildOptions({ currentDecision: null, onChoiceSelected }))
+      );
+
+      await act(async () => {
+        await result.current.handleCustomSubmit('I yell into the void');
+      });
+
+      expect(onChoiceSelected).not.toHaveBeenCalled();
+      expect(mockNarrativeStoreState.updateDecision).not.toHaveBeenCalled();
+    });
+
+    it('registers the option and triggers generation when a decision is active', async () => {
+      const onChoiceSelected = jest.fn();
+      const decision = {
+        id: 'decision-2',
+        prompt: 'What do you do?',
+        options: [{ id: 'opt-1', text: 'Run away' }],
+      };
+      const { result } = renderHook(() =>
+        useActiveGameSessionActions(buildOptions({ currentDecision: decision, onChoiceSelected }))
+      );
+
+      await act(async () => {
+        await result.current.handleCustomSubmit('I draw my sword');
+      });
+
+      expect(mockNarrativeStoreState.updateDecision).toHaveBeenCalledTimes(1);
+      const [updatedId, patch] = mockNarrativeStoreState.updateDecision.mock.calls[0];
+      expect(updatedId).toBe('decision-2');
+      expect(patch.options).toHaveLength(2);
+      expect(patch.options[1].text).toBe('I draw my sword');
+      expect(patch.options[1].isCustomInput).toBe(true);
+
+      // onChoiceSelected must be called with the same id that was registered
+      expect(onChoiceSelected).toHaveBeenCalledTimes(1);
+      expect(onChoiceSelected).toHaveBeenCalledWith(patch.selectedOptionId);
+    });
   });
 });

--- a/src/components/GameSession/hooks/useActiveGameSessionActions.ts
+++ b/src/components/GameSession/hooks/useActiveGameSessionActions.ts
@@ -114,6 +114,12 @@ export const useActiveGameSessionActions = ({
       return;
     }
 
+    // Can't register a custom action without an active decision; bail before touching
+    // generation state so we never fire onChoiceSelected with an id that backs no option.
+    if (!currentDecision) {
+      return;
+    }
+
     // Handle custom player input
     const customChoiceId = generateUniqueId('custom');
 


### PR DESCRIPTION
## Description
Typing your own action between turns (or while choices were loading) did nothing useful: `handleCustomSubmit` added the custom option only when there was an active decision, but it always called `onChoiceSelected`. With no decision, generation fired with a choice id that backed no option — the controller couldn't find it, skill checks were skipped, and the prompt got the raw id instead of your text.

The fix makes registration and generation atomic: if there's no active decision, bail before touching any generation state. So a typed action either registers on a real decision and reaches the prompt, or does nothing — it never generates with an unbacked id.

## Related Issue
Closes #1427

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — defect fix from the v1.0 QA walkthrough (#1417, F45).

## Component Development
N/A — hook-level logic change, no new UI.

## Implementation Notes
- One early-return guard on `currentDecision`; no behavior change when a decision is active.
- The custom action-rail input is desktop-only, which is why the "nothing happens" symptom was viewport-dependent.

## Screenshots
N/A.

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed — N/A
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm test src/components/GameSession/hooks/__tests__/useActiveGameSessionActions.test.ts` — with no active decision, submitting a custom action calls neither `updateDecision` nor `onChoiceSelected`; with a decision, it calls both.
2. In a live session (desktop width), type a custom action and submit — the story reflects your text.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] No new warnings generated
- [x] Accessibility considerations addressed (no UI change)
