### PR TITLE
docs: rewrite stale guides caught by the doc-rot audit (judgment calls)

### DIFF
--- a/public_docs/api/playwright-visual-api.md
+++ b/public_docs/api/playwright-visual-api.md
@@ -73,54 +73,50 @@ projects: [
 
 ## Helper Functions API
 
-### `waitForAppReady(page)`
-
-Ensures the Narraitor application is fully loaded before taking screenshots.
+Visual tests import their wait/stability helpers from `tests/visual/utils/wait-helpers.ts`. The two you'll use in almost every test are `waitForContentStable` and `hideDynamicContent` — run them after `page.goto()` and before any `toHaveScreenshot()` call.
 
 ```typescript
-async function waitForAppReady(page: Page): Promise<void>
+import {
+  waitForContentStable,
+  hideDynamicContent,
+} from './utils/wait-helpers';
 ```
 
-**Parameters:**
-- `page: Page` - Playwright page object
+### `waitForContentStable(page)`
 
-**Implementation:**
+The main "is the page settled" helper. Waits for the network to go idle, waits for known loading indicators (`.loading`, `[data-testid="loading"]`, `[aria-label="Loading"]`, `.spinner`, and the archetype-seeding spinner) to disappear, then adds a short settle so data seeding can finish. Tolerant by design — if `networkidle` times out on a page with long-lived connections, it logs and keeps going rather than failing the test.
+
 ```typescript
-async function waitForAppReady(page) {
-  try {
-    // Wait for initial page load
-    await page.waitForLoadState('networkidle', { timeout: 30000 });
-    
-    // Wait for React hydration
-    await page.waitForSelector('main', { timeout: 15000 });
-    
-    // Wait for fonts to load (critical for visual consistency)
-    await page.waitForFunction(() => document.fonts.ready, { timeout: 10000 });
-    
-    // Additional stabilization time
-    await page.waitForTimeout(2000);
-    
-    // Give time for dynamic content
-    await page.waitForTimeout(3000);
-    
-    // Check if loading screen is still visible
-    const loadingVisible = await page.locator('text=Loading').isVisible().catch(() => false);
-    
-    if (loadingVisible) {
-      console.warn('Application still showing loading screen');
-      await page.waitForTimeout(5000);
-    }
-  } catch (error) {
-    console.warn('waitForAppReady encountered an error:', error.message);
-  }
-}
+async function waitForContentStable(page: Page): Promise<void>
 ```
+
+### `hideDynamicContent(page)`
+
+Injects CSS that hides content which would otherwise cause false diffs — timestamps and random tips, the Joyride tutorial overlay, the in-app DevTools panel, and the Next.js dev overlay — and disables all animations and transitions for a stable capture. Pair it with `waitForContentStable` right before the screenshot.
+
+```typescript
+async function hideDynamicContent(page: Page): Promise<void>
+```
+
+### Other helpers
+
+| Helper | Signature | Use it for |
+|--------|-----------|------------|
+| `hideNextDevOverlay` | `(page)` | Hide only the Next.js dev overlay, keeping app-level tutorial UI visible. |
+| `waitForNavigationHeading` | `(page, expectedHeading, { timeout = 5000, exact = false })` | Block until an `h1`/`h2`/`h3` containing (or exactly matching) the given text renders. |
+| `waitForImagesLoaded` | `(page, timeout = 5000)` | Wait until every image on the page is `complete`. |
+| `waitForImagesLoadedIn` | `(page, selector, timeout = 30000)` | Scoped image wait for a container — forces lazy images eager and requires real pixels. Use for locator screenshots of image-bearing surfaces. |
+| `waitForStableScrollHeight` | `(page, { timeout = 5000, stableDuration = 500 })` | Wait for the document height to stop changing. |
+| `pinAppShell` | `(page)` | Pin the sticky workshop sidebar and header into normal flow so full-page/tall screenshots don't capture the header overlaid mid-content. |
+| `expandAllCollapsibleSections` | `(page, container?)` | Expand all `CollapsibleSection` components so their content shows in the capture. |
+| `takeStableScreenshot` | `(page, name, options?)` | Convenience wrapper that runs `waitForContentStable` + `hideDynamicContent`, then writes a raw screenshot to `test-results/`. Note: this does not do baseline comparison — use `toHaveScreenshot()` for regression assertions. |
 
 **Usage:**
 ```typescript
 test('page visual test', async ({ page }) => {
   await page.goto('/');
-  await waitForAppReady(page);
+  await waitForContentStable(page);
+  await hideDynamicContent(page);
   await expect(page).toHaveScreenshot('page.png');
 });
 ```
@@ -241,7 +237,8 @@ Run tests in debug mode with step-by-step execution.
 ```typescript
 test('page layout test', async ({ page }) => {
   await page.goto('/page');
-  await waitForAppReady(page);
+  await waitForContentStable(page);
+  await hideDynamicContent(page);
   await expect(page).toHaveScreenshot('page-layout.png');
 });
 ```
@@ -251,7 +248,8 @@ test('page layout test', async ({ page }) => {
 ```typescript
 test('component visual test', async ({ page }) => {
   await page.goto('/component-demo');
-  await waitForAppReady(page);
+  await waitForContentStable(page);
+  await hideDynamicContent(page);
   
   const component = page.locator('[data-testid="component"]');
   await expect(component).toHaveScreenshot('component.png');
@@ -265,7 +263,8 @@ test('responsive layout', async ({ page }) => {
   // Desktop
   await page.setViewportSize({ width: 1280, height: 720 });
   await page.goto('/');
-  await waitForAppReady(page);
+  await waitForContentStable(page);
+  await hideDynamicContent(page);
   await expect(page).toHaveScreenshot('desktop-layout.png');
   
   // Mobile
@@ -279,7 +278,8 @@ test('responsive layout', async ({ page }) => {
 ```typescript
 test('interactive states', async ({ page }) => {
   await page.goto('/buttons');
-  await waitForAppReady(page);
+  await waitForContentStable(page);
+  await hideDynamicContent(page);
   
   const button = page.locator('button');
   
@@ -306,7 +306,8 @@ test('slow page test', async ({ page }) => {
   test.setTimeout(120000); // 2 minutes
   
   await page.goto('/slow-page');
-  await waitForAppReady(page);
+  await waitForContentStable(page);
+  await hideDynamicContent(page);
   await expect(page).toHaveScreenshot('slow-page.png');
 });
 ```
@@ -330,13 +331,11 @@ test.describe('Flaky tests', () => {
 test('test with error recovery', async ({ page }) => {
   await page.goto('/');
   
-  try {
-    await waitForAppReady(page);
-  } catch (error) {
-    console.warn('App loading timeout, proceeding anyway');
-    await page.waitForTimeout(5000);
-  }
-  
+  // waitForContentStable tolerates its own timeouts internally — it logs and
+  // continues rather than throwing — so no try/catch is needed here.
+  await waitForContentStable(page);
+  await hideDynamicContent(page);
+
   await expect(page).toHaveScreenshot('page.png');
 });
 ```
@@ -406,7 +405,8 @@ export class HomePage {
   
   async goto() {
     await this.page.goto('/');
-    await waitForAppReady(this.page);
+    await waitForContentStable(this.page);
+    await hideDynamicContent(this.page);
   }
   
   async takeScreenshot(name: string) {
@@ -464,7 +464,8 @@ test('performance test', async ({ page }) => {
   const startTime = Date.now();
   
   await page.goto('/');
-  await waitForAppReady(page);
+  await waitForContentStable(page);
+  await hideDynamicContent(page);
   
   const loadTime = Date.now() - startTime;
   console.log(`Page load time: ${loadTime}ms`);

--- a/public_docs/technical-guides/components/recovery-notification.md
+++ b/public_docs/technical-guides/components/recovery-notification.md
@@ -196,24 +196,16 @@ const validDate = formattedDate && formattedDate !== 'Invalid date' ? formattedD
 
 ### ARIA Attributes
 
-Dialog accessibility:
+Dialog accessibility is handled by the shared `SimpleModal` wrapper, which owns the overlay, the dialog role and labelling, and focus trapping — the component doesn't hand-roll any of it:
 
 ```typescript
-<div
-  className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50"
-  role="alertdialog"
-  aria-labelledby="recovery-title"
-  aria-describedby="recovery-description"
+<SimpleModal
+  isOpen={isVisible}
+  onClose={onDismiss}
+  title="Character Creation Progress Found"
 >
-  <div className="bg-white rounded-lg shadow-xl max-w-lg w-full p-6">
-    <h3 id="recovery-title" className="text-lg font-medium text-gray-900">
-      Character Creation Progress Found
-    </h3>
-    <div id="recovery-description" className="mb-6">
-      {/* Dialog content */}
-    </div>
-  </div>
-</div>
+  {/* Dialog content */}
+</SimpleModal>
 ```
 
 ### Focus Management
@@ -428,6 +420,6 @@ Storybook stories:
 When upgrading or integrating the component:
 
 1. **Props Interface**: Component props may evolve - check TypeScript definitions
-2. **CSS Classes**: Uses Tailwind CSS classes - ensure Tailwind is configured
+2. **CSS Classes**: Styling comes from the design system's semantic CSS classes and the shared `SimpleModal` — there's no Tailwind to configure
 3. **Dependencies**: Requires `Button` component from UI system
 4. **Accessibility**: Maintains WCAG 2.1 AA compliance requirements

--- a/public_docs/technical-guides/components/shared-wizard-system.md
+++ b/public_docs/technical-guides/components/shared-wizard-system.md
@@ -116,17 +116,16 @@ Located in `utils/validation.ts`:
 Centralized styling in `wizardStyles.ts`:
 
 ```typescript
+// Semantic class hooks only — no Tailwind. The visual rules live in the
+// design-system CSS, so theming happens there, not here.
 export const wizardStyles = {
-  container: "max-w-2xl mx-auto p-6",
-  card: {
-    base: "bg-white rounded-lg shadow-md p-6 mb-6",
-    hover: "hover:shadow-lg transition-shadow",
-  },
-  form: {
-    label: "block text-sm font-medium text-gray-700 mb-2",
-    input: "w-full px-3 py-2 border border-gray-300 rounded-md...",
-    error: "mt-1 text-sm text-red-600",
-  }
+  container: "wizard-container",
+  header: "wizard-header",
+  title: "wizard-title",
+  step: { title: "wizard-step-title", description: "wizard-step-description", content: "wizard-step-content" },
+  form: { group: "form-group", label: "form-label", input: "form-input", error: "form-error" },
+  card: { base: "wizard-card", selected: "wizard-card-selected", unselected: "wizard-card-unselected" },
+  // ...navigation, progress, badge, and toggle groups follow the same semantic pattern
 };
 ```
 

--- a/public_docs/technical-guides/navigation-persistence-guide.md
+++ b/public_docs/technical-guides/navigation-persistence-guide.md
@@ -12,61 +12,44 @@ Users hate losing their place when they refresh the browser or come back later. 
 ## Core Usage
 
 ```typescript
-// Navigation store
+// Navigation store — this is an App Router codebase, so read the path from
+// next/navigation (usePathname), not the Pages Router's router.pathname.
 const {
   currentPath,
   history,
   addToHistory,
-  setCurrentPath
+  setCurrentPath,
 } = useNavigationStore();
 
-// Track navigation
-useEffect(() => {
-  addToHistory(router.pathname);
-  setCurrentPath(router.pathname);
-}, [router.pathname]);
+const pathname = usePathname(); // from 'next/navigation'
 
-// Recent pages dropdown
-<RecentPagesDropdown 
-  onPageSelect={(path) => router.push(path)}
-  maxItems={5}
-/>
+// setCurrentPath(path, title?, params?) updates the path and records history;
+// addToHistory takes a full NavigationHistoryEntry, not a bare string.
+setCurrentPath(pathname);
+addToHistory({ path: pathname, timestamp: getTimestamp(), title });
+
+// Recent pages dropdown — its only prop is className. It reads history from the
+// store, filters out the current page, and navigates internally via
+// navigateWithLoading. The item cap comes from preferences.maxRecentPages.
+<RecentPagesDropdown className="recent-pages" />
 ```
+
+Heads up: `setCurrentPath`/`addToHistory` expose the real store API, but nothing in app navigation calls them today — only the store internals, tests, and the DevTools state panel do. So `RecentPagesDropdown` reads from `history`, but that history isn't actively populated during normal navigation yet. Wire the calls above into a navigation effect if you want live tracking.
 
 ## Storage Strategy
 
-Different types of navigation data need different storage approaches:
+Different types of navigation data live in different places:
 
-- **IndexedDB**: Long-term history that persists across browser restarts
-- **sessionStorage**: Current session breadcrumbs that reset on new tabs
-- **localStorage**: User preferences that stick around
+- **localStorage**: The durable layer. The store uses Zustand's `persist` middleware (default localStorage) under `narraitor-navigation-store`, and `partialize` keeps only `history` and `preferences`. Flow state is stored separately under `narraitor-flow-state`.
+- **sessionStorage**: The current path and breadcrumbs, for browser-refresh recovery within a tab (`narraitor-session-path`, `narraitor-navigation-breadcrumbs`). These reset on a new tab.
 
-## URL State Persistence
-
-```typescript
-// Persist state in URL query parameters
-const useURLState = <T>(key: string, defaultValue: T) => {
-  const router = useRouter();
-  
-  const value = useMemo(() => {
-    const param = router.query[key];
-    return param ? JSON.parse(param as string) : defaultValue;
-  }, [router.query, key, defaultValue]);
-
-  const setValue = useCallback((newValue: T) => {
-    const query = { ...router.query, [key]: JSON.stringify(newValue) };
-    router.replace({ pathname: router.pathname, query }, undefined, { shallow: true });
-  }, [router, key]);
-
-  return [value, setValue] as const;
-};
-```
+There's no IndexedDB in the navigation system — history is small (capped at `maxRecentPages`, default 10), so localStorage is plenty.
 
 ## Best Practices
 
 Keep the navigation system fast and reliable:
 
-- Limit history size (last 50 entries) to avoid bloating storage
-- Use shallow routing for URL updates to avoid full page reloads
+- History is capped at `preferences.maxRecentPages` (default 10) and dedupes by path, so revisiting a page moves it to the top rather than duplicating it
+- Read recent pages through `getRecentPages(limit?)` and check prior visits with `hasVisited(path)` rather than poking at `history` directly
 - Store minimal data in navigation state - just what you need to reconstruct context
 - Handle storage quota limits gracefully with fallbacks

--- a/public_docs/technical-guides/state-management-usage.md
+++ b/public_docs/technical-guides/state-management-usage.md
@@ -15,7 +15,7 @@ Each domain gets its own store - World, Character, Narrative, etc. They all foll
 
 ## Available Stores
 
-There are eleven domain stores, all in `src/state/` and exported as `useXStore` hooks:
+There are fourteen domain stores, all in `src/state/` and exported as `useXStore` hooks:
 
 | Store | Purpose | Features |
 |-------|---------|----------|
@@ -30,6 +30,9 @@ There are eleven domain stores, all in `src/state/` and exported as `useXStore` 
 | `useGoalStore` | Goals/objectives | Character goal tracking |
 | `useLoreStore` | World knowledge base | Facts, aliases, deduplication, resolution (split `loreStore.*` family) |
 | `useAiContextStore` | AI prompt context | Context building, token management |
+| `useCalibrationStore` | Token-budget snapshots (DevTools) | Ephemeral, dev-only, not persisted |
+| `useContinuityStore` | Continuity validation (DevTools) | Ephemeral, dev-only, not persisted |
+| `useProviderStore` | AI provider config | Provider/model selection, encrypted keys, persisted |
 
 ## Basic Usage
 

--- a/public_docs/technical-guides/state-stores.md
+++ b/public_docs/technical-guides/state-stores.md
@@ -14,7 +14,7 @@ lives in `src/state/` and is exported as a `useXStore` hook.
 
 ## The stores
 
-There are eleven domain stores today:
+There are fourteen domain stores today:
 
 1. **`useWorldStore`** — game worlds, their attributes, skills, and configuration.
 2. **`useCharacterStore`** — player characters, scoped to a world, with their attributes and skills.
@@ -30,6 +30,9 @@ There are eleven domain stores today:
     family of files (`loreStore.ts` plus `loreStore.actions`, `.aliases`, `.deduplication`,
     `.extraction`, `.helpers`, `.import-export`, `.resolution`, `.state`, `.utils`), which keeps
     the dedup/resolution logic out of the core store file.
+12. **`useCalibrationStore`** — token-budget request snapshots for the DevTools panel. Ephemeral, dev-only observability; never persisted.
+13. **`useContinuityStore`** — narrative-continuity validation results for the DevTools panel. Ephemeral, dev-only observability; never persisted.
+14. **`useProviderStore`** — AI provider configuration: provider/model selection and encrypted key storage. Persisted.
 
 Two more files in `src/state/` support the stores rather than being stores themselves:
 

--- a/public_docs/technical-guides/storage-resilience-guide.md
+++ b/public_docs/technical-guides/storage-resilience-guide.md
@@ -43,14 +43,14 @@ The implementation details are in `src/lib/storage/resilientStorage.ts`.
 
 ## Inventory Persistence Contract
 
-Inventory persistence used to lean on a guard that rebuilt character inventories whenever a legacy object shape showed up. That kept players unblocked, but it also hid data loss. The store now treats those payloads as invalid and starts with an empty slate instead, which means engineers get cleaner telemetry and players stop wondering why items disappeared.
+Inventory persistence used to lean on a guard that rebuilt character inventories whenever a legacy object shape showed up. That kept players unblocked, but it also hid data loss. The store now treats those legacy object-shaped payloads as invalid and empties just the offending entries instead of silently rebuilding them, which means engineers get cleaner telemetry and players stop wondering why items disappeared.
 
 Quick references for what changed:
-- `narraitor-inventory-store` now runs at schema version `3`. Anything saved before that version is dropped outright during hydration so the app never boots with half-migrated data.
+- `narraitor-inventory-store` runs at schema version `3`, but migration is non-destructive: `migrate` returns the persisted state untouched and only falls back to an empty store when nothing is persisted at all (`persistedState || getInitialState()`). Old saves are kept, not dropped.
 - Character inventories must stay `Record<EntityID, EntityID[]>`. Hydration strips non-array values and prunes bad entries, logging through the `InventoryPersistence` channel so it is obvious when the guard steps in.
-- A schema bump records a `schema-reset` log with the previous character count. With `NEXT_PUBLIC_DEBUG_LOGGING=true`, the console makes it clear that the destructive reset is intentional.
+- Cleanup is lazy, not a one-shot reset. `sanitizeInventoryValue` empties non-array `characterInventories` entries and drops non-string/empty IDs at access time, logging each cleanup through the `InventoryPersistence` channel (message "Inventory guard sanitized payload"). There's no `schema-reset` log and no version-keyed wipe — with `NEXT_PUBLIC_DEBUG_LOGGING=true` you'll see the per-entry sanitization events instead.
 - Runtime access to `characterInventories` still runs through the sanitizer, so even freshly corrupted values disappear immediately instead of leaking into gameplay.
 
 ### QA Playbook: Inventory Reset
 
-Whether you are double-checking the migration or investigating a report, follow the same loop. Seed a stale payload by writing an object-shaped `characterInventories` field into the `narraitor-inventory-store` entry (any export from before February 2025 works). Reload the app and confirm the `schema-reset` log appears while the inventory UI resets. Add a new item, reload again, and verify IndexedDB only stores string IDs with no additional logs. To spot-check the guard, edit one entry to include a bad value such as a number, reload once more, and watch a single sanitization event show up as the bad value disappears.
+Whether you are double-checking the migration or investigating a report, follow the same loop. Seed a stale payload by writing an object-shaped `characterInventories` field into the `narraitor-inventory-store` entry (any export from before February 2025 works). Reload the app and confirm the `InventoryPersistence` "Inventory guard sanitized payload" log appears as the object-shaped entry is emptied. Add a new item, reload again, and verify IndexedDB only stores string IDs with no additional logs. To spot-check the guard, edit one entry to include a bad value such as a number, reload once more, and watch a single sanitization event show up as the bad value disappears.

--- a/src/hooks/useCharacterCreationAutoSave.ts
+++ b/src/hooks/useCharacterCreationAutoSave.ts
@@ -47,8 +47,7 @@ interface RecoveryDataPreview {
  * - Recovery data detection on mount
  * - Visual save status feedback
  * - Manual save clearing on completion
- * - Migration from sessionStorage to localStorage
- * 
+ *
  * @param worldId - The ID of the world for which the character is being created
  * @returns Object containing save state, data handlers, and recovery status
  * 


### PR DESCRIPTION
## Description

The judgment-call follow-ups to the doc-rot audit (the mechanical batch merged as #1469). These are the docs that needed a real rewrite, not a one-line swap — each verified against develop's source before rewriting, with a few agent-suggested "fixes" rejected on verification (e.g. the calibration/continuity stores are dev-only DevTools observability, not the gameplay features a quick read would assume).

Three commits:

- **navigation-persistence-guide** — documented Next.js **Pages Router** APIs (`router.pathname`, `router.query`, shallow routing) and a `useURLState` hook, none of which exist in this App Router codebase. Rewritten to the real `next/navigation` + `navigationStore` API; fictional `useURLState` section cut; history cap corrected (10, not 50). Flagged honestly that `setCurrentPath`/`addToHistory` aren't wired into live navigation yet.
- **playwright-visual-api** — documented a `waitForAppReady(page)` helper (with a full fake implementation) that exists nowhere. Replaced with the real `tests/visual/utils/wait-helpers.ts` toolkit (export list verified); every example call site swapped.
- **Tailwind / store-count / storage-resilience** — two component docs still showed Tailwind (repo removed it): a hand-rolled Tailwind modal → real `SimpleModal`, pre-migration `wizardStyles` → real semantic hooks. Store count "eleven" → fourteen. The storage-resilience "destructive schema-reset" narrative → the real non-destructive `migrate` + lazy per-entry sanitization. Dropped a stale sessionStorage-migration line from the auto-save hook's JSDoc.

## Related Issue
N/A — surfaced by the documentation audit behind #1469.

## Type of Change
- [x] Documentation update

## TDD Compliance
N/A — documentation and a single comment-only source edit; no behavior changed.

## User Stories Addressed
N/A

## Flow Diagrams
N/A

## Component Development
N/A — no UI changes.

## Implementation Notes
Every rewritten claim was checked against the real code on develop — `navigationStore.ts` for the navigation API, `tests/visual/utils/wait-helpers.ts` for the real helper exports, `wizardStyles.ts` and `RecoveryNotification.tsx` for the styling approach, `inventoryStore.ts` `migrate()` for the storage behavior, and each of the three previously-undocumented stores for its actual purpose. Where a finding couldn't be confirmed it was left alone.

## Screenshots
N/A

## Quality Checks (if applicable)
- [x] Linting passed (`eslint --quiet`, via the pre-commit hook)
- [x] Type checking passed (`tsc --noEmit`, via the pre-commit hook)

## Testing Instructions
Spot-check a rewrite against its source: the navigation guide vs `src/state/navigationStore.ts`; the playwright helpers vs `tests/visual/utils/wait-helpers.ts`; the storage-resilience narrative vs `inventoryStore.ts` `migrate()`. The one `src/` change (auto-save JSDoc) is comment-only.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Documentation updated (if required)
- [x] No new warnings generated
