### PR TITLE
fix(player-decision-system): gate trust changes on NPC scene presence (#1425)

### DIFF
--- a/src/state/__tests__/narrativeStore.worldState.integration.test.ts
+++ b/src/state/__tests__/narrativeStore.worldState.integration.test.ts
@@ -75,7 +75,7 @@ describe('Narrative store world state integration', () => {
       worldId,
       content: 'The guard eyes you suspiciously.',
       type: 'scene',
-      metadata: { tags: [], characterIds: [characterId] },
+      metadata: { tags: [], characterIds: [characterId, npcId] },
       timestamp: segmentTimestamp,
       updatedAt: segmentTimestamp.toISOString(),
     });
@@ -148,7 +148,7 @@ describe('Narrative store world state integration', () => {
       worldId,
       content: 'Marta slides the ledger across the table.',
       type: 'scene',
-      metadata: { tags: [], characterIds: [characterId] },
+      metadata: { tags: [], characterIds: [characterId, npcId] },
       timestamp: segmentTimestamp,
       updatedAt: segmentTimestamp.toISOString(),
     });
@@ -232,6 +232,81 @@ describe('Narrative store world state integration', () => {
       useCharacterStore.getState().characters[characterId].alignment
     ).toBeUndefined();
   });
+  it('drops relationship deltas for NPCs not present in the latest segment', () => {
+    const worldId = useWorldStore.getState().createWorld({
+      name: 'Presence Test Realm',
+      description: 'A realm for presence-gate tests',
+      genre: 'fantasy',
+      attributes: [],
+      skills: [],
+      settings: {
+        maxAttributes: 5,
+        maxSkills: 5,
+        attributePointPool: 10,
+        skillPointPool: 10,
+      },
+    });
+    const sessionId = 'session-presence-gate';
+    const presentNpcId = 'npc-present';
+    const absentNpcId = 'npc-absent';
+    const characterId = useCharacterStore
+      .getState()
+      .createCharacter(createTestCharacterData({ worldId }));
+    useSessionStore.getState().upsertSessionLifecycle({
+      id: sessionId,
+      worldId,
+      characterId,
+      status: 'active',
+      lastActivity: new Date().toISOString(),
+    });
+    // Only npc-present is in the scene; npc-absent is not.
+    const segmentTimestamp = new Date();
+    useNarrativeStore.getState().addSegment(sessionId, {
+      worldId,
+      content: 'The present NPC watches you from the corner.',
+      type: 'scene',
+      metadata: { tags: [], characterIds: [characterId, presentNpcId] },
+      timestamp: segmentTimestamp,
+      updatedAt: segmentTimestamp.toISOString(),
+    });
+    const optionId = 'option-act';
+    const decisionId = useNarrativeStore.getState().addDecision(sessionId, {
+      prompt: 'What do you do?',
+      options: [
+        {
+          id: optionId,
+          text: 'Do something notable.',
+          alignment: 'neutral',
+          consequences: [
+            {
+              type: 'relationship',
+              action: 'add',
+              targetId: presentNpcId,
+              value: 12,
+            },
+            {
+              type: 'relationship',
+              action: 'add',
+              targetId: absentNpcId,
+              value: 8,
+            },
+          ],
+        },
+      ],
+    });
+
+    useNarrativeStore
+      .getState()
+      .selectDecisionOption(decisionId, optionId, characterId);
+
+    const worldState = useWorldStore.getState().getWorldState(worldId);
+    // Present NPC trust should move (default 50 + 12 = 62)
+    expect(worldState.npcRelationships[presentNpcId]).toBeDefined();
+    expect(worldState.npcRelationships[presentNpcId].trust).toBe(62);
+    // Absent NPC should get nothing
+    expect(worldState.npcRelationships[absentNpcId]).toBeUndefined();
+  });
+
   it('marks session lifecycle status as ended when markSessionEnded is called', () => {
     const worldId = 'existing-world';
     const sessionId = 'session-ending';

--- a/src/state/narrativeStore.decisions.ts
+++ b/src/state/narrativeStore.decisions.ts
@@ -129,15 +129,39 @@ export const createNarrativeDecisionActions = (
 
       if (sessionId && worldId) {
         const impacts = extractWorldStateImpacts(decision, selectedOption, characterId);
+
+        // Gate NPC relationship updates on scene presence. An NPC counts as
+        // present if its id appears in the latest segment's characterIds (the
+        // same model useNarrativeParticipants uses for the Scene Status panel).
+        const segmentIds = state.sessionSegments[sessionId] || [];
+        const latestSegment = segmentIds.length
+          ? state.segments[segmentIds[segmentIds.length - 1]]
+          : undefined;
+        const presentNpcIds = new Set<EntityID>([
+          ...(latestSegment?.metadata?.characterIds ?? []),
+          ...(latestSegment?.characterIds ?? []),
+        ]);
+
+        const gatedRelationships: Record<EntityID, typeof impacts.relationships[EntityID]> = {};
+        for (const [npcId, update] of Object.entries(impacts.relationships)) {
+          if (presentNpcIds.has(npcId as EntityID)) {
+            gatedRelationships[npcId as EntityID] = update;
+          } else {
+            logger.warn(
+              `Dropped relationship update for absent NPC "${npcId}" — not present in the current scene`
+            );
+          }
+        }
+
         if (
-          Object.keys(impacts.relationships).length > 0 ||
+          Object.keys(gatedRelationships).length > 0 ||
           impacts.events.length > 0 ||
           impacts.alignmentDelta !== 0
         ) {
           worldStatePayload = {
             worldId,
             sessionId,
-            relationships: impacts.relationships,
+            relationships: gatedRelationships,
             events: impacts.events,
             alignmentDelta: impacts.alignmentDelta,
           };


### PR DESCRIPTION
## Description
Relationship/trust deltas were landing on NPCs who aren't in the scene — the AI-generated choice consequences resolve names against the whole world NPC roster, with no check for who's actually present. So yelling into an empty boathouse moved trust for Old Man Jenkins, Chad, and Maya, none of whom were there.

This gates NPC relationship updates on scene presence at the one choke point — `selectDecisionOption`, right where the impacts are about to be written. An NPC counts as present if its id is in the latest segment's `metadata.characterIds` (the same presence model `useNarrativeParticipants` already uses for the Scene Status panel). Deltas for absent NPCs are dropped with a warning. If there's no segment yet, nothing applies — the safe direction for this bug.

`applyWorldStateThreadUpdates.ts` is left alone: it works on player-character ids (empty in single-player) and writes `characterRelationships`, never `npcRelationships`, so it isn't the source here.

## Related Issue
Closes #1425

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — defect fix from the v1.0 QA walkthrough (#1417, F43).

## Component Development
N/A — state-layer change, no UI component.

## Implementation Notes
- Single gate point; no new validation beyond presence (the parser already caps deltas at ±20 and relationships are bounded [0,100]).
- Only NPC relationship updates are filtered — world events and alignment/player-self impacts are untouched.

## Screenshots
N/A.

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed — N/A
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm test src/state/__tests__/narrativeStore.worldState.integration.test.ts` — a present NPC's trust moves; an absent NPC's does not.
2. In a live session, take an expressive action while alone — no trust chips should fire for NPCs who aren't in the scene.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] No new warnings generated
- [x] Accessibility considerations addressed (no UI change)
