### PR TITLE
fix(lore): dedup role/descriptor aliases to a known character

### DIFF
--- a/src/app/api/lore/check-similarity/__tests__/route.test.ts
+++ b/src/app/api/lore/check-similarity/__tests__/route.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment node
+ */
+
+const mockGenerateContent = jest.fn();
+
+jest.mock('@/lib/ai/geminiClient', () => ({
+  GeminiClient: jest.fn().mockImplementation(() => ({
+    generateContent: mockGenerateContent,
+  })),
+}));
+jest.mock('@/lib/ai/config', () => ({
+  getDefaultConfig: jest.fn(() => ({ apiKey: 'test-api-key' })),
+}));
+jest.mock('@/lib/ai/resolveApiKey', () => ({
+  resolveApiKey: jest.fn(() => 'test-api-key'),
+}));
+jest.mock('@/lib/utils/logger', () => {
+  return jest.fn().mockImplementation(() => ({
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  }));
+});
+
+import { NextRequest } from 'next/server';
+import { POST } from '../route';
+
+const makeRequest = (body: unknown) =>
+  new NextRequest('http://localhost:3000/api/lore/check-similarity', {
+    method: 'POST',
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+
+describe('/api/lore/check-similarity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGenerateContent.mockResolvedValue({
+      content: '{"similar": true, "confidence": 0.9, "rationale": "same person"}',
+    });
+  });
+
+  it('returns 400 when a name is missing', async () => {
+    const response = await POST(makeRequest({ name1: 'Maya' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Both name1 and name2 are required');
+  });
+
+  it('asks the model to treat role/descriptor aliases as the same entity', async () => {
+    await POST(makeRequest({ name1: 'Maya the counselor', name2: 'Maya Chandra', category: 'characters' }));
+
+    const prompt = mockGenerateContent.mock.calls[0][0];
+    expect(prompt).toContain('Role or descriptor references');
+    expect(prompt).toContain('role, title, or descriptor attached to a shared given name');
+  });
+});

--- a/src/app/api/lore/check-similarity/route.ts
+++ b/src/app/api/lore/check-similarity/route.ts
@@ -59,8 +59,10 @@ Consider:
 - Nicknames and shortened forms (Elizabeth vs Liz, Jonathan vs Jon)
 - Special characters and punctuation ("Sir John's Tavern" vs "Sir Johns Tavern")
 - Common fantasy name variations
+- Role or descriptor references (e.g. "Maya the counselor" and "Maya Chandra" — one names a role/occupation, the other a full name, sharing a given name)
 
 If they clearly refer to the same entity, return similar: true with high confidence.
+When one name is a role, title, or descriptor attached to a shared given name (e.g. "<Name> the <role>"), treat it as the SAME entity as a known character with that given name, unless the context clearly indicates two different people.
 If they're definitely different entities, return similar: false.
 For uncertain cases, adjust confidence accordingly.
 


### PR DESCRIPTION
## Description
Lore dedup runs Levenshtein first, then an AI similarity check for the uncertain middle band (0.60–0.85). That AI prompt knew about nicknames, titles, word order, and spelling drift, but it never knew about role/descriptor aliases — so "Maya the counselor" and "Maya Chandra" read as two different people and ended up as two lore entries for one NPC. This strengthens the prompt to treat a role/descriptor reference that shares a given name with a known character as the same entity.

## Related Issue
Closes #1428

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
As a player, when the story refers to a tracked NPC by their role instead of their name, the game recognizes it's the same person instead of duplicating them in my lore.

## Flow Diagrams
N/A

## Component Development
N/A — no UI change.

## Implementation Notes
- Prompt-only change in `src/app/api/lore/check-similarity/route.ts`. The thresholds and the Levenshtein stage (`fuzzyMatcher.ts`) are untouched, per the issue's scope.
- The new route test mocks the Gemini client and asserts the constructed prompt carries the role/descriptor guidance. Live model behavior is probabilistic, so the deterministic gate here is the prompt content, not a real AI call.

## Screenshots
N/A

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed (N/A)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
`npm test -- src/app/api/lore/check-similarity`, then read the prompt in `route.ts` to confirm the role/descriptor guidance reads sensibly.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (not required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed (N/A — no UI)
