### PR TITLE
fix(ds): dark-mode semantic buttons clear AA contrast (#1379)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -240,19 +240,23 @@ body > * {
 /* Variant: destructive */
 .button-destructive {
   background: var(--color-danger);
-  color: var(--color-text-inverse);
+  color: var(--color-on-danger);
   border: 1px solid var(--color-danger);
 }
 
 .button-destructive:hover {
   background: var(--color-danger-hover);
   border-color: var(--color-danger-hover);
+
+  /* Hover darkens the fill, so white clears AA here even though the lighter
+   * base fill uses dark ink (mirrors .button-default). #1379 */
+  color: var(--color-text-inverse);
 }
 
 /* Variant: success */
 .button-success {
   background: var(--color-success);
-  color: var(--color-text-inverse);
+  color: var(--color-on-success);
   border: 1px solid var(--color-success);
 }
 
@@ -282,7 +286,10 @@ body > * {
 
 .button-warning:hover {
   background: var(--color-warning);
-  color: var(--color-text-inverse);
+
+  /* Filled hover: the warning fill is a light amber in dark mode, so dark ink
+   * (not white) keeps the label AA. Base/soft state keeps its colored text. #1379 */
+  color: var(--color-on-warning);
 }
 
 /* Size: default — applied via .button-size-default */

--- a/src/lib/theme/themes/ds1.css
+++ b/src/lib/theme/themes/ds1.css
@@ -25,6 +25,12 @@
    * Dark mode (below): accent is light, so a dark ink keeps button labels AA. */
   --color-on-accent: rgb(255 255 255);
 
+  /* Text on filled semantic surfaces (success/danger/warning). Same logic as
+   * --color-on-accent: white here, dark ink in dark mode (see dark block). #1379 */
+  --color-on-success: rgb(255 255 255);
+  --color-on-danger: rgb(255 255 255);
+  --color-on-warning: rgb(255 255 255);
+
   /* Mechanical Accent - Archival Ink Blue */
   --color-accent: rgb(49 46 129);
   --color-accent-hover: rgb(30 27 75);
@@ -153,6 +159,11 @@
   --color-text-muted: rgb(129 129 138);
   --color-text-inverse: rgb(255 255 255);
   --color-on-accent: rgb(9 9 11);
+
+  /* Dark ink on the light semantic fills so filled buttons clear AA in dark mode. #1379 */
+  --color-on-success: rgb(9 9 11);
+  --color-on-danger: rgb(9 9 11);
+  --color-on-warning: rgb(9 9 11);
 
   --color-accent: rgb(129 140 248);
 

--- a/src/lib/theme/themes/ds2.css
+++ b/src/lib/theme/themes/ds2.css
@@ -24,6 +24,11 @@
   /* Text on a filled accent surface — white in light, dark ink in dark (see dark block). */
   --color-on-accent: rgb(255 255 255);
 
+  /* Text on filled semantic surfaces — white here, dark ink in dark mode. #1379 */
+  --color-on-success: rgb(255 255 255);
+  --color-on-danger: rgb(255 255 255);
+  --color-on-warning: rgb(255 255 255);
+
   /* Sage Green accent — darkened so white button text clears WCAG AA (4.5:1);
      ~5.3:1 on white vs the previous ~3.6:1, still reads as Warm Earth. */
   --color-accent: rgb(99 111 89);
@@ -153,6 +158,11 @@
   --color-text-muted: rgb(156 141 126);
   --color-text-inverse: rgb(255 255 255);
   --color-on-accent: rgb(26 22 20);
+
+  /* Dark ink on the light semantic fills so filled buttons clear AA in dark mode. #1379 */
+  --color-on-success: rgb(26 22 20);
+  --color-on-danger: rgb(26 22 20);
+  --color-on-warning: rgb(26 22 20);
 
   --color-accent: rgb(156 170 138);
 

--- a/src/lib/theme/themes/ds3.css
+++ b/src/lib/theme/themes/ds3.css
@@ -158,6 +158,7 @@
 
   /* Dark ink on the light semantic fills so filled buttons clear AA in dark mode. #1379 */
   --color-on-success: rgb(23 19 16);
+
   /* Slightly deeper than the canvas ink: ds3's muted-red danger fill needs it to clear 4.5:1 (4.72:1). */
   --color-on-danger: rgb(15 12 10);
   --color-on-warning: rgb(23 19 16);

--- a/src/lib/theme/themes/ds3.css
+++ b/src/lib/theme/themes/ds3.css
@@ -24,6 +24,11 @@
   /* Text on a filled accent surface — white in light, dark ink in dark (see dark block). */
   --color-on-accent: rgb(255 255 255);
 
+  /* Text on filled semantic surfaces — white here, dark ink in dark mode. #1379 */
+  --color-on-success: rgb(255 255 255);
+  --color-on-danger: rgb(255 255 255);
+  --color-on-warning: rgb(255 255 255);
+
   /* Steel Blue accent */
   --color-accent: rgb(91 122 140);
   --color-accent-hover: rgb(74 105 120);
@@ -150,6 +155,12 @@
   --color-text-muted: rgb(141 130 121);
   --color-text-inverse: rgb(255 255 255);
   --color-on-accent: rgb(23 19 16);
+
+  /* Dark ink on the light semantic fills so filled buttons clear AA in dark mode. #1379 */
+  --color-on-success: rgb(23 19 16);
+  /* Slightly deeper than the canvas ink: ds3's muted-red danger fill needs it to clear 4.5:1 (4.72:1). */
+  --color-on-danger: rgb(15 12 10);
+  --color-on-warning: rgb(23 19 16);
 
   --color-accent: rgb(123 160 180);
 


### PR DESCRIPTION
## Description
In dark mode the filled semantic buttons (success/danger/warning) kept white text on what are *light* fills in dark themes, so they fell below WCAG AA across all three design systems — green ~2.3:1, red ~3.8:1, amber hover ~1.7:1. #1471 already fixed the accent button this way with a dark-ink `--color-on-accent` token; this just extends the same pattern to the other semantic variants. Light mode is untouched.

## Related Issue
Closes #1379

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [ ] All new code is tested
- [ ] All tests pass locally
- [ ] Test coverage maintained or improved

This is a CSS design-token contrast fix — no JS surface, so it follows the house norm of not pinning a trivial token/contrast change with a unit test. It's verified by reading computed contrast off the live DOM (table below) rather than a spec. Local Jest couldn't run in this worktree (the `jest` package isn't installed in its `node_modules`); CI runs the full suite as a required check. Stylelint, type-check, and ESLint all pass locally.

## User Stories Addressed
N/A — accessibility fix.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

No new component — token + variant change only. Verified live against all three themes in dark mode (screenshot below).

## Implementation Notes
- Adds `--color-on-success` / `--color-on-danger` / `--color-on-warning` to each theme (`ds1`/`ds2`/`ds3`): white in light mode, dark ink in dark mode — mirroring the existing `--color-on-accent`.
- `.button-success` and `.button-destructive` base text now use their on-token. `.button-destructive:hover` gets an explicit `--color-text-inverse` (white), because the fill *darkens* to red-600 on hover where dark ink would fail and white passes — same base/hover split `.button-default` already uses.
- `.button-warning`'s rest state is a soft/ghost style (colored text on a translucent fill) that already passes; only its filled `:hover` needed the dark ink.
- `ds3`'s dark danger fill is a muted light-red, so its `--color-on-danger` is a touch deeper than the canvas ink to clear 4.5:1 (lands at 4.72:1).

Computed contrast, dark mode (all clear AA 4.5:1):

| theme | success | danger (base / hover) | warning (soft / hover) |
|---|---|---|---|
| ds1 | 8.64 | 5.29 / 4.83 | 9.37 / 11.92 |
| ds2 | 7.80 | 4.77 / 4.83 | 7.99 / 10.76 |
| ds3 | 5.98 | 4.72 / 5.50 | 4.98 / 6.04 |

Out of scope, flagging for follow-up: `ds3` *light* mode's soft warning button text reads 3.68:1 — a pre-existing AA miss in a different mode and state that this PR doesn't touch.

## Screenshots
Dark mode, all three themes — Play (success) and Delete (destructive) now carry legible dark-ink labels; End Story (warning) keeps its amber text at rest:

(verified live via preview; computed-contrast table above is the authoritative proof)

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
Contrast ratios read from the live DOM via the preview server's computed styles across ds1/ds2/ds3 in both light and dark — see table.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm run dev`, open the app, switch to dark mode (Appearance menu).
2. For each theme (ds1/ds2/ds3), find a green Play / success button, a red Delete button, and a warning button; hover each.
3. Confirm labels stay legible (dark ink on the filled green/red, dark ink on the amber hover) and nothing regressed in light mode.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed