### PR TITLE
fix(play): style play-entry empty/error states and give them a way back (#1479)

### DIFF
--- a/src/components/GameSession/GameSession.tsx
+++ b/src/components/GameSession/GameSession.tsx
@@ -13,6 +13,8 @@ import ActiveGameSession from './ActiveGameSession';
 import GameSessionResume from './GameSessionResume';
 import { ErrorDisplay } from '@/components/ui/ErrorDisplay';
 import { Button } from '@/components/ui/button';
+import { EmptyState } from '@/components/ui/EmptyState/EmptyState';
+import { Users, BookOpen } from 'lucide-react';
 
 interface GameSessionProps {
   worldId: string;
@@ -270,17 +272,19 @@ const GameSession: React.FC<GameSessionProps> = ({
   // Client-side only checks from here on
   if (!worldExists) {
     return (
-      <div data-testid="game-session-error-container">
+      <div className="manuscript-play-entry" data-testid="game-session-error-container">
         <ErrorDisplay
           variant="section"
           title="World Not Found"
           message="The world you're trying to access doesn't exist or has been deleted."
           severity="error"
-          showRetry
-          onRetry={handleRetry}
-          showDismiss
-          onDismiss={handleDismissError}
         />
+        <Button
+          variant="default"
+          onClick={() => router?.push('/worlds')}
+        >
+          Back to Worlds
+        </Button>
       </div>
     );
   }
@@ -305,40 +309,60 @@ const GameSession: React.FC<GameSessionProps> = ({
     // Check if there are any characters for this world
     if (worldCharacters.length === 0) {
       return (
-        <div data-testid="game-session-no-characters" >
-          <div>
-            <h2>No Characters Found</h2>
-            <p>
-              You need to create a character before you can start playing in this world.
-            </p>
-            <Button
-              variant="default"
-              onClick={() => router?.push(`/characters/create?worldId=${worldId}`)}
-            >
-              Create Character
-            </Button>
-          </div>
+        <div className="manuscript-play-entry" data-testid="game-session-no-characters">
+          <EmptyState
+            icon={<Users aria-hidden="true" />}
+            title="No Characters Found"
+            description="You'll need a character before you can start playing in this world."
+            action={
+              <>
+                <Button
+                  variant="default"
+                  onClick={() => router?.push(`/characters/create?worldId=${worldId}`)}
+                >
+                  Create Character
+                </Button>
+                <Button
+                  variant="secondary"
+                  onClick={() => router?.push('/worlds')}
+                >
+                  Back to Worlds
+                </Button>
+              </>
+            }
+          />
         </div>
       );
     }
     
     return (
-      <div data-testid="game-session-initializing" >
-        <div>
-          <h2>Session Not Started</h2>
-          <p>No active game session.</p>
-          {process.env.NODE_ENV === 'development' && (
-            <div>
-              Debug: Session ID: {sessionState.id || 'none'}, Status: {sessionState.status}
-            </div>
-          )}
-          <Button
-            variant="default"
-            onClick={startSession}
-          >
-            Start Session
-          </Button>
-        </div>
+      <div className="manuscript-play-entry" data-testid="game-session-initializing">
+        <EmptyState
+          icon={<BookOpen aria-hidden="true" />}
+          title="Session Not Started"
+          description="No active game session yet."
+          action={
+            <>
+              <Button
+                variant="default"
+                onClick={startSession}
+              >
+                Start Session
+              </Button>
+              <Button
+                variant="secondary"
+                onClick={() => router?.push('/worlds')}
+              >
+                Back to Worlds
+              </Button>
+            </>
+          }
+        />
+        {process.env.NODE_ENV === 'development' && (
+          <div className="manuscript-play-entry-debug">
+            Debug: Session ID: {sessionState.id || 'none'}, Status: {sessionState.status}
+          </div>
+        )}
       </div>
     );
   }
@@ -351,11 +375,19 @@ const GameSession: React.FC<GameSessionProps> = ({
   
   if (error || sessionState.error) {
     return (
-      <GameSessionError 
-        error={(error?.message || sessionState.error || 'Unknown error')}
-        onRetry={handleRetry}
-        onDismiss={handleDismissError}
-      />
+      <div className="manuscript-play-entry">
+        <GameSessionError
+          error={(error?.message || sessionState.error || 'Unknown error')}
+          onRetry={handleRetry}
+          onDismiss={handleDismissError}
+        />
+        <Button
+          variant="ghost"
+          onClick={() => router?.push('/worlds')}
+        >
+          Back to Worlds
+        </Button>
+      </div>
     );
   }
   

--- a/src/components/GameSession/__tests__/GameSession.test.tsx
+++ b/src/components/GameSession/__tests__/GameSession.test.tsx
@@ -134,6 +134,9 @@ describe('GameSession', () => {
       renderGameSession({ worldId: 'world-does-not-exist' });
       expect(screen.getByTestId('game-session-error-container')).toBeInTheDocument();
       expect(screen.getByText(/World Not Found/i)).toBeInTheDocument();
+      // #1479: every play-entry early-exit state offers a way back to navigation
+      // rather than stranding the player on the chrome-free manuscript surface.
+      expect(screen.getByRole('button', { name: /back to worlds/i })).toBeInTheDocument();
     });
 
     it('shows the no-characters CTA when initializing with no characters for the world', () => {
@@ -152,6 +155,8 @@ describe('GameSession', () => {
       renderGameSession();
       expect(screen.getByTestId('game-session-no-characters')).toBeInTheDocument();
       expect(screen.getByText(/No Characters Found/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /create character/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /back to worlds/i })).toBeInTheDocument();
 
       // Restore default character store for following tests.
       (require('@/state/characterStore').useCharacterStore as jest.Mock).mockReturnValue(characterStore);
@@ -161,7 +166,8 @@ describe('GameSession', () => {
       sessionStore = createMockSessionStore({ status: 'initializing' });
       renderGameSession();
       expect(screen.getByTestId('game-session-initializing')).toBeInTheDocument();
-      expect(screen.getByText(/Start Session/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /start session/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /back to worlds/i })).toBeInTheDocument();
     });
 
     it('shows the resume prompt when a saved session is present and no session has started', () => {

--- a/src/components/ui/EmptyState/EmptyState.css
+++ b/src/components/ui/EmptyState/EmptyState.css
@@ -1,0 +1,61 @@
+/* EmptyState — global semantic styles for src/components/ui/EmptyState/EmptyState.tsx (#1479)
+ *
+ * The canonical empty-state primitive (Journal, Inventory, the play-entry branches,
+ * the characters list) shipped the `.component-empty-state` class with no styling, so
+ * each empty state rendered as bare top-left text. This gives the shared component one
+ * token-based treatment — centered, comfortable measure, clear hierarchy — so every
+ * empty state reads as finished. Per-theme look comes from the design tokens under the
+ * active `data-theme` scope (ds{1,2,3}.css); no hardcoded colors.
+ */
+
+.component-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-4);
+  max-width: 32rem;
+  margin: 0 auto;
+  padding: var(--space-6) var(--space-4);
+  text-align: center;
+}
+
+.component-empty-state-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-secondary);
+}
+
+.component-empty-state-icon svg {
+  width: 2.5rem;
+  height: 2.5rem;
+}
+
+.component-empty-state-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.component-empty-state-content h3 {
+  margin: 0;
+  font-family: var(--font-interface);
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.component-empty-state-content p {
+  margin: 0;
+  font-family: var(--font-interface);
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+}
+
+.component-empty-state-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  justify-content: center;
+}

--- a/src/components/ui/EmptyState/EmptyState.tsx
+++ b/src/components/ui/EmptyState/EmptyState.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { clsx } from 'clsx';
+import './EmptyState.css';
 
 export interface EmptyStateProps {
   title: string;
@@ -23,11 +24,11 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
   return (
     <div className={clsx('component-empty-state', className)}>
       {icon && (
-        <div>
+        <div className="component-empty-state-icon">
           {icon}
         </div>
       )}
-      <div>
+      <div className="component-empty-state-content">
         <h3>
           {title}
         </h3>
@@ -38,7 +39,7 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
         )}
       </div>
       {action && (
-        <div>
+        <div className="component-empty-state-actions">
           {action}
         </div>
       )}

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -139,6 +139,26 @@ body.manuscript-overlay-open {
   min-height: 100vh;
 }
 
+/* Play-entry early-exit states (world-not-found, no-characters, session-not-started,
+   generation error). The manuscript surface is deliberately chrome-free for immersion,
+   so these states get their own centered treatment with an explicit way back to
+   navigation, rather than stranding the player on a bare top-left banner (#1479). */
+.manuscript-play-entry {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-4);
+  min-height: 60vh;
+  padding: var(--space-8) var(--space-4);
+}
+
+.manuscript-play-entry-debug {
+  font-family: var(--font-system);
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+}
+
 /* ─── /play route wrapper ───
    `.play-page` wraps every render path of /src/app/play/page.tsx so per-theme
    typography lands on PageLayout's unstyled <header>/<h1>/<p>. DS3 = base;


### PR DESCRIPTION
## Description

The play-entry early-exit states — no-characters, session-not-started, world-not-found, and the generation error — rendered as bare, top-left `<div>`s on the play route's deliberately chrome-free "manuscript" surface. So a player who hit one (say, they open a world before making a character) got raw unstyled text with a big blank void below and no way back to navigation. A dead end.

This routes the empty branches through the shared `EmptyState` component, centers every early-exit state, and gives each one a "Back to Worlds" escape.

The root of the "unstyled" half turned out to be that `EmptyState` itself — the canonical empty-state primitive used by Journal, Inventory, and now play — shipped the `.component-empty-state` class with no CSS behind it. It was canonical by convention, not by appearance. Giving it real token-based styling fixes every empty state in the app at once, not just play.

## Related Issue
Closes #1479

(Targets `develop`, so GitHub won't auto-close on merge — I'll close it manually post-merge.)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Extended the existing GameSession render-branch tests to assert the "Back to Worlds" affordance on each early-exit state (implementation came first here, not test-first — being honest about that).

## User Stories Addressed
Bug fix rather than a user story. Acceptance criteria from #1479:
- Empty branches ("No Characters Found", "Session Not Started", "Unknown state") render through the shared empty-state treatment, not bare divs.
- Play-entry error/empty states render with app chrome or, at minimum, a "Back to Worlds" affordance so they're not dead ends.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

No Storybook changes — this restyles the existing shared `EmptyState` and reuses it. Verified live in the browser instead of in isolation.

## Implementation Notes
- The manuscript surface (`/worlds/[id]/play`) is intentionally full-bleed for immersion — no header or sidebar, via `AppSurfaceShell`'s manuscript mode. So the fix does NOT force `PageLayout`/a sidebar onto it (that'd fight the intended design and churn a pile of visual baselines). Instead each early-exit state gets a centered `.manuscript-play-entry` wrapper and an explicit way back.
- `.component-empty-state` had no CSS anywhere in the repo. Added a co-located `EmptyState.css` (matching the `card.css`/`alert.css` precedent) — token-based, no hardcoded colors.
- World-not-found drops its "Try Again"/"Dismiss" for a single "Back to Worlds": retrying can't conjure a deleted world, so it was a misleading no-op. Called out here since it's a small behavior change beyond pure styling.
- Zero visual-regression impact: every committed visual spec seeds populated data, so none screenshots an empty state (checked before touching the shared component).

## Screenshots
Before: early-exit states rendered as bare top-left text with a blank canvas below and no nav.

After (verified live, DS1):
- World-not-found — centered error card with a "Back to Worlds" button.
- No-characters — centered `EmptyState`: `Users` icon, "No Characters Found", description, "Create Character" + "Back to Worlds".

(Captured during live verification; not committing image files to the repo.)

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
Verified live with the browser preview: navigated to `/worlds/does-not-exist/play` (world-not-found) and seeded a world with no characters (no-characters). Confirmed via the a11y tree that each state exposes its actions and the "Back to Worlds" button, and via computed styles that `.manuscript-play-entry` centers (`display:flex; flex-direction:column; align-items/justify-content:center; min-height:60vh`). No console errors.

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm run dev`, open `/worlds/does-not-exist/play` → world-not-found renders centered with a "Back to Worlds" button (no seeding needed).
2. Seed a world with no characters and open its play route → styled "No Characters Found" `EmptyState` with "Create Character" + "Back to Worlds".
3. `npm test -- src/components/GameSession/__tests__/GameSession.test.tsx` → the render-branch tests assert each early-exit state exposes a Back-to-Worlds affordance.

Full local gate green: type-check, lint, lint:css, lint:layout-usage, lint:ds-canon, knip, deps:validate, skott, 2403 unit tests, production build (+ Storybook), npm audit.

## Checklist
- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

Note on file size: `GameSession.tsx` is 423 lines — it was already over 300 before this PR (net +43 here). Pre-existing overage, flagged rather than introduced; splitting it is out of scope for this fix. Accessibility: icons are `aria-hidden`, "Back to Worlds" is a real `<button>`, and `EmptyState` keeps its heading semantics (`<h3>` title).
