### PR TITLE
docs: fix stale documentation caught by a doc-rot audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Committed under `.claude/` and shipped with the repo:
 - `narraitor-pattern-alignment-skill` — run AFTER any code change touching src/, before committing.
 - `style-port` skill — the only sanctioned way to port reference/demo inline styles into production CSS (rigid 6-phase process, token-based, no `!important`).
 - `review` skill — PR review flow: fetch the latest remote diff, run lint + tests, verdict.
-- Agents: design-system-cop, formatting-cop, issue-prioritizer, pr-closer, test-fixer.
+- Agents: design-system-enforcer, format-check, issue-prioritizer, pr-merge-issue-updater, test-fix.
 
 ## Running in Claude Code cloud
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -17,7 +17,7 @@ This is where the multi-theme design system migration goes public. Phases 0-2 of
 - Non-game-session surfaces brought into the system: home, worlds list, world detail/edit, characters list, character detail/edit, journal, settings, dev tooling.
 - Cross-theme audit pass and follow-on cleanup — wizard layouts, form wrappers, collapsible toggles, journal panes, classless buttons all resolved across DS1/DS2/DS3.
 - [DESIGN.md](DESIGN.md) at the repo root as the canonical AI-readable summary of the system. Canon order pinned: showcase pages > Storybook > app code.
