### PR TITLE
fix(world-image): ground manual-wizard image in world attributes/skills

### DIFF
--- a/src/app/api/generate-world-image/__tests__/route.test.ts
+++ b/src/app/api/generate-world-image/__tests__/route.test.ts
@@ -153,6 +153,83 @@ describe('/api/generate-world-image', () => {
     });
   });
 
+  describe('World Element Grounding', () => {
+    // The manual world wizard passes the full world (attributes + skills) but the
+    // /worlds Generate path passes only id/name/description/genre. Grounding the
+    // prompt in the world's structured elements when present enriches thin manual
+    // descriptions (#1437) without changing the /worlds-shape prompt.
+    it('includes world attribute and skill names in the AI elaboration prompt', async () => {
+      mockGeminiClient.generateContent.mockResolvedValue({
+        content: 'AI-generated detailed description',
+      });
+      mockGenerateImageWithGemini.mockResolvedValue({
+        url: 'data:image/png;base64,abc123',
+        mimeType: 'image/png',
+        base64Data: 'abc123',
+      });
+
+      const worldWithElements: World = {
+        ...mockWorld,
+        attributes: [
+          {
+            id: 'attr-1',
+            worldId: 'test-world',
+            name: 'Arcane Resonance',
+            description: 'Attunement to ambient magic',
+            baseValue: 5,
+            minValue: 1,
+            maxValue: 10,
+          },
+        ],
+        skills: [
+          {
+            id: 'skill-1',
+            worldId: 'test-world',
+            name: 'Runeweaving',
+            description: 'Binding spells into objects',
+            difficulty: 'medium',
+            baseValue: 5,
+            minValue: 1,
+            maxValue: 10,
+          },
+        ],
+      };
+
+      const request = new NextRequest('http://localhost:3000/api/generate-world-image', {
+        method: 'POST',
+        body: JSON.stringify({ world: worldWithElements }),
+      });
+
+      await POST(request);
+
+      expect(mockGeminiClient.generateContent).toHaveBeenCalled();
+      const elaborationPrompt = mockGeminiClient.generateContent.mock.calls[0][0] as string;
+      expect(elaborationPrompt).toContain('Arcane Resonance');
+      expect(elaborationPrompt).toContain('Runeweaving');
+    });
+
+    it('omits the world-elements block when no attributes or skills are defined', async () => {
+      mockGeminiClient.generateContent.mockResolvedValue({
+        content: 'AI-generated detailed description',
+      });
+      mockGenerateImageWithGemini.mockResolvedValue({
+        url: 'data:image/png;base64,abc123',
+        mimeType: 'image/png',
+        base64Data: 'abc123',
+      });
+
+      const request = new NextRequest('http://localhost:3000/api/generate-world-image', {
+        method: 'POST',
+        body: JSON.stringify({ world: mockWorld }),
+      });
+
+      await POST(request);
+
+      const elaborationPrompt = mockGeminiClient.generateContent.mock.calls[0][0] as string;
+      expect(elaborationPrompt).not.toContain('World elements');
+    });
+  });
+
   describe('Genre-Specific Image Generation', () => {
     it('should generate appropriate fallback for different genres', async () => {
       // Mock no API key to force fallback

--- a/src/app/api/generate-world-image/route.ts
+++ b/src/app/api/generate-world-image/route.ts
@@ -13,6 +13,24 @@ interface GenerateWorldImageRequest {
   customPrompt?: string;
 }
 
+// Summarize the world's defined attributes/skills so a thin free-text description
+// still grounds the image in the world's actual theme. The manual wizard carries
+// these (via FinalizeStep's full world); the /worlds Generate path passes none, so
+// its prompt is unchanged. Names only — keep the prompt tight. (#1437)
+function describeWorldElements(world: World): string {
+  const attributeNames = (world.attributes || []).map((attr) => attr.name).filter(Boolean);
+  const skillNames = (world.skills || []).map((skill) => skill.name).filter(Boolean);
+
+  const parts: string[] = [];
+  if (attributeNames.length > 0) {
+    parts.push(`defining attributes (${attributeNames.join(', ')})`);
+  }
+  if (skillNames.length > 0) {
+    parts.push(`signature skills (${skillNames.join(', ')})`);
+  }
+  return parts.join(' and ');
+}
+
 // Generate a detailed image prompt based on world characteristics
 function generateImagePrompt(world: World): string {
   const genre = world.genre || 'fantasy';
@@ -22,10 +40,15 @@ function generateImagePrompt(world: World): string {
   // Create a detailed prompt for image generation
   const basePrompt = `Create a highly detailed, cinematic landscape image representing the world "${name}". Genre: ${genre}. Description: ${description}`;
 
+  const worldElements = describeWorldElements(world);
+  const elementsBlock = worldElements
+    ? `\n\nWorld elements to reflect: ${worldElements}.`
+    : '';
+
   // Get genre-specific style guidance from shared utility
   const styleGuidance = getGenreStyleGuidance(genre, 'landscape');
 
-  return `${basePrompt}
+  return `${basePrompt}${elementsBlock}
 
 ${styleGuidance}
 


### PR DESCRIPTION
## Description
The manual world-creation wizard's "World Image" step generated off-theme images, while the `/worlds` "Generate" modal produced good ones — even though both call the same `/api/generate-world-image` route. So the model is fine; the difference is the input. `/worlds` feeds an AI-elaborated description (rich, visual prose), while the manual wizard feeds the user's raw typed description, which tends to be thinner and less visual. The manual path already sends the world's attributes and skills (FinalizeStep passes the full world), but the route ignored everything except name/genre/description.

This folds the world's defining attributes and signature skills into the image prompt when they're present, giving the route's elaboration hop something concrete to anchor on when the free-text description is thin. Because the `/worlds` path passes no attributes/skills, its prompt is byte-for-byte unchanged — the fix can only help the manual path, never regress the working one.

## Related Issue
Closes #1437

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — bug surfaced during the v1.0 QA walkthrough (#1417, finding F16).

## Flow Diagrams
N/A

## Component Development
N/A — this is an API-route prompt-construction change, no UI.
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes
- The enrichment lives in `generateImagePrompt()` in `src/app/api/generate-world-image/route.ts`, behind a presence check, so it's purely additive.
- Verification boundary worth calling out: this environment has no server-side Gemini key (BYO-key keeps the real key in the browser), so I couldn't run the end-to-end "does the image look on-theme" check. The deterministic half — that the world's attributes/skills now flow into the elaboration prompt — is covered by a unit test. End-to-end image quality is worth a quick confirm with a real key during review/QA.

## Screenshots
N/A

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm test -- src/app/api/generate-world-image` — the route suite, including the new "World Element Grounding" cases, passes (12/12).
2. With a real Gemini key in the browser: create a world via the manual wizard (`/worlds/create`) with attributes/skills and a short description, reach the World Image step, and confirm the generated image reflects the described world.
3. Regression: the `/worlds` "Generate" modal still produces on-theme images (its request shape is unchanged).

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
