### PR TITLE
fix(narrative): rebalance lethality and choice weighting (#1426)

### DIFF
--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -19,7 +19,10 @@ import {
 } from '@/types/narrative.types';
 import { isSessionEndingSegment } from '@/lib/narrative/isSessionEndingSegment';
 import { getNarrativeError } from '@/lib/narrative/narrativeErrors';
-import { evaluateDecisionSkillChecks } from '@/lib/narrative/evaluateDecisionSkillChecks';
+import {
+  evaluateDecisionSkillChecks,
+  isFatalCriticalDecision,
+} from '@/lib/narrative/evaluateDecisionSkillChecks';
 import { logger } from '@/lib/utils/logger';
 import { AI_GENERATION_TIMEOUT_MS } from '@/lib/constants/timeouts';
 import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
@@ -615,14 +618,19 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
           onSkillCheckPerformed,
         });
 
-      // Fatal outcome check: Any failure on a critical decision ends the game
-      // This makes critical decisions truly life-or-death
-      const hasCriticalFailure =
-        decisionWeight === 'critical' && rollResults.some((r) => !r.success);
+      // Fatal outcome check: a critical decision only ends the run on a true
+      // critical-failure roll (natural 1). An ordinary missed roll is a
+      // survivable setback the AI narrates (and can still escalate via the
+      // fatal-outcome tag below), so one unlucky-but-ordinary roll no longer
+      // ends the story (issue #1426).
+      const isFatalCriticalFailure = isFatalCriticalDecision(
+        decisionWeight,
+        rollResults
+      );
 
