### PR TITLE
fix(ai): request timeouts, explicit choice routing, shared parsing

### DIFF
--- a/src/lib/ai/__tests__/aiFetch.test.ts
+++ b/src/lib/ai/__tests__/aiFetch.test.ts
@@ -47,4 +47,28 @@ describe('aiFetch', () => {
 
     expect(lastFetchHeaders().has('x-provider-api-key')).toBe(false);
   });
+
+  test('attaches a timeout signal by default when the runtime supports it', async () => {
+    // jsdom's AbortSignal has no static timeout; emulate the browser/Node API.
+    const signal = new AbortController().signal;
+    (AbortSignal as unknown as { timeout?: (ms: number) => AbortSignal }).timeout = jest.fn(() => signal);
+    try {
+      mockGetKey.mockResolvedValue(null);
+      await aiFetch('/api/x');
+
+      const init = (global.fetch as jest.Mock).mock.calls[0][1];
+      expect(init.signal).toBe(signal);
+    } finally {
+      delete (AbortSignal as unknown as { timeout?: unknown }).timeout;
+    }
+  });
+
+  test('preserves a caller-supplied signal', async () => {
+    mockGetKey.mockResolvedValue(null);
+    const controller = new AbortController();
+    await aiFetch('/api/x', { signal: controller.signal });
+
+    const init = (global.fetch as jest.Mock).mock.calls[0][1];
+    expect(init.signal).toBe(controller.signal);
+  });
 });

--- a/src/lib/ai/__tests__/choiceGenerator.test.ts
+++ b/src/lib/ai/__tests__/choiceGenerator.test.ts
@@ -127,6 +127,22 @@ describe('ChoiceGenerator', () => {
       expect(result.prompt).toBeTruthy();
     });
     
