### PR TITLE
feat(storybook): backfill stories for the in-scope set; storybookGaps -> 0 (#1487)

### DIFF
--- a/.ds-canon-baseline.json
+++ b/.ds-canon-baseline.json
@@ -33,33 +33,5 @@
     "SSRClientOnly": "Behavior wrapper — defers render to the client; no visual variants/states to canonize.",
     "toaster": "Infra mount — renders the toast viewport/portal; exercised via the toast stories."
   },
-  "storybookGaps": [
-    "dialog",
-    "table",
-    "ActiveStateIndicator",
-    "BackNavigation",
-    "CharacterDerivedStatsDisplay",
-    "DashboardContinueCard",
-    "DataField",
-    "ErrorBlock",
-    "ExportImportControls",
-    "FormComponents",
-    "ImageGenerationSection",
-    "NotFoundState",
-    "PortraitCustomizationSection",
-    "PreviewModal",
-    "ProviderCard",
-    "RequirementBadges",
-    "SectionWrapper",
-    "SimpleModal",
-    "SkipLinks",
-    "ToggleButton",
-    "ToneSettingsDisplay",
-    "WizardContainer",
-    "WizardNavigation",
-    "WizardProgress",
-    "WizardStep",
-    "WorldFormFields",
-    "WorldImageDisplay"
-  ]
+  "storybookGaps": []
 }

--- a/src/stories/01-atoms/display/DataField.stories.tsx
+++ b/src/stories/01-atoms/display/DataField.stories.tsx
@@ -1,0 +1,27 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { DataField } from '@/components/shared/DataField/DataField';
+
+const meta: Meta<typeof DataField> = {
+  title: '01-Atoms/display/DataField',
+  component: DataField,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: 'select', options: ['default', 'outline', 'stacked'] },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DataField>;
+
+export const Default: Story = {
+  args: { label: 'Genre', value: 'Dark fantasy' },
+};
+
+export const Outline: Story = {
+  args: { label: 'Genre', value: 'Dark fantasy', variant: 'outline' },
+};
+
+export const Stacked: Story = {
+  args: { label: 'Genre', value: 'Dark fantasy', variant: 'stacked' },
+};

--- a/src/stories/01-atoms/feedback/ActiveStateIndicator.stories.tsx
+++ b/src/stories/01-atoms/feedback/ActiveStateIndicator.stories.tsx
@@ -1,0 +1,19 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { ActiveStateIndicator } from '@/components/shared/cards/ActiveStateIndicator';
+
+const meta: Meta<typeof ActiveStateIndicator> = {
+  title: '01-Atoms/feedback/ActiveStateIndicator',
+  component: ActiveStateIndicator,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  argTypes: { text: { control: 'text' } },
+};
+
+export default meta;
+type Story = StoryObj<typeof ActiveStateIndicator>;
+
+export const Default: Story = {};
+
+export const CustomText: Story = {
+  args: { text: 'Now playing' },
+};

