### PR TITLE
fix(ai-service): world images return data URLs so they survive serverless (#1423)

### DIFF
--- a/src/app/api/generate-world-image/__tests__/route.test.ts
+++ b/src/app/api/generate-world-image/__tests__/route.test.ts
@@ -6,7 +6,6 @@
 jest.mock('@/lib/ai/defaultGeminiClient');
 jest.mock('@/lib/ai/geminiImageGenerator', () => ({
   generateImageWithGemini: jest.fn(),
-  generateAndSaveImageWithGemini: jest.fn(),
 }));
 jest.mock('@/lib/utils/logger', () => {
   return jest.fn().mockImplementation(() => ({
@@ -28,13 +27,12 @@ jest.mock('@/lib/utils/genrePromptGuide', () => ({
 import { NextRequest } from 'next/server';
 import { POST } from '../route';
 import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
-import { generateImageWithGemini, generateAndSaveImageWithGemini } from '@/lib/ai/geminiImageGenerator';
+import { generateImageWithGemini } from '@/lib/ai/geminiImageGenerator';
 import type { World } from '@/types/world.types';
 
 // Create typed mocks
 const mockCreateDefaultGeminiClient = createDefaultGeminiClient as jest.MockedFunction<typeof createDefaultGeminiClient>;
 const mockGenerateImageWithGemini = generateImageWithGemini as jest.MockedFunction<typeof generateImageWithGemini>;
-const mockGenerateAndSaveImageWithGemini = generateAndSaveImageWithGemini as jest.MockedFunction<typeof generateAndSaveImageWithGemini>;
 
 describe('/api/generate-world-image', () => {
   const mockWorld: World = {
@@ -61,7 +59,7 @@ describe('/api/generate-world-image', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockCreateDefaultGeminiClient.mockReturnValue(mockGeminiClient as unknown as ReturnType<typeof createDefaultGeminiClient>);
-    
+
     // Mock environment variable
     process.env.GEMINI_API_KEY = 'test-api-key';
   });
@@ -103,12 +101,13 @@ describe('/api/generate-world-image', () => {
       const customPrompt = 'A dark and stormy castle on a hilltop';
 
       mockGeminiClient.generateContent.mockResolvedValue({
-        content: customPrompt // Use custom prompt directly when provided
+        content: customPrompt
       });
 
-      mockGenerateAndSaveImageWithGemini.mockResolvedValue({
-        url: '/uploads/worlds/test-world.png',
-        fileSize: 102400
+      mockGenerateImageWithGemini.mockResolvedValue({
+        url: 'data:image/png;base64,abc123',
+        mimeType: 'image/png',
+        base64Data: 'abc123',
       });
 
       const request = new NextRequest('http://localhost:3000/api/generate-world-image', {
@@ -125,7 +124,7 @@ describe('/api/generate-world-image', () => {
       expect(response.status).toBe(200);
       expect(data.aiGenerated).toBe(true);
       expect(data.placeholder).toBe(false);
-      expect(data.imageUrl).toBe('/uploads/worlds/test-world.png');
+      expect(data.imageUrl).toBe('data:image/png;base64,abc123');
       expect(data.description).toBe(customPrompt);
     });
 
@@ -160,7 +159,7 @@ describe('/api/generate-world-image', () => {
       delete process.env.GEMINI_API_KEY;
 
       const testGenres = ['fantasy', 'sci-fi', 'cyberpunk'];
-      
+
       for (const genre of testGenres) {
         const worldWithGenre = { ...mockWorld, genre };
         const request = new NextRequest('http://localhost:3000/api/generate-world-image', {
@@ -186,9 +185,10 @@ describe('/api/generate-world-image', () => {
         content: 'Generated image description'
       });
 
-      mockGenerateAndSaveImageWithGemini.mockResolvedValue({
-        url: '/uploads/worlds/test-world.png',
-        fileSize: 102400
+      mockGenerateImageWithGemini.mockResolvedValue({
+        url: 'data:image/png;base64,abc123',
+        mimeType: 'image/png',
+        base64Data: 'abc123',
       });
 
       const request = new NextRequest('http://localhost:3000/api/generate-world-image', {
@@ -202,9 +202,9 @@ describe('/api/generate-world-image', () => {
       expect(response.status).toBe(200);
       expect(data.aiGenerated).toBe(true);
       expect(data.placeholder).toBe(false);
-      expect(data.imageUrl).toBe('/uploads/worlds/test-world.png');
+      expect(data.imageUrl).toBe('data:image/png;base64,abc123');
       expect(data.service).toBe('gemini-image-generation');
-      expect(mockGenerateAndSaveImageWithGemini).toHaveBeenCalled();
+      expect(mockGenerateImageWithGemini).toHaveBeenCalled();
     });
 
     it('should fallback to placeholder when Gemini API fails', async () => {
@@ -212,7 +212,7 @@ describe('/api/generate-world-image', () => {
         content: 'Generated description'
       });
 
-      mockGenerateAndSaveImageWithGemini.mockResolvedValue(null);
+      mockGenerateImageWithGemini.mockResolvedValue(null);
 
       const request = new NextRequest('http://localhost:3000/api/generate-world-image', {
         method: 'POST',

--- a/src/app/api/generate-world-image/route.ts
+++ b/src/app/api/generate-world-image/route.ts
@@ -3,7 +3,7 @@ import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
 import { resolveApiKey } from '@/lib/ai/resolveApiKey';
 import type { World } from '@/types/world.types';
 import Logger from '@/lib/utils/logger';
-import { generateAndSaveImageWithGemini } from '@/lib/ai/geminiImageGenerator';
+import { generateImageWithGemini } from '@/lib/ai/geminiImageGenerator';
 import { getGenreStyleGuidance, getGenreFallbackImage } from '@/lib/utils/genrePromptGuide';
 
 const logger = new Logger('WorldImageAPI');
@@ -116,20 +116,18 @@ Requirements:
 - No text, logos, or watermarks
 - Landscape orientation suitable for world imagery`;
 
-          // Generate and save the image to the file system
-          const savedImage = await generateAndSaveImageWithGemini(
+          // Generate image as a data URL so it persists in IndexedDB (no disk write)
+          const generatedImage = await generateImageWithGemini(
             imagePromptForGemini,
-            apiKey,
-            body.world.id,
-            'worlds'
+            apiKey
           );
 
-          if (savedImage) {
-            imageUrl = savedImage.url;
+          if (generatedImage) {
+            imageUrl = generatedImage.url;
             aiGenerated = true;
             placeholder = false;
 
-            logger.debug('generate-world-image', `Gemini image saved successfully: ${savedImage.url} (${savedImage.fileSize} bytes)`);
+            logger.debug('generate-world-image', `Gemini image generated successfully: ${generatedImage.url.slice(0, 50)}...`);
           } else {
             logger.warn('generate-world-image', 'Image generation failed, using fallback');
             imageUrl = generateFallbackImage(body.world);

--- a/src/lib/ai/geminiImageGenerator.ts
+++ b/src/lib/ai/geminiImageGenerator.ts
@@ -7,7 +7,6 @@
  */
 
 import Logger from '@/lib/utils/logger';
-import { saveBase64Image, type SaveImageOptions } from '@/lib/utils/fileStorage';
 import { getAIConfig } from './config';
 
 const logger = new Logger('GeminiImageGenerator');
@@ -108,11 +107,9 @@ export function extractImageFromResponse(
 /**
  * High-level function to generate an image using Gemini.
  * Combines API call and image extraction into one operation and returns a
- * base64 data URL. This is the right choice when the image is persisted by the
- * caller (e.g. into a store / IndexedDB) rather than written to disk, since
- * runtime file writes don't survive on serverless hosts. Used by the journal,
- * portrait, and ending image routes. For the disk-backed variant (file URL),
- * see generateAndSaveImageWithGemini.
+ * base64 data URL. The image is persisted by the caller (e.g. into a store /
+ * IndexedDB) rather than written to disk, so it survives serverless instance
+ * recycling. Used by the journal, portrait, ending, and world image routes.
  *
  * @param prompt - The text prompt for image generation
  * @param apiKey - The Gemini API key
@@ -136,61 +133,6 @@ export async function generateImageWithGemini(
 
   } catch (error) {
     logger.error('generateImageWithGemini', 'Image generation failed:', error);
-    return null;
-  }
-}
-
-/**
- * Generate an image with Gemini and save it to the file system
- * Returns a file URL instead of a base64 data URI for better performance
- *
- * @param prompt - The text prompt for image generation
- * @param apiKey - The Gemini API key
- * @param entityId - Unique ID for the entity (e.g., world ID)
- * @param category - Image category (e.g., 'worlds', 'characters')
- * @returns Object with the public URL and file info, or null if generation failed
- */
-export async function generateAndSaveImageWithGemini(
-  prompt: string,
-  apiKey: string,
-  entityId: string,
-  category: SaveImageOptions['category']
-): Promise<{ url: string; fileSize: number } | null> {
-  try {
-    const response = await callGeminiImageAPI(prompt, apiKey);
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      logger.error('generateAndSaveImageWithGemini', 'Gemini API Error:', errorText);
-      return null;
-    }
-
-    const data = await response.json();
-    const imageData = extractImageFromResponse(data);
-
-    if (!imageData) {
-      logger.error('generateAndSaveImageWithGemini', 'No image data in response');
-      return null;
-    }
-
-    // Save the image to the file system
-    logger.debug('generateAndSaveImageWithGemini', `Saving image for ${category}/${entityId}`);
-    const saveResult = await saveBase64Image({
-      category,
-      entityId,
-      mimeType: imageData.mimeType,
-      base64Data: imageData.base64Data,
-    });
-
-    logger.info('generateAndSaveImageWithGemini', `Image saved: ${saveResult.url} (${saveResult.fileSize} bytes)`);
-
-    return {
-      url: saveResult.url,
-      fileSize: saveResult.fileSize,
-    };
-
-  } catch (error) {
-    logger.error('generateAndSaveImageWithGemini', 'Image generation and save failed:', error);
     return null;
   }
 }

--- a/src/lib/utils/fileStorage.ts
+++ b/src/lib/utils/fileStorage.ts
@@ -5,14 +5,13 @@
  * Images are saved to the public directory for easy serving.
  */
 
-import { writeFile, mkdir } from 'fs/promises';
 import { join, resolve } from 'path';
 import { existsSync } from 'fs';
 import Logger from './logger';
 
 const logger = new Logger('FileStorage');
 
-export interface SaveImageOptions {
+interface SaveImageOptions {
   /**
    * Category/type of image (e.g., 'worlds', 'characters', 'portraits')
    */
@@ -34,23 +33,6 @@ export interface SaveImageOptions {
   base64Data: string;
 }
 
-export interface SaveImageResult {
-  /**
-   * Public URL path to access the saved image
-   * Format: /uploads/{category}/{entityId}.{ext}
-   */
-  url: string;
-
-  /**
-   * Absolute file system path where the image was saved
-   */
-  filePath: string;
-
-  /**
-   * File size in bytes
-   */
-  fileSize: number;
-}
 
 /**
  * Sanitize entity ID to prevent path traversal attacks
@@ -78,27 +60,6 @@ function validateCategory(category: string): asserts category is SaveImageOption
   }
 }
 
-/**
- * Validate and get file extension from MIME type
- * Only allows whitelisted image MIME types
- */
-function getExtensionFromMimeType(mimeType: string): string {
-  const mimeMap: Record<string, string> = {
-    'image/png': 'png',
-    'image/jpeg': 'jpg',
-    'image/jpg': 'jpg',
-    'image/webp': 'webp',
-    'image/gif': 'gif',
-  };
-
-  const extension = mimeMap[mimeType.toLowerCase()];
-
-  if (!extension) {
-    throw new Error(`Invalid MIME type: ${mimeType}. Only image types are allowed.`);
-  }
-
-  return extension;
-}
 
 /**
  * Validate that the final file path is within the allowed directory
@@ -119,72 +80,6 @@ function validatePathWithinDirectory(filePath: string, allowedDirectory: string)
   return absoluteFilePath;
 }
 
-/**
- * Save a base64 encoded image to the file system
- *
- * @param options - Configuration for saving the image
- * @returns Information about the saved file
- * @throws Error if save fails
- */
-export async function saveBase64Image(options: SaveImageOptions): Promise<SaveImageResult> {
-  const { category, entityId, mimeType, base64Data } = options;
-
-  try {
-    // Validate and sanitize inputs to prevent path traversal
-    validateCategory(category);
-    const safeEntityId = sanitizeEntityId(entityId);
-
-    // Get file extension from MIME type
-    const extension = getExtensionFromMimeType(mimeType);
-
-    // Create filename: entityId.ext (e.g., world-123.png)
-    const filename = `${safeEntityId}.${extension}`;
-
-    // Define directory path: public/uploads/{category}
-    const uploadDir = join(process.cwd(), 'public', 'uploads', category);
-
-    // Create directory if it doesn't exist
-    if (!existsSync(uploadDir)) {
-      logger.debug('saveBase64Image', `Creating directory: ${uploadDir}`);
-      await mkdir(uploadDir, { recursive: true });
-    }
-
-    // Full file path
-    const filePath = join(uploadDir, filename);
-
-    // Final security check: ensure path is within allowed directory and get validated absolute path
-    const validatedPath = validatePathWithinDirectory(filePath, uploadDir);
-
-    // Convert base64 to buffer (validated user data, safe to write)
-    const imageBuffer = Buffer.from(base64Data, 'base64');
-
-    // Save file to validated path
-    // Path is validated through defense-in-depth:
-    // 1. entityId sanitized (alphanumeric + hyphens/underscores only)
-    // 2. category validated against whitelist
-    // 3. MIME type validated against whitelist
-    // 4. Path constructed using safe join()
-    // 5. Final absolute path validated to be within allowed directory
-    logger.debug('saveBase64Image', `Saving image to: ${validatedPath} (${imageBuffer.length} bytes)`);
-    // codeql[js/path-injection]
-    await writeFile(validatedPath, imageBuffer);
-
-    // Generate public URL (relative to public directory)
-    const publicUrl = `/uploads/${category}/${filename}`;
-
-    logger.info('saveBase64Image', `Image saved successfully: ${publicUrl}`);
-
-    return {
-      url: publicUrl,
-      filePath,
-      fileSize: imageBuffer.length,
-    };
-
-  } catch (error) {
-    logger.error('saveBase64Image', 'Failed to save image:', error);
-    throw new Error(`Failed to save image: ${error instanceof Error ? error.message : 'Unknown error'}`);
-  }
-}
 
 /**
  * Delete an image file
@@ -234,7 +129,7 @@ export async function deleteImage(url: string): Promise<boolean> {
     }
 
     const { unlink } = await import('fs/promises');
-    // Path is validated through defense-in-depth (same as saveBase64Image)
+    // Path is validated through defense-in-depth: category whitelist, entity ID sanitization, path boundary check
     // codeql[js/path-injection]
     await unlink(validatedPath);
 


### PR DESCRIPTION
## Description
World banner images were written to `public/uploads/worlds/{id}.png` and returned as a disk path. On Vercel that path 404s once the serverless instance recycles, so the banner breaks. This switches `/api/generate-world-image` to return a base64 data URL — same as the portrait, ending, and journal routes already do — so the image rides along in the world data (IndexedDB) and survives a fresh request.

Switching the route orphaned the disk-write path, so I removed it: `generateAndSaveImageWithGemini` and the `saveBase64Image` helper it was the sole caller of (Knip fails on dead exports otherwise). `deleteImage` and its shared `validateCategory` / `SaveImageOptions` stay — they still clean up legacy file-backed images. `SaveImageOptions` is unexported since nothing outside `fileStorage.ts` imports it anymore.

## Related Issue
Closes #1423

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (code improvements without changing functionality)

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — defect fix from the v1.0 QA walkthrough (#1417, F30).

## Component Development
N/A — no UI component change (the response shape is unchanged; `WorldImage.tsx` already renders data URLs).

## Implementation Notes
- Response shape is unchanged; only the contents of `imageUrl` change (data URL instead of `/uploads/...`).
- The world store, `WorldImage.tsx`, and the callers already handle data URLs (the other three image routes prove the pattern end to end), so nothing changed there.
- Removing `saveBase64Image` also deletes the disk-write path-injection sink.

## Screenshots
N/A.

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed — N/A (no new deps; removed a file-write sink)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm test src/app/api/generate-world-image` — the route returns a `data:image/...;base64,` URL on success and the picsum fallback otherwise.
2. With a real key, generate a world image and confirm the banner renders from a data URL and persists across reloads.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] No new warnings generated
- [x] Accessibility considerations addressed (no UI change)
