### PR TITLE
feat(dashboard): distill the Continue Your Game card

### DIFF
--- a/src/app/dashboard.css
+++ b/src/app/dashboard.css
@@ -174,25 +174,11 @@
   text-overflow: ellipsis;
 }
 
-/* Progress + last-played as one consistent muted meta line. */
+/* Last-played timestamp as a single muted meta line. */
 .dashboard-continue-card-meta {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: var(--space-1) var(--space-3);
   margin: 0;
   font-family: var(--font-system);
   font-size: 0.75rem;
-  color: var(--color-text-muted);
-}
-
-.dashboard-continue-card-progress {
-  font-weight: 600;
-  color: var(--color-text-secondary);
-}
-
-.dashboard-continue-card-meta time {
-  font-family: var(--font-system);
   color: var(--color-text-muted);
 }
 
@@ -210,7 +196,7 @@
   }
 
   .dashboard-continue-card-meta {
-    justify-content: center;
+    text-align: center;
   }
 }
 

--- a/src/components/Dashboard/DashboardContinueCard.tsx
+++ b/src/components/Dashboard/DashboardContinueCard.tsx
@@ -84,9 +84,6 @@ export function DashboardContinueCard({
             </dl>
 
             <p className="dashboard-continue-card-meta">
-              <span className="dashboard-continue-card-progress">
-                {session.narrativeCount} entries
-              </span>
               <time dateTime={session.lastPlayed}>
                 Last played {lastPlayedText}
               </time>
@@ -106,7 +103,7 @@ export function DashboardContinueCard({
             {
               label: 'Delete',
               onClick: () => setIsDeleteDialogOpen(true),
-              variant: 'danger',
+              variant: 'ghost',
             },
           ]}
         />

--- a/src/components/Dashboard/__tests__/DashboardContinueCard.test.tsx
+++ b/src/components/Dashboard/__tests__/DashboardContinueCard.test.tsx
@@ -66,7 +66,6 @@ describe('DashboardContinueCard', () => {
 
     expect(screen.getByText('Fantasy Realm')).toBeInTheDocument();
     expect(screen.getByText('Aragorn')).toBeInTheDocument();
-    expect(screen.getByText(/15.*entries/i)).toBeInTheDocument();
   });
 
   it('calls onContinue when continue button clicked', async () => {

--- a/src/components/Dashboard/__tests__/DashboardHome.test.tsx
+++ b/src/components/Dashboard/__tests__/DashboardHome.test.tsx
@@ -165,8 +165,10 @@ describe('DashboardHome', () => {
     it('shows progress card with session metrics', () => {
       render(<DashboardHome />);
 
-      // Should show metrics including session count
-      expect(screen.getByText(/15.*entries/i)).toBeInTheDocument();
+      // The entries count is surfaced by the progress card's labeled stat,
+      // not the continue card.
+      const entriesStat = screen.getByText('Entries').closest('.dashboard-progress-stat');
+      expect(entriesStat).toHaveTextContent('15');
     });
 
     it('shows recent worlds for quick access', () => {


### PR DESCRIPTION
## Description

An `/impeccable distill` pass on the dashboard's "Continue Your Game" card. The card's one job is getting a returning player back into their game, and a few things were competing with that:

- **Dropped "N entries" from the meta line.** For someone coming back, the entry count isn't a number they act on -- the "Last played" timestamp is the useful signal. The same count still lives in the progress card as a labeled stat, so nothing's actually lost from the dashboard.
- **Demoted Delete from `danger` to `ghost`.** It was sitting at co-equal visual weight with "Continue Last Game" and pulling the eye for no reason. Still right there, still works, still guarded by the confirmation dialog -- just no longer shouting in red next to the primary action.
- **Simplified the meta CSS.** The `.dashboard-continue-card-meta` line was flex-wrapped to lay out two items; now it wraps a single `<time>`, so the flex/gap/align machinery and the dead `.dashboard-continue-card-progress` rule came out with the span.

## Related Issue

N/A -- not tied to a tracked issue; came out of an impeccable distill pass on the dashboard.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

<!-- Note: functionally unchanged (continue + delete both still work); the visible changes are intentional UX de-noising, described above. The template has no "visual/UX polish" bucket, so this is the closest honest mapping. -->

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

This wasn't a TDD feature -- it's a refinement, so tests were updated to match the refined intent rather than driving it. The `DashboardContinueCard` suite already covered the card; the one assertion that pinned the removed "15 entries" string was dropped there and **repointed** (not deleted) in `DashboardHome` -- see Implementation Notes.

## User Stories Addressed

As a returning player, I want the Continue card to point me straight at resuming my game, without a stat I don't act on or a destructive button competing with the primary action.

## Flow Diagrams

N/A.

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

No story changes -- the existing `DashboardContinueCard` rendering reflects the change automatically. Visual consistency was verified against the test-rendered DOM (confirmed `button button-ghost` on Delete and a single-child `<time>` meta), not a live multi-theme browser pass. A quick live spot-check across the three design systems x dark/light is a reasonable follow-up before release, but this change (remove a span, swap a button variant, drop flex props) is low-risk across themes.

## Implementation Notes

The interesting part was a hidden test coupling. `DashboardHome.test.tsx` has a test named *"shows progress card with session metrics"* whose assertion was `getByText(/15.*entries/i)`. That regex was actually matching the **continue card's** combined `"15 entries"` text node -- not the progress card it claims to test. The progress card shows the same metric, but split across `<span>15</span>` and `<p>Entries</p>`, so the regex never matched there.

Remove the continue-card span and that assertion silently loses its only match. So I repointed it at the progress card's `Entries` stat tile (`getByText('Entries').closest('.dashboard-progress-stat')` -> `toHaveTextContent('15')`) -- same fact, correct surface, not weakened. The test now verifies what its name says it does.

## Screenshots

Not captured (no live multi-theme run this pass). Before/after is described above: meta line loses the leading "15 entries", Delete renders as a quiet ghost button instead of red.

## Code Review Summary (if applicable)

N/A.

## Chrome DevTools MCP Verification Summary (if applicable)

N/A.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed <!-- N/A -- no security-relevant surface in this change -->
- [x] No console.log statements in production code
- [x] No unhandled promises

Full local gate: `npm test -- Dashboard` (39/39 across 6 suites), `npm run type-check`, `npm run lint`, `npm run lint:css` -- all green.

## Testing Instructions

1. From a dashboard state with a saved session, look at the "Continue Your Game" card.
2. Confirm the meta line reads just "Last played ..." (no "N entries" in front).
3. Confirm Delete renders as a low-emphasis ghost button next to the green "Continue Last Game", and that clicking it still opens the delete-confirmation dialog.
4. Confirm the progress card still shows the Entries stat (the count just lives there now, not on the card).
5. `npm test -- Dashboard`, `npm run type-check`, `npm run lint`, `npm run lint:css`.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) <!-- N/A -->
- [x] No new warnings generated <!-- the DialogContent aria-describedby warning is pre-existing, unrelated to this change -->
- [x] Accessibility considerations addressed
