### PR TITLE
fix(ai): record the real checkpoint model + keep dev tools out of prod

### DIFF
--- a/src/components/GameSession/ActiveGameSession.tsx
+++ b/src/components/GameSession/ActiveGameSession.tsx
@@ -95,6 +95,11 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
   const [isEndingSuggestionPreview, setIsEndingSuggestionPreview] = React.useState(false);
 
   const isProgressiveDisclosureEnabled = isFeatureEnabled('PROGRESSIVE_DISCLOSURE');
+  // Authoring-only Tools-menu affordances (Simulate Next Turn, Toggle Streaming
+  // State, Show Ending Suggestion). NODE_ENV is statically replaced at build time,
+  // so these callbacks are stripped from a production bundle and the menu hides
+  // each button when its callback is absent (#1430 F58).
+  const showDevTools = process.env.NODE_ENV === 'development';
   const { theme } = useTheme();
   const isDS3 = theme === 'ds3';
 
@@ -390,21 +395,21 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
               onOpenCharacterPanel={() => {
                 setIsCharacterSummaryExpanded(true);
               }}
-              onSimulateTurn={() => {
+              onSimulateTurn={showDevTools ? () => {
                 const fallbackChoiceId = currentDecision?.options?.[0]?.id;
                 if (fallbackChoiceId) {
                   handleChoiceSelected(fallbackChoiceId);
                   return;
                 }
                 handleCustomSubmit('Simulate next turn');
-              }}
-              onToggleStreamingPreview={() => {
+              } : undefined}
+              onToggleStreamingPreview={showDevTools ? () => {
                 setIsStreamingPreview((prev) => !prev);
-              }}
+              } : undefined}
               isStreamingPreview={isStreamingPreview}
-              onToggleEndingSuggestionPreview={() => {
+              onToggleEndingSuggestionPreview={showDevTools ? () => {
                 setIsEndingSuggestionPreview((prev) => !prev);
-              }}
+              } : undefined}
               isEndingSuggestionPreview={isEndingSuggestionPreview}
             />
           )}

--- a/src/components/GameSession/__tests__/ActiveGameSession.manuscriptLayout.test.tsx
+++ b/src/components/GameSession/__tests__/ActiveGameSession.manuscriptLayout.test.tsx
@@ -322,6 +322,27 @@ describe('ActiveGameSession Manuscript Layout', () => {
       expect(screen.getByRole('button', { name: /toggle tools menu/i })).toBeInTheDocument();
     });
 
+    it('keeps dev-only authoring tools out of the Tools menu outside development', async () => {
+      // NODE_ENV is 'test' here, which the dev-tools gate treats like production,
+      // so the authoring affordances must not render for real players (#1430 F58).
+      (isFeatureEnabled as jest.Mock).mockImplementation((flag) => flag === 'PROGRESSIVE_DISCLOSURE');
+
+      render(
+        <ActiveGameSession
+          worldId={mockWorldId}
+          sessionId={mockSessionId}
+          onChoiceSelected={jest.fn()}
+        />
+      );
+
+      const toolsToggle = await screen.findByRole('button', { name: /toggle tools menu/i });
+      fireEvent.click(toolsToggle);
+
+      expect(screen.queryByRole('button', { name: /simulate next turn/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /toggle streaming state/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /ending suggestion/i })).not.toBeInTheDocument();
+    });
+
         it('opens character drawer from Tools menu when trigger is clicked (flag ON)', async () => {
 
           (isFeatureEnabled as jest.Mock).mockImplementation((flag) => flag === 'PROGRESSIVE_DISCLOSURE');

--- a/src/lib/ai/__tests__/storyCheckpointGenerator.test.ts
+++ b/src/lib/ai/__tests__/storyCheckpointGenerator.test.ts
@@ -56,7 +56,8 @@ describe('generateStoryCheckpointSummary', () => {
         includedEvents: 1,
         includedDecisions: 1,
         lastEventTimestamp: '2025-11-20T18:00:00Z',
-        model: 'gemini-test',
+        // Stale value the prompt example used to teach the model to echo (#1430 F37).
+        model: 'gemini-1.5-pro',
       }),
     });
 