--- a/src/stories/01-atoms/feedback/ErrorBlock.stories.tsx
+++ b/src/stories/01-atoms/feedback/ErrorBlock.stories.tsx
@@ -1,0 +1,26 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { ErrorBlock } from '@/components/shared/ErrorBlock';
+
+const meta: Meta<typeof ErrorBlock> = {
+  title: '01-Atoms/feedback/ErrorBlock',
+  component: ErrorBlock,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ErrorBlock>;
+
+export const SingleError: Story = {
+  args: { errors: ['A name is required before you can continue.'] },
+};
+
+export const MultipleErrors: Story = {
+  args: {
+    errors: [
+      'A name is required before you can continue.',
+      'Pick at least one attribute.',
+      'The description is too short.',
+    ],
+  },
+};

--- a/src/stories/01-atoms/forms/ToggleButton.stories.tsx
+++ b/src/stories/01-atoms/forms/ToggleButton.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { ToggleButton } from '@/components/shared/wizard/components/ToggleButton';
+
+const meta: Meta<typeof ToggleButton> = {
+  title: '01-Atoms/forms/ToggleButton',
+  component: ToggleButton,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  args: { isActive: true, onClick: () => {} },
+  argTypes: { isActive: { control: 'boolean' }, disabled: { control: 'boolean' } },
+};
+
+export default meta;
+type Story = StoryObj<typeof ToggleButton>;
+
+export const Active: Story = { args: { isActive: true } };
+export const Inactive: Story = { args: { isActive: false } };
+export const Disabled: Story = { args: { disabled: true } };

--- a/src/stories/01-atoms/navigation/BackNavigation.stories.tsx
+++ b/src/stories/01-atoms/navigation/BackNavigation.stories.tsx
@@ -1,0 +1,19 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { BackNavigation } from '@/components/shared/BackNavigation';
+
+const meta: Meta<typeof BackNavigation> = {
+  title: '01-Atoms/navigation/BackNavigation',
+  component: BackNavigation,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  args: { label: 'Back to worlds', onClick: () => {} },
+};
+
+export default meta;
+type Story = StoryObj<typeof BackNavigation>;
+
+export const Default: Story = {};
+
+export const CustomLabel: Story = {
+  args: { label: 'Back to character' },
+};

--- a/src/stories/01-atoms/navigation/SkipLinks.stories.tsx
+++ b/src/stories/01-atoms/navigation/SkipLinks.stories.tsx
@@ -1,0 +1,32 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { SkipLinks } from '@/components/shared/SkipLinks';
+
+const meta: Meta<typeof SkipLinks> = {
+  title: '01-Atoms/navigation/SkipLinks',
+  component: SkipLinks,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Accessibility skip links — visually hidden until focused. Tab into the frame to reveal them.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="story-skiplinks">
+        <Story />
+        <main id="main-content" tabIndex={-1} style={{ padding: 'var(--spacing-4, 1rem)' }}>
+          Press Tab to reveal the skip links above.
+        </main>
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof SkipLinks>;
+
+export const Default: Story = {};

--- a/src/stories/01-atoms/ui/Dialog.stories.tsx
+++ b/src/stories/01-atoms/ui/Dialog.stories.tsx
@@ -1,0 +1,28 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+const meta: Meta<typeof Dialog> = {
+  title: '01-Atoms/ui/Dialog',
+  component: Dialog,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Dialog>;
+
+export const Open: Story = {
+  render: () => (
+    <Dialog open>
+      <DialogContent className="story-dialog">
+        <DialogTitle>Delete this world?</DialogTitle>
+        <p>This removes the world and every character in it. This can&apos;t be undone.</p>
+        <div style={{ display: 'flex', gap: 'var(--spacing-2, 0.5rem)', justifyContent: 'flex-end' }}>
+          <Button variant="secondary">Cancel</Button>
+          <Button variant="destructive">Delete</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  ),
+};

--- a/src/stories/01-atoms/ui/Table.stories.tsx
+++ b/src/stories/01-atoms/ui/Table.stories.tsx
@@ -1,0 +1,45 @@
+import { Meta, StoryObj } from '@storybook/react';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/table';
+
+const meta: Meta<typeof Table> = {
+  title: '01-Atoms/ui/Table',
+  component: Table,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Table>;
+
+export const Default: Story = {
+  render: () => (
+    <Table className="story-table">
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead>Class</TableHead>
+          <TableHead>Level</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow>
+          <TableCell>Aria Starweaver</TableCell>
+          <TableCell>Swordmage</TableCell>
+          <TableCell>5</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>Vex</TableCell>
+          <TableCell>Operative</TableCell>
+          <TableCell>3</TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  ),
+};

--- a/src/stories/02-molecules/ai/ProviderCard.stories.tsx
+++ b/src/stories/02-molecules/ai/ProviderCard.stories.tsx
@@ -1,0 +1,40 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { ProviderCard } from '@/components/ai/ProviderCard';
+
+const meta: Meta<typeof ProviderCard> = {
+  title: '02-Molecules/ai/ProviderCard',
+  component: ProviderCard,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  args: {
+    provider: {
+      id: 'gemini-1',
+      type: 'gemini',
+      name: 'My Gemini key',
+      endpoint: 'https://generativelanguage.googleapis.com',
+      model: 'gemini-2.5-flash',
+      capabilities: { text: true, images: true, streaming: true },
+      createdAt: '2025-01-01T00:00:00Z',
+      updatedAt: '2025-01-01T00:00:00Z',
+    },
+    onSetActive: () => {},
+    onValidate: () => {},
+    onDelete: () => {},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ProviderCard>;
+
+export const Active: Story = { args: { isActive: true } };
+
+export const Inactive: Story = { args: { isActive: false } };
+
+export const Valid: Story = {
+  args: {
+    isActive: true,
+    validation: { valid: true, lastChecked: 1718000000000 },
+  },
+};
+
+export const Validating: Story = { args: { isActive: true, isValidating: true } };

--- a/src/stories/02-molecules/character-display/CharacterDerivedStatsDisplay.stories.tsx
+++ b/src/stories/02-molecules/character-display/CharacterDerivedStatsDisplay.stories.tsx
@@ -1,0 +1,21 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { CharacterDerivedStatsDisplay } from '@/components/characters/CharacterDerivedStatsDisplay';
+
+const meta: Meta<typeof CharacterDerivedStatsDisplay> = {
+  title: '02-Molecules/character-display/CharacterDerivedStatsDisplay',
+  component: CharacterDerivedStatsDisplay,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof CharacterDerivedStatsDisplay>;
+
+export const Default: Story = {
+  args: {
+    derivedStats: [
+      { id: 'ds-hp', characterId: 'char-1', derivedStatId: 'hp', name: 'Hit Points', currentValue: 38, maxValue: 45, lastCalculated: '2025-01-15T00:00:00Z' },
+      { id: 'ds-mp', characterId: 'char-1', derivedStatId: 'mp', name: 'Mana', currentValue: 22, maxValue: 30, lastCalculated: '2025-01-15T00:00:00Z' },
+    ],
+  },
+};

--- a/src/stories/02-molecules/dashboard/DashboardContinueCard.stories.tsx
+++ b/src/stories/02-molecules/dashboard/DashboardContinueCard.stories.tsx
@@ -1,0 +1,29 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { DashboardContinueCard } from '@/components/Dashboard/DashboardContinueCard';
+import { mockWorldA, mockCharacterA } from '@/components/Dashboard/DashboardHome.stories.helpers';
+
+const meta: Meta<typeof DashboardContinueCard> = {
+  title: '02-Molecules/dashboard/DashboardContinueCard',
+  component: DashboardContinueCard,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof DashboardContinueCard>;
+
+export const Default: Story = {
+  args: {
+    session: {
+      id: 'session-1',
+      worldId: mockWorldA.id,
+      characterId: mockCharacterA.id,
+      lastPlayed: '2025-06-14T18:30:00Z',
+      narrativeCount: 12,
+    },
+    world: mockWorldA,
+    character: mockCharacterA,
+    onContinue: () => {},
+    onDelete: () => {},
+  },
+};

--- a/src/stories/02-molecules/forms/ImageGenerationSection.stories.tsx
+++ b/src/stories/02-molecules/forms/ImageGenerationSection.stories.tsx
@@ -1,0 +1,39 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { ImageGenerationSection } from '@/components/shared/ImageGenerationSection';
+
+const placeholder = (
+  <div
+    className="story-image-placeholder"
+    style={{
+      width: '160px',
+      height: '160px',
+      background: 'var(--color-surface-raised)',
+      border: '1px solid var(--color-border)',
+      borderRadius: 'var(--radius-md, 0.5rem)',
+    }}
+  />
+);
+
+const meta: Meta<typeof ImageGenerationSection> = {
+  title: '02-Molecules/forms/ImageGenerationSection',
+  component: ImageGenerationSection,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  args: {
+    title: 'Portrait',
+    description: 'Generate a portrait for your character.',
+    isGenerating: false,
+    onGenerate: () => {},
+    onRemove: () => {},
+    imageComponent: placeholder,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ImageGenerationSection>;
+
+export const Idle: Story = {};
+export const Generating: Story = { args: { isGenerating: true } };
+export const WithError: Story = {
+  args: { error: 'Generation failed. Check your provider key and try again.' },
+};

--- a/src/stories/02-molecules/forms/PortraitCustomizationSection.stories.tsx
+++ b/src/stories/02-molecules/forms/PortraitCustomizationSection.stories.tsx
@@ -1,0 +1,24 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { PortraitCustomizationSection } from '@/components/shared/PortraitCustomizationSection';
+
+const meta: Meta<typeof PortraitCustomizationSection> = {
+  title: '02-Molecules/forms/PortraitCustomizationSection',
+  component: PortraitCustomizationSection,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  args: {
+    physicalDescription: 'Silver hair, storm-grey eyes, a scar across the left temple.',
+    setPhysicalDescription: () => {},
+    environmentHint: 'A rain-soaked harbour at dusk.',
+    setEnvironmentHint: () => {},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PortraitCustomizationSection>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+  args: { physicalDescription: '', environmentHint: '' },
+};

--- a/src/stories/02-molecules/layout/SectionWrapper.stories.tsx
+++ b/src/stories/02-molecules/layout/SectionWrapper.stories.tsx
@@ -1,0 +1,19 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { SectionWrapper } from '@/components/shared/SectionWrapper';
+
+const meta: Meta<typeof SectionWrapper> = {
+  title: '02-Molecules/layout/SectionWrapper',
+  component: SectionWrapper,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof SectionWrapper>;
+
+export const Default: Story = {
+  args: {
+    title: 'Attributes',
+    children: <p>Strength, Intelligence, Charisma…</p>,
+  },
+};

--- a/src/stories/02-molecules/narrative/RequirementBadges.stories.tsx
+++ b/src/stories/02-molecules/narrative/RequirementBadges.stories.tsx
@@ -1,0 +1,35 @@
+import { Meta, StoryObj } from '@storybook/react';
+import {
+  AlignmentBadge,
+  SkillRequirementBadges,
+} from '@/components/shared/ChoiceSelector/RequirementBadges';
+
+const meta: Meta = {
+  title: '02-Molecules/narrative/RequirementBadges',
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Alignments: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 'var(--spacing-2, 0.5rem)' }}>
+      <AlignmentBadge alignment="lawful" />
+      <AlignmentBadge alignment="chaotic" />
+    </div>
+  ),
+};
+
+export const SkillRequirements: Story = {
+  render: () => (
+    <SkillRequirementBadges
+      optionId="opt-1"
+      requirements={[
+        { skillName: 'Persuasion', met: true, dc: 12 },
+        { skillName: 'Stealth', met: false, dc: 16 },
+      ]}
+    />
+  ),
+};

--- a/src/stories/02-molecules/ui-components/ExportImportControls.stories.tsx
+++ b/src/stories/02-molecules/ui-components/ExportImportControls.stories.tsx
@@ -1,0 +1,22 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { ExportImportControls } from '@/components/shared/ExportImportControls';
+
+const meta: Meta<typeof ExportImportControls> = {
+  title: '02-Molecules/ui-components/ExportImportControls',
+  component: ExportImportControls,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Export/import controls for game state. The buttons are wired to the storage service; rendered here for visual review.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ExportImportControls>;
+
+export const Default: Story = {};

--- a/src/stories/02-molecules/ui-components/NotFoundState.stories.tsx
+++ b/src/stories/02-molecules/ui-components/NotFoundState.stories.tsx
@@ -1,0 +1,21 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { NotFoundState } from '@/components/shared/NotFoundState';
+
+const meta: Meta<typeof NotFoundState> = {
+  title: '02-Molecules/ui-components/NotFoundState',
+  component: NotFoundState,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof NotFoundState>;
+
+export const Default: Story = {
+  args: {
+    title: 'World not found',
+    message: "We couldn't find the world you were looking for. It may have been deleted.",
+    backUrl: '/worlds',
+    backLabel: 'Back to worlds',
+  },
+};

--- a/src/stories/02-molecules/ui-components/PreviewModal.stories.tsx
+++ b/src/stories/02-molecules/ui-components/PreviewModal.stories.tsx
@@ -1,0 +1,33 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { PreviewModal } from '@/components/shared/PreviewModal/PreviewModal';
+
+const meta: Meta<typeof PreviewModal> = {
+  title: '02-Molecules/ui-components/PreviewModal',
+  component: PreviewModal,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof PreviewModal>;
+
+const world = { name: 'The Shattered Isles', genre: 'Fantasy' };
+
+export const Default: Story = {
+  render: () => (
+    <PreviewModal<typeof world>
+      isOpen
+      data={world}
+      title="Preview world"
+      subtitle="Review before you commit"
+      onConfirm={() => {}}
+      onCancel={() => {}}
+      renderContent={(d) => (
+        <div className="story-preview-content">
+          <h3>{d.name}</h3>
+          <p>{d.genre}</p>
+        </div>
+      )}
+    />
+  ),
+};

--- a/src/stories/02-molecules/ui-components/SimpleModal.stories.tsx
+++ b/src/stories/02-molecules/ui-components/SimpleModal.stories.tsx
@@ -1,0 +1,33 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { SimpleModal } from '@/components/shared/SimpleModal';
+import { Button } from '@/components/ui/button';
+
+const meta: Meta<typeof SimpleModal> = {
+  title: '02-Molecules/ui-components/SimpleModal',
+  component: SimpleModal,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  args: { isOpen: true, onClose: () => {}, title: 'Confirm' },
+};
+
+export default meta;
+type Story = StoryObj<typeof SimpleModal>;
+
+export const Default: Story = {
+  args: {
+    children: <p>Are you sure you want to start a new story?</p>,
+  },
+};
+
+export const WithFooter: Story = {
+  args: {
+    title: 'Start over?',
+    children: <p>Your current progress will be saved before you begin.</p>,
+    footer: (
+      <>
+        <Button variant="secondary">Cancel</Button>
+        <Button>Start</Button>
+      </>
+    ),
+  },
+};

--- a/src/stories/02-molecules/wizard/FormComponents.stories.tsx
+++ b/src/stories/02-molecules/wizard/FormComponents.stories.tsx
@@ -1,0 +1,47 @@
+import { Meta, StoryObj } from '@storybook/react';
+import {
+  WizardFormSection,
+  WizardFormGroup,
+  WizardTextField,
+  WizardTextArea,
+  WizardSelect,
+} from '@/components/shared/wizard/components/FormComponents';
+
+const meta: Meta = {
+  title: '02-Molecules/wizard/FormComponents',
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj;
+
+const genres = [
+  { value: 'fantasy', label: 'Fantasy' },
+  { value: 'sci-fi', label: 'Sci-Fi' },
+  { value: 'noir', label: 'Noir' },
+];
+
+export const FullForm: Story = {
+  render: () => (
+    <WizardFormSection title="World basics" description="The essentials before we generate.">
+      <WizardFormGroup label="Name" required>
+        <WizardTextField value="The Shattered Isles" onChange={() => {}} />
+      </WizardFormGroup>
+      <WizardFormGroup label="Genre" required>
+        <WizardSelect value="fantasy" onChange={() => {}} options={genres} />
+      </WizardFormGroup>
+      <WizardFormGroup label="Description" helpText="A sentence or two sets the tone.">
+        <WizardTextArea value="A storm-ravaged archipelago where ancient magic stirs." onChange={() => {}} />
+      </WizardFormGroup>
+    </WizardFormSection>
+  ),
+};
+
+export const WithError: Story = {
+  render: () => (
+    <WizardFormGroup label="Name" required error="A name is required.">
+      <WizardTextField value="" onChange={() => {}} error="A name is required." />
+    </WizardFormGroup>
+  ),
+};

--- a/src/stories/02-molecules/wizard/WizardContainer.stories.tsx
+++ b/src/stories/02-molecules/wizard/WizardContainer.stories.tsx
@@ -1,0 +1,19 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { WizardContainer } from '@/components/shared/wizard/WizardContainer';
+
+const meta: Meta<typeof WizardContainer> = {
+  title: '02-Molecules/wizard/WizardContainer',
+  component: WizardContainer,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof WizardContainer>;
+
+export const Default: Story = {
+  args: {
+    title: 'Create a World',
+    children: <p>Step content goes here.</p>,
+  },
+};

--- a/src/stories/02-molecules/wizard/WizardNavigation.stories.tsx
+++ b/src/stories/02-molecules/wizard/WizardNavigation.stories.tsx
@@ -1,0 +1,25 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { WizardNavigation } from '@/components/shared/wizard/WizardNavigation';
+
+const meta: Meta<typeof WizardNavigation> = {
+  title: '02-Molecules/wizard/WizardNavigation',
+  component: WizardNavigation,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  args: {
+    onCancel: () => {},
+    onBack: () => {},
+    onNext: () => {},
+    totalSteps: 4,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof WizardNavigation>;
+
+export const FirstStep: Story = { args: { currentStep: 0 } };
+export const MiddleStep: Story = { args: { currentStep: 1 } };
+export const LastStep: Story = {
+  args: { currentStep: 3, onComplete: () => {}, onNext: undefined },
+};
+export const Loading: Story = { args: { currentStep: 1, isLoading: true } };

--- a/src/stories/02-molecules/wizard/WizardProgress.stories.tsx
+++ b/src/stories/02-molecules/wizard/WizardProgress.stories.tsx
@@ -1,0 +1,25 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { WizardProgress } from '@/components/shared/wizard/WizardProgress';
+
+const steps = [
+  { id: 'basics', label: 'Basics' },
+  { id: 'attributes', label: 'Attributes' },
+  { id: 'skills', label: 'Skills' },
+  { id: 'review', label: 'Review' },
+];
+
+const meta: Meta<typeof WizardProgress> = {
+  title: '02-Molecules/wizard/WizardProgress',
+  component: WizardProgress,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  args: { steps },
+  argTypes: { currentStep: { control: { type: 'range', min: 0, max: 3 } } },
+};
+
+export default meta;
+type Story = StoryObj<typeof WizardProgress>;
+
+export const FirstStep: Story = { args: { currentStep: 0 } };
+export const MidWay: Story = { args: { currentStep: 2 } };
+export const LastStep: Story = { args: { currentStep: 3 } };

--- a/src/stories/02-molecules/wizard/WizardStep.stories.tsx
+++ b/src/stories/02-molecules/wizard/WizardStep.stories.tsx
@@ -1,0 +1,23 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { WizardStep } from '@/components/shared/wizard/WizardStep';
+
+const meta: Meta<typeof WizardStep> = {
+  title: '02-Molecules/wizard/WizardStep',
+  component: WizardStep,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof WizardStep>;
+
+export const Default: Story = {
+  args: { children: <p>Tell us about your world.</p> },
+};
+
+export const WithError: Story = {
+  args: {
+    children: <p>Tell us about your world.</p>,
+    error: 'Please give your world a name before continuing.',
+  },
+};

--- a/src/stories/02-molecules/world-forms/ToneSettingsDisplay.stories.tsx
+++ b/src/stories/02-molecules/world-forms/ToneSettingsDisplay.stories.tsx
@@ -1,0 +1,22 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { ToneSettingsDisplay } from '@/components/world/ToneSettingsDisplay';
+
+const meta: Meta<typeof ToneSettingsDisplay> = {
+  title: '02-Molecules/world-forms/ToneSettingsDisplay',
+  component: ToneSettingsDisplay,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ToneSettingsDisplay>;
+
+export const Default: Story = {
+  args: {
+    toneSettings: {
+      contentRating: 'PG-13',
+      narrativeStyle: 'balanced',
+      languageComplexity: 'moderate',
+    },
+  },
+};

--- a/src/stories/02-molecules/world-forms/WorldFormFields.stories.tsx
+++ b/src/stories/02-molecules/world-forms/WorldFormFields.stories.tsx
@@ -1,0 +1,32 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { WorldFormFields } from '@/components/shared/WorldFormFields/WorldFormFields';
+
+const meta: Meta = {
+  title: '02-Molecules/world-forms/WorldFormFields',
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Fields: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 'var(--spacing-4, 1rem)', maxWidth: '480px' }}>
+      <WorldFormFields.NameInput value="The Shattered Isles" onChange={() => {}} />
+      <WorldFormFields.GenreSelect value="fantasy" onChange={() => {}} />
+      <WorldFormFields.DescriptionTextArea
+        value="A storm-ravaged archipelago where ancient magic stirs beneath volcanic rock."
+        onChange={() => {}}
+      />
+    </div>
+  ),
+};
+
+export const WithError: Story = {
+  render: () => (
+    <div style={{ maxWidth: '480px' }}>
+      <WorldFormFields.NameInput value="" onChange={() => {}} error="A name is required." />
+    </div>
+  ),
+};

--- a/src/stories/02-molecules/world-forms/WorldImageDisplay.stories.tsx
+++ b/src/stories/02-molecules/world-forms/WorldImageDisplay.stories.tsx
@@ -1,0 +1,23 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { WorldImageDisplay } from '@/components/world/WorldImageDisplay';
+
+const meta: Meta<typeof WorldImageDisplay> = {
+  title: '02-Molecules/world-forms/WorldImageDisplay',
+  component: WorldImageDisplay,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof WorldImageDisplay>;
+
+export const Default: Story = {
+  args: {
+    image: {
+      type: 'ai-generated',
+      url: '/visual-assets/world-cyberpunk.png',
+      generatedAt: '2025-01-01T00:00:00Z',
+      prompt: 'A sweeping fantasy landscape under a storm-lit sky.',
+    },
+  },
+};


### PR DESCRIPTION
## Description

Phase 3 of the Storybook-as-canon epic (#1484): backfill stories for the 27 in-scope components that Phase 2 (#1486) grandfathered into `storybookGaps`, shrinking that list to **zero**.

Stories added for:
- nested `ui/` primitives — `dialog`, `table`
- the `shared/` presentational layer — modals (`SimpleModal`, `PreviewModal`), wizard pieces (`WizardContainer/Step/Progress/Navigation`, `FormComponents`, `ToggleButton`), form fields (`WorldFormFields`, `PortraitCustomizationSection`, `ImageGenerationSection`), and layout/feedback bits (`SectionWrapper`, `ErrorBlock`, `DataField`, `ActiveStateIndicator`, `SkipLinks`, `BackNavigation`, `NotFoundState`, `ExportImportControls`, `RequirementBadges`)
- allowlisted domain components — `CharacterDerivedStatsDisplay`, `DashboardContinueCard`, `ProviderCard`, `ToneSettingsDisplay`, `WorldImageDisplay`

`storybookGaps` is now `[]`. The broadened guard enforces it stays that way — any new in-scope component without a story fails CI.

## Related Issue
Part of #1484. (Targets `develop`, won't auto-close.)
Closes #1487

## Type of Change
- [x] New feature (Storybook coverage)
- [x] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation — N/A per house style: stories are MVP visual coverage, no new unit tests. The canon guard (verified green with 0 gaps) is the enforcement.
- [x] All tests pass locally

## User Stories Addressed
#1487 — backfill stories to shrink the baseline to zero.

## Component Development
- [x] Storybook stories created/updated — 27 new stories.
- [x] Components developed in isolation first
- [x] Visual consistency verified — `npm run build-storybook` green; theming/router already mocked in preview.tsx.

## Implementation Notes
- MVP stories: variant/state matrices, not exhaustive. No product code changed.
- All 27 render backend-free off the Phase 1 infra — none needed live stores. Router-dependent ones (`NotFoundState`, `BackNavigation`) work via the existing `nextjs.navigation` mock in `preview.tsx`.
- `DashboardContinueCard` reuses the existing `mockWorldA`/`mockCharacterA` fixtures.

## Quality Checks
- [x] Linting passed; `npm run lint:ds-canon` green (73 in-scope, 0 storybook gaps)
- [x] Type checking passed
- [x] knip passed; `npm run build-storybook` green

## Testing Instructions
1. `npm run lint:ds-canon` → "0 grandfathered storybook gap(s)".
2. `npm run storybook` → the new stories render under 01-Atoms / 02-Molecules across DS1/2/3 + light/dark.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected
- [x] Self-review of code performed
- [x] No new warnings generated
- [x] Accessibility considerations addressed — `SkipLinks` story documents the focus-to-reveal behavior; a11y addon unaffected.
