### PR TITLE
fix(CharacterPortrait): size prop has no effect — apply size modifier + variant CSS

### DIFF
--- a/src/components/CharacterPortrait/CharacterPortrait.tsx
+++ b/src/components/CharacterPortrait/CharacterPortrait.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import Image from 'next/image';
+import { clsx } from 'clsx';
 import { GeneratedImage } from '@/types/common.types';
 
 interface CharacterPortraitProps {
@@ -48,7 +49,10 @@ export function CharacterPortrait({
       .toUpperCase();
   };
 
-  const containerClasses = 'component-character-portrait';
+  const containerClasses = clsx(
+    'component-character-portrait',
+    `component-character-portrait-${size}`
+  );
 
   if (isGenerating) {
     return (

--- a/src/components/CharacterPortrait/__tests__/CharacterPortrait.test.tsx
+++ b/src/components/CharacterPortrait/__tests__/CharacterPortrait.test.tsx
@@ -68,28 +68,40 @@ describe('CharacterPortrait', () => {
   });
 
   describe('size variants', () => {
-    it('renders different sizes appropriately', () => {
+    it('applies the size modifier class so each size renders distinctly', () => {
       const { rerender } = render(
-        <CharacterPortrait 
-          portrait={{ type: 'placeholder', url: null }} 
+        <CharacterPortrait
+          portrait={{ type: 'placeholder', url: null }}
           characterName="Test"
           size="small"
         />
       );
 
-      // Small size should still display initials correctly
-      expect(screen.getByText('TE')).toBeInTheDocument();
+      const portrait = screen.getByTestId('character-portrait');
+      expect(portrait).toHaveClass('component-character-portrait');
+      expect(portrait).toHaveClass('component-character-portrait-small');
+      expect(portrait).not.toHaveClass('component-character-portrait-large');
 
       rerender(
-        <CharacterPortrait 
-          portrait={{ type: 'placeholder', url: null }} 
+        <CharacterPortrait
+          portrait={{ type: 'placeholder', url: null }}
           characterName="Test"
           size="large"
         />
       );
 
-      // Large size should still display initials correctly
-      expect(screen.getByText('TE')).toBeInTheDocument();
+      expect(screen.getByTestId('character-portrait')).toHaveClass('component-character-portrait-large');
+    });
+
+    it('defaults to the medium size modifier when no size is given', () => {
+      render(
+        <CharacterPortrait
+          portrait={{ type: 'placeholder', url: null }}
+          characterName="Test"
+        />
+      );
+
+      expect(screen.getByTestId('character-portrait')).toHaveClass('component-character-portrait-medium');
     });
   });
 

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -2156,6 +2156,39 @@ body.manuscript-overlay-open {
   object-fit: cover;
 }
 
+/* Size variants give the portrait an intrinsic square size for the size prop
+   (small/medium/large/xlarge). They only take effect where no wrapper sizes the
+   portrait — Storybook, the QuickPlay CTA, the editor preview. Every consumer
+   that frames the portrait in a sized wrapper does so with a higher-specificity
+   `.wrapper .component-character-portrait` rule, so those layouts are unchanged. */
+.component-character-portrait-small {
+  width: 3rem;
+  height: 3rem;
+}
+
+.component-character-portrait-medium {
+  width: 5rem;
+  height: 5rem;
+}
+
+.component-character-portrait-large {
+  width: 8rem;
+  height: 8rem;
+}
+
+.component-character-portrait-xlarge {
+  width: 12rem;
+  height: 12rem;
+}
+
+/* CharacterCard sizes its own wrapper and lets the portrait fill it. Keep that
+   fill so the size variant doesn't override the card's framing (the other
+   wrapper-sized consumers already carry an equivalent override). */
+.character-card-portrait .component-character-portrait {
+  width: 100%;
+  height: 100%;
+}
+
 .manuscript-character-snapshot-portrait {
   position: relative;
   width: 80px;


### PR DESCRIPTION
## Description
`CharacterPortrait` accepted a `size` prop (small/medium/large/xlarge) but never applied it — the container class was hardcoded and there were no size-variant CSS rules, so the component only ever filled its parent. Anywhere it isn't wrapped in a sized container (the Storybook SizeComparison story, the QuickPlay CTA, the editor preview) it collapsed and every size looked identical. This applies a `component-character-portrait-${size}` modifier class (matching the existing `button`/`badge` size pattern) and adds explicit square dimensions per size.

## Related Issue
Closes #1393

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
As someone viewing characters without portraits, the initials placeholder renders at the size the surrounding UI asked for instead of collapsing.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated (the existing CharacterPortrait → SizeComparison story now renders four distinct sizes; no new story needed)
- [x] Components developed in isolation first
- [x] Visual consistency verified — see Implementation Notes for the blast-radius analysis

## Implementation Notes
- The base `.component-character-portrait` fill rule is untouched. Every consumer that frames the portrait in a sized wrapper (table, header, both dashboard cards, character summary, character snapshot, portrait step) does so with a higher-specificity `.wrapper .component-character-portrait` rule, so those layouts are unchanged.
- CharacterCard was the one consumer sizing its wrapper while letting the portrait fill via the base rule, so it gets a matching `.character-card-portrait .component-character-portrait` fill override to stay exactly as it was.
- QuickPlay and the editor portrait preview render the portrait in unsized containers — they were collapsed too, and now pick up a real size (an improvement, not a regression).
- The visual-regression suite is macOS-local and not a required check; it wasn't run in this session. The specificity analysis above is why I expect no baseline churn for the wrapper-sized consumers.

## Screenshots
Storybook → CharacterPortrait → SizeComparison now shows S/M/L/XL at distinct dimensions.

## Quality Checks
- [x] Linting passed
- [x] Type checking passed (incl. `npm run lint:css`)
- [ ] Security audit passed (N/A)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
`npm test -- src/components/CharacterPortrait` and `npm run lint:css`. In Storybook, open CharacterPortrait → SizeComparison and confirm the four placeholders are visibly different sizes.

## Checklist
- [x] Code follows the project's coding standards (design tokens / rem dimensions consistent with neighboring portrait rules; no hardcoded colors)
- [x] File size limits respected
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (not required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed (no change to alt text / roles)
