### PR TITLE
feat(storybook): backend-free infra — MSW, withStores, viewport (#1485)

### DIFF
--- a/.storybook/decorators/withStores.tsx
+++ b/.storybook/decorators/withStores.tsx
@@ -1,0 +1,67 @@
+import React, { useRef } from 'react';
+import { useWorldStore } from '../../src/state/worldStore';
+import { useCharacterStore } from '../../src/state/characterStore';
+import { useSessionStore } from '../../src/state/sessionStore';
+import { useNarrativeStore } from '../../src/state/narrativeStore';
+import { useInventoryStore } from '../../src/state/inventoryStore';
+import { useJournalStore } from '../../src/state/journalStore';
+import { useNPCStore } from '../../src/state/npcStore';
+import { useGoalStore } from '../../src/state/goalStore';
+import { useLoreStore } from '../../src/state/loreStore';
+
+/**
+ * One reusable decorator for seeding Zustand stores in Storybook (issue #1485).
+ *
+ * Generalizes the per-story `useXStore.setState(...)` pattern (e.g.
+ * `withDashboardScenario`, the game-session decorators) into a single call:
+ *
+ *   decorators: [withStores({ world: { worlds: {...} }, character: {...} })]
+ *
+ * Each value is merged into its store via the store's imperative `setState`,
+ * so you only pass the slices a story reads. Seeding happens synchronously
+ * before the story's first render — components that read store state on mount
+ * have data immediately (matching the inline ActiveGameSession pattern), with a
+ * ref guard so it runs once per mount instead of on every render.
+ *
+ * Stores are NOT auto-reset between stories (mirrors the existing helpers): seed
+ * everything a story depends on rather than relying on prior-story leftovers.
+ *
+ * Note: the jest-based `mockStoreFactories` can't run in Storybook, so this
+ * uses real store `setState` with plain mock data instead.
+ */
+export interface StoreSeed {
+  world?: Partial<ReturnType<typeof useWorldStore.getState>>;
+  character?: Partial<ReturnType<typeof useCharacterStore.getState>>;
+  session?: Partial<ReturnType<typeof useSessionStore.getState>>;
+  narrative?: Partial<ReturnType<typeof useNarrativeStore.getState>>;
+  inventory?: Partial<ReturnType<typeof useInventoryStore.getState>>;
+  journal?: Partial<ReturnType<typeof useJournalStore.getState>>;
+  npc?: Partial<ReturnType<typeof useNPCStore.getState>>;
+  goal?: Partial<ReturnType<typeof useGoalStore.getState>>;
+  lore?: Partial<ReturnType<typeof useLoreStore.getState>>;
+}
+
+const applySeed = (seed: StoreSeed): void => {
+  if (seed.world) useWorldStore.setState(seed.world);
+  if (seed.character) useCharacterStore.setState(seed.character);
+  if (seed.session) useSessionStore.setState(seed.session);
+  if (seed.narrative) useNarrativeStore.setState(seed.narrative);
+  if (seed.inventory) useInventoryStore.setState(seed.inventory);
+  if (seed.journal) useJournalStore.setState(seed.journal);
+  if (seed.npc) useNPCStore.setState(seed.npc);
+  if (seed.goal) useGoalStore.setState(seed.goal);
+  if (seed.lore) useLoreStore.setState(seed.lore);
+};
+
+export function withStores(seed: StoreSeed) {
+  const Decorator = (Story: React.ComponentType) => {
+    const seeded = useRef(false);
+    if (!seeded.current) {
+      seeded.current = true;
+      applySeed(seed);
+    }
+    return <Story />;
+  };
+  Decorator.displayName = 'withStores';
+  return Decorator;
+}

--- a/.storybook/msw/handlers.ts
+++ b/.storybook/msw/handlers.ts
@@ -1,0 +1,118 @@
+// Default MSW handlers for Storybook (issue #1485).
+//
+// Storybook is the canonical, backend-free view of the frontend. These handlers
+// intercept the app's AI/HTTP generation routes so page and organism stories
+// render without ever touching the real network or a player's provider key.
+// Payloads are deterministic and structurally valid — enough for components to
+// render a happy path, not faithful AI prose. A story that needs a richer or a
+// failing response overrides these per-story via `parameters.msw.handlers`.
+//
+// The app's own parsers (e.g. choiceGenerator.parser + its fallback) tolerate
+// imperfect content, so these stay intentionally minimal.
+
+import { http, HttpResponse } from 'msw';
+
+// Text-generation routes share one response contract: { content, finishReason }.
+// See src/utils/apiHelpers.ts (processGeminiTextRequest) and the client reader
+// in src/lib/ai/clientGeminiClient.ts.
+const textResponse = (content: string) =>
+  HttpResponse.json({
+    content,
+    finishReason: 'STOP',
+    promptTokens: 0,
+    completionTokens: 0,
+  });
+
+const CANNED_NARRATIVE =
+  'The corridor opens into a vaulted hall. Dust hangs in the lantern light, ' +
+  'and somewhere ahead water drips in a slow, deliberate rhythm. You sense ' +
+  'you are not the first to stand here, nor the first to hesitate.';
+
+// Loose text format the choice parser understands; the parser falls back to
+// sensible defaults if this ever drifts, so it never crashes a story.
+const CANNED_CHOICES = [
+  'Decision Weight: Minor',
+  '',
+  '1. Press deeper into the hall',
+  '2. Hold your position and listen',
+  '3. Raise the lantern and call out',
+  '4. Retreat the way you came',
+].join('\n');
+
+const placeholderImage = (seed: string) =>
+  `https://api.dicebear.com/7.x/shapes/svg?seed=${encodeURIComponent(seed)}`;
+
+export const handlers = [
+  // --- Narrative text routes ---
+  http.post('/api/narrative/generate', () => textResponse(CANNED_NARRATIVE)),
+  http.post('/api/narrative/choices', () => textResponse(CANNED_CHOICES)),
+  http.post('/api/narrative/ending', () => textResponse(CANNED_NARRATIVE)),
+  http.post('/api/narrative/summarize', () => textResponse('A brief recap of events so far.')),
+  http.post('/api/narrative/story-checkpoint', () => textResponse('Checkpoint reached.')),
+  http.post('/api/narrative/validate-event-significance', () =>
+    textResponse('minor'),
+  ),
+
+  // --- Other AI text routes ---
+  http.post('/api/ai/analyze-world', () => textResponse('A balanced, story-rich world.')),
+  http.post('/api/ai/validate-provider', () =>
+    HttpResponse.json({
+      valid: true,
+      capabilities: { text: true, images: true, streaming: true },
+      model: 'mock-model',
+    }),
+  ),
+  http.post('/api/inventory/categorize', () => textResponse('general')),
+  http.post('/api/inventory/check-similarity', () => textResponse('false')),
+  http.post('/api/lore/check-similarity', () => textResponse('false')),
+
+  // --- Structured generation routes (return the entity directly) ---
+  http.post('/api/generate-world', () =>
+    HttpResponse.json({
+      name: 'The Mock Reaches',
+      description: 'A deterministic world used for Storybook rendering.',
+      genre: 'fantasy',
+      attributes: [],
+      skills: [],
+    }),
+  ),
+  http.post('/api/generate-character', () =>
+    HttpResponse.json({
+      name: 'Mock Wanderer',
+      description: 'A deterministic character used for Storybook rendering.',
+      level: 1,
+      attributes: [],
+      skills: [],
+    }),
+  ),
+
+  // --- Image routes ---
+  http.post('/api/generate-portrait', () =>
+    HttpResponse.json({
+      portrait: {
+        type: 'ai-generated',
+        url: placeholderImage('portrait'),
+        generatedAt: new Date(0).toISOString(),
+        prompt: 'Mock portrait',
+      },
+    }),
+  ),
+  http.post('/api/generate-world-image', () =>
+    HttpResponse.json({
+      imageUrl: placeholderImage('world'),
+      description: 'Mock world image',
+      aiGenerated: false,
+      placeholder: true,
+    }),
+  ),
+  http.post('/api/generate-item-image', () =>
+    HttpResponse.json({ imageUrl: placeholderImage('item'), aiGenerated: false, placeholder: true }),
+  ),
+  http.post('/api/generate-journal-image', () =>
+    HttpResponse.json({ imageUrl: placeholderImage('journal'), aiGenerated: false, placeholder: true }),
+  ),
+  http.post('/api/generate-ending-image', () =>
+    HttpResponse.json({ imageUrl: placeholderImage('ending'), aiGenerated: false, placeholder: true }),
+  ),
+  http.post('/api/delete-image', () => HttpResponse.json({ success: true })),
+];

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -11,9 +11,11 @@ import {
   Fira_Code,
   DM_Sans,
 } from 'next/font/google';
+import { initialize, mswLoader } from 'msw-storybook-addon';
 import { ThemeProvider, useTheme } from '../src/lib/theme/ThemeProvider';
 import type { DesignSystem, ColorScheme } from '../src/lib/theme';
 import { TutorialProvider } from '../src/components/TutorialProvider/TutorialProvider';
+import { handlers } from './msw/handlers';
 
 import '../src/app/globals.css';
 import '../src/app/workshop.css';
@@ -44,6 +46,11 @@ const fontVariables = [
   crimsonPro.variable, jetbrainsMono.variable, manrope.variable,
   newsreader.variable, firaCode.variable, dmSans.variable,
 ].join(' ');
+
+// Start the MSW service worker once. `onUnhandledRequest: 'bypass'` lets
+// fonts/static assets through while the default handlers (./msw/handlers)
+// intercept the app's AI/HTTP routes, so stories never hit the real network.
+initialize({ onUnhandledRequest: 'bypass' });
 
 // Syncs Storybook toolbar selections into ThemeProvider's React context
 // so components using useTheme() render the correct theme variant.
@@ -113,7 +120,16 @@ const preview: Preview = {
     colorScheme: 'light',
   },
   decorators: [withTheme],
+  loaders: [mswLoader],
   parameters: {
+    msw: { handlers },
+    viewport: {
+      viewports: {
+        mobile: { name: 'Mobile (375)', styles: { width: '375px', height: '720px' } },
+        tablet: { name: 'Tablet (768)', styles: { width: '768px', height: '1024px' } },
+        desktop: { name: 'Desktop (1280)', styles: { width: '1280px', height: '900px' } },
+      },
+    },
     actions: { argTypesRegex: '^on[A-Z].*' },
     controls: {
       matchers: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,8 @@
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "knip": "^6.13.1",
+        "msw": "^2.14.6",
+        "msw-storybook-addon": "^2.0.7",
         "playwright": "^1.56.1",
         "postcss": "^8.5.10",
         "postcss-load-config": "^6.0.1",
@@ -3064,6 +3066,93 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "dev": true,
@@ -3684,6 +3773,31 @@
         "react": ">=16"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -3958,6 +4072,31 @@
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
+      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
       "version": "0.130.0",
@@ -7005,8 +7144,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
+      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -9371,6 +9527,16 @@
         "node": ">= 10.0"
       }
     },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "license": "MIT"
@@ -9613,6 +9779,20 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.42.0",
@@ -11752,6 +11932,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.0.6",
       "dev": true,
@@ -11766,6 +11963,16 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -12619,6 +12826,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/gtoken": {
       "version": "7.1.0",
       "license": "MIT",
@@ -12744,6 +12961,17 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
+      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.10",
+        "set-cookie-parser": "^3.0.1"
       }
     },
     "node_modules/hmac-drbg": {
@@ -13482,6 +13710,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -15390,6 +15625,93 @@
       "version": "2.1.3",
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.14.6",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.6.tgz",
+      "integrity": "sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^6.0.11",
+        "@mswjs/interceptors": "^0.41.3",
+        "@open-draft/deferred-promise": "^3.0.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.1.1",
+        "graphql": "^16.13.2",
+        "headers-polyfill": "^5.0.1",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.11.11",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.1",
+        "type-fest": "^5.5.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw-storybook-addon": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/msw-storybook-addon/-/msw-storybook-addon-2.0.7.tgz",
+      "integrity": "sha512-TGmlxXy2TsaB6QcClVKRxqvay5f93xoLguHOihRFQ+gIEIyiyvcoQjkEeuOe7Y9qvddzGB1LyFomzPo9/EpnuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.0.1"
+      },
+      "peerDependencies": {
+        "msw": "^2.0.0"
+      }
+    },
+    "node_modules/msw/node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/multimatch": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
@@ -15408,6 +15730,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/nanoid": {
@@ -15832,6 +16164,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "dev": true,
@@ -16114,6 +16453,13 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "dev": true,
@@ -16261,7 +16607,6 @@
     },
     "node_modules/playwright/node_modules/fsevents": {
       "version": "2.3.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17486,6 +17831,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/rettime": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
+      "integrity": "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "dev": true,
@@ -17785,6 +18137,13 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.1.tgz",
+      "integrity": "sha512-vM9SUhjsUYs6UeJUmygc5Ofm5eQGe85riob5ju6XCgFGJI5PLV4nrDAQpQjd+LkFBpAkADn5BQQpZ9EUNkyLuA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -18403,6 +18762,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -18487,6 +18856,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -19146,6 +19522,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "dev": true,
@@ -19315,6 +19704,26 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.5.tgz",
+      "integrity": "sha512-RfEzKWcq5fHUOFq7J3rl3Oz6ylKGtcHqUznzj4EcXsxLSIjJcvpbXAQtWGeJQ0xKnimR5e0Cn+cn9TssfMzm+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.5"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.5.tgz",
+      "integrity": "sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -19836,6 +20245,16 @@
         "@unrs/resolver-binding-win32-arm64-msvc": "1.7.2",
         "@unrs/resolver-binding-win32-ia32-msvc": "1.7.2",
         "@unrs/resolver-binding-win32-x64-msvc": "1.7.2"
+      }
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -111,6 +111,8 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "knip": "^6.13.1",
+    "msw": "^2.14.6",
+    "msw-storybook-addon": "^2.0.7",
     "playwright": "^1.56.1",
     "postcss": "^8.5.10",
     "postcss-load-config": "^6.0.1",
