### PR TITLE
docs: correct README API-key security claims to match the BYOK model

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Release notes for each tagged version live in [RELEASES.md](RELEASES.md).
 
 ## Getting It Running
 
-You'll need Node.js (v18+), npm, and a Google Gemini API key. The API key stays server-side for security; no client exposure.
+You'll need Node.js (v18+), npm, and a Google Gemini API key. For local development the key lives in a server-side env file (`GEMINI_API_KEY`, below). In normal use, players bring their own key — see [AI Integration Details](#ai-integration-details).
 
 ```bash
 # Clone and set up
@@ -229,13 +229,13 @@ The app separates concerns into clear domains:
 
 **State Persistence**: Zustand stores with IndexedDB backing. Game sessions persist across browser sessions, and there's graceful fallback to memory-only if IndexedDB fails.
 
-**Security**: API keys stay server-side. All AI requests go through Next.js API routes with rate limiting (50/hour per IP) to prevent abuse.
+**Security**: All AI requests go through Next.js API routes with rate limiting (50/hour per IP) to prevent abuse. Players bring their own Gemini key, sent per request and used server-side for that one call — never persisted or logged. A server-side `GEMINI_API_KEY` env var acts as a local/dev fallback.
 
 **Design System**: Three structurally-different design systems (DS1/DS2/DS3) ship together; the user picks one. See [DESIGN.md](DESIGN.md) for the AI-readable design surface (tokens, components, do's and don'ts), [ADR-011](public_docs/architecture/ADR-011-three-design-systems.md) for the rationale, and [public_docs/design-system/](public_docs/design-system/) for the full reference. Canon order is **showcase routes (`/dev/design-system{,-2,-3}`) > Storybook (`npm run storybook`) > app** — Storybook's toolbar has a DS1/DS2/DS3 + light/dark switcher for verifying components across all six combinations.
 
 ## AI Integration Details
 
-The AI system routes everything through Next.js API endpoints (`/api/narrative/generate`, `/api/narrative/choices`) for security. Your API key never touches the browser.
+The AI system routes everything through Next.js API endpoints (`/api/narrative/generate`, `/api/narrative/choices`). A player's own Gemini key travels from the browser to those routes in a per-request header (`x-provider-api-key`), gets used server-side for that single call, and is never logged or persisted. The `GEMINI_API_KEY` env var below is a local/dev fallback that stays server-side.
 
 ```bash
 # .env.local


### PR DESCRIPTION
## Description

The README's security section claimed the Gemini API key "stays server-side" and "never touches the browser." That's no longer how it works. `src/lib/ai/resolveApiKey.ts` resolves the player's bring-your-own key from a per-request header (`x-provider-api-key`), and the server `GEMINI_API_KEY` env var is only a dev/local fallback — so in normal use a key does travel from the browser, per request. This reword makes the README match the actual code and CLAUDE.md.

Three spots updated (Getting It Running, the Security bullet, AI Integration Details): the player brings their own key, sent per request and used server-side for that one call (never logged or persisted); the env key is the local/dev fallback.

## Related Issue
N/A — surfaced by a documentation (doc-rot) audit, not a tracked issue.

## Type of Change
- [x] Documentation update

## TDD Compliance
N/A — documentation-only change, no code touched.

## User Stories Addressed
N/A

## Flow Diagrams
N/A

## Component Development
N/A — no UI changes.

## Implementation Notes
Verified against `src/lib/ai/resolveApiKey.ts` and `src/lib/ai/providerKeyHeader.ts` before writing. The new wording matches CLAUDE.md's "AI generation runs through the player's own provider key." The local-setup instructions (setting `GEMINI_API_KEY` in `.env.local`) are unchanged and still correct — that's the fallback path.

The mechanical fixes from the same audit are on a separate branch (`docs/doc-rot-cleanup`); this one was split out because it's a security claim that needed a real reword rather than a find-and-replace.

## Screenshots
N/A

## Quality Checks (if applicable)
- [x] Linting passed (markdown only, no code changed)
- [x] Type checking passed (no code changed)

## Testing Instructions
Read the three updated README sections (Getting It Running, Security, AI Integration Details) and confirm they match `resolveApiKey.ts`: the player key arrives via the `x-provider-api-key` header per request and is used server-side for that one call; the `GEMINI_API_KEY` env var is the local/dev fallback.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Documentation updated (if required)
- [x] No new warnings generated