-- [ADR-011](public_docs/decisions/adr-011-three-design-systems.md) documenting the three-design-systems decision and the structural-differentiation roadmap.
+- [ADR-011](public_docs/architecture/ADR-011-three-design-systems.md) documenting the three-design-systems decision and the structural-differentiation roadmap.
 - Release model itself ([#1170](https://github.com/jerseycheese/narraitor/pull/1210)): `main` is release-only, `develop` is rolling, branch protection rebuilt accordingly.
 
 The headline integration PR is [#1081](https://github.com/jerseycheese/narraitor/pull/1081). The last two gate items — GuidedFirstTimeExperience wizard styling ([#1199](https://github.com/jerseycheese/narraitor/issues/1199)) and worlds journal DS treatment ([#1159](https://github.com/jerseycheese/narraitor/issues/1159)) — closed together via [#1200](https://github.com/jerseycheese/narraitor/pull/1200), which is what cleared the way for this release.

--- a/public_docs/api/character-creation-auto-save-api.md
+++ b/public_docs/api/character-creation-auto-save-api.md
@@ -16,7 +16,6 @@ What you get back:
 interface UseCharacterCreationAutoSaveReturn {
   data: CharacterCreationState | undefined;
   setData: (newData: CharacterCreationState | undefined) => void;
-  handleFieldBlur: () => void; // @deprecated
   clearAutoSave: () => void;
   hasRecoveryData: boolean;
   recoveryPreview: RecoveryDataPreview | undefined;
@@ -31,7 +30,6 @@ interface UseCharacterCreationAutoSaveReturn {
 |----------|------|-------------|
 | `data` | `CharacterCreationState \| undefined` | Current character creation data with save metadata |
 | `setData` | `(newData: CharacterCreationState \| undefined) => void` | Function to update character data (triggers auto-save) |
-| `handleFieldBlur` | `() => void` | **@deprecated** Legacy field blur handler - auto-save is now automatic |
 | `clearAutoSave` | `() => void` | Function to clear all auto-save data and reset state |
 | `hasRecoveryData` | `boolean` | Whether recovery data was detected on mount |
 | `recoveryPreview` | `RecoveryDataPreview \| undefined` | Analyzed preview data for recovery dialog |

--- a/public_docs/api/goal-system-api.md
+++ b/public_docs/api/goal-system-api.md
@@ -106,11 +106,11 @@ This is how goals get fed into the AI system. When generating new narrative cont
 #### Goal Context Building
 ```typescript
 // Build complete context for session including goals
-buildContextForSession(sessionId: EntityID, options?: ContextBuildOptions): AISessionContext
+buildContextForSession(sessionId: EntityID, options?: ContextBuildOptions): Promise<AISessionContext>
 
 interface ContextBuildOptions {
   includeGoals?: boolean; // Default: true
-  maxTokens?: number; // Default: 1000
+  maxChars?: number; // Default: 5000
   prioritizeRecent?: boolean; // Default: false
 }
 

--- a/public_docs/api/playwright-visual-api.md
+++ b/public_docs/api/playwright-visual-api.md
@@ -22,7 +22,7 @@ export default defineConfig({
   timeout: 60 * 1000,
   expect: {
     toHaveScreenshot: {
-      maxDiffPixels: 500,
+      maxDiffPixels: 10000,
       threshold: 0.2,
       animations: 'disabled',
     },
@@ -35,7 +35,7 @@ export default defineConfig({
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `maxDiffPixels` | `number` | `500` | Maximum allowed pixel differences |
+| `maxDiffPixels` | `number` | `10000` | Maximum allowed pixel differences |
 | `threshold` | `number` | `0.2` | Pixel difference threshold (0-1) |
 | `animations` | `'disabled' \| 'allow'` | `'allow'` | Animation handling during screenshots |
 | `clip` | `{x, y, width, height}` | `undefined` | Clip screenshot to specific region |
@@ -50,7 +50,7 @@ projects: [
     name: 'chromium',
     use: { 
       ...devices['Desktop Chrome'],
-      viewport: { width: 1280, height: 720 },
+      viewport: { width: 1280, height: 1024 },
       launchOptions: {
         args: [
           '--font-render-hinting=none',

--- a/public_docs/api/types-reference.md
+++ b/public_docs/api/types-reference.md
@@ -45,7 +45,6 @@ interface World extends NamedEntity, TimestampedEntity {
   reference?: string;
   relationship?: 'set_within' | 'inspired_by';
   toneSettings?: ToneSettings;
-  characterTemplates?: CharacterTemplate[];
 }
 
 interface WorldAttribute extends NamedEntity {

--- a/public_docs/architecture/ADR-006-gemini-server-side-api.md
+++ b/public_docs/architecture/ADR-006-gemini-server-side-api.md
@@ -33,7 +33,7 @@ Use **Google Gemini** (via the `@google/genai` SDK) as the AI provider, and put 
 so on — which attach the key and call Gemini server-side. The client never sees the key or a
 `googleapis.com` URL.
 
-The default text model is `gemini-2.0-flash` (`src/lib/ai/config.ts`); image generation uses a
+The default text model is `gemini-2.5-flash` (`src/lib/ai/config.ts`); image generation uses a
 Gemini image model. A small in-memory per-IP rate limiter (`src/utils/rateLimiter.ts`, 50/hr in
 production) guards the generation routes.
 
@@ -63,7 +63,7 @@ where latency is felt directly.
 
 - The API key never reaches the client; all AI traffic is same-origin and server-mediated.
 - The API routes are a single choke point for validation, rate limiting, and error handling.
-- `gemini-2.0-flash` keeps interactive generation fast and inexpensive.
+- `gemini-2.5-flash` keeps interactive generation fast and inexpensive.
 
 ### Downsides
 

--- a/public_docs/systems/mvp-type-simplification.md
+++ b/public_docs/systems/mvp-type-simplification.md
@@ -26,7 +26,6 @@ We cut out all the fancy RPG mechanics that would take months to implement prope
 **Removed Properties:**
 - `weight` - Advanced encumbrance system (Post-MVP)
 - `value` - Economy/trading system (Post-MVP)
-- `equipped` - Equipment system (Post-MVP)
 - `properties` - Complex item effects (Post-MVP)
 
 **Kept Properties:**

--- a/public_docs/systems/world-creation-wizard.md
+++ b/public_docs/systems/world-creation-wizard.md
@@ -121,7 +121,7 @@ interface SkillSuggestion {
   description: string;
   difficulty: 'easy' | 'medium' | 'hard';
   category?: string;
-  linkedAttributeName?: string;
+  linkedAttributeNames?: string[];
   accepted: boolean;
 }
 ```

--- a/public_docs/technical-guides/components/shared-wizard-system.md
+++ b/public_docs/technical-guides/components/shared-wizard-system.md
@@ -102,7 +102,7 @@ interface UseWizardStateOptions<T> {
 
 **Features:**
 - Step navigation with bounds checking
-- Data persistence to sessionStorage
+- Data persistence to localStorage
 - Optional per-step validation via `validation` config
 - Async completion handling
 

--- a/public_docs/technical-guides/navigation-loading-system.md
+++ b/public_docs/technical-guides/navigation-loading-system.md
@@ -104,8 +104,8 @@ const handleGenerate = async () => {
 
 ### Timeout Settings
 ```typescript
-// NavigationLoadingProvider.tsx
-const SAFETY_TIMEOUT = 30000; // 30 seconds
+// @/lib/constants/timeouts.ts (imported by NavigationLoadingProvider.tsx)
+export const NAV_SAFETY_TIMEOUT_MS = 30000; // 30 seconds
 
 // useNavigationLoading.ts
 const MIN_LOADING_DURATION = 150; // Minimum display time

--- a/public_docs/technical-guides/response-extractor.md
+++ b/public_docs/technical-guides/response-extractor.md
@@ -62,7 +62,6 @@ helps, so it fails fast instead of burning quota.
 
 ## Where it's used
 
-The world and template generators lean on this (`src/lib/generators/worldGenerator.ts`,
-`src/lib/ai/templateGenerator.ts`). It sits alongside the more specialized extractors like
+The world generator leans on this (`src/lib/generators/worldGenerator.ts`). It sits alongside the more specialized extractors like
 `goalExtractor` (`src/lib/ai/goalExtractor.ts`) — those handle domain-specific extraction, while
 `aiResponseParser` handles the generic "turn an AI response into a validated object" step.

--- a/public_docs/technical-guides/state-stores.md
+++ b/public_docs/technical-guides/state-stores.md
@@ -104,7 +104,7 @@ function WorldList() {
   const createWorld = useWorldStore((state) => state.createWorld);
 
   const handleCreate = () => {
-    const id = createWorld({ name: 'New World', theme: 'fantasy' });
+    const id = createWorld({ name: 'New World', genre: 'fantasy' });
   };
 
   // ...

--- a/public_docs/technical-guides/storage-resilience-guide.md
+++ b/public_docs/technical-guides/storage-resilience-guide.md
@@ -46,7 +46,7 @@ The implementation details are in `src/lib/storage/resilientStorage.ts`.
 Inventory persistence used to lean on a guard that rebuilt character inventories whenever a legacy object shape showed up. That kept players unblocked, but it also hid data loss. The store now treats those payloads as invalid and starts with an empty slate instead, which means engineers get cleaner telemetry and players stop wondering why items disappeared.
 
 Quick references for what changed:
-- `narraitor-inventory-store` now runs at schema version `2`. Anything saved before that version is dropped outright during hydration so the app never boots with half-migrated data.
+- `narraitor-inventory-store` now runs at schema version `3`. Anything saved before that version is dropped outright during hydration so the app never boots with half-migrated data.
 - Character inventories must stay `Record<EntityID, EntityID[]>`. Hydration strips non-array values and prunes bad entries, logging through the `InventoryPersistence` channel so it is obvious when the guard steps in.
 - A schema bump records a `schema-reset` log with the previous character count. With `NEXT_PUBLIC_DEBUG_LOGGING=true`, the console makes it clear that the destructive reset is intentional.
 - Runtime access to `characterInventories` still runs through the sanitizer, so even freshly corrupted values disappear immediately instead of leaking into gameplay.

--- a/public_docs/technical-guides/type-guards-usage-guide.md
+++ b/public_docs/technical-guides/type-guards-usage-guide.md
@@ -198,8 +198,6 @@ if (!formResult.valid) {
 - `validateGeneratedImage`
 
 ### Other Domain Objects
-- `isNarrativeSegment`
-- `isJournalEntry`
 - `isPlayerDecision`
 
 ## Migration from Basic Type Checking

--- a/src/app/api/generate-ending-image/route.ts
+++ b/src/app/api/generate-ending-image/route.ts
@@ -32,7 +32,6 @@ function generateImagePrompt(ending: StoryEnding, world?: World, character?: Cha
   const characterName = character?.name || 'The Hero';
   const tone = ending.tone;
   
-  // Create a detailed prompt for ending image generation
   const basePrompt = `Create a highly detailed, cinematic image representing the conclusion of ${characterName}'s story in ${worldName}. This is a ${tone} ending to their journey.`;
   
   // Add tone-specific visual guidance

--- a/src/app/api/generate-world-image/route.ts
+++ b/src/app/api/generate-world-image/route.ts
@@ -37,7 +37,6 @@ function generateImagePrompt(world: World): string {
   const name = world.name;
   const description = world.description;
 
-  // Create a detailed prompt for image generation
   const basePrompt = `Create a highly detailed, cinematic landscape image representing the world "${name}". Genre: ${genre}. Description: ${description}`;
 
   const worldElements = describeWorldElements(world);

--- a/src/app/api/narrative/ending/route.ts
+++ b/src/app/api/narrative/ending/route.ts
@@ -41,7 +41,6 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // Create the ending generation request
     const endingRequest: EndingGenerationRequest = {
       sessionId,
       characterId,
@@ -74,7 +73,6 @@ export async function POST(request: NextRequest) {
       tokenUsage: result.tokenUsage
     });
 
-    // Return the generated ending
     return NextResponse.json({
       success: true,
       data: result
@@ -85,7 +83,6 @@ export async function POST(request: NextRequest) {
       error: error instanceof Error ? error.message : 'Unknown error'
     });
 
-    // Return appropriate error response
     if (error instanceof Error) {
       if (error.message.includes('not found')) {
         return NextResponse.json(

--- a/src/app/dev/journal-access/page.tsx
+++ b/src/app/dev/journal-access/page.tsx
@@ -315,7 +315,6 @@ export default function JournalAccessTestPage() {
             </button>
             <button
               onClick={() => {
-                // Clear existing journal entries for this session
                 useJournalStore.getState().reset();
                 // Force re-creation with proper content
                 setEntryCount(0);

--- a/src/app/dev/lore-viewer/page.tsx
+++ b/src/app/dev/lore-viewer/page.tsx
@@ -156,7 +156,6 @@ export default function LoreViewerTestPage() {
       return;
     }
 
-    // Add aliases to the first few characters
     characterFacts.slice(0, 3).forEach(fact => {
       if (fact.value.includes('Marcus')) {
         setAliases(fact.id, ['Marcus', 'The Brave', 'Hero of Willowbrook']);
@@ -165,7 +164,6 @@ export default function LoreViewerTestPage() {
       } else if (fact.value.includes('Gareth')) {
         setAliases(fact.id, ['Gareth', 'Captain', 'Guard Captain']);
       } else {
-        // Add generic aliases for other characters
         const firstName = fact.value.split(' ')[0];
         setAliases(fact.id, [firstName, fact.value]);
       }

--- a/src/app/dev/narrative-system/MockNarrativeController.tsx
+++ b/src/app/dev/narrative-system/MockNarrativeController.tsx
@@ -50,18 +50,12 @@ export const MockNarrativeController: React.FC<MockNarrativeControllerProps> = (
       setHasGeneratedInitial(true);
       logger.debug('[MockNarrativeController] Marked initial generation as completed');
     } else {
-      // Reset state for new sessions
       setHasGeneratedInitial(false);
       logger.debug('[MockNarrativeController] Reset initial generation flag');
     }
-    
-    // Update segments state
+
     setSegments(existingSegments);
-    
-    // Reset loading state
     setIsLoading(false);
-    
-    // Reset lastChoiceId for new sessions
     setLastChoiceId(null);
     
     // Cleanup function - important for unmounting properly

--- a/src/app/worlds/[id]/page.tsx
+++ b/src/app/worlds/[id]/page.tsx
@@ -22,7 +22,6 @@ export default function WorldViewPage() {
   const setCurrentWorld = useWorldStore((state) => state.setCurrentWorld);
   const characters = useCharacterStore((state) => state.characters);
 
-  // Check if this world has any characters
   const worldCharacters = Object.values(characters).filter((char): char is Character => char.worldId === worldId);
   const isActive = currentWorldId === worldId;
 

--- a/src/app/worlds/[id]/play/page.tsx
+++ b/src/app/worlds/[id]/play/page.tsx
@@ -41,7 +41,6 @@ export default function PlayPage() {
   // Check if this should be a fresh session (from "Start New Session" button)
   const disableAutoResume = searchParams?.get('fresh') === 'true';
 
-  // Get current session progress for confirmation dialog
   const currentProgress = currentSessionId ? getSessionSegments(currentSessionId).length : 0;
 
   // Set isClient to true once component mounts

--- a/src/app/worlds/page.tsx
+++ b/src/app/worlds/page.tsx
@@ -38,7 +38,6 @@ export default function WorldsPage() {
   );
   const tourStartedRef = useRef(false);
 
-  // Reset tour started flag when modal closes
   useEffect(() => {
     if (!showPrompt) {
       tourStartedRef.current = false;
@@ -115,7 +114,6 @@ export default function WorldsPage() {
         suggestedName: worldName || undefined,
       });
 
-      // Create the world using the service
       setGeneratingStatus('Creating world...');
       const { worldId } = await worldCreationService.createWorldFromGeneration({
         generatedData,
@@ -126,7 +124,6 @@ export default function WorldsPage() {
       setGeneratingStatus('Generating world image...');
       // Image generation is handled by the service in the background
 
-      // Set as current world
       useWorldStore.getState().setCurrentWorld(worldId);
 
       // Hide the prompt and reset state

--- a/src/components/Narrative/hooks/usePlayerChoices.ts
+++ b/src/components/Narrative/hooks/usePlayerChoices.ts
@@ -34,7 +34,7 @@ interface UsePlayerChoicesResult {
 /**
  * Owns player-choice generation for the active session: the AI call (with a
  * timeout race and fallback choices), decision persistence, and the overlap
- * guard. Extracted from NarrativeController with no behavior change.
+ * guard.
  */
 export function usePlayerChoices({
   sessionId,

--- a/src/components/Narrative/useEndingDetection.ts
+++ b/src/components/Narrative/useEndingDetection.ts
@@ -1,7 +1,7 @@
 // src/components/Narrative/useEndingDetection.ts
 //
-// Pure AI-based ending detection extracted from NarrativeController so the
-// controller can stay focused on orchestrating narrative generation. Sends
+// Pure AI-based ending detection, kept separate so the controller can stay
+// focused on orchestrating narrative generation. Sends
 // recent narrative context to Gemini and asks whether the story has reached
 // a natural conclusion. Only fires onEndingSuggested for medium/high
 // confidence responses; silent on any AI/parse/network failure (no fallback).

--- a/src/lib/services/imageRequestCoordinator.ts
+++ b/src/lib/services/imageRequestCoordinator.ts
@@ -6,8 +6,8 @@ const delay = (ms: number): Promise<void> =>
 /**
  * Shared in-flight cache + rate-limited batch runner used by the NPC portrait
  * and item image services. Each service supplies its own entity lookup,
- * payload building, and store updates; the coordinator owns the bits that
- * were previously duplicated (Promise cache, error cleanup, batch pacing).
+ * payload building, and store updates; the coordinator owns the Promise
+ * cache, error cleanup, and batch pacing.
  */
 export class ImageRequestCoordinator<TResult> {
   private readonly cache = new Map<string, Promise<TResult>>();

--- a/src/lib/utils/narrativeParser.ts
+++ b/src/lib/utils/narrativeParser.ts
@@ -6,8 +6,7 @@ const logger = new Logger('NarrativeParser');
 /**
  * Parse narrative content from AI responses with multiple fallback strategies
  * Handles JSON code blocks, malformed JSON, and control character sanitization
- * 
- * This function implements the same parsing logic previously embedded in NarrativeDisplay component.
+ *
  * It handles various AI response formats and provides graceful fallback mechanisms.
  * 
  * @param content - Raw content from AI response


### PR DESCRIPTION
## Description

A doc-rot audit turned up documentation that contradicts the code. This is the mechanical batch — every fix re-verified against develop's source before applying (telling a *renamed* reference from an *actually gone* one). The judgment calls (the README security model, two fictional-API doc sections, the Tailwind-removal cluster) are split out; the README one already merged as #1468.

Three groups, one commit each:

- **public_docs (13 files):** wrong constants, signatures, and refs — default model name, playwright config values, an async signature + `maxChars`, `theme` → `genre`, schema versions, `linkedAttributeNames`, and dropped dead references (`handleFieldBlur`, `characterTemplates`, two type-guards, `templateGenerator.ts`).
- **root docs:** RELEASES.md dead ADR-011 link (`decisions/` → `architecture/`), CLAUDE.md agent names (4 of 5 were stale).
- **src comments:** archaeology trims (kept the WHY, dropped the "extracted from X" history) and obvious restate-the-code comments in `app/dev/*` and `app/api/*`.

## Related Issue
N/A — surfaced by a documentation audit, not a tracked issue.

## Type of Change
- [x] Documentation update

## TDD Compliance
N/A — documentation and comment-only; no behavior changed.

## User Stories Addressed
N/A

## Flow Diagrams
N/A

## Component Development
N/A — no UI changes.

## Implementation Notes
Each doc claim was checked against the actual source on develop before editing — e.g. ADR-006's model name against `src/lib/ai/config.ts`, the goal-system signature against `aiContextStore.ts`, the wizard persistence against `useWizardState.ts`. A couple of audit "findings" turned out to be false alarms on verification (the rate-limit claim, `buildGoalContext`'s `maxTokens`) and were deliberately left alone.

The `src/` changes touch comments only — no logic.

## Screenshots
N/A

## Quality Checks (if applicable)
- [x] Linting passed (`eslint --quiet` on the changed files, exit 0)
- [x] Type checking passed (`tsc --noEmit`, exit 0)

## Testing Instructions
Spot-check a few fixes against their cited source: ADR-006 model name vs `src/lib/ai/config.ts`; `goal-system-api.md` signature vs `src/state/aiContextStore.ts`; the RELEASES ADR-011 link resolves on disk. The `src/` comment changes are comment-only; `tsc` and `eslint` pass.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Documentation updated (if required)
- [x] No new warnings generated