@@ -65,7 +66,8 @@ describe('generateStoryCheckpointSummary', () => {
     expect(result.segment).toContain('Maera disbanded the council');
     expect(result.highlights).toEqual(['Council dissolved', 'Royal guard split']);
     expect(result.majorEvents).toEqual(['Maera disbands the council']);
-    expect(result.model).toBe('gemini-test');
+    // Records the model the default client actually runs on, not the AI echo.
+    expect(result.model).toBe('gemini-2.5-flash');
     expect(mockClient.generateContent).toHaveBeenCalledTimes(1);
   });
 

--- a/src/lib/ai/storyCheckpointGenerator.ts
+++ b/src/lib/ai/storyCheckpointGenerator.ts
@@ -1,4 +1,5 @@
 import { createDefaultGeminiClient } from './defaultGeminiClient';
+import { getAIConfig } from './config';
 import { StoryCheckpointRequestBody, StoryCheckpointResponseBody } from '@/types/story-checkpoint.types';
 import { safeTrim } from '@/lib/utils';
 import { getDetailedToneInstructions } from './toneSettingsGuidance';
@@ -13,8 +14,7 @@ const RESPONSE_SCHEMA = `{
   "themes": ["Optional list of tonal throughlines"],
   "includedEvents": 3,
   "includedDecisions": 1,
-  "lastEventTimestamp": "2025-11-20T15:31:39Z",
-  "model": "gemini-1.5-pro"
+  "lastEventTimestamp": "2025-11-20T15:31:39Z"
 }`;
 
 const formatEvents = (events: StoryCheckpointRequestBody['events']): string => {
@@ -140,7 +140,10 @@ const parseResponse = (content: string): StoryCheckpointResponseBody => {
     includedEvents: typeof parsed.includedEvents === 'number' ? parsed.includedEvents : 0,
     includedDecisions: typeof parsed.includedDecisions === 'number' ? parsed.includedDecisions : 0,
     lastEventTimestamp: sanitizeString(parsed.lastEventTimestamp),
-    model: sanitizeString(parsed.model),
+    // Record the model the default client actually runs on, not whatever the AI
+    // echoed back. The prompt used to carry a stale "gemini-1.5-pro" example and
+    // the model dutifully repeated it, mislabelling every checkpoint (#1430 F37).
+    model: getAIConfig().modelName,
   };
 };
 


### PR DESCRIPTION
## Description
Two small hygiene fixes from the v1.0 QA walkthrough (#1417):

- **F37 — checkpoint model label.** Story checkpoints run on the default client (gemini-2.5-flash), but the response-schema example carried `"model": "gemini-1.5-pro"`, the model dutifully echoed it, and we stored the echo — so every checkpoint recorded the wrong model. The stored model now comes from `getAIConfig().modelName` (the model the client actually runs on), and the stale example is dropped from the schema.
- **F58 — dev tools out of prod.** The play Tools menu wired up "Simulate Next Turn", "Toggle Streaming State", and "Show Ending Suggestion" whenever progressive disclosure was on, with no environment gate. Those callbacks are now passed only when `NODE_ENV === 'development'`, so they're stripped from a production bundle and the menu hides each button when its callback is absent.

## Related Issue
Closes #1430

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
- As a developer, checkpoint metadata reflects the model that actually wrote the summary, so the data is trustworthy.
- As a player, the production Tools menu shows only player tools — no authoring affordances leak in.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated (N/A)
- [x] Components developed in isolation first
- [x] Visual consistency verified (no visual change — dev tools never rendered for players)

## Implementation Notes
- The fallback path still records `model: 'fallback'`, which is honest: that degraded summary isn't produced by the AI at all, so it shouldn't claim a model name.
- The F58 gate sits at the callback source in `ActiveGameSession`; `ManuscriptDrawerPanels` already hides each button when its callback is undefined, so one gate covers all three. In Jest (`NODE_ENV='test'`) the tools are gated off, which is what the new test asserts.

## Screenshots
N/A

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed (N/A)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
`npm test -- src/lib/ai/__tests__/storyCheckpointGenerator.test.ts src/components/GameSession/__tests__/ActiveGameSession.manuscriptLayout.test.tsx`. For F37, a curl smoke of the checkpoint route shows the stored model is `gemini-2.5-flash`. For F58, open the Tools menu in a production build and confirm only player tools appear.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (not required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed (no UI change)
