### PR TITLE
fix(state): complete the WORLD_DELETED cascade + stop loreStore migrate wiping lore

### DIFF
--- a/src/state/__tests__/worldDeletionCascade.test.ts
+++ b/src/state/__tests__/worldDeletionCascade.test.ts
@@ -1,0 +1,106 @@
+/**
+ * World-deletion cascade through the real event wiring.
+ *
+ * characterStore and inventoryStore already cascade on deletion; these tests
+ * cover the stores that previously leaked orphaned data into IndexedDB when a
+ * world was deleted: npcStore, goalStore, and loreStore. Also pins loreStore's
+ * migrate() to the sibling contract (preserve data, only clear if null) —
+ * it used to wipe all persisted lore on every version bump.
+ */
+import '@/state/storeEventWiring';
+import { useNPCStore } from '@/state/npcStore';
+import { useGoalStore } from '@/state/goalStore';
+import { useLoreStore } from '@/state/loreStore';
+import { storeEvents, StoreEventTypes } from '@/lib/state/storePubSub';
+import type { NPC } from '@/types/npc.types';
+import type { NarrativeGoal } from '@/types/goal.types';
+
+const seedNPC = (npcId: string, worldId: string): void => {
+  const npc = { id: npcId, worldId, name: `NPC ${npcId}` } as unknown as NPC;
+  useNPCStore.setState((state) => ({
+    npcs: { ...state.npcs, [npcId]: npc },
+    entities: { ...state.entities, [npcId]: npc },
+    worldNpcs: {
+      ...state.worldNpcs,
+      [worldId]: [...(state.worldNpcs[worldId] ?? []), npcId],
+    },
+  }));
+};
+
+const seedGoal = (goalId: string, worldId: string | undefined, sessionId: string): void => {
+  const goal = {
+    id: goalId,
+    worldId,
+    sessionId,
+    title: `Goal ${goalId}`,
+    description: 'Seeded goal',
+    status: 'active',
+  } as unknown as NarrativeGoal;
+  useGoalStore.setState((state) => ({
+    goals: { ...state.goals, [goalId]: goal },
+    entities: { ...state.entities, [goalId]: goal },
+    sessionGoals: {
+      ...state.sessionGoals,
+      [sessionId]: [...(state.sessionGoals[sessionId] ?? []), goalId],
+    },
+  }));
+};
+
+const seedLoreFact = (factId: string, worldId: string): void => {
+  const fact = { id: factId, worldId, key: `key-${factId}`, value: 'Seeded fact' };
+  useLoreStore.setState((state) => ({
+    facts: { ...state.facts, [factId]: fact },
+    entities: { ...state.entities, [factId]: fact },
+  }) as never);
+};
+
+describe('WORLD_DELETED cascade', () => {
+  beforeEach(() => {
+    useNPCStore.setState({ npcs: {}, entities: {}, worldNpcs: {} });
+    useGoalStore.setState({ goals: {}, entities: {}, sessionGoals: {}, activeGoalIds: [] });
+    useLoreStore.setState({ facts: {}, entities: {}, factHistory: {} } as never);
+  });
+
+  it('clears the deleted world\'s NPCs, goals, and lore facts', async () => {
+    seedNPC('npc-1', 'world-1');
+    seedGoal('goal-1', 'world-1', 'session-1');
+    seedLoreFact('fact-1', 'world-1');
+
+    await storeEvents.emit(StoreEventTypes.WORLD_DELETED, { worldId: 'world-1' });
+
+    expect(useNPCStore.getState().npcs['npc-1']).toBeUndefined();
+    expect(useGoalStore.getState().goals['goal-1']).toBeUndefined();
+    expect(useLoreStore.getState().facts['fact-1']).toBeUndefined();
+  });
+
+  it('preserves other worlds\' data and unattributed goals', async () => {
+    seedNPC('npc-2', 'world-2');
+    seedGoal('goal-2', 'world-2', 'session-2');
+    seedGoal('goal-no-world', undefined, 'session-2');
+    seedLoreFact('fact-2', 'world-2');
+
+    await storeEvents.emit(StoreEventTypes.WORLD_DELETED, { worldId: 'world-1' });
+
+    expect(useNPCStore.getState().npcs['npc-2']).toBeDefined();
+    expect(useGoalStore.getState().goals['goal-2']).toBeDefined();
+    expect(useGoalStore.getState().goals['goal-no-world']).toBeDefined();
+    expect(useLoreStore.getState().facts['fact-2']).toBeDefined();
+  });
+});
+
+describe('loreStore migrate contract', () => {
+  const getMigrate = () =>
+    (useLoreStore as unknown as {
+      persist: { getOptions: () => { migrate?: (state: unknown, version: number) => unknown } };
+    }).persist.getOptions().migrate;
+
+  it('preserves persisted state across a version bump', () => {
+    const persisted = { facts: { 'fact-1': { id: 'fact-1' } }, factHistory: {}, mergeAuditLog: [] };
+    expect(getMigrate()?.(persisted, 2)).toBe(persisted);
+  });
+
+  it('falls back to initial state only when nothing was persisted', () => {
+    const migrated = getMigrate()?.(null, 2) as { facts: Record<string, unknown> };
+    expect(migrated.facts).toEqual({});
+  });
+});