+    it('prefers the explicit generateChoices entry point when the client has one', async () => {
+      const routingClient: jest.Mocked<AIClient> = {
+        generateContent: jest.fn(),
+        generateChoices: jest.fn().mockResolvedValueOnce({ content: '', finishReason: 'STOP' }),
+      };
+
+      await generateChoices(routingClient, {
+        worldId: 'world-1',
+        narrativeContext: createMockNarrativeContext(),
+        characterIds: ['char-1']
+      });
+
+      expect(routingClient.generateChoices).toHaveBeenCalled();
+      expect(routingClient.generateContent).not.toHaveBeenCalled();
+    });
+
     it('should handle empty or malformed AI responses', async () => {
       // Mock an empty response
       mockAIClient.generateContent.mockResolvedValueOnce({ content: '', finishReason: 'STOP' });

--- a/src/lib/ai/__tests__/endingGenerator.errors.test.ts
+++ b/src/lib/ai/__tests__/endingGenerator.errors.test.ts
@@ -120,9 +120,9 @@ describe('EndingGenerator - Error Handling and Retry', () => {
   });
 
   describe('Retry Generation', () => {
-    it('should retry failed generation attempts', async () => {
-      // Use real timers for this test since it involves retry delays
-      jest.useRealTimers();
+    // Retries live inside GeminiClient (config.maxRetries); the generator
+    // makes exactly one call and surfaces failures to the caller.
+    it('makes a single generation call and propagates client failures', async () => {
       const mockRequest: EndingGenerationRequest = {
         sessionId: 'session-789',
         characterId: 'char-456',
@@ -138,22 +138,10 @@ describe('EndingGenerator - Error Handling and Retry', () => {
       };
 
       mockBuildEndingContext.mockResolvedValue(mockContext);
+      mockGeminiClient.generateContent.mockRejectedValueOnce(new Error('API error'));
 
-      // First attempt fails, second succeeds
-      mockGeminiClient.generateContent
-        .mockRejectedValueOnce(new Error('API error'))
-        .mockResolvedValueOnce({ content: `{
-          "epilogue": "Success after retry...",
-          "characterLegacy": "A persistent hero...",
-          "worldImpact": "Changed through determination...",
-          "tone": "triumphant",
-          "achievements": ["Never Give Up"]
-        }` });
-
-      const result = await generateEnding(mockRequest);
-
-      expect(result.epilogue).toContain('Success after retry');
-      expect(mockGeminiClient.generateContent).toHaveBeenCalledTimes(2);
+      await expect(generateEnding(mockRequest)).rejects.toThrow('Failed to create ending: API error');
+      expect(mockGeminiClient.generateContent).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/lib/ai/abortTimeout.ts
+++ b/src/lib/ai/abortTimeout.ts
@@ -1,0 +1,8 @@
+/**
+ * AbortSignal.timeout guarded for environments that lack it (jsdom in Jest).
+ * Every production runtime here — modern browsers and Node 18+ — supports it;
+ * returning undefined in jsdom just means no timeout guard inside tests.
+ */
+export function timeoutSignal(ms: number): AbortSignal | undefined {
+  return typeof AbortSignal.timeout === 'function' ? AbortSignal.timeout(ms) : undefined;
+}

--- a/src/lib/ai/aiFetch.ts
+++ b/src/lib/ai/aiFetch.ts
@@ -2,6 +2,7 @@
 
 import { PROVIDER_API_KEY_HEADER } from './providerKeyHeader';
 import { getActiveProviderKey } from '@/state/providerStore';
+import { timeoutSignal } from './abortTimeout';
 
 /**
  * fetch() wrapper for browser -> our own AI routes.
@@ -12,14 +13,24 @@ import { getActiveProviderKey } from '@/state/providerStore';
  * unchanged. The plaintext key lives only in this closure for the duration of
  * the call; it's never stored or logged.
  */
+// Outer guard for the whole round-trip (server processing + Gemini call +
+// its internal retries: worst case ~93s at 3x30s attempts plus backoff).
+// GeminiClient enforces its own per-attempt timeout; this catches everything
+// else so a hung request can't block the story loop forever.
+export const AI_REQUEST_TIMEOUT_MS = 120_000;
+
 export async function aiFetch(input: string, init: RequestInit = {}): Promise<Response> {
   const key = await getActiveProviderKey().catch(() => null);
+  const withTimeout: RequestInit = {
+    ...init,
+    signal: init.signal ?? timeoutSignal(AI_REQUEST_TIMEOUT_MS),
+  };
   // No configured key -> identical to a plain fetch (env fallback applies
   // server-side). This keeps aiFetch a true drop-in: dev, tests, and E2E behave
   // exactly as before, and only a configured BYO key adds the header.
-  if (!key) return fetch(input, init);
+  if (!key) return fetch(input, withTimeout);
 
-  const headers = new Headers(init.headers);
+  const headers = new Headers(withTimeout.headers);
   headers.set(PROVIDER_API_KEY_HEADER, key);
-  return fetch(input, { ...init, headers });
+  return fetch(input, { ...withTimeout, headers });
 }

--- a/src/lib/ai/aiFetch.ts
+++ b/src/lib/ai/aiFetch.ts
@@ -17,7 +17,7 @@ import { timeoutSignal } from './abortTimeout';
 // its internal retries: worst case ~93s at 3x30s attempts plus backoff).
 // GeminiClient enforces its own per-attempt timeout; this catches everything
 // else so a hung request can't block the story loop forever.
-export const AI_REQUEST_TIMEOUT_MS = 120_000;
+const AI_REQUEST_TIMEOUT_MS = 120_000;
 
 export async function aiFetch(input: string, init: RequestInit = {}): Promise<Response> {
   const key = await getActiveProviderKey().catch(() => null);

--- a/src/lib/ai/choiceGenerator.ts
+++ b/src/lib/ai/choiceGenerator.ts
@@ -49,7 +49,12 @@ export async function generateChoices(
       maxOptions,
     });
 
-    const response = await aiClient.generateContent(prompt);
+    // Prefer the explicit choices entry point when the client has one (the
+    // browser proxy routes it to /api/narrative/choices); server-side clients
+    // hit the SDK directly so generateContent is equivalent there.
+    const response = aiClient.generateChoices
+      ? await aiClient.generateChoices(prompt)
+      : await aiClient.generateContent(prompt);
 
 
     if (!response?.content || safeTrim(response?.content ?? '') === '') {

--- a/src/lib/ai/clientGeminiClient.ts
+++ b/src/lib/ai/clientGeminiClient.ts
@@ -20,73 +20,57 @@ export class ClientGeminiClient implements AIClient {
   }
 
   /**
-   * Generate content via server-side API route
-   * Automatically routes to the appropriate endpoint based on prompt content
+   * POSTs to an API route and unwraps the JSON payload, normalizing the
+   * shared error branches (rate limiting, HTTP errors, network failures)
+   * into user-friendly messages.
    */
-  async generateContent(prompt: string): Promise<AIResponse> {
+  private async postJson<T>(endpoint: string, body: unknown, logContext: string): Promise<T> {
     try {
-      // Detect if this is a choice generation request based on prompt content
-      const isChoiceGeneration = this.isChoiceGenerationPrompt(prompt);
-      const endpoint = isChoiceGeneration ? '/api/narrative/choices' : '/api/narrative/generate';
-      
       const response = await aiFetch(`${this.baseUrl}${endpoint}`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({
-          prompt,
-          config: {
-            temperature: 0.7,
-            maxTokens: 1024
-          }
-        })
+        body: JSON.stringify(body),
       });
 
       if (!response.ok) {
-        if (response.status === 429) {
-          // Rate limiting error
-          const data = await response.json();
-          throw new Error(data.error || 'Rate limit exceeded. Please try again later.');
-        }
-        
         const errorData = await response.json();
+        if (response.status === 429) {
+          throw new Error(errorData.error || 'Rate limit exceeded. Please try again later.');
+        }
         throw new Error(errorData.error || `HTTP ${response.status}: ${response.statusText}`);
       }
 
-      const data = await response.json();
-      
-      return {
-        content: data.content,
-        finishReason: data.finishReason || 'STOP',
-        promptTokens: data.promptTokens,
-        completionTokens: data.completionTokens
-      };
+      return await response.json();
     } catch (error) {
-      logger.error('ClientGeminiClient error:', error);
-      
-      // Use existing error handling utilities
+      logger.error(`ClientGeminiClient ${logContext} error:`, error);
       const friendlyMessage = userFriendlyError(error instanceof Error ? error : new Error('Unknown error'));
       throw new Error(friendlyMessage);
     }
   }
 
+  private toAIResponse(data: { content: string; finishReason?: string; promptTokens?: number; completionTokens?: number }): AIResponse {
+    return {
+      content: data.content,
+      finishReason: data.finishReason || 'STOP',
+      promptTokens: data.promptTokens,
+      completionTokens: data.completionTokens,
+    };
+  }
+
   /**
-   * Detect if a prompt is for choice generation based on content patterns
+   * Generate narrative content via the server-side API route. Choice
+   * generation goes through generateChoices() — callers pick the endpoint
+   * explicitly instead of this method inferring it from prompt content.
    */
-  private isChoiceGenerationPrompt(prompt: string): boolean {
-    const choiceIndicators = [
-      'create 4 distinct action choices',
-      'generate player choices',
-      'ALIGNMENT DEFINITIONS',
-      'alignedPlayerChoice',
-      'playerChoice',
-      'create choices',
-      'decision options'
-    ];
-    
-    const lowerPrompt = prompt.toLowerCase();
-    return choiceIndicators.some(indicator => lowerPrompt.includes(indicator.toLowerCase()));
+  async generateContent(prompt: string): Promise<AIResponse> {
+    const data = await this.postJson<{ content: string; finishReason?: string; promptTokens?: number; completionTokens?: number }>(
+      '/api/narrative/generate',
+      { prompt, config: { temperature: 0.7, maxTokens: 1024 } },
+      'generation'
+    );
+    return this.toAIResponse(data);
   }
 
   /**
@@ -94,86 +78,27 @@ export class ClientGeminiClient implements AIClient {
    * This method is used specifically for choice generation
    */
   async generateChoices(prompt: string): Promise<AIResponse> {
-    try {
-      const response = await aiFetch(`${this.baseUrl}/api/narrative/choices`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          prompt,
-          config: {
-            temperature: 0.7,
-            maxTokens: 1024
-          }
-        })
-      });
-
-      if (!response.ok) {
-        if (response.status === 429) {
-          // Rate limiting error
-          const data = await response.json();
-          throw new Error(data.error || 'Rate limit exceeded. Please try again later.');
-        }
-        
-        const errorData = await response.json();
-        throw new Error(errorData.error || `HTTP ${response.status}: ${response.statusText}`);
-      }
-
-      const data = await response.json();
-      
-      return {
-        content: data.content,
-        finishReason: data.finishReason || 'STOP',
-        promptTokens: data.promptTokens,
-        completionTokens: data.completionTokens
-      };
-    } catch (error) {
-      logger.error('ClientGeminiClient choice generation error:', error);
-      
-      // Use existing error handling utilities
-      const friendlyMessage = userFriendlyError(error instanceof Error ? error : new Error('Unknown error'));
-      throw new Error(friendlyMessage);
-    }
+    const data = await this.postJson<{ content: string; finishReason?: string; promptTokens?: number; completionTokens?: number }>(
+      '/api/narrative/choices',
+      { prompt, config: { temperature: 0.7, maxTokens: 1024 } },
+      'choice generation'
+    );
+    return this.toAIResponse(data);
   }
 
   /**
    * Generate portrait image via existing server-side API route
    */
   async generateImage(prompt: string): Promise<AIImageResponse> {
-    try {
-      const response = await aiFetch(`${this.baseUrl}/api/generate-portrait`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ prompt })
-      });
-
-      if (!response.ok) {
-        if (response.status === 429) {
-          // Rate limiting error
-          const data = await response.json();
-          throw new Error(data.error || 'Rate limit exceeded. Please try again later.');
-        }
-        
-        const errorData = await response.json();
-        throw new Error(errorData.error || `HTTP ${response.status}: ${response.statusText}`);
-      }
-
-      const data = await response.json();
-      
-      return {
-        image: data.image,
-        prompt: data.prompt
-      };
-    } catch (error) {
-      logger.error('ClientGeminiClient image generation error:', error);
-      
-      // Use existing error handling utilities
-      const friendlyMessage = userFriendlyError(error instanceof Error ? error : new Error('Unknown error'));
-      throw new Error(friendlyMessage);
-    }
+    const data = await this.postJson<{ image: string; prompt: string }>(
+      '/api/generate-portrait',
+      { prompt },
+      'image generation'
+    );
+    return {
+      image: data.image,
+      prompt: data.prompt,
+    };
   }
 
   /**

--- a/src/lib/ai/customActionSkillInference.ts
+++ b/src/lib/ai/customActionSkillInference.ts
@@ -9,6 +9,7 @@ import type { World, WorldSkill } from '@/types/world.types';
 import type { Character } from '@/state/characterStore';
 import type { DecisionRequirement, NarrativeSegment } from '@/types/narrative.types';
 import { safeTrim } from '@/lib/utils';
+import { extractFencedJson } from './parseJSON';
 
 import Logger from '@/lib/utils/logger';
 const logger = new Logger('CustomActionSkillInference');
@@ -109,14 +110,14 @@ function parseInferenceResponse(
   content: string,
   worldSkills: WorldSkill[]
 ): DecisionRequirement[] {
-  const jsonMatch = content.match(/```json\s*([\s\S]*?)\s*```/);
-  if (!jsonMatch) {
+  const fenced = extractFencedJson(content);
+  if (!fenced) {
     return [];
   }
 
   let parsed: unknown;
   try {
-    parsed = JSON.parse(jsonMatch[1]);
+    parsed = JSON.parse(fenced);
   } catch {
     return [];
   }

--- a/src/lib/ai/endingGenerator.ts
+++ b/src/lib/ai/endingGenerator.ts
@@ -13,9 +13,6 @@ import type {
 } from '../../types/narrative.types';
 import type { JournalEntry } from '../../types/journal.types';
 
-const MAX_RETRIES = 2;
-const RETRY_DELAY_MS = 1000;
-
 function extractRecentNarrative(segments: NarrativeSegment[]): string[] {
   const recentSegments = segments
     .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
@@ -123,10 +120,6 @@ function parseResponse(response: string): EndingGenerationResult {
   }
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
 export async function generateEnding(request: EndingGenerationRequest, apiKey?: string | null): Promise<EndingGenerationResult> {
   try {
     logger.debug('Generating story ending', { request });
@@ -163,34 +156,24 @@ export async function generateEnding(request: EndingGenerationRequest, apiKey?: 
 
     finalPrompt += '\n\nIMPORTANT: Return ONLY valid JSON with no additional text, markdown formatting, or commentary. The response must be parseable JSON.';
 
-    let lastError: Error | null = null;
-    for (let i = 0; i <= MAX_RETRIES; i++) {
-      try {
-        const client = createDefaultGeminiClient(apiKey);
-        const response = await client.generateContent(finalPrompt);
-        const result = parseResponse(response.content);
+    // Retryable API errors are already retried inside GeminiClient
+    // (config.maxRetries with backoff) — an outer loop here multiplied the
+    // attempts. Parse failures throw straight to the caller, matching how
+    // narrativeGenerator and choiceGenerator handle them.
+    const client = createDefaultGeminiClient(apiKey);
+    const response = await client.generateContent(finalPrompt);
+    const result = parseResponse(response.content);
 
-        if (context.sessionStartTime) {
-          result.playTime = Math.floor((Date.now() - context.sessionStartTime.getTime()) / 1000);
-        }
-
-        logger.debug('Story ending generated successfully', {
-          tone: result.tone,
-          achievementCount: result.achievements.length
-        });
-
-        return result;
-      } catch (error) {
-        lastError = error as Error;
-        logger.warn(`Ending generation attempt ${i + 1} failed`, { error });
-
-        if (i < MAX_RETRIES) {
-          await delay(RETRY_DELAY_MS * (i + 1));
-        }
-      }
+    if (context.sessionStartTime) {
+      result.playTime = Math.floor((Date.now() - context.sessionStartTime.getTime()) / 1000);
     }
 
-    throw new Error(`Failed to create ending after ${MAX_RETRIES + 1} attempts: ${lastError?.message}`);
+    logger.debug('Story ending generated successfully', {
+      tone: result.tone,
+      achievementCount: result.achievements.length
+    });
+
+    return result;
   } catch (error) {
     logger.error('Failed to create ending', {
       error,

--- a/src/lib/ai/eventSignificanceValidator.ts
+++ b/src/lib/ai/eventSignificanceValidator.ts
@@ -1,6 +1,7 @@
 import { GoogleGenAI } from '@google/genai';
 import { logger } from '@/lib/utils/logger';
 import { getAIConfig } from './config';
+import { extractJsonObject } from './parseJSON';
 
 /**
  * Event Significance Validation Result
@@ -150,12 +151,12 @@ Respond ONLY with valid JSON in this exact format:
 function parseValidationResponse(responseText: string): SignificanceValidationResult {
   try {
     // Extract JSON from the response (handle cases where LLM adds extra text)
-    const jsonMatch = responseText.match(/\{[\s\S]*\}/);
-    if (!jsonMatch) {
+    const json = extractJsonObject(responseText);
+    if (!json) {
       throw new Error('No JSON found in response');
     }
 
-    const parsed = JSON.parse(jsonMatch[0]);
+    const parsed = JSON.parse(json);
 
     if (typeof parsed.isSignificant !== 'boolean') {
       throw new Error('Invalid response: isSignificant must be boolean');

--- a/src/lib/ai/geminiClient.ts
+++ b/src/lib/ai/geminiClient.ts
@@ -4,6 +4,7 @@ import { GoogleGenAI } from '@google/genai';
 import { AIResponse, AIServiceConfig, AIClient } from './types';
 import { isRetryableError } from '@/lib/utils/errorUtils';
 import { getGenerationConfig, getSafetySettings } from './config';
+import { timeoutSignal } from './abortTimeout';
 
 import Logger from '@/lib/utils/logger';
 const logger = new Logger('GeminiClient');
@@ -70,7 +71,10 @@ export class GeminiClient implements AIClient {
         contents: prompt,
         config: {
           generationConfig: this.config.generationConfig,
-          safetySettings: this.config.safetySettings
+          safetySettings: this.config.safetySettings,
+          // config.timeout existed but was never enforced — a hung request
+          // previously blocked forever (retries only fire on rejection).
+          abortSignal: timeoutSignal(this.config.timeout)
         }
       });
 

--- a/src/lib/ai/inventoryCategorizer.ts
+++ b/src/lib/ai/inventoryCategorizer.ts
@@ -2,6 +2,7 @@ import { GeminiClient } from '@/lib/ai/geminiClient';
 import { getAIConfig, getGenerationConfig, getSafetySettings } from '@/lib/ai/config';
 import { STANDARD_CATEGORIES } from '@/lib/inventory/categories';
 import { truncate } from '@/lib/utils';
+import { extractFencedJson, extractJsonObject } from '@/lib/ai/parseJSON';
 import { logger } from '@/lib/utils/logger';
 import type { StandardInventoryCategory } from '@/types/inventory.types';
 
@@ -70,27 +71,27 @@ function parseAIResponse(raw: string): AIResponseShape | null {
       preview: truncate(raw, 150),
     });
 
-    const match = raw.match(/```json\s*([\s\S]*?)```/i);
-    if (match) {
+    const fenced = extractFencedJson(raw);
+    if (fenced) {
       try {
-        return JSON.parse(match[1]) as AIResponseShape;
+        return JSON.parse(fenced) as AIResponseShape;
       } catch (blockError) {
         logger.debug('InventoryCategorizer', 'Failed to parse AI code block', {
           error: blockError,
-          preview: truncate(match[1], 150),
+          preview: truncate(fenced, 150),
         });
         return null;
       }
     }
 
-    const jsonLike = raw.match(/\{[\s\S]*\}/);
+    const jsonLike = extractJsonObject(raw);
     if (jsonLike) {
       try {
-        return JSON.parse(jsonLike[0]) as AIResponseShape;
+        return JSON.parse(jsonLike) as AIResponseShape;
       } catch (fallbackError) {
         logger.debug('InventoryCategorizer', 'Failed to parse AI JSON fallback', {
           error: fallbackError,
-          preview: truncate(jsonLike[0], 150),
+          preview: truncate(jsonLike, 150),
         });
         return null;
       }

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -79,6 +79,10 @@ export interface AIImageResponse {
  */
 export interface AIClient {
   generateContent(prompt: string): Promise<AIResponse>;
+  // Choice generation is a distinct endpoint on the browser path; callers that
+  // need it (choiceGenerator) prefer this over generateContent so routing is
+  // explicit rather than inferred from prompt content.
+  generateChoices?(prompt: string): Promise<AIResponse>;
   generateImage?(prompt: string): Promise<AIImageResponse>;
   generateStructuredContent?<T = unknown>(prompt: string, schema: unknown): Promise<T>;
   isAvailable?(): Promise<boolean>;

--- a/src/types/@google/genai.d.ts
+++ b/src/types/@google/genai.d.ts
@@ -31,6 +31,8 @@ declare module '@google/genai' {
   export interface GenerateContentConfig {
     generationConfig?: GenerationConfig;
     safetySettings?: SafetySetting[];
+    // Client-side cancellation only; the service still bills the request.
+    abortSignal?: AbortSignal;
   }
 
   export interface ModelInterface {


### PR DESCRIPTION
## Description
Four AI-layer hardening fixes from this week's structural audit, all in `src/lib/ai`. Net -27 lines.

**Timeouts (the big one).** Nothing in the AI layer had a request timeout — `GeminiClient`'s retries only fire on a *rejected* promise, so a hung Gemini call blocked the story loop indefinitely. Turns out `config.timeout: 30000` existed all along and was never enforced; that's the root cause, not a missing feature. Now `GeminiClient` honors it per attempt via the SDK's `abortSignal`, and `aiFetch` guards the whole browser round-trip at 120s (sized to worst-case server retries plus backoff). jsdom has no `AbortSignal.timeout`, hence the small guarded `timeoutSignal` helper both use.

**Explicit choice routing.** `ClientGeminiClient.generateContent` decided between `/api/narrative/choices` and `/api/narrative/generate` by substring-matching the prompt for phrases like "create 4 distinct action choices" — and it was load-bearing, since `choiceGenerator` called the generic entry point. Rewording a prompt template would've silently misrouted choice generation. `AIClient` grows an optional `generateChoices`, `choiceGenerator` prefers it, the sniffing is deleted.

**Retry stacking.** `endingGenerator` ran its own 3-attempt retry loop around `client.generateContent`, which already retries internally — retryable errors got up to 9 attempts. Dropped the outer loop; parse failures now propagate immediately, matching `narrativeGenerator`/`choiceGenerator`.

**Duplication.** Three modules hand-rolled JSON-from-LLM extraction that `parseJSON.ts` already owns (`eventSignificanceValidator`, `customActionSkillInference`, `inventoryCategorizer`); `ClientGeminiClient` repeated the same 429/HTTP-error branch three times. Both consolidated.

## Related Issue
N/A — audit findings, no pre-existing issue.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

New tests: aiFetch attaches a timeout signal by default and preserves a caller-supplied one; choiceGenerator prefers `generateChoices` when the client has it. Updated: the endingGenerator retry test now pins the single-call contract (retries belong to GeminiClient).

## User Stories Addressed
N/A

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated — N/A, no UI changes
- [ ] Components developed in isolation first — N/A
- [ ] Visual consistency verified — N/A

## Implementation Notes
The repo shadows the SDK with `src/types/@google/genai.d.ts`; that local `GenerateContentConfig` needed `abortSignal` added (the real SDK 0.13.0 type already has it). Behavior note on the ending path: a malformed-JSON response no longer gets re-requested — it fails fast to the caller like the sibling generators. If we ever want parse-retry back it belongs in one place, not per-generator.

## Screenshots
N/A

## Code Review Summary (if applicable)
Findings confirmed by adversarial verifier agents against file/line evidence before implementation; timeout finding re-verified by hand (zero AbortController/maxDuration hits outside tests).

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Local gate: 2406 tests / 353 suites green, `tsc --noEmit` clean, ESLint clean, `deps:validate` clean.

## Testing Instructions
1. `npx jest src/lib/ai` — 67 suites.
2. Manual: play a story turn and generate choices in the running app — choices still arrive (now via the explicit endpoint); pull the network offline mid-generation and confirm the request aborts rather than hanging forever.
3. Full gate: `npm test && npm run type-check && npm run lint`

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) — N/A
- [x] No new warnings generated
- [x] Accessibility considerations addressed — N/A, no UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)