-      if (hasCriticalFailure) {
+      if (isFatalCriticalFailure) {
         suggestEnding(
-          'fatal: failure on a pivotal decision left the character unable to continue.',
+          'fatal: a catastrophic failure on a pivotal decision left the character unable to continue.',
           'story-complete'
         );
       }
@@ -748,14 +756,14 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
       await checkForEndingIndicators(newSegment);
 
       // Generate choices if enabled - skip when the session is ending
-      // (fatal/ending segment or a critical-decision failure).
-      // A critical failure only ends the session when an ending handler is
-      // wired: suggestEnding() is a no-op without onEndingSuggested. Without a
-      // handler, keep generating choices so a standalone controller (harness,
+      // (fatal/ending segment or a fatal critical-decision failure).
+      // A fatal critical failure only ends the session when an ending handler
+      // is wired: suggestEnding() is a no-op without onEndingSuggested. Without
+      // a handler, keep generating choices so a standalone controller (harness,
       // story, embedder) can still move forward instead of stalling with no
       // ending and no choices.
       const criticalFailureEndsSession =
-        hasCriticalFailure && Boolean(onEndingSuggested);
+        isFatalCriticalFailure && Boolean(onEndingSuggested);
       if (
         generateChoices &&
         !isSessionEndingSegment(newSegment) &&

--- a/src/components/Narrative/__tests__/useEndingDetection.frequency.test.ts
+++ b/src/components/Narrative/__tests__/useEndingDetection.frequency.test.ts
@@ -82,13 +82,15 @@ describe('useEndingDetection frequency gating', () => {
     expect(mockGenerateContent).toHaveBeenCalledTimes(1);
   });
 
-  it('always runs on a critical decision outcome even off-interval', async () => {
+  it('does NOT treat a critical decision outcome as high-signal (throttles like routine)', async () => {
+    // Under the rebalanced lethality (#1426) a critical failure is usually a
+    // survivable setback, so it no longer forces an off-interval ending check.
     const { result } = renderDetection(makeSegments(4)); // total 5 -> off-interval
     await result.current.checkForEndingIndicators(
       segment('5', { decisionOutcome: 'critical-failure' })
     );
 
-    expect(mockGenerateContent).toHaveBeenCalledTimes(1);
+    expect(mockGenerateContent).not.toHaveBeenCalled();
   });
 
   it('runs again once the routine interval comes back around', async () => {

--- a/src/components/Narrative/useEndingDetection.ts
+++ b/src/components/Narrative/useEndingDetection.ts
@@ -43,20 +43,19 @@ interface UseEndingDetectionOptions {
 
 /**
  * Decides whether to spend an AI call checking for an ending on this segment.
- * Always checks high-signal segments (major events, critical decision outcomes)
- * since endings cluster there; otherwise throttles to every Nth segment.
+ * Always checks segments flagged as a major event (endings cluster there);
+ * otherwise throttles to every Nth segment. Critical decision outcomes are
+ * deliberately NOT treated as high-signal: under the rebalanced lethality a
+ * critical failure is usually a survivable setback, not an ending, so running
+ * the ending check on every critical outcome surfaced spurious "wrap it up"
+ * prompts mid-story (issue #1426). Genuinely lethal moments still end the run
+ * via the fatal-outcome tag, and climactic resolutions get majorEvent.
  */
 function shouldRunEndingCheck(
   segment: NarrativeSegment,
   totalSegments: number
 ): boolean {
-  const outcome = segment.metadata?.decisionOutcome;
-  const isHighSignal =
-    Boolean(segment.metadata?.majorEvent) ||
-    outcome === 'critical-success' ||
-    outcome === 'critical-failure';
-
-  if (isHighSignal) return true;
+  if (segment.metadata?.majorEvent) return true;
 
   return (totalSegments - MIN_SEGMENTS_FOR_ANALYSIS) % ROUTINE_CHECK_INTERVAL === 0;
 }

--- a/src/lib/ai/choiceGenerator.fallback.ts
+++ b/src/lib/ai/choiceGenerator.fallback.ts
@@ -66,7 +66,7 @@ export const generateFallbackChoices = (
         { id: generateUniqueId('option'), text: 'Access the terminal', alignment: 'lawful' },
         {
           id: generateUniqueId('option'),
-          text: 'Reroute power to the coffee machine',
+          text: 'Override the airlock and vent the corridor',
           alignment: 'chaotic',
         }
       );
@@ -77,7 +77,7 @@ export const generateFallbackChoices = (
         { id: generateUniqueId('option'), text: 'Call for help', alignment: 'lawful' },
         {
           id: generateUniqueId('option'),
-          text: 'Start laughing maniacally',
+          text: 'Set the room ablaze and run for the door',
           alignment: 'chaotic',
         }
       );
@@ -88,7 +88,7 @@ export const generateFallbackChoices = (
         { id: generateUniqueId('option'), text: 'Talk to someone', alignment: 'lawful' },
         {
           id: generateUniqueId('option'),
-          text: 'Do something completely unexpected',
+          text: 'Upend the table and seize the upper hand',
           alignment: 'chaotic',
         }
       );

--- a/src/lib/narrative/__tests__/isFatalCriticalDecision.test.ts
+++ b/src/lib/narrative/__tests__/isFatalCriticalDecision.test.ts
@@ -1,0 +1,34 @@
+// Guards the rebalanced lethality rule (issue #1426): a CRITICAL decision is
+// fatal only on a true critical-failure roll (natural 1), not on an ordinary
+// missed roll, and lower-weight decisions are never instantly fatal.
+
+import { isFatalCriticalDecision } from '../evaluateDecisionSkillChecks';
+
+const critFail = { isCriticalFailure: true };
+const ordinaryFail = { isCriticalFailure: false };
+
+describe('isFatalCriticalDecision', () => {
+  it('is fatal when a critical decision has a critical-failure roll (nat 1)', () => {
+    expect(isFatalCriticalDecision('critical', [critFail])).toBe(true);
+  });
+
+  it('is fatal when any roll on a critical decision is a critical failure', () => {
+    expect(
+      isFatalCriticalDecision('critical', [ordinaryFail, critFail])
+    ).toBe(true);
+  });
+
+  it('is NOT fatal on an ordinary missed roll on a critical decision', () => {
+    expect(isFatalCriticalDecision('critical', [ordinaryFail])).toBe(false);
+  });
+
+  it('is NOT fatal for non-critical weights even on a critical-failure roll', () => {
+    expect(isFatalCriticalDecision('major', [critFail])).toBe(false);
+    expect(isFatalCriticalDecision('minor', [critFail])).toBe(false);
+    expect(isFatalCriticalDecision(undefined, [critFail])).toBe(false);
+  });
+
+  it('is NOT fatal when there are no rolls', () => {
+    expect(isFatalCriticalDecision('critical', [])).toBe(false);
+  });
+});

--- a/src/lib/narrative/evaluateDecisionSkillChecks.ts
+++ b/src/lib/narrative/evaluateDecisionSkillChecks.ts
@@ -12,6 +12,7 @@ import type { World } from '@/types/world.types';
 import type {
   DecisionOption,
   DecisionOutcome,
+  DecisionWeight,
   SkillCheckRoll,
 } from '@/types/narrative.types';
 import type { ToastData } from '@/components/ui/toast/toaster';
@@ -200,4 +201,24 @@ export function evaluateDecisionSkillChecks({
   }
 
   return { skillCheckTags, rollResults, decisionOutcome };
+}
+
+/**
+ * Whether a decision's skill rolls should end the run outright.
+ *
+ * A CRITICAL-weight decision is fatal only on a true critical-failure roll
+ * (natural 1) — a catastrophic outcome that feels earned. An ordinary missed
+ * roll on a critical decision is a survivable setback: the narrative reflects
+ * the failure, and the AI can still mark the segment fatal in genuinely lethal
+ * context. This keeps deadly stakes for the worst rolls without ending the
+ * story on a single unlucky-but-ordinary failure (issue #1426).
+ */
+export function isFatalCriticalDecision(
+  decisionWeight: DecisionWeight | undefined,
+  rollResults: Pick<SkillCheckRoll, 'isCriticalFailure'>[]
+): boolean {
+  return (
+    decisionWeight === 'critical' &&
+    rollResults.some((r) => r.isCriticalFailure)
+  );
 }

--- a/src/lib/promptTemplates/templates/narrative/choiceTypeTemplates.ts
+++ b/src/lib/promptTemplates/templates/narrative/choiceTypeTemplates.ts
@@ -94,7 +94,7 @@ Based on the SPECIFIC narrative situation above, create 4 distinct action choice
 ALIGNMENT DEFINITIONS:
 - LAWFUL: Follows rules, respects authority, seeks order, honors agreements, protects others
 - NEUTRAL: Balanced approach, practical solutions, adapts to situation, moderate response
-- CHAOTIC: WILDLY UNEXPECTED and DISRUPTIVE actions that completely change the situation. These should be dramatic, potentially dangerous, creative solutions that ignore social norms, defy expectations, and could lead to entirely different story outcomes. Think "throw a fireball at the ceiling," "start singing loudly to distract everyone," "pretend to be possessed by a spirit," or "challenge them to a dance-off." The goal is to provide players with options that can dramatically shift the narrative in surprising ways.
+- CHAOTIC: WILDLY UNEXPECTED and DISRUPTIVE actions that completely change the situation. Dramatic, potentially dangerous, creative solutions that ignore social norms, defy expectations, and could lead to entirely different story outcomes. VARY THE KIND of chaos and do NOT default to making noise (yelling, shouting, singing). Draw from a wide range, fitted to the scene: sudden physical risk ("leap from the balcony onto the chandelier," "kick over the lantern to set the drapes alight"), trickery or deception ("impersonate the captain and bark orders," "bluff an outrageous lie with total confidence"), sabotage or destruction ("cut the rope bridge behind you," "smash the control panel," "throw open the cells and free the prisoners"), turning the tables ("start a brawl to scatter the room," "switch sides mid-negotiation"), or abandoning the obvious goal for something no one expects. The goal is options that dramatically shift the narrative in surprising ways.
 
 PERSONALITY-INFORMED CHOICES (when character personality context is provided):
 - Within the REQUIRED alignment distribution (1 lawful, 2 neutral, 1 chaotic), create options that offer ways to express the character's traits
@@ -129,7 +129,7 @@ Carefully evaluate the narrative situation and determine the significance of thi
 - MAJOR: Important choices that significantly impact the story direction (meeting key characters, choosing major paths, using powerful abilities, entering dangerous areas, making moral choices)
 - CRITICAL: Life-changing decisions with major consequences (combat with deadly enemies, final confrontations, destiny-altering choices, choosing between life and death)
 
-Consider the stakes, potential consequences, and story impact. Don't default to MINOR - use MAJOR for interesting story moments and CRITICAL for climactic situations.
+Consider the stakes, potential consequences, and story impact. MOST decisions are MINOR or MAJOR: MINOR for everyday beats, MAJOR for the interesting story moments. Reserve CRITICAL for the RARE, genuinely life-or-death turning points - deadly combat, final confrontations, or choices where failure would plausibly end the character's story. When unsure between MAJOR and CRITICAL, choose MAJOR.
 
 FORMAT (REQUIRED - include alignment tags, decision weight, and context summary):
 Decision Weight: [MINOR/MAJOR/CRITICAL]

--- a/src/lib/promptTemplates/templates/narrative/playerChoiceTemplate.ts
+++ b/src/lib/promptTemplates/templates/narrative/playerChoiceTemplate.ts
@@ -107,7 +107,7 @@ NEGATIVE CONSTRAINTS (CRITICAL):
 ALIGNMENT VARIETY (when appropriate):
 - LAWFUL: Follows rules, respects authority, seeks order, honors agreements, protects others
 - NEUTRAL: Balanced approach, practical solutions, adapts to situation, moderate response  
-- CHAOTIC: Unexpected, disruptive actions that change the situation dramatically
+- CHAOTIC: Unexpected, disruptive actions that change the situation dramatically. Vary the KIND of chaos and do not default to making noise (yelling, shouting, singing) - draw from physical risk, trickery/deception, sabotage/destruction, turning the tables, or abandoning the obvious goal
 
 PERSONALITY-INFORMED CHOICES (when character personality context is provided):
 - Create options that offer ways to express the character's traits
@@ -148,7 +148,7 @@ Carefully evaluate the narrative situation and determine the significance of thi
 - MAJOR: Important choices that significantly impact the story direction (meeting key characters, choosing major paths, using powerful abilities, entering dangerous areas, making moral choices)
 - CRITICAL: Life-changing decisions with major consequences (combat with deadly enemies, final confrontations, destiny-altering choices, choosing between life and death)
 
-Consider the stakes, potential consequences, and story impact. Don't default to MINOR - use MAJOR for interesting story moments and CRITICAL for climactic situations.
+Consider the stakes, potential consequences, and story impact. MOST decisions are MINOR or MAJOR: MINOR for everyday beats, MAJOR for the interesting story moments. Reserve CRITICAL for the RARE, genuinely life-or-death turning points - deadly combat, final confrontations, or choices where failure would plausibly end the character's story. When unsure between MAJOR and CRITICAL, choose MAJOR.
 
 FORMAT:
 Decision Weight: [MINOR/MAJOR/CRITICAL]


### PR DESCRIPTION
## Description
Players hit a game-over too early. Three things compounded: the choice prompt biased toward CRITICAL decision weight, any failed roll on a CRITICAL decision was an instant fatal, and the ending detector ran on every critical outcome. This rebalances all three so a normal player can sustain a session through real story beats, and dying feels earned rather than like a coin flip. Also broadens the chaotic-choice exemplars (F42), which kept coming back as "yell / make noise".

## Related Issue
Closes #1426

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
v1.0 QA walkthrough (#1417), findings F44 and F42: a normal player should be able to play through real story beats without an unlucky d20 ending the run, and chaotic choices should feel varied rather than always "make noise".

## Component Development
N/A - no UI changes (narrative-engine + prompt tuning only).

## Implementation Notes
- The lethality rule moved into a small pure helper, `isFatalCriticalDecision(decisionWeight, rollResults)`, colocated with `evaluateDecisionSkillChecks`. A CRITICAL decision is now fatal only on a true critical-failure roll (natural 1); an ordinary missed roll on a critical decision passes through as a survivable setback. The narrative still receives the failure context, and the existing `fatal-outcome` AI tag path remains the escalation route for genuinely lethal scenes - so it's a two-layer model (deterministic nat-1 floor + AI judgement for narrative lethality) rather than a coin flip.
- Decision-weight guidance reworded in both the live (`alignedChoiceTemplate`) and fallback (`playerChoiceTemplate`) prompts so MINOR/MAJOR are the common case and CRITICAL is reserved for life-or-death turns.
- `useEndingDetection` no longer treats critical outcomes as high-signal, so the AI ending check stops firing after every crit; major events still trigger it, and the routine throttle is unchanged.
- Chaos exemplars broadened across kinds (physical risk, trickery, sabotage, turning the tables, goal-swerve) in both the prompts and the genre fallbacks.
- Prompt-wording effects are non-deterministic by nature, so they're best judged in playtesting; the deterministic behavior changes (fatal rule, ending-check gating) are unit-tested.

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
- `npm test` - new `isFatalCriticalDecision` suite plus the updated `useEndingDetection.frequency` spec; ran the full narrative/ai blast radius (97 suites, 629 tests) green locally.
- `npm run type-check` and `npm run lint` clean.
- Manual: start a session, reach a CRITICAL decision, fail an ordinary roll - the run continues as a setback instead of ending; a natural-1 on a CRITICAL decision still ends it.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
