### PR TITLE
refactor(ai): route components through lib/api services + enforce the boundary

### DIFF
--- a/.dependency-cruiser-known-violations.json
+++ b/.dependency-cruiser-known-violations.json
@@ -581,5 +581,68 @@
       "severity": "warn",
       "name": "no-orphans"
     }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/WorldCreationWizard/WorldCreationWizard.tsx",
+    "to": "src/lib/ai/worldImageGenerator.ts",
+    "rule": {
+      "severity": "error",
+      "name": "components-no-direct-lib-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/WorldCreationWizard/WorldCreationWizard.tsx",
+    "to": "src/lib/ai/worldAnalyzerClient.ts",
+    "rule": {
+      "severity": "error",
+      "name": "components-no-direct-lib-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/WorldCreationWizard/steps/FinalizeStep.tsx",
+    "to": "src/lib/ai/worldImageGenerator.ts",
+    "rule": {
+      "severity": "error",
+      "name": "components-no-direct-lib-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/forms/WorldImageForm.tsx",
+    "to": "src/lib/ai/worldImageGenerator.ts",
+    "rule": {
+      "severity": "error",
+      "name": "components-no-direct-lib-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/ai/ProviderWizard.tsx",
+    "to": "src/lib/ai/validateProviderClient.ts",
+    "rule": {
+      "severity": "error",
+      "name": "components-no-direct-lib-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/ai/ProviderWizard.tsx",
+    "to": "src/lib/ai/presets.ts",
+    "rule": {
+      "severity": "error",
+      "name": "components-no-direct-lib-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/ai/ProviderPresets.tsx",
+    "to": "src/lib/ai/presets.ts",
+    "rule": {
+      "severity": "error",
+      "name": "components-no-direct-lib-imports"
+    }
   }
 ]

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -153,15 +153,19 @@ module.exports = {
     },
     {
       name: 'components-no-direct-lib-imports',
-      severity: 'info',
+      severity: 'error',
       comment:
-        'Components importing directly from lib/ services. Consider if this business logic ' +
-        'should be in a store instead for better testability and separation of concerns.',
+        'Components must reach the AI layer through lib/api services or hooks/ (worldApi ' +
+        'pattern), not import lib/ai internals directly. Devtools panels are exempt — they ' +
+        'exist to poke internals. Known stragglers live in the baseline; do not add new ones.',
       from: {
-        path: '^src/components/'
+        path: '^src/components/',
+        // Exempt: devtools (exist to poke internals), colocated hook files
+        // (use*.ts ARE the mediating layer), and tests.
+        pathNot: '^src/components/devtools/|/use[A-Z][^/]*\\.ts$|\\.(test|spec)\\.[jt]sx?$'
       },
       to: {
-        path: '^src/lib/(?:gemini|prompt)/'
+        path: '^src/lib/ai/'
       }
     },
     {

--- a/src/app/api/generate-portrait/route.ts
+++ b/src/app/api/generate-portrait/route.ts
@@ -120,6 +120,7 @@ export async function POST(request: NextRequest) {
     let prompt: string;
     let character: Character | undefined;
     let world: World | undefined;
+    const apiKey = resolveApiKey(request);
 
     if (typeof body === 'string') {
       prompt = body;
@@ -153,7 +154,7 @@ export async function POST(request: NextRequest) {
           physicalDesc,
           worldGenre,
           isKnownFigure,
-          resolveApiKey(request)
+          apiKey
         );
 
         return NextResponse.json({
@@ -175,7 +176,7 @@ export async function POST(request: NextRequest) {
           physicalDesc,
           worldGenre,
           isKnownFigure,
-          resolveApiKey(request)
+          apiKey
         );
       }
     } else {
@@ -197,8 +198,6 @@ export async function POST(request: NextRequest) {
       'Generating portrait with prompt:',
       truncate(prompt, 100)
     );
-
-    const apiKey = resolveApiKey(request);
 
     if (!apiKey) {
       // Return a mock portrait for development

--- a/src/app/characters/page.tsx
+++ b/src/app/characters/page.tsx
@@ -23,7 +23,7 @@ import { ActionButtonGroup } from '@/components/shared/ActionButtonGroup';
 import { EmptyState } from '@/components/ui/EmptyState/EmptyState';
 import { Button } from '@/components/ui/button';
 import { generateUniqueId } from '@/lib/utils/generateId';
-import type { GeneratedCharacterData } from '@/lib/ai/characterGenerator';
+import type { GeneratedCharacterData } from '@/lib/generators/characterGenerator';
 import { World } from '@/types/world.types';
 import DeleteConfirmationDialog from '@/components/DeleteConfirmationDialog';
 import { Toast } from '@/components/ui/toast';
@@ -31,7 +31,7 @@ import { getGenreLabel } from '@/lib/constants/genres';
 import { GameSessionConfirmationDialog } from '@/components/GameSession/GameSessionConfirmationDialog';
 import type { GeneratedImage } from '@/types/common.types';
 import { generatePortrait } from '@/lib/api/generatePortrait';
-import { aiFetch } from '@/lib/ai/aiFetch';
+import { characterApi } from '@/lib/api/characterApi';
 
 // CharacterTable pulls @tanstack/react-table but only renders in table view,
 // and the generate dialog only matters once the page is interactive. Load both
@@ -312,24 +312,13 @@ export default function CharactersPage() {
       const nameToUse =
         generationType === 'specific' ? characterName : undefined;
 
-      const response = await aiFetch('/api/generate-character', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          worldId: effectiveWorldId,
-          characterType: generationType,
-          existingNames: existingNames,
-          suggestedName: nameToUse,
-          world: currentWorld,
-        }),
+      const generatedData: GeneratedCharacterData = await characterApi.generateCharacter({
+        worldId: effectiveWorldId,
+        characterType: generationType,
+        existingNames: existingNames,
+        suggestedName: nameToUse,
+        world: currentWorld,
       });
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || 'Failed to generate character');
-      }
-
-      const generatedData: GeneratedCharacterData = await response.json();
 
       const characterId = createCharacter({
         name: generatedData.name,

--- a/src/components/CharacterCreationWizard/components/CharacterSuggestions.tsx
+++ b/src/components/CharacterCreationWizard/components/CharacterSuggestions.tsx
@@ -8,8 +8,8 @@ import { Label } from '@/components/ui/label';
 import { ErrorBlock } from '@/components/shared';
 import { World } from '@/types/world.types';
 import { CharacterCreationData } from '@/hooks/useCharacterCreationWizard';
-import type { GeneratedCharacterData } from '@/lib/ai/characterGenerator';
-import { aiFetch } from '@/lib/ai/aiFetch';
+import type { GeneratedCharacterData } from '@/lib/generators/characterGenerator';
+import { characterApi } from '@/lib/api/characterApi';
 
 type CardKey = 'description' | 'background' | 'attributes' | 'skills';
 
@@ -59,23 +59,12 @@ export const CharacterSuggestions: React.FC<CharacterSuggestionsProps> = ({
     setLoading(true);
     setError(null);
     try {
-      const response = await aiFetch('/api/generate-character', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          world,
-          concept,
-          characterType: 'original',
-          existingNames: [],
-        }),
+      const data: GeneratedCharacterData = await characterApi.generateCharacter({
+        world,
+        concept,
+        characterType: 'original',
+        existingNames: [],
       });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.error || 'Failed to generate suggestions');
-      }
-
-      const data: GeneratedCharacterData = await response.json();
       setSuggestion(data);
       setDismissed(new Set());
       setEditingCard(null);

--- a/src/components/CharacterEditor/CharacterEditor.tsx
+++ b/src/components/CharacterEditor/CharacterEditor.tsx
@@ -13,7 +13,7 @@ import { BasicInfoForm } from './components/BasicInfoForm';
 import { BackgroundForm } from './components/BackgroundForm';
 import { AttributesForm } from './components/AttributesForm';
 import { SkillsForm } from './components/SkillsForm';
-import { aiFetch } from '@/lib/ai/aiFetch';
+import { generatePortrait } from '@/lib/api/generatePortrait';
 
 import Logger from '@/lib/utils/logger';
 const logger = new Logger('CharacterEditor');
@@ -127,22 +127,11 @@ const CharacterEditor: React.FC<CharacterEditorProps> = ({ characterId }) => {
     setGeneratingPortrait(true);
     setPortraitError(null); // Clear previous portrait errors
     try {
-      const response = await aiFetch('/api/generate-portrait', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          character: { ...editingCharacter, id: characterId },
-          world: world,
-          customDescription: customDescription
-        }),
+      const { portrait } = await generatePortrait({
+        character: { ...editingCharacter, id: characterId },
+        world: world,
+        customDescription: customDescription,
       });
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || 'Failed to generate portrait');
-      }
-
-      const { portrait } = await response.json();
 
       // Update both local editing state and store
       setEditingCharacter({ ...editingCharacter, portrait });

--- a/src/components/GameSession/EndingScreen.tsx
+++ b/src/components/GameSession/EndingScreen.tsx
@@ -29,7 +29,7 @@ import Image from 'next/image';
 import { buildStoryFromCheckpoints } from '@/lib/narrative/storyCheckpointHelpers';
 import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
 import { isStorybookEnv } from '@/lib/utils/isStorybookEnv';
-import { aiFetch } from '@/lib/ai/aiFetch';
+import { generateEndingImage as requestEndingImage } from '@/lib/api/endingImageApi';
 
 import Logger from '@/lib/utils/logger';
 const logger = new Logger('EndingScreen');
@@ -122,24 +122,12 @@ export function EndingScreen() {
         .slice(-5)
         .map((segment) => segment.content);
 
-      const response = await aiFetch('/api/generate-ending-image', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          ending: currentEnding,
-          world,
-          character,
-          recentNarrative,
-        }),
+      const data = await requestEndingImage({
+        ending: currentEnding,
+        world,
+        character,
+        recentNarrative,
       });
-
-      if (!response.ok) {
-        throw new Error('Failed to load ending image');
-      }
-
-      const data = await response.json();
       setEndingImage(data.imageUrl);
 
       // Update the ending in the store with the image URL

--- a/src/components/Journal/JournalEntryImage.tsx
+++ b/src/components/Journal/JournalEntryImage.tsx
@@ -6,7 +6,7 @@ import { ImageOff, AlertCircle } from 'lucide-react';
 import { JournalEntry } from '@/types/journal.types';
 import { GeneratedImage } from '@/types/common.types';
 import { ImageGenerationSection } from '@/components/shared';
-import { generateJournalImage } from '@/lib/ai/journalImageGenerator';
+import { generateJournalImage } from '@/lib/api/journalImageApi';
 import { useJournalStore } from '@/state/journalStore';
 import { useWorldStore } from '@/state/worldStore';
 import { getTimestamp } from '@/lib/utils';

--- a/src/components/Journal/__tests__/JournalEntryImage.test.tsx
+++ b/src/components/Journal/__tests__/JournalEntryImage.test.tsx
@@ -4,9 +4,9 @@ import '@testing-library/jest-dom';
 import { JournalEntryImage } from '../JournalEntryImage';
 import { useJournalStore } from '@/state/journalStore';
 import { JournalEntry } from '@/types/journal.types';
-import { generateJournalImage } from '@/lib/ai/journalImageGenerator';
+import { generateJournalImage } from '@/lib/api/journalImageApi';
 
-jest.mock('@/lib/ai/journalImageGenerator', () => ({
+jest.mock('@/lib/api/journalImageApi', () => ({
   generateJournalImage: jest.fn(),
 }));
 

--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -6,8 +6,7 @@ import React, {
   useCallback,
 } from 'react';
 import { NarrativeHistory } from './NarrativeHistory';
-import { NarrativeGenerator } from '@/lib/ai/narrativeGenerator';
-import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
+import { useNarrativeGenerator } from '@/hooks/useNarrativeGenerator';
 import { useNarrativeStore } from '@/state/narrativeStore';
 import { useEndingDetection } from './useEndingDetection';
 import { usePlayerChoices } from './hooks/usePlayerChoices';
@@ -90,10 +89,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
     (state) => state.clearGenerationError
   );
   const hasHydrated = useNarrativeStore((state) => state._hasHydrated);
-  const narrativeGenerator = useMemo(
-    () => new NarrativeGenerator(createDefaultGeminiClient()),
-    []
-  );
+  const narrativeGenerator = useNarrativeGenerator();
 
   const npcIds = useNPCStore(
     useCallback((state) => state.worldNpcs[worldId] ?? EMPTY_NPC_IDS, [worldId])

--- a/src/hooks/useNarrativeGenerator.ts
+++ b/src/hooks/useNarrativeGenerator.ts
@@ -1,0 +1,12 @@
+import { useMemo } from 'react';
+import { NarrativeGenerator } from '@/lib/ai/narrativeGenerator';
+import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
+
+/**
+ * Environment-aware NarrativeGenerator instance for components.
+ * createDefaultGeminiClient branches on browser vs server internally; keeping
+ * the construction here means components never import lib/ai directly.
+ */
+export function useNarrativeGenerator(): NarrativeGenerator {
+  return useMemo(() => new NarrativeGenerator(createDefaultGeminiClient()), []);
+}

--- a/src/lib/api/__tests__/characterApi.test.ts
+++ b/src/lib/api/__tests__/characterApi.test.ts
@@ -1,0 +1,59 @@
+jest.mock('@/lib/ai/aiFetch', () => ({
+  aiFetch: jest.fn(),
+}));
+
+import { characterApi } from '../characterApi';
+import { aiFetch } from '@/lib/ai/aiFetch';
+
+const mockAiFetch = aiFetch as jest.MockedFunction<typeof aiFetch>;
+
+describe('characterApi.generateCharacter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('POSTs the params and returns the generated data', async () => {
+    const generated = { name: 'Hero' };
+    mockAiFetch.mockResolvedValue({
+      ok: true,
+      json: async () => generated,
+    } as unknown as Response);
+
+    const result = await characterApi.generateCharacter({
+      characterType: 'original',
+      existingNames: ['Alice'],
+    });
+
+    expect(result).toEqual(generated);
+    const [url, init] = mockAiFetch.mock.calls[0];
+    expect(url).toBe('/api/generate-character');
+    expect(JSON.parse(init?.body as string)).toMatchObject({
+      characterType: 'original',
+      existingNames: ['Alice'],
+    });
+  });
+
+  it('throws the server error message on a failed response', async () => {
+    mockAiFetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: 'World not found' }),
+    } as unknown as Response);
+
+    await expect(
+      characterApi.generateCharacter({ characterType: 'known', existingNames: [] })
+    ).rejects.toThrow('World not found');
+  });
+
+  it('falls back to a generic message when the error body is unparseable', async () => {
+    mockAiFetch.mockResolvedValue({
+      ok: false,
+      json: async () => {
+        throw new Error('bad json');
+      },
+    } as unknown as Response);
+
+    await expect(
+      characterApi.generateCharacter({ characterType: 'known', existingNames: [] })
+    ).rejects.toThrow('Failed to generate character');
+  });
+});

--- a/src/lib/api/__tests__/journalImageApi.test.ts
+++ b/src/lib/api/__tests__/journalImageApi.test.ts
@@ -1,4 +1,4 @@
-import { generateJournalImage } from '../journalImageGenerator';
+import { generateJournalImage } from '../journalImageApi';
 import type { JournalEntry } from '@/types/journal.types';
 
 const entry: JournalEntry = {

--- a/src/lib/api/characterApi.ts
+++ b/src/lib/api/characterApi.ts
@@ -1,0 +1,33 @@
+import type { GeneratedCharacterData } from '@/lib/generators/characterGenerator';
+import type { World } from '@/types/world.types';
+import { aiFetch } from '@/lib/ai/aiFetch';
+
+export interface GenerateCharacterParams {
+  worldId?: string;
+  characterType: 'known' | 'original' | 'specific';
+  existingNames: string[];
+  suggestedName?: string;
+  world?: World | null;
+  concept?: string;
+}
+
+/**
+ * Centralized API service for character generation (worldApi pattern) —
+ * components call this instead of hand-rolling the fetch + error handling.
+ */
+export const characterApi = {
+  async generateCharacter(params: GenerateCharacterParams): Promise<GeneratedCharacterData> {
+    const response = await aiFetch('/api/generate-character', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(params),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error((errorData as { error?: string }).error || 'Failed to generate character');
+    }
+
+    return response.json();
+  },
+};

--- a/src/lib/api/endingImageApi.ts
+++ b/src/lib/api/endingImageApi.ts
@@ -1,0 +1,29 @@
+import type { World } from '@/types/world.types';
+import type { Character } from '@/state/characterStore';
+import type { StoryEnding } from '@/types/narrative.types';
+import { aiFetch } from '@/lib/ai/aiFetch';
+
+export interface EndingImageParams {
+  ending: StoryEnding;
+  world?: World;
+  character?: Character;
+  recentNarrative: string[];
+}
+
+/**
+ * Request the AI-generated ending illustration (worldApi pattern) —
+ * components call this instead of hand-rolling the fetch + error handling.
+ */
+export async function generateEndingImage(params: EndingImageParams): Promise<{ imageUrl: string }> {
+  const response = await aiFetch('/api/generate-ending-image', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(params),
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to load ending image');
+  }
+
+  return response.json();
+}

--- a/src/lib/api/journalImageApi.ts
+++ b/src/lib/api/journalImageApi.ts
@@ -5,7 +5,7 @@ import { World } from '@/types/world.types';
 import { GeneratedImage } from '@/types/common.types';
 import { getTimestamp } from '@/lib/utils';
 import Logger from '@/lib/utils/logger';
-import { aiFetch } from './aiFetch';
+import { aiFetch } from '@/lib/ai/aiFetch';
 
 const logger = new Logger('JournalImageGenerator');
 


### PR DESCRIPTION
## Description
Batch C of the audit series (after #1505/#1506/#1507): fixes the UI-to-AI-layer boundary drift, then makes the linter actually guard it.

Five components hand-rolled `aiFetch` + error handling inline (all traceable to #893) while `worldApi.ts` was the established pattern two files over. Now: a new `characterApi` replaces the *duplicated* generate-character POST in `characters/page.tsx` and `CharacterSuggestions` (they'd diverged in error handling); `CharacterEditor` uses the existing `lib/api/generatePortrait` it was duplicating verbatim; `EndingScreen` gets `endingImageApi`; `journalImageGenerator` moves to `lib/api` where it always belonged; and `NarrativeController` — the only component constructing a Gemini client in its body — now uses a `useNarrativeGenerator` hook. Plus the generate-portrait route resolved the API key three times per request; hoisted to once.

The enforcement half: `components-no-direct-lib-imports` matched `lib/(gemini|prompt)/` — directories that barely exist — at non-blocking `info`, catching ~1 of 15 real import sites. It now matches `^src/lib/ai/` at **error** severity. Devtools panels (exist to poke internals), colocated `use*.ts` hook files (they *are* the mediating layer), and tests are exempt. The seven remaining edges (world wizard image/analyzer, WorldImageForm, provider settings) are deliberately baselined — new violations fail CI from here on, and the baseline shrinks as those migrate.

## Related Issue
N/A — audit findings.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation — new characterApi contract tests; existing suites pin the migrated behavior
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated — N/A, no visual changes
- [ ] Components developed in isolation first — N/A
- [ ] Visual consistency verified — N/A

## Implementation Notes
Type imports for `GeneratedCharacterData` moved from `@/lib/ai/characterGenerator` to `@/lib/generators/characterGenerator` — this pre-resolves the conflict with #1507, which deletes the lib/ai pass-through. The NarrativeController tests' module mocks still hold because the new hook consumes the exact modules they mock. `EndingScreen` had a local callback also named `generateEndingImage`, so the API import is aliased.

## Screenshots
N/A

## Code Review Summary (if applicable)
Findings confirmed by adversarial verifier agents against file/line evidence before implementation.

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Local gate: 2,406 tests / 354 suites green, `tsc --noEmit` clean, ESLint clean, Knip clean, `deps:validate` clean with the new rule active.

## Testing Instructions
1. `npx jest src/lib/api src/components/Narrative src/components/GameSession`
2. `npm run deps:validate` — passes; `npx depcruise src --config --no-ignore-known --output-type err` shows the seven baselined edges under the broadened rule.
3. Manual: generate a character, a portrait, and play to an ending — all three AI flows now route through lib/api.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) — N/A
- [x] No new warnings generated
- [x] Accessibility considerations addressed — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)