### PR TITLE
chore(impeccable): initialize project context (PRODUCT.md + live config)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,9 @@ build-output.log
 
 \n# Local tool logs\n.bdg/
 characters-debug.png
+
+# impeccable (design tool): keep local state out of git, share only the live config
+.impeccable/*
+!.impeccable/live/
+.impeccable/live/*
+!.impeccable/live/config.json

--- a/.impeccable/live/config.json
+++ b/.impeccable/live/config.json
@@ -1,0 +1,6 @@
+{
+  "files": ["src/app/layout.tsx"],
+  "insertBefore": "</body>",
+  "commentSyntax": "jsx",
+  "cspChecked": true
+}

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,55 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Solo players and storytellers running a single-player, browser-based narrative RPG. They
+bring their own AI provider key (BYO-key); all data lives locally (IndexedDB). The draw, in
+the README's words: tabletop-style RPG experiences "without coordinating schedules or finding
+a game master." Context: building a world, creating characters, then reading prose and making
+choices over long sessions.
+
+## Product Purpose
+
+Narraitor is a world-adaptive AI storytelling app. You define a fictional world's rules,
+attributes, and tone; create characters that fit it; and play a generated, choice-driven
+story with tracked consequences, inventory, and a journal. The story adapts to your world's
+voice rather than defaulting to generic fantasy. No backend database; generation runs through
+the player's own key. Success is an immersive, coherent, replayable story loop that stays out
+of its own way. Currently in v1.0 polish + launch-gate phase.
+
+## Brand Personality
+
+Archival and literary. The interface borrows from drafting tables, manuscripts, and design
+notebooks — surfaces that imply care and craft. It should read like writing tools, not
+entertainment software: immersive, unobtrusive, calm typographic restraint, with the
+generated story (not the UI, and never the AI) as the hero. The AI is never named or themed
+in player-facing copy.
+
+## Anti-references
+
+- "Game UI" sheen, neon, glassmorphism — the app is deliberately not entertainment software.
+- Flashy AI-gimmick products — robot/chatbot aesthetics, "powered by AI" badges, sparkle
+  icons. Narraitor keeps "AI" out of UI strings entirely.
+- Sterile corporate SaaS dashboards — gray-on-gray enterprise chrome, soulless admin panels.
+
+## Design Principles
+
+- Reading first — long-form narrative is the load-bearing surface; line length, rhythm, and
+  legibility win over everything else.
+- Three systems, one soul — DS1/DS2/DS3 differ structurally (ADR-011), never just reskinned;
+  tokens carry the variation, components stay theme-blind.
+- Storybook is canon — when production drifts from Storybook, production is wrong (ADR-012).
+- No seams showing — never surface the generation machinery in player-facing copy.
+- Earn density — show consequence / state / inventory affordances only when there's data
+  behind them.
+
+## Accessibility & Inclusion
+
+WCAG 2.1 AA. 4.5:1 minimum text contrast, verified in light and dark across all three design
+systems (the open #1379 release gate is an AA contrast miss). Visible focus indicators in
+every theme; no color-only signaling; full keyboard operation; text resizes to 200% without
+breaking; touch targets at least 44px (#1477); honor reduced-motion.

--- a/next.config.ts
+++ b/next.config.ts
@@ -20,8 +20,11 @@ const isDev = process.env.NODE_ENV !== 'production';
 //   with eval(); production (next build) never uses eval.
 // - va.vercel-scripts.com: Vercel Analytics loads its debug script from this
 //   origin in dev; in production it is served same-origin (/_vercel/insights).
+// Dev-only allowance so impeccable live mode (http://localhost:8400) can load.
+// Guarded by NODE_ENV; never present in production builds.
+const impeccableLiveDev = isDev ? ['http://localhost:8400'] : [];
 const devScriptSrc = isDev ? ["'unsafe-eval'", 'https://va.vercel-scripts.com'] : [];
-const scriptSrc = ["'self'", "'unsafe-inline'", ...devScriptSrc].join(' ');
+const scriptSrc = ["'self'", "'unsafe-inline'", ...devScriptSrc, ...impeccableLiveDev].join(' ');
 
 const contentSecurityPolicy = [
   "default-src 'self'",
@@ -29,7 +32,7 @@ const contentSecurityPolicy = [
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
   "font-src 'self' https://fonts.gstatic.com",
   "img-src 'self' data: blob: https://picsum.photos https://i.pravatar.cc https://api.dicebear.com",
-  "connect-src 'self' https://vitals.vercel-insights.com",
+  `connect-src ${["'self'", 'https://vitals.vercel-insights.com', ...impeccableLiveDev].join(' ')}`,
   "frame-ancestors 'none'",
   "base-uri 'self'",
   "form-action 'self'",


### PR DESCRIPTION
## Description

Runs the impeccable (impeccable.style) init step the project skipped. The repo already had a well-formed `DESIGN.md`, but no `PRODUCT.md` — so impeccable's `context.mjs` reported `NO_PRODUCT_MD` and every critique/audit ran with no strategic priming (which is why its deterministic detector kept false-flagging the deliberate DS1 status side-stripes from ADR-011). This writes the missing strategic half and pre-configures live mode.

- **`PRODUCT.md`** — register `product`, sourced from the repo's own docs: `DESIGN.md` for the brand ("archival + literary... writing tools, not entertainment software"), `README.md` + `public_docs/project-overview.md` for users/purpose, `public_docs/development/ui-ux-guidelines.md` for the a11y bar (WCAG 2.1 AA, 4.5:1, 200% zoom). Encodes the current user-chosen-theme stance; the README's "genre auto-skin" idea is parked as post-1.0 since `DESIGN.md` bans per-world theming today.
- **`.impeccable/live/config.json`** — live-mode config for the Next.js App Router (`src/app/layout.tsx`).
- **`next.config.ts`** — dev-only CSP allowance so impeccable's live picker (`http://localhost:8400`) can load. Guarded by the file's existing `isDev` flag, so it only appears in development and never ships to production.
- **`.gitignore`** — keep impeccable's local state (`hook.cache.json`, future `critique/`, `live/sessions/`) out of git; track only the shared `live/config.json`.

## Related Issue

N/A — no tracked issue. This is the missing impeccable initialization itself.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [ ] Test addition or improvement

Primarily project-context docs (`PRODUCT.md`) plus tooling config. The one code touch is a dev-only build-config allowance in `next.config.ts`.

## TDD Compliance

N/A — no application logic changed. The `next.config.ts` change is a dev-only build-config allowance, verified by replicating its CSP-construction logic (see Testing Instructions) rather than a unit test.

## User Stories Addressed

N/A.

## Flow Diagrams

N/A.

## Component Development

N/A — no UI components.
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes

The CSP patch follows the file's own pattern: `next.config.ts` already builds `script-src` from an `isDev`-guarded array, so the live-mode origin is appended the same way, and `connect-src` becomes a template literal carrying the same dev-only spread. Nothing about the production policy changes.

`PRODUCT.md` is intentionally strategic, not visual — register, users, purpose, personality, anti-references, design principles, accessibility. Visual specifics stay in `DESIGN.md`.

## Screenshots

N/A — no visual change.

## Quality Checks
- [x] Linting passed (`eslint next.config.ts` clean)
- [x] Type checking passed (`tsc --noEmit` clean)
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Note: `type-check` initially surfaced 15 stale `.next/types/` errors referencing the retired `/dev/design-system*` routes (#1488) — a stale local build cache, not this change. Clearing `.next` and re-running returns clean. CI builds `.next` fresh, so it's unaffected.

## Testing Instructions

1. From the repo root: `node ~/.claude/plugins/cache/impeccable/impeccable/3.6.0/skills/impeccable/scripts/context.mjs` — prints the `PRODUCT.md` (+ `DESIGN.md`) block instead of `NO_PRODUCT_MD`.
2. CSP is dev-only: with `NODE_ENV=development` the policy's `script-src` and `connect-src` include `http://localhost:8400`; with `NODE_ENV=production` they don't.
3. `npm run type-check` and `npx eslint next.config.ts` pass.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed

(`PRODUCT.md` records the project's accessibility bar; no UI behavior changes here.)
