### PR TITLE
feat(ds-canon): broaden the canon guard to the full in-scope set (#1486)

### DIFF
--- a/.ds-canon-baseline.json
+++ b/.ds-canon-baseline.json
@@ -1,14 +1,65 @@
 {
-  "comment": "Design-system canon guard (scripts/verify-ds-canon.cjs, npm run lint:ds-canon). The living style guide (src/app/dev/design-system*) must render REAL production components as canon, with styling defined in production so it flows downstream — the app must never be the canon source. Three checks: (1) skinning — the guide must not re-skin a real primitive with guide-local classes; (2) coverage — every src/components/ui/* primitive must be represented in the guide; (3) storybook — every primitive must also appear in a story under src/stories/** (#1325). All fail only on NEW violations; existing ones are grandfathered below with tracking issues. Shrink these lists as canon work proceeds. Mirrors the .skott-baseline.json pattern.",
+  "comment": "Design-system canon guard (scripts/verify-ds-canon.cjs, npm run lint:ds-canon). Storybook is the canonical, backend-free view of the frontend (#1484); the living style guide (src/app/dev/design-system*) is being retired. Three checks: (1) skinning — the guide must not re-skin a real primitive with guide-local classes; (2) guide coverage — every src/components/ui/* primitive must be represented in the guide (stays until the guide is retired in Phase 4 / #1488); (3) storybook coverage (#1486) — every in-scope component must appear in a story under src/stories/**. In-scope = componentScope below (nested ui/** + the whole shared/** presentational layer + an explicit domain allowlist of presentational cards/portraits/displays). All checks fail only on NEW violations; existing gaps are grandfathered here with tracking. Shrink storybookGaps to empty in Phase 3 (#1487). Mirrors the .skott-baseline.json pattern.",
+  "componentScope": {
+    "globs": [
+      "src/components/ui/**/*.{tsx,jsx}",
+      "src/components/shared/**/*.tsx"
+    ],
+    "domainAllowlist": [
+      "src/components/CharacterCard/CharacterCard.tsx",
+      "src/components/WorldCard/WorldCard.tsx",
+      "src/components/CharacterPortrait/CharacterPortrait.tsx",
+      "src/components/characters/CharacterAttributeDisplay.tsx",
+      "src/components/characters/CharacterBackgroundDisplay.tsx",
+      "src/components/characters/CharacterDerivedStatsDisplay.tsx",
+      "src/components/characters/CharacterDetailsDisplay.tsx",
+      "src/components/characters/CharacterSkillDisplay.tsx",
+      "src/components/Dashboard/DashboardContinueCard.tsx",
+      "src/components/Dashboard/DashboardProgressCard.tsx",
+      "src/components/ai/ProviderCard.tsx",
+      "src/components/world/WorldDetailsDisplay.tsx",
+      "src/components/world/WorldSettingsDisplay.tsx",
+      "src/components/world/ToneSettingsDisplay.tsx",
+      "src/components/world/WorldImageDisplay.tsx"
+    ]
+  },
   "skinning": [
     "src/app/dev/design-system/_ui/ComponentShowcase.tsx::overlayClassName::dsc-dialog-overlay"
   ],
   "coverageGaps": [],
   "coverageExceptions": {
-    "scroll-area": "Behavior/utility wrapper (adds scroll styling around arbitrary content) — no visual variants/states to canonize."
+    "scroll-area": "Behavior/utility wrapper (adds scroll styling around arbitrary content) — no visual variants/states to canonize.",
+    "choiceStyling": "Styling helper — exports class-name maps for ChoiceSelector, not a rendered component.",
+    "SSRClientOnly": "Behavior wrapper — defers render to the client; no visual variants/states to canonize.",
+    "toaster": "Infra mount — renders the toast viewport/portal; exercised via the toast stories."
   },
   "storybookGaps": [
     "dialog",
-    "table"
+    "table",
+    "ActiveStateIndicator",
+    "BackNavigation",
+    "CharacterDerivedStatsDisplay",
+    "DashboardContinueCard",
+    "DataField",
+    "ErrorBlock",
+    "ExportImportControls",
+    "FormComponents",
+    "ImageGenerationSection",
+    "NotFoundState",
+    "PortraitCustomizationSection",
+    "PreviewModal",
+    "ProviderCard",
+    "RequirementBadges",
+    "SectionWrapper",
+    "SimpleModal",
+    "SkipLinks",
+    "ToggleButton",
+    "ToneSettingsDisplay",
+    "WizardContainer",
+    "WizardNavigation",
+    "WizardProgress",
+    "WizardStep",
+    "WorldFormFields",
+    "WorldImageDisplay"
   ]
 }

--- a/scripts/__tests__/ds-canon-lib.test.js
+++ b/scripts/__tests__/ds-canon-lib.test.js
@@ -1,0 +1,97 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for the design-system canon guard's pure matching logic (#1486).
+ * Fixture-based and deterministic — no fs, no live codebase scan.
+ */
+
+import {
+  isStoryableComponentFile,
+  componentNameFromPath,
+  collectComponentImportSegments,
+  findUncovered,
+  dedupeByName,
+} from '../ds-canon-lib.cjs';
+
+describe('isStoryableComponentFile', () => {
+  it('accepts a real component file', () => {
+    expect(isStoryableComponentFile('src/components/shared/Hero.tsx')).toBe(true);
+    expect(isStoryableComponentFile('src/components/ui/EmptyState/EmptyState.tsx')).toBe(true);
+  });
+
+  it('rejects tests, stories, and barrel indexes', () => {
+    expect(isStoryableComponentFile('src/components/ui/button.test.tsx')).toBe(false);
+    expect(isStoryableComponentFile('src/components/ui/button.stories.tsx')).toBe(false);
+    expect(isStoryableComponentFile('src/components/shared/index.tsx')).toBe(false);
+    expect(isStoryableComponentFile('src/components/shared/cards/index.ts')).toBe(false);
+  });
+});
+
+describe('componentNameFromPath', () => {
+  it('returns the basename without the React extension', () => {
+    expect(componentNameFromPath('src/components/ui/button.tsx')).toBe('button');
+    expect(componentNameFromPath('src/components/shared/cards/ActiveStateCard.tsx')).toBe('ActiveStateCard');
+    expect(componentNameFromPath('src/components/ui/toast/toast.tsx')).toBe('toast');
+  });
+});
+
+describe('collectComponentImportSegments', () => {
+  it('captures every path segment of @/components imports', () => {
+    const segs = collectComponentImportSegments([
+      "import { Hero } from '@/components/shared/Hero';",
+      "import ActiveStateCard from '@/components/shared/cards/ActiveStateCard';",
+      "import { Button } from '@/components/ui/button';",
+    ]);
+    expect(segs.has('Hero')).toBe(true);
+    expect(segs.has('ActiveStateCard')).toBe(true);
+    expect(segs.has('cards')).toBe(true);
+    expect(segs.has('button')).toBe(true);
+  });
+
+  it('ignores non-component imports', () => {
+    const segs = collectComponentImportSegments([
+      "import { useWorldStore } from '@/state/worldStore';",
+      "import { getTimestamp } from '@/lib/utils';",
+    ]);
+    expect(segs.size).toBe(0);
+  });
+});
+
+describe('findUncovered', () => {
+  const names = ['button', 'Hero', 'SimpleModal', 'scroll-area'];
+
+  it('flags names with no story', () => {
+    const covered = new Set(['button']);
+    expect(findUncovered(names, covered)).toEqual(['Hero', 'SimpleModal', 'scroll-area']);
+  });
+
+  it('honors documented exceptions and grandfathered gaps', () => {
+    const covered = new Set(['button']);
+    const result = findUncovered(names, covered, {
+      exceptions: { 'scroll-area': 'behavior wrapper' },
+      grandfathered: new Set(['SimpleModal']),
+    });
+    expect(result).toEqual(['Hero']);
+  });
+
+  it('returns nothing when everything is covered or excused', () => {
+    const covered = new Set(['button', 'Hero']);
+    const result = findUncovered(names, covered, {
+      exceptions: { 'scroll-area': 'x' },
+      grandfathered: new Set(['SimpleModal']),
+    });
+    expect(result).toEqual([]);
+  });
+});
+
+describe('dedupeByName', () => {
+  it('keys by component name and skips non-component files', () => {
+    const map = dedupeByName([
+      'src/components/shared/Hero.tsx',
+      'src/components/shared/Hero.test.tsx',
+      'src/components/ui/EmptyState/EmptyState.tsx',
+    ]);
+    expect([...map.keys()].sort()).toEqual(['EmptyState', 'Hero']);
+    expect(map.get('Hero')).toBe('src/components/shared/Hero.tsx');
+  });
+});

--- a/scripts/ds-canon-lib.cjs
+++ b/scripts/ds-canon-lib.cjs
@@ -1,0 +1,77 @@
+// Pure matching logic for the design-system canon guard (issue #1486).
+//
+// No fs, no glob, no process: every function takes its inputs and returns a
+// value, so the scope/coverage logic is unit-testable against fixtures. The CLI
+// wrapper (scripts/verify-ds-canon.cjs) does the file I/O and feeds these.
+//
+// Mirrors the route-validation.js / validate-routes.js split (issue #420).
+
+// A component file is "storyable" (in scope as a standalone catalog entry) only
+// if it's a real component module — not a test, a story, or a barrel index.
+const NON_COMPONENT_RE = /(\.test\.|\.stories\.|(^|[/\\])index\.)/;
+
+function isStoryableComponentFile(relPath) {
+  return !NON_COMPONENT_RE.test(relPath);
+}
+
+// The component's identity for coverage matching: its basename without the
+// React extension. e.g. 'src/components/shared/cards/ActiveStateCard.tsx' ->
+// 'ActiveStateCard'. Matches how the guard has always keyed primitives.
+function componentNameFromPath(relPath) {
+  const base = relPath.split(/[/\\]/).pop() || relPath;
+  return base.replace(/\.(tsx|jsx|ts|js)$/, '');
+}
+
+// Every path segment of every `@/components/...` import found in the given file
+// contents, as a Set. A story that imports `@/components/shared/Hero` or
+// `@/components/shared/cards/ActiveStateCard` contributes 'shared', 'Hero',
+// 'cards', 'ActiveStateCard' — so coverage matching works across nested dirs,
+// the shared layer, and domain dirs alike (the old guard only matched
+// `@/components/ui/<name>`).
+function collectComponentImportSegments(contents) {
+  const segments = new Set();
+  const importRe = /@\/components\/([A-Za-z0-9/_-]+)/g;
+  for (const content of contents) {
+    let m;
+    importRe.lastIndex = 0;
+    while ((m = importRe.exec(content)) !== null) {
+      for (const seg of m[1].split('/')) if (seg) segments.add(seg);
+    }
+  }
+  return segments;
+}
+
+// Given the in-scope component names and the set of names that appear in some
+// story, return the names that are genuinely uncovered: not storied, not a
+// documented non-visual exception, and not grandfathered. Mirrors the guide
+// coverage check so both halves share one rule.
+function findUncovered(componentNames, coveredNames, { exceptions = {}, grandfathered = new Set() } = {}) {
+  const uncovered = [];
+  for (const name of componentNames) {
+    if (coveredNames.has(name)) continue;     // has a story
+    if (exceptions[name]) continue;            // documented non-visual exception
+    if (grandfathered.has(name)) continue;     // tracked baseline gap
+    uncovered.push(name);
+  }
+  return uncovered;
+}
+
+// De-duplicate component names across the in-scope file list, preserving the
+// first path seen for each (used only for nicer error messages).
+function dedupeByName(relPaths) {
+  const byName = new Map();
+  for (const p of relPaths) {
+    if (!isStoryableComponentFile(p)) continue;
+    const name = componentNameFromPath(p);
+    if (!byName.has(name)) byName.set(name, p);
+  }
+  return byName;
+}
+
+module.exports = {
+  isStoryableComponentFile,
+  componentNameFromPath,
+  collectComponentImportSegments,
+  findUncovered,
+  dedupeByName,
+};

--- a/scripts/verify-ds-canon.cjs
+++ b/scripts/verify-ds-canon.cjs
@@ -13,9 +13,12 @@
 //   2. Full coverage — every production primitive (src/components/ui/*) must be
 //      represented in the living style guide. If the app uses a primitive the guide
 //      doesn't render, the app has become the canon source. (#1317)
-//   3. Storybook coverage — every production primitive must also appear in a story
-//      under `src/stories/**`, so Storybook stays a real canon surface and doesn't
-//      silently drift from the guide and the app. (#1325)
+//   3. Storybook coverage (broadened, #1486) — every in-scope component must
+//      appear in a story under `src/stories/**`. Scope is no longer just flat
+//      `ui/*`: it's `componentScope` from the baseline (nested `ui/**` + the
+//      whole `shared/**` presentational layer + an explicit domain allowlist of
+//      presentational cards/portraits/displays). This is the surface that keeps
+//      Storybook canon as it becomes the single source of truth (#1325, #1484).
 //
 // Existing violations are grandfathered in `.ds-canon-baseline.json` (mirrors the
 // .skott-baseline.json pattern). The guard fails only on NEW violations, so it
@@ -25,6 +28,11 @@
 const fs = require('fs');
 const path = require('path');
 const glob = require('glob');
+const {
+  dedupeByName,
+  collectComponentImportSegments,
+  findUncovered,
+} = require('./ds-canon-lib.cjs');
 
 const ROOT = process.cwd();
 const GUIDE_GLOB = 'src/app/dev/design-system*/**/*.{ts,tsx}';
@@ -123,30 +131,35 @@ for (const name of primitives) {
   coverageViolations.push(name);
 }
 
-// --- Check 3: Storybook coverage --------------------------------------------
-// Storybook is a real canon surface for the primitives (#1325). Every
-// src/components/ui/* primitive must appear in a story under src/stories/**, or
-// Storybook silently drifts from the guide + the app. Mirrors Check 2: scan
-// story files for `@/components/ui/<name>` imports.
-const storyFiles = STORIES_GLOBS.flatMap((g) =>
-  glob.sync(g, { cwd: ROOT, absolute: true, nodir: true }),
-);
-const storyImports = new Set();
-for (const file of storyFiles) {
-  let content;
-  try { content = fs.readFileSync(file, 'utf8'); } catch { continue; }
-  importRe.lastIndex = 0;
-  let m;
-  while ((m = importRe.exec(content)) !== null) storyImports.add(m[1]);
-}
+// --- Check 3: Storybook coverage (broadened, #1486) -------------------------
+// Storybook is THE canon surface (#1484). Every in-scope component — nested
+// `ui/**`, the whole `shared/**` presentational layer, and the explicit domain
+// allowlist — must appear in a story under src/stories/**, or it can drift with
+// nothing catching it. Scope comes from `componentScope` in the baseline; story
+// coverage is matched by import path segments (works across nested/shared/domain
+// dirs), not just `@/components/ui/<name>`.
+const scope = baseline.componentScope || {};
+const scopeGlobs = scope.globs || [];
+const domainAllowlist = scope.domainAllowlist || [];
 
-const storybookViolations = [];
-for (const name of primitives) {
-  if (storyImports.has(name)) continue;            // has a story
-  if (coverageExceptions[name]) continue;          // documented non-visual exception
-  if (baselineStorybook.has(name)) continue;       // grandfathered gap (tracked)
-  storybookViolations.push(name);
-}
+const scopeFiles = scopeGlobs
+  .flatMap((g) => glob.sync(g, { cwd: ROOT, nodir: true }))
+  .concat(domainAllowlist);
+const inScopeByName = dedupeByName(scopeFiles); // name -> relPath
+const inScopeNames = [...inScopeByName.keys()];
+
+const storyFiles = STORIES_GLOBS.flatMap((g) =>
+  glob.sync(g, { cwd: ROOT, nodir: true }),
+);
+const storyContents = storyFiles.map((f) => {
+  try { return fs.readFileSync(path.join(ROOT, f), 'utf8'); } catch { return ''; }
+});
+const coveredNames = collectComponentImportSegments(storyContents);
+
+const storybookViolations = findUncovered(inScopeNames, coveredNames, {
+  exceptions: coverageExceptions,
+  grandfathered: baselineStorybook,
+}).map((name) => ({ name, file: inScopeByName.get(name) }));
 
 // --- Report ------------------------------------------------------------------
 let failed = false;
@@ -169,9 +182,9 @@ if (coverageViolations.length > 0) {
 
 if (storybookViolations.length > 0) {
   failed = true;
-  console.error('Canon violation — production primitive(s) without a Storybook story:');
-  console.error('Every src/components/ui/* primitive must appear in a story under src/stories/**, or Storybook drifts from canon.\n');
-  for (const name of storybookViolations) console.error(` - ${name} (src/components/ui/${name}.tsx) — add a story under src/stories/**`);
+  console.error('Canon violation — in-scope component(s) without a Storybook story:');
+  console.error('Every in-scope component (componentScope in .ds-canon-baseline.json) must appear in a story under src/stories/**, or it can drift uncaught.\n');
+  for (const v of storybookViolations) console.error(` - ${v.name} (${v.file}) — add a story under src/stories/**`);
   console.error('\nIf it is a non-visual behavior/utility wrapper, add it to "coverageExceptions" in .ds-canon-baseline.json with a reason.');
 }
 
@@ -184,4 +197,8 @@ const skinN = (baseline.skinning || []).length;
 const gapN = baselineCoverage.size;
 const sbN = baselineStorybook.size;
 const excN = Object.keys(coverageExceptions).length;
-console.log(`DS canon OK — ${primitives.length} primitives checked (${gapN} grandfathered guide gap(s), ${sbN} grandfathered storybook gap(s), ${excN} exception(s)); ${skinN} grandfathered skin(s) within baseline.`);
+console.log(
+  `DS canon OK — ${primitives.length} guide primitive(s) + ${inScopeNames.length} in-scope Storybook component(s) checked ` +
+  `(${gapN} grandfathered guide gap(s), ${sbN} grandfathered storybook gap(s), ${excN} exception(s)); ` +
+  `${skinN} grandfathered skin(s) within baseline.`,
+);


### PR DESCRIPTION
## Description

Phase 2 of the Storybook-as-canon epic (#1484): broaden the design-system canon guard so new in-scope components can't drift in without a story.

Today `scripts/verify-ds-canon.cjs` only enforces Storybook coverage for flat `src/components/ui/*.tsx` (~16 files). It's blind to nested `ui/` components, the whole `src/components/shared/*` reusable layer, and every presentational domain component — so most of the frontend could change with nothing catching it.

Check 3 (Storybook coverage) now runs over a `componentScope` read from the baseline:
- `src/components/ui/**/*.{tsx,jsx}` (nested dirs included)
- `src/components/shared/**/*.tsx` (the presentational layer)
- an explicit `domainAllowlist` of presentational cards/portraits/displays (domain dirs can't be auto-classified by path, so they're listed)

Coverage is matched by **import-path segments**, so a story importing `@/components/shared/cards/ActiveStateCard` counts — not just the old `@/components/ui/<name>` form. **73 in-scope components** are now checked (was 16).

## Related Issue
Part of #1484. (Targets `develop`, won't auto-close.)
Closes #1486

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation — the pure matching logic was extracted into `scripts/ds-canon-lib.cjs` and unit-tested first (`scripts/__tests__/ds-canon-lib.test.js`, 9 tests).
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
#1486 — broaden the canon guard to the in-scope set.

## Implementation Notes
- Mirrors the `route-validation.js` / `validate-routes.js` split (#420): pure, fixture-testable logic in a lib; the `.cjs` CLI does the I/O. Lib is CommonJS so the existing `.cjs` CLI can `require` it; the `.js` test imports it (ts-jest transpiles `import`→`require`).
- Baseline seeded so CI is green on day one: 27 currently-uncovered components grandfathered into `storybookGaps` (Phase 3 / #1487 shrinks to zero), 4 non-visual wrappers excepted (`scroll-area`, `choiceStyling`, `SSRClientOnly`, `toaster`).
- Preserves the "fail on new, grandfather existing" property — verified by adding a throwaway in-scope component (guard fails) and removing it (guard passes).
- Checks 1 (skinning) and 2 (guide coverage, flat `ui/*`) are unchanged; the guide and its check retire in Phase 4 (#1488).

## Quality Checks
- [x] Linting passed (`npm run lint`, `npm run lint:ds-canon`)
- [x] Type checking passed
- [x] knip passed; unit tests green

## Testing Instructions
1. `npm run lint:ds-canon` → green, reports "73 in-scope Storybook component(s) checked".
2. Add a throwaway `src/components/shared/Foo.tsx` with no story → guard fails. Remove it → green.
3. `npx jest scripts/__tests__/ds-canon-lib.test.js` → 9 pass.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] No new warnings generated
- [x] Accessibility considerations addressed — N/A (tooling).
