### PR TITLE
fix(ds): darken ds3 light warning so soft button text clears AA

### DIFF
--- a/src/lib/theme/themes/ds3.css
+++ b/src/lib/theme/themes/ds3.css
@@ -67,11 +67,13 @@
   --warning-border: 36 38% 70%;
   --warning-muted: 36 38% 88%;
 
-  /* Manuscript warning button colors */
-  --color-warning: rgb(140 109 63);
-  --color-warning-soft: rgb(140 109 63 / 14%);
-  --color-warning-border: rgb(140 109 63 / 50%);
-  --color-warning-muted: rgb(140 109 63 / 10%);
+  /* Manuscript warning button colors.
+   * Darkened from rgb(140 109 63): the soft warning button (colored text on the
+   * translucent fill) only read 3.68:1 in light mode; same bronze hue, deeper, now 4.97:1. */
+  --color-warning: rgb(113 88 51);
+  --color-warning-soft: rgb(113 88 51 / 14%);
+  --color-warning-border: rgb(113 88 51 / 50%);
+  --color-warning-muted: rgb(113 88 51 / 10%);
   --color-success: rgb(74 124 89);
   --color-success-bg: rgb(74 124 89 / 10%);
   --color-info: rgb(91 122 140);


### PR DESCRIPTION
## Description
DS3's soft/ghost warning button (`.button-warning` at rest — colored text on a translucent fill) read only 3.68:1 in light mode, below WCAG AA's 4.5:1 for normal text. The bronze `--color-warning` was too light against the soft-fill-over-canvas background. This darkens the whole DS3-light `--color-warning` rgb family — same hue and saturation, ~8% deeper lightness — so the soft button (and every other DS3-light warning consumer) clears AA. Other themes and all dark modes are untouched.

This is a sibling of #1379 (which fixed the dark-mode *filled* semantic buttons); this is the distinct light-mode *soft* case surfaced while verifying that work.

## Related Issue
N/A — no tracked issue; spun off as a follow-up to #1379.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [ ] All new code is tested
- [ ] All tests pass locally
- [ ] Test coverage maintained or improved

A single design-token contrast fix with no JS surface — follows the house norm of not pinning a trivial token/contrast change with a unit test. Verified by reading computed contrast off the live DOM (below). Stylelint passes locally; CI runs the full suite.

## User Stories Addressed
N/A — accessibility fix.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

Token-only change, no new component. Verified live in light mode across all three themes.

## Implementation Notes
- `--color-warning` (and its `-soft` / `-border` / `-muted` siblings, which are independent literals, so they move together) darkened from `rgb(140 109 63)` to `rgb(113 88 51)` in the DS3 **light** block only — `hsl(36 38% 40%)` to `hsl(36 38% 32%)`, same hue/sat.
- `--color-warning` feeds warning text well beyond this button (badges, alerts, toasts, wizard, character display, manuscript callouts), so the darker bronze lifts all of them in DS3 light; the filled `:hover` (white on the fill) also improves.
- Left the parallel `--warning` HSL token alone — it's a separate family, narrowly used in manuscript callouts, and out of scope here.

Computed contrast, soft warning button (text vs soft-fill-over-canvas):

| theme | before | after |
|---|---|---|
| ds3 light | 3.68 (fail) | **4.97 (pass)** |
| ds3 dark | 4.98 | 4.98 (untouched) |
| ds1 / ds2 light | 5.52 / 5.39 | 5.52 / 5.39 (untouched) |

## Screenshots
Light mode, all three themes — DS3 "End Story" and the WARNING badge now use a deeper, legible bronze; ds1/ds2 unchanged. (Verified live; the table above is the authoritative proof.)

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
Contrast read from the live DOM via the preview server's computed styles across ds1/ds2/ds3 in light and dark — see table.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm run dev`, open the app in light mode, switch to the DS3 theme (Appearance menu).
2. Find a soft warning button (e.g. "End Story" in a session) or a warning badge/alert.
3. Confirm the bronze text reads clearly against the soft fill, and that DS1/DS2 and dark modes look unchanged.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed