### PR TITLE
fix(characters): route the no-world empty state through EmptyState (#1493)

### DIFF
--- a/src/app/characters/page.tsx
+++ b/src/app/characters/page.tsx
@@ -20,6 +20,8 @@ import { PageLayout } from '@/components/shared/PageLayout';
 import { Hero } from '@/components/shared/Hero';
 import { SSRClientOnly } from '@/components/shared/SSRClientOnly';
 import { ActionButtonGroup } from '@/components/shared/ActionButtonGroup';
+import { EmptyState } from '@/components/ui/EmptyState/EmptyState';
+import { Button } from '@/components/ui/button';
 import { generateUniqueId } from '@/lib/utils/generateId';
 import type { GeneratedCharacterData } from '@/lib/ai/characterGenerator';
 import { World } from '@/types/world.types';
@@ -496,24 +498,18 @@ export default function CharactersPage() {
 
   if (mounted && (!effectiveWorldId || !currentWorld)) {
     return (
-      <PageLayout
-        title="My Characters"
-        description="Choose a world to view your characters."
-      >
-        <div>
-          <Globe aria-hidden="true" />
-          <h2>Choose Your World</h2>
-          <ActionButtonGroup
-            actions={[
-              {
-                label: 'Go to Worlds',
-                onClick: () => router.push('/worlds'),
-                variant: 'primary',
-                size: 'lg',
-              },
-            ]}
-          />
-        </div>
+      <PageLayout title="My Characters">
+        <EmptyState
+          className="characters-empty-no-world"
+          icon={<Globe aria-hidden="true" />}
+          title="Choose Your World"
+          description="Characters live inside a world. Head to Worlds to pick one, then come back here to view and create characters."
+          action={
+            <Button variant="default" onClick={() => router.push('/worlds')}>
+              Go to Worlds
+            </Button>
+          }
+        />
       </PageLayout>
     );
   }


### PR DESCRIPTION
## Description

When no world is active, the `/characters` list rendered a bare top-left `<div>` — an unstyled globe icon, an `<h2>`, and a button — with no card, no centering, and a big blank canvas below it. Next to every other empty state in the app it read as unfinished.

This routes that branch through the canonical `EmptyState` primitive, which picked up real token-based CSS in #1479. So the fix is pure composition: icon + heading + a descriptive line + a "Go to Worlds" action, centered and on-system for free. No new CSS, no third empty-state variant.

## Related Issue

Closes #1493

(Note: merges into `develop`, so GitHub won't auto-close — I'll close it manually after merge.)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Presentational-only change — a composition swap with no new logic, and there's no existing characters-list-page test to extend. Verified live at desktop and mobile instead (see below), consistent with the project's "don't pin a trivial layout fix with a spec" guidance. Full suite stays green: 353 suites / 2403 tests.

## User Stories Addressed

N/A — design-system consistency fix.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

No new component — reuses the existing `EmptyState`, which already has stories (`EmptyState.stories.tsx`). Consistency verified live against the Journal/Inventory/play-entry empty states.

## Implementation Notes

- Root cause was already fixed in #1479: `EmptyState` shipped `.component-empty-state` with no styling, so every consumer rendered as bare top-left text. #1479 co-located token-based CSS with the component, so the characters fix is now just composition.
- Kept `PageLayout` (this is a normal chrome-full route, unlike the deliberately chrome-free play surface), and dropped the page-level `description` that echoed the empty-state heading.
- Uses the `<Button>`-in-`action` pattern established by #1479 rather than the local `ActionButtonGroup`, so all empty-state actions stay consistent.

## Screenshots

Verified live via the preview tools (IndexedDB unavailable in that env, so no active world → the branch fires):

- **Desktop (~1600px):** centered globe, "Choose Your World" heading, well-measured description, accent-filled "Go to Worlds" button. `EmptyState` centers with equal 207.5px auto margins inside the 959px content column.
- **Mobile (375px):** same layout, comfortable measure, good tap target.

Before: unstyled, top-left, big blank area below. After: centered, boxed, on-system — matching the rest of the app.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

Verified with the preview MCP tools:
- `/characters` with no active world renders the `EmptyState` structure (icon + `h3` + `p` + action button) — confirmed via accessibility snapshot.
- Computed styles confirm the token-based treatment: `flex` column, `align-items: center`, `text-align: center`, `max-width: 512px`, equal auto margins.
- "Go to Worlds" navigates to `/worlds` (confirmed `window.location.pathname`).
- No console errors.

## Quality Checks (if applicable)

- [x] Linting passed (`npm run lint` — exit 0; warnings are all pre-existing in other files)
- [x] Type checking passed (`npm run type-check` — exit 0)
- [ ] Security audit passed (N/A — no dependency or server-side changes)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

1. Start the app (`npm run dev`) with no active world (fresh browser / cleared app data).
2. Go to `/characters`.
3. **Expect:** a centered, styled empty state — globe icon, "Choose Your World", a descriptive line, and a "Go to Worlds" button — not a bare top-left block.
4. Click "Go to Worlds" → lands on `/worlds`.
5. Check at 375px and a wide desktop width; both should read as finished and centered.

## Checklist

- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file) — `page.tsx` predates this guideline at 663 lines; this change *reduces* it by 4 lines rather than adding to it.
- [x] Self-review of code performed
- [ ] Comments added for complex logic — N/A, no complex logic
- [ ] Documentation updated (if required) — N/A
- [x] No new warnings generated
- [x] Accessibility considerations addressed (icon is `aria-hidden`; heading/description/action are semantic)