@@ -157,5 +159,10 @@
   "bugs": {
     "url": "https://github.com/jerseycheese/Narraitor/issues"
   },
-  "homepage": "https://github.com/jerseycheese/Narraitor#readme"
+  "homepage": "https://github.com/jerseycheese/Narraitor#readme",
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
+  }
 }

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.14.6'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/src/stories/05-pages/game-session/ActiveGameSession.stories.tsx
+++ b/src/stories/05-pages/game-session/ActiveGameSession.stories.tsx
@@ -8,6 +8,7 @@ import { useSessionStore } from '@/state/sessionStore';
 import { useCharacterStore } from '@/state/characterStore';
 import { ToastProvider } from '@/components/ui/toast';
 import { getTimestamp } from '@/lib/utils';
+import { withStores } from '../../../../.storybook/decorators/withStores';
 
 const meta: Meta<typeof ActiveGameSession> = {
   title: '05-Pages/game-session/ActiveGameSession',
@@ -30,9 +31,11 @@ const meta: Meta<typeof ActiveGameSession> = {
   decorators: [
     // ActiveGameSession's useAutoSave calls useToast, so every story needs a ToastProvider ancestor.
     (Story) => <ToastProvider><Story /></ToastProvider>,
-    (Story) => {
-      // Reset stores before each story and clear any endings to prevent endscreen display
-      useNarrativeStore.setState({
+    // Reset stores to a clean active-session baseline before each story (clears
+    // any ending so the endscreen doesn't show). Per-story decorators layer
+    // character/narrative data on top. Dogfoods the shared withStores helper.
+    withStores({
+      narrative: {
         segments: {},
         sessionSegments: {},
         decisions: {},
@@ -41,9 +44,8 @@ const meta: Meta<typeof ActiveGameSession> = {
         isGeneratingEnding: false,
         error: null,
         loading: false,
-      });
-      
-      useSessionStore.setState({
+      },
+      session: {
         id: 'session-123',
         status: 'active',
         currentSceneId: null,
@@ -52,19 +54,16 @@ const meta: Meta<typeof ActiveGameSession> = {
         worldId: 'world-123',
         characterId: 'char-123',
         savedSessions: {},
-      });
-      
-      useCharacterStore.setState({
+      },
+      character: {
         characters: {},
         entities: {},
         currentCharacterId: null,
         currentEntityId: null,
         error: null,
         loading: false,
-      });
-      
-      return <Story />;
-    },
+      },
+    }),
   ],
 };
 


### PR DESCRIPTION
## Description

Phase 1 of the Storybook-as-canon epic (#1484): close the infra gaps so any page/organism story renders fully decoupled from real AI, HTTP, and a provider key. This is the keystone — MSW and the `withStores` decorator unblock every backend-free page story in Phases 3+.

Three gaps closed:

- **MSW.** Added `msw` + `msw-storybook-addon`, initialized the worker in `public/`, and wired `initialize()` + `mswLoader` into `.storybook/preview.tsx`. `.storybook/msw/handlers.ts` intercepts the app's generation routes (`/api/narrative/*`, `/api/generate-*`, `/api/ai/*`, image routes) with deterministic, structurally-valid payloads. Stories no longer hit the network. A story that needs a richer or failing response overrides per-story via `parameters.msw.handlers`.
- **`withStores` decorator.** Generalizes the per-story `useXStore.setState(...)` seeding (the `withDashboardScenario` / game-session pattern) into one call: `withStores({ world, character, session, ... })`. Seeds synchronously before first render so store-reading components have data on mount.
- **Viewport toolbar.** mobile 375 / tablet 768 / desktop 1280.

Theming (DS1/2/3 + dark) already worked in `preview.tsx` — left untouched. Chromatic stays unwired (the epic uses a structural guard, not visual regression).

## Related Issue
Part of #1484. (Targets `develop`, so GitHub won't auto-close — closed manually post-merge.)
Closes #1485

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test addition or improvement (Storybook infra)

## TDD Compliance
- [ ] Tests written before implementation — N/A, this is Storybook config + a decorator; no unit-testable logic (verified by the Storybook build + type-check instead). Phase 2's guard logic is where TDD applies.
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
#1485 — Storybook backend-free infra (MSW + withStores + viewport).

## Component Development
- [x] Storybook stories created/updated — `ActiveGameSession` dogfoods `withStores`.
- [x] Components developed in isolation first
- [x] Visual consistency verified — no product CSS touched; theming untouched.

## Implementation Notes
- The jest-based `mockStoreFactories` can't run in Storybook, so `withStores` uses real store `setState` with plain mock data rather than those factories.
- `withStores` is intentionally seed-only (no auto-reset between stories), mirroring the existing helpers — seed everything a story reads.
- `onUnhandledRequest: 'bypass'` lets fonts/static assets through while the AI/HTTP routes are intercepted.
- Known minor edge: the deployed Storybook at `/storybook/` would need a base-aware service-worker URL for MSW to run there; local dev and CI build both work with the default. Out of scope for the gate; noted as a future tweak.

## Quality Checks
- [x] Linting passed (`npm run lint`, `npm run lint:ds-canon`)
- [x] Type checking passed (`npm run type-check`)
- [x] No console.log statements in production code
- [x] No unhandled promises
- [x] knip passed; `npm run build-storybook` green

## Testing Instructions
1. `npm run storybook`, open `05-Pages/game-session/ActiveGameSession`.
2. With the network tab open, confirm zero real `/api/*` calls — MSW intercepts.
3. Flip the theme (DS1/2/3 + light/dark) and viewport (mobile/tablet/desktop) toolbars; the story re-renders correctly.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) — N/A this phase; the ADR + docs land in Phase 4.
- [x] No new warnings generated
- [x] Accessibility considerations addressed — a11y addon unaffected.