--- a/src/state/goalStore.ts
+++ b/src/state/goalStore.ts
@@ -12,6 +12,7 @@ import type { NarrativeSegment } from '../types/narrative.types';
 import { EntityID } from '../types/common.types';
 import { generateUniqueId } from '../lib/utils/generateId';
 import { createIndexedDBStorage } from './persistence';
+import { storeEvents, StoreEventTypes, type WorldDeletedEvent } from '@/lib/state/storePubSub';
 import { goalExtractor } from '../lib/ai/goalExtractor';
 import { CrudStore } from './createCrudStore';
 
@@ -40,6 +41,7 @@ export interface GoalStore extends CrudStore<NarrativeGoal> {
   incrementMentionCount: (goalId: EntityID) => void;
   addProgressNote: (goalId: EntityID, note: string) => void;
   clearSessionGoals: (sessionId: EntityID) => void;
+  clearWorldGoals: (worldId: EntityID) => void;
   processSegmentForGoals: (segment: NarrativeSegment, sessionId: EntityID, characterId?: EntityID) => Promise<ProcessSegmentResult>;
 }
 
@@ -282,6 +284,14 @@ export const useGoalStore = create<GoalStore>()(
         goalIds.forEach((goalId) => get().delete(goalId));
       },
 
+      clearWorldGoals: (worldId) => {
+        // Goals without a worldId can't be attributed to the deleted world,
+        // so they're left alone.
+        Object.values(get().goals)
+          .filter((goal) => goal.worldId === worldId)
+          .forEach((goal) => get().delete(goal.id));
+      },
+
       processSegmentForGoals: async (segment, sessionId, characterId) => {
         set({ loading: true, error: null });
         try {
@@ -365,4 +375,14 @@ export const useGoalStore = create<GoalStore>()(
       migrate: (persistedState) => persistedState || getInitialState(), // Preserve data, only clear if null
     }
   )
+);
+
+// Cascade cleanup: deleting a world orphans its goals otherwise (mirrors
+// characterStore's WORLD_DELETED subscription). Plain subscribe — the handler
+// only clears data, so a double-fire is a no-op.
+storeEvents.subscribe<WorldDeletedEvent>(
+  StoreEventTypes.WORLD_DELETED,
+  ({ worldId }) => {
+    useGoalStore.getState().clearWorldGoals(worldId);
+  }
 );

--- a/src/state/loreStore.ts
+++ b/src/state/loreStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { createIndexedDBStorage } from './persistence';
+import { storeEvents, StoreEventTypes, type WorldDeletedEvent } from '@/lib/state/storePubSub';
 import { getInitialState } from './loreStore.state';
 import {
   createLoreBaseActions,
@@ -34,7 +35,17 @@ export const useLoreStore = create<LoreStore>()(
         factHistory: state.factHistory,
         mergeAuditLog: state.mergeAuditLog,
       }),
-      migrate: () => getInitialState(),
+      migrate: (persistedState) => persistedState || getInitialState(), // Preserve data, only clear if null
     }
   )
+);
+
+// Cascade cleanup: deleting a world orphans its lore facts otherwise (mirrors
+// characterStore's WORLD_DELETED subscription). Plain subscribe — the handler
+// only clears data, so a double-fire is a no-op.
+storeEvents.subscribe<WorldDeletedEvent>(
+  StoreEventTypes.WORLD_DELETED,
+  ({ worldId }) => {
+    useLoreStore.getState().clearFacts(worldId);
+  }
 );

