### PR TITLE
fix(about): stop the footer overflowing at mobile widths

### DIFF
--- a/src/app/about.css
+++ b/src/app/about.css
@@ -199,6 +199,10 @@
    centers to the same measure. */
 
 .component-about-footer {
+  /* Without this it falls back to content-box, so width:100% + the inline
+     padding overflows the viewport (~20px) and margin:0 auto resolves both
+     auto margins negative. Matches .component-about. */
+  box-sizing: border-box;
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-5);


### PR DESCRIPTION
## Description
The `/about` page scrolled sideways ~20px on a phone. `.component-about-footer` (the Privacy/Terms row, a sibling of `.component-about`) copied that block's layout — `width: 100%`, inline padding, `margin: 0 auto` — but dropped `box-sizing: border-box`. So it fell back to `content-box`: the padding rendered outside the 100% width and pushed the document past narrow viewports. `margin: 0 auto` then resolved both auto margins negative (the stray `margin-right: -32px` in computed styles) — a symptom of the overflow, not a cause.

One-line fix: add the missing `box-sizing: border-box`. The footer now fits the viewport at 320/375/390 and aligns to `.component-about`'s 860px measure on desktop — which is what the "self-centers to the same measure" comment always intended, but the missing property had quietly broken. It renders outside the `.component-about` baseline locator, so no visual baselines move.

Found while verifying #1381 (header overflow), deliberately split out since #1381 was header-only. A landing/legal-page bug from the #1365 / #1366 work.

## Related Issue
Closes #1450

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
No automated test added — this is a one-line layout fix, and a dedicated Playwright spec guarding a `box-sizing` value would be test bloat (KISS). Verified live instead (see below); the visual-regression suite already screenshots the surrounding pages.

## Component Development
<!-- N/A — token-safe CSS fix to an existing component; no new component or story -->
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

## Implementation Notes
- The `-32px margin-right` was never authored — it's the spec's resolution of `margin: 0 auto` when an element's border-box overflows its container. Fixing `box-sizing` makes both auto margins resolve to `0` (mobile) / centered (desktop), so there was nothing to "remove."
- Single property change, fully token-safe (no values/colors touched). `lint:css` clean.

## Screenshots
Live probe (system Chrome) against the worktree dev server, `.component-about-footer` computed style:

| width | doc scrollWidth / clientWidth | overflows | box-sizing | margin L / R |
|---|---|---|---|---|
| 320 | 320 / 320 | no | border-box | 0px / 0px |
| 375 | 375 / 375 | no | border-box | 0px / 0px |
| 390 | 390 / 390 | no | border-box | 0px / 0px |
| 1280 | 1280 / 1280 | no | border-box | 146px / 146px (centered, 860px) |

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed <!-- CodeQL runs in CI -->
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm run dev`, open `/about` at 320 / 375 / 390px (DevTools device mode or a real phone).
2. Confirm no horizontal scroll: `document.documentElement.scrollWidth === clientWidth`.
3. Confirm `.component-about-footer` computed `margin-right` is `0px` (not `-32px`) and `box-sizing` is `border-box`.
4. Confirm desktop (>=1024px) is unchanged — footer centered at 860px.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) <!-- N/A -->
- [x] No new warnings generated
- [x] Accessibility considerations addressed <!-- footer nav markup unchanged -->