### PR TITLE
chore: promote CLAUDE.md to committed canon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,11 +110,10 @@ public_docs/architecture/*.dot
 public_docs/architecture/*.html
 dependency-violations.html
 
-# Claude Code
+# Claude Code (CLAUDE.md is committed canon; the rest stays local)
 .claude/*
 .claude-workflow/
 .clauderc
-CLAUDE.md
 CLAUDE.local.md
 
 # Claude Code cloud (web sessions): commit only these reviewed, shareable files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Narraitor
+# CLAUDE.md — Narraitor
 
 Narraitor is an AI-driven narrative RPG framework. You build a world (its theme, attributes, skills, and tone), create characters in it, and play through a generated, choice-driven story with a tracked inventory and journal. It's a single-player web app — there's no backend database; player data lives in the browser (IndexedDB via Zustand persistence), and AI generation runs through the player's own provider key.
 
@@ -9,34 +9,89 @@ Narraitor is an AI-driven narrative RPG framework. You build a world (its theme,
 - **Plain CSS + design tokens** for styling: `var(--token)` values plus `clsx` for conditional classes. There is **no Tailwind** (it was removed) — don't add utility classes or reintroduce `cva`/`cn()`.
 - AI generation goes through `src/lib/ai/` (Google Gemini via `@google/genai`), keyed by the player's own provider key rather than a server-held key.
 
+## Run it
+
+```bash
+npm run dev          # scripts/dev.sh — port 3000 in the main checkout; worktrees auto-select their own port
+npm run storybook    # port 6006
+npm run kill         # emergency: pkill -f 'next dev'
+```
+
+- Check whether a dev server is already running before starting one (`lsof -iTCP:3000`). rcv-simulator-va's main checkout also defaults to 3000 — don't run both at once.
+- Verify: `curl -s localhost:3000 | head -1` returns HTML; Storybook responds at http://localhost:6006.
+
+## The quality gate
+
+Run before any commit — CI runs these separately and the production build enforces lint and types anyway:
+
+```bash
+npm test                   # Jest unit/integration suite
+npm run type-check         # tsc --noEmit
+npm run lint               # ESLint (Next + test/script globs)
+npm run lint:css           # Stylelint over **/*.css — run after ANY .css edit
+```
+
+- `npm run build` — production build (includes a Storybook build step).
+- Structural changes (imports crossing domains): `npm run deps:validate` — dependency-cruiser against the known-violations baseline (`deps:validate:strict` shows everything; re-baseline only deliberately with `deps:baseline`).
+- Visual work: `npm run test:visual` (Playwright, chromium). Update snapshots deliberately with `test:visual:update`; prune orphans with `test:visual:prune`.
+- If local jest runs out of memory, `npm run test:ci` exists for that (4GB Node heap).
+
 ## Layout
 
 `src/` is domain-driven:
+
 - `app/` — Next.js routes (App Router).
-- `components/` — React components.
-- `state/` — Zustand stores (the source of truth for app data).
+- `components/` — React components, organized by domain.
+- `state/` — Zustand stores (the source of truth for app data): world, character, narrative, lore, inventory, npc, journal, goal, navigation, session, plus `persistence.ts` (IndexedDB).
 - `lib/` — non-UI logic: `ai/`, `api/`, `design-tokens/`, `generators/`, `devtools/`, feature flags.
 - `services/`, `hooks/`, `utils/`, `types/`, `styles/`, `stories/` (Storybook).
-
-## Commands
-
-- `npm run dev` — dev server on **port 3000** (per-worktree port auto-selected outside the main checkout). Check whether one's already running before starting it.
-- `npm test` — Jest unit/integration suite.
-- `npm run type-check` — `tsc --noEmit`.
-- `npm run lint` — ESLint (Next + test/script globs).
-- `npm run lint:css` — Stylelint over `**/*.css`. Run this after any `.css` edit; CI runs it separately and it'll fail the build if skipped.
-- `npm run build` — production build (includes a Storybook build step).
 
 ## Conventions
 
 - **Target the `develop` branch** for PRs, not `main`. `main` is release-only; `develop` is the rolling integration branch.
 - KISS by default, in implementation and in tests — MVP-level tests, not exhaustive coverage. Never rig a test to pass.
-- Style with design tokens, not hardcoded values. Avoid `!important` unless there's truly no alternative.
+- Style with design tokens, not hardcoded values. Stylelint enforces it: no hex, no named colors, no rgb/rgba in product CSS (theme files have scoped overrides). Avoid `!important`.
 - Put an identifying class attribute on components.
 - Look for an existing pattern/utility before adding a new one. One canon version per file — no `simple`/`enhanced` variants.
+- Three design systems coexist deliberately — that's ADR-011, not an accident. The showcase routes are canon; DESIGN.md is the map.
+- State: CRUD-style store methods; cross-store events via `storeEvents`/`StoreEventTypes`; static imports only (`eval(require())` was eradicated in #1206). Wizard step state goes through sessionStorage (`generated-world-data`); theme prefs through localStorage.
+- Current house style: no wrapper services (ExportService was removed on purpose), use `clsx` directly, extract hooks/helpers before things get clever.
+- Issue work runs the standard global pipeline: analyze-issue, then tdd-implement, then post-merge.
+
+## Local skills and agents — use them
+
+Committed under `.claude/` and shipped with the repo:
+
+- `narraitor-architecture` skill — invoke BEFORE writing new components, stores, API routes, or planning a feature. Domain boundaries, naming, state patterns, AI integration conventions.
+- `narraitor-pattern-alignment-skill` — run AFTER any code change touching src/, before committing.
+- `style-port` skill — the only sanctioned way to port reference/demo inline styles into production CSS (rigid 6-phase process, token-based, no `!important`).
+- `review` skill — PR review flow: fetch the latest remote diff, run lint + tests, verdict.
+- Agents: design-system-cop, formatting-cop, issue-prioritizer, pr-closer, test-fixer.
 
 ## Running in Claude Code cloud
 
 Cloud sessions clone this repo fresh, so the `SessionStart` hook in `.claude/settings.json` runs `scripts/install_pkgs.sh` to `npm ci` on startup. Unit tests, type-check, lint, and build all work on the Linux cloud VM.
 
 **Don't run the visual-regression or E2E suites in cloud** (`test:visual`, `test:e2e:*`) — the Playwright baselines are macOS-only and will fail on pixel diffs against a Linux runner. Those belong on a local Mac or the macOS CI job.
+
+## Automation directives
+
+Slash commands in this repo may carry directives at the top of the file:
+
+```
+# AUTO-APPROVE: ALL
+# AUTO-ACCEPT-EDITS: ALL
+```
+
+For truly automatic execution, select "Yes, and don't ask again this session" on the first prompt. Helper scripts are pre-approved in `.claude/settings.local.json` (machine-local, not committed).
+
+## Known failure modes
+
+- Port 3000 taken → an orphan `next dev` or rcv-simulator-va's main checkout.
+- Stylelint color failures → a raw color landed outside a theme file; route it through tokens.
+- deps:validate failures → fix the boundary violation, or (rarely, deliberately) re-baseline.
+
+## Pointers
+
+- README.md — product overview.
+- DESIGN.md and ADR-011 (#1210) — design-system architecture.


### PR DESCRIPTION
## Description
Promotes `CLAUDE.md` to committed canon and expands it: drops `CLAUDE.md` from `.gitignore` (it was already tracked but still ignore-listed) and adds "Run it" + "The quality gate" sections plus fuller layout/conventions guidance.

This is the local promotion commit (`a1ee9b07`, Jun 12) re-applied onto current `develop` — a direct push is blocked by the branch ruleset, so it goes through a PR.

## Type of Change
- [x] Documentation update

## Implementation Notes
Docs/config only — no source, tests, or behavior touched.

## Checklist
- [x] Self-review performed
- [x] No new warnings generated