--- a/src/state/npcStore.ts
+++ b/src/state/npcStore.ts
@@ -6,6 +6,7 @@ import { NPC } from '../types/npc.types';
 import { EntityID } from '../types/common.types';
 import { generateUniqueId } from '../lib/utils/generateId';
 import { createIndexedDBStorage } from './persistence';
+import { storeEvents, StoreEventTypes, type WorldDeletedEvent } from '@/lib/state/storePubSub';
 import { CrudStore } from './createCrudStore';
 
 export interface NPCStore extends CrudStore<NPC> {
@@ -241,3 +242,13 @@ export const useNPCStore = create<NPCStore>()(
 if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
   window.useNPCStore = useNPCStore;
 }
+
+// Cascade cleanup: deleting a world orphans its NPCs otherwise (mirrors
+// characterStore's WORLD_DELETED subscription). Plain subscribe — the handler
+// only clears data, so a double-fire is a no-op.
+storeEvents.subscribe<WorldDeletedEvent>(
+  StoreEventTypes.WORLD_DELETED,
+  ({ worldId }) => {
+    useNPCStore.getState().clearWorldNPCs(worldId);
+  }
+);

--- a/src/state/storeEventWiring.ts
+++ b/src/state/storeEventWiring.ts
@@ -15,6 +15,12 @@
  */
 import './narrativeStore';
 import './inventoryStore';
+// World-deletion cascade subscribers (WORLD_DELETED at each module tail).
+// Imported here so the cleanup is registered on every route — a world can be
+// deleted from a page that never renders NPCs, goals, or lore.
+import './npcStore';
+import './goalStore';
+import './loreStore';
 import {
   storeEvents,
   StoreEventTypes,


### PR DESCRIPTION
## Description
Two data-integrity bugs surfaced by this week's whole-repo structural audit, both in the persistence layer.

**World deletion leaked NPCs, goals, and lore.** `worldStore` emits `WORLD_DELETED`, but only `characterStore` was listening. `npcStore.clearWorldNPCs`, `goalStore`'s cleanup, and `loreStore.clearFacts` were all built for exactly this and never wired up — so deleting a world orphaned its NPCs, goals, and lore facts in IndexedDB permanently. This wires the three missing module-tail subscriptions (same pattern `characterStore` uses) and force-registers them in `storeEventWiring.ts` so the cascade is live on every route, not just pages that happen to import those stores. goalStore needed a new world-scoped clear (`clearWorldGoals`) — its existing one was session-keyed. Goals with no `worldId` are deliberately left alone; they can't be attributed to the deleted world.

**`loreStore.migrate()` wiped all lore on every version bump.** It returned `getInitialState()` unconditionally, where every sibling store preserves the persisted payload unless it's literally null. Landed that way in `fc18a5eb` (#952), and the store's been version-bumped since — so this has likely already eaten real lore. Now matches the sibling contract.

## Related Issue
N/A — audit finding, no pre-existing issue.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

`worldDeletionCascade.test.ts` drives the real event wiring (emits `WORLD_DELETED` through `storeEventWiring`), asserts the deleted world's data clears while other worlds' data and unattributed goals survive, and pins `loreStore`'s migrate to the preserve-unless-null contract.

## User Stories Addressed
N/A — data-integrity fix.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated — N/A, no UI changes
- [ ] Components developed in isolation first — N/A
- [ ] Visual consistency verified — N/A

## Implementation Notes
One deliberate non-fix: `loreStore`'s IndexedDB name (`lore-store`) breaks the `narraitor-*-store` convention, but renaming it would orphan existing persisted data unless we write a DB migration — not worth it. Accepted debt.

## Screenshots
N/A

## Code Review Summary (if applicable)
Findings came from a 14-agent audit workflow (finder + adversarial verifier per dimension); both bugs were confirmed against file/line/commit evidence before any code was written.

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Full gate run locally: 2407 tests / 354 suites green, `tsc --noEmit` clean, ESLint clean (pre-existing warnings only), `deps:validate` clean.

## Testing Instructions
1. `npm test src/state/__tests__/worldDeletionCascade.test.ts`
2. Manual: create a world with NPCs/goals/lore, delete the world, inspect IndexedDB — the three stores no longer retain its entries.
3. Full gate: `npm test && npm run type-check && npm run lint`

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) — N/A
- [x] No new warnings generated
- [x] Accessibility considerations addressed — N/A, no UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)