### PR TITLE
fix(ai): abort narrative generation on race timeout, align client/server timeout budgets

### DIFF
--- a/src/app/api/ai/validate-provider/route.ts
+++ b/src/app/api/ai/validate-provider/route.ts
@@ -17,6 +17,9 @@ import { PROVIDER_API_KEY_HEADER } from '@/lib/ai/providerKeyHeader';
  * UNSUPPORTED_PROVIDER.
  */
 
+// Vercel function budget: one single-attempt Gemini ping (30s) + overhead.
+export const maxDuration = 60;
+
 const GEMINI_MODELS_BASE = 'https://generativelanguage.googleapis.com/v1beta/models';
 const DEFAULT_MODEL = 'gemini-2.5-flash';
 

--- a/src/app/api/narrative/choices/route.ts
+++ b/src/app/api/narrative/choices/route.ts
@@ -3,6 +3,12 @@
 import { NextRequest } from 'next/server';
 import { processGeminiTextRequest } from '../../../../utils/apiHelpers';
 
+// Vercel function budget. Must be a static literal (Next.js segment config);
+// sized as the single 30s Gemini attempt (GEMINI_ATTEMPT_TIMEOUT_MS in
+// lib/constants/aiTimeouts) plus server-side overhead, so deploys don't ride
+// a plan default shorter than the attempt itself.
+export const maxDuration = 60;
+
 export async function POST(request: NextRequest) {
   return processGeminiTextRequest(request, {
     maxTokens: 2048,

--- a/src/app/api/narrative/generate/route.ts
+++ b/src/app/api/narrative/generate/route.ts
@@ -3,6 +3,12 @@
 import { NextRequest } from 'next/server';
 import { processGeminiTextRequest } from '../../../../utils/apiHelpers';
 
+// Vercel function budget. Must be a static literal (Next.js segment config);
+// sized as the single 30s Gemini attempt (GEMINI_ATTEMPT_TIMEOUT_MS in
+// lib/constants/aiTimeouts) plus server-side overhead, so deploys don't ride
+// a plan default shorter than the attempt itself.
+export const maxDuration = 60;
+
 export async function POST(request: NextRequest) {
   return processGeminiTextRequest(request, {
     maxTokens: 1024,

--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -408,6 +408,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
     }
     initialGenerationLocksRef.current.add(lockKey);
 
+    let generationTimeoutId: ReturnType<typeof setTimeout> | undefined;
     try {
       // CHECK FIRST: Don't generate an initial scene if one already exists
       // Do a fresh check of the store to get the latest state
@@ -425,27 +426,27 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
       setIsLoading(true);
       setError(null);
 
-      // Race AI generation with a timeout so we can fallback gracefully
-      const timeoutPromise = new Promise<
-        ReturnType<typeof narrativeGenerator.generateInitialScene>
-      >((_, reject) => {
-        setTimeout(
-          () =>
-            reject(
-              new Error(`Initial generation timed out after ${AI_GENERATION_TIMEOUT_MS}ms`)
-            ),
-          AI_GENERATION_TIMEOUT_MS
-        );
+      // Race AI generation with a timeout so we can fallback gracefully.
+      // Losing the race must also ABORT the generation: without the signal,
+      // the abandoned request keeps running (and spending) until aiFetch's
+      // ceiling, then mutates lore/inventory/NPC state when it settles.
+      const generationAbort = new AbortController();
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        generationTimeoutId = setTimeout(() => {
+          generationAbort.abort();
+          reject(
+            new Error(`Initial generation timed out after ${AI_GENERATION_TIMEOUT_MS}ms`)
+          );
+        }, AI_GENERATION_TIMEOUT_MS);
       });
       const result = await Promise.race([
         narrativeGenerator.generateInitialScene(
           worldId,
           characterId ? [characterId] : [],
-          sessionId
+          sessionId,
+          { signal: generationAbort.signal }
         ),
-        timeoutPromise as unknown as Promise<
-          ReturnType<typeof narrativeGenerator.generateInitialScene>
-        >,
+        timeoutPromise,
       ]);
 
       // Skip if component unmounted during async operation
@@ -556,6 +557,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
         setError(getNarrativeError(error as Error).message);
       }
     } finally {
+      clearTimeout(generationTimeoutId);
       initialGenerationLocksRef.current.delete(lockKey);
       if (mountedRef.current) {
         setIsLoading(false);
@@ -577,6 +579,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
     setError(null);
     clearGenerationError();
 
+    let segmentTimeoutId: ReturnType<typeof setTimeout> | undefined;
     try {
       // Use recent segments for context (last 3 segments for efficiency)
       const recentSegments = segments.slice(-3);
@@ -667,47 +670,49 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
         skillCheckContext = ` [Skill checks: ${skillResultDescriptions.join(', ')}]`;
       }
 
-      const segmentTimeoutPromise = new Promise<
-        ReturnType<typeof narrativeGenerator.generateSegment>
-      >((_, reject) => {
-        setTimeout(
-          () =>
-            reject(
-              new Error(`Segment generation timed out after ${AI_GENERATION_TIMEOUT_MS}ms`)
-            ),
-          AI_GENERATION_TIMEOUT_MS
-        );
+      // Same contract as the initial-scene race: losing the race aborts the
+      // generation at the fetch layer instead of orphaning it until aiFetch's
+      // ceiling fires.
+      const segmentAbort = new AbortController();
+      const segmentTimeoutPromise = new Promise<never>((_, reject) => {
+        segmentTimeoutId = setTimeout(() => {
+          segmentAbort.abort();
+          reject(
+            new Error(`Segment generation timed out after ${AI_GENERATION_TIMEOUT_MS}ms`)
+          );
+        }, AI_GENERATION_TIMEOUT_MS);
       });
       const result = await Promise.race([
-        narrativeGenerator.generateSegment({
-          worldId,
-          sessionId,
-          characterIds: characterId ? [characterId] : [],
-          narrativeContext: {
+        narrativeGenerator.generateSegment(
+          {
             worldId,
-            currentSceneId: `scene-${Date.now()}`,
-            characterIds: characterId ? [characterId] : [],
-            previousSegments: recentSegments,
-            currentTags,
             sessionId,
-            recentSegments,
-            currentSituation: `Player chose: "${choiceText}"${skillCheckContext}`,
+            characterIds: characterId ? [characterId] : [],
+            narrativeContext: {
+              worldId,
+              currentSceneId: `scene-${Date.now()}`,
+              characterIds: characterId ? [characterId] : [],
+              previousSegments: recentSegments,
+              currentTags,
+              sessionId,
+              recentSegments,
+              currentSituation: `Player chose: "${choiceText}"${skillCheckContext}`,
+            },
+            generationParameters: {
+              includedTopics: [choiceText],
+              desiredLength: 'short',
+              decisionWeight,
+              // Critical decisions with critical failures should have tragic tone
+              desiredTone:
+                decisionWeight === 'critical' &&
+                rollResults.some((r) => r.isCriticalFailure)
+                  ? 'tragic'
+                  : undefined,
+            },
           },
-          generationParameters: {
-            includedTopics: [choiceText],
-            desiredLength: 'short',
-            decisionWeight,
-            // Critical decisions with critical failures should have tragic tone
-            desiredTone:
-              decisionWeight === 'critical' &&
-              rollResults.some((r) => r.isCriticalFailure)
-                ? 'tragic'
-                : undefined,
-          },
-        }),
-        segmentTimeoutPromise as unknown as ReturnType<
-          typeof narrativeGenerator.generateSegment
-        >,
+          { signal: segmentAbort.signal }
+        ),
+        segmentTimeoutPromise,
       ]);
 
       // Skip if component unmounted during async operation
@@ -801,6 +806,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
       );
       setGenerationError(getNarrativeError(err as Error));
     } finally {
+      clearTimeout(segmentTimeoutId);
       if (mountedRef.current) {
         setIsLoading(false);
       }

--- a/src/components/Narrative/__tests__/NarrativeController.timeout.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeController.timeout.test.tsx
@@ -174,4 +174,38 @@ describe('NarrativeController — per-choice segment timeout (#1429)', () => {
     // Loading state must have cleared — we should NOT see the loading indicator
     expect(screen.queryByTestId('loading-indicator')).toBeNull();
   });
+
+  it('aborts the losing generation when the race times out', async () => {
+    // Losing the race must cancel the request itself, not just abandon the
+    // promise — otherwise the fetch lives on until aiFetch's outer ceiling
+    // (a zombie that wastes spend and mutates stores when it settles).
+    mockGenerateSegment.mockReturnValue(new Promise(() => {}));
+
+    renderWithToast(
+      <NarrativeController
+        worldId="test-world"
+        sessionId="test-session"
+        triggerGeneration={true}
+        generateChoices={false}
+        choiceId="choice-1"
+      />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockGenerateSegment).toHaveBeenCalledTimes(1);
+    const options = mockGenerateSegment.mock.calls[0][1] as
+      | { signal?: AbortSignal }
+      | undefined;
+    expect(options?.signal).toBeInstanceOf(AbortSignal);
+    expect(options?.signal?.aborted).toBe(false);
+
+    await act(async () => {
+      jest.advanceTimersByTime(AI_GENERATION_TIMEOUT_MS + 100);
+    });
+
+    expect(options?.signal?.aborted).toBe(true);
+  });
 });

--- a/src/lib/ai/__tests__/aiFetch.test.ts
+++ b/src/lib/ai/__tests__/aiFetch.test.ts
@@ -71,4 +71,37 @@ describe('aiFetch', () => {
     const init = (global.fetch as jest.Mock).mock.calls[0][1];
     expect(init.signal).toBe(controller.signal);
   });
+
+  test('composes a caller signal WITH the timeout ceiling instead of replacing it', async () => {
+    // Emulate a runtime with AbortSignal.timeout so the ceiling exists.
+    const ceiling = new AbortController();
+    (AbortSignal as unknown as { timeout?: (ms: number) => AbortSignal }).timeout =
+      jest.fn(() => ceiling.signal);
+    try {
+      mockGetKey.mockResolvedValue(null);
+      const caller = new AbortController();
+      await aiFetch('/api/x', { signal: caller.signal });
+
+      const init = (global.fetch as jest.Mock).mock.calls[0][1];
+      // The composed signal fires when the CALLER aborts (race loss)…
+      expect(init.signal.aborted).toBe(false);
+      caller.abort();
+      expect(init.signal.aborted).toBe(true);
+    } finally {
+      delete (AbortSignal as unknown as { timeout?: unknown }).timeout;
+    }
+  });
+
+  test('honors a per-call timeoutMs budget', async () => {
+    const timeoutSpy = jest.fn(() => new AbortController().signal);
+    (AbortSignal as unknown as { timeout?: (ms: number) => AbortSignal }).timeout = timeoutSpy;
+    try {
+      mockGetKey.mockResolvedValue(null);
+      await aiFetch('/api/narrative/generate', {}, { timeoutMs: 45_000 });
+
+      expect(timeoutSpy).toHaveBeenCalledWith(45_000);
+    } finally {
+      delete (AbortSignal as unknown as { timeout?: unknown }).timeout;
+    }
+  });
 });

--- a/src/lib/ai/abortTimeout.ts
+++ b/src/lib/ai/abortTimeout.ts
@@ -6,3 +6,30 @@
 export function timeoutSignal(ms: number): AbortSignal | undefined {
   return typeof AbortSignal.timeout === 'function' ? AbortSignal.timeout(ms) : undefined;
 }
+
+/**
+ * Compose signals so the result aborts when ANY input aborts — lets a caller's
+ * cancellation signal ride alongside a timeout ceiling instead of replacing it.
+ * Uses native AbortSignal.any where available, with a manual fallback for
+ * runtimes that lack it (jsdom). Undefined inputs are skipped; composing fewer
+ * than two real signals returns the lone signal (or undefined) unchanged.
+ */
+export function anySignal(
+  ...signals: Array<AbortSignal | undefined>
+): AbortSignal | undefined {
+  const present = signals.filter((s): s is AbortSignal => Boolean(s));
+  if (present.length <= 1) return present[0];
+  if (typeof AbortSignal.any === 'function') return AbortSignal.any(present);
+
+  const controller = new AbortController();
+  for (const signal of present) {
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+      break;
+    }
+    signal.addEventListener('abort', () => controller.abort(signal.reason), {
+      once: true,
+    });
+  }
+  return controller.signal;
+}

--- a/src/lib/ai/aiFetch.ts
+++ b/src/lib/ai/aiFetch.ts
@@ -2,7 +2,8 @@
 
 import { PROVIDER_API_KEY_HEADER } from './providerKeyHeader';
 import { getActiveProviderKey } from '@/state/providerStore';
-import { timeoutSignal } from './abortTimeout';
+import { anySignal, timeoutSignal } from './abortTimeout';
+import { RETRYING_ROUTE_TIMEOUT_MS } from '@/lib/constants/aiTimeouts';
 
 /**
  * fetch() wrapper for browser -> our own AI routes.
@@ -13,17 +14,32 @@ import { timeoutSignal } from './abortTimeout';
  * unchanged. The plaintext key lives only in this closure for the duration of
  * the call; it's never stored or logged.
  */
-// Outer guard for the whole round-trip (server processing + Gemini call +
-// its internal retries: worst case ~93s at 3x30s attempts plus backoff).
-// GeminiClient enforces its own per-attempt timeout; this catches everything
-// else so a hung request can't block the story loop forever.
-const AI_REQUEST_TIMEOUT_MS = 120_000;
 
-export async function aiFetch(input: string, init: RequestInit = {}): Promise<Response> {
+export interface AiFetchOptions {
+  /**
+   * Ceiling for this request. Callers hitting a single-attempt route should
+   * pass a budget derived from that route's server timeout (see
+   * lib/constants/aiTimeouts); the default covers the worst-case retrying/
+   * image routes so a hung request can never block the story loop forever.
+   */
+  timeoutMs?: number;
+}
+
+export async function aiFetch(
+  input: string,
+  init: RequestInit = {},
+  options: AiFetchOptions = {}
+): Promise<Response> {
   const key = await getActiveProviderKey().catch(() => null);
   const withTimeout: RequestInit = {
     ...init,
-    signal: init.signal ?? timeoutSignal(AI_REQUEST_TIMEOUT_MS),
+    // A caller-supplied signal (e.g. the narrative race's AbortController)
+    // composes with the ceiling rather than replacing it: the request dies
+    // on whichever fires first.
+    signal: anySignal(
+      init.signal ?? undefined,
+      timeoutSignal(options.timeoutMs ?? RETRYING_ROUTE_TIMEOUT_MS)
+    ),
   };
   // No configured key -> identical to a plain fetch (env fallback applies
   // server-side). This keeps aiFetch a true drop-in: dev, tests, and E2E behave

--- a/src/lib/ai/clientGeminiClient.ts
+++ b/src/lib/ai/clientGeminiClient.ts
@@ -1,8 +1,9 @@
 // src/lib/ai/clientGeminiClient.ts
 
-import { AIClient, AIResponse, AIImageResponse } from './types';
+import { AIClient, AIGenerateOptions, AIResponse, AIImageResponse } from './types';
 import { userFriendlyError } from './userFriendlyErrors';
 import { aiFetch } from './aiFetch';
+import { SINGLE_ATTEMPT_TEXT_TIMEOUT_MS } from '@/lib/constants/aiTimeouts';
 
 import Logger from '@/lib/utils/logger';
 const logger = new Logger('ClientGeminiClient');
@@ -24,15 +25,25 @@ export class ClientGeminiClient implements AIClient {
    * shared error branches (rate limiting, HTTP errors, network failures)
    * into user-friendly messages.
    */
-  private async postJson<T>(endpoint: string, body: unknown, logContext: string): Promise<T> {
+  private async postJson<T>(
+    endpoint: string,
+    body: unknown,
+    logContext: string,
+    options: AIGenerateOptions & { timeoutMs?: number } = {}
+  ): Promise<T> {
     try {
-      const response = await aiFetch(`${this.baseUrl}${endpoint}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
+      const response = await aiFetch(
+        `${this.baseUrl}${endpoint}`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(body),
+          signal: options.signal,
         },
-        body: JSON.stringify(body),
-      });
+        { timeoutMs: options.timeoutMs }
+      );
 
       if (!response.ok) {
         const errorData = await response.json();
@@ -64,11 +75,14 @@ export class ClientGeminiClient implements AIClient {
    * generation goes through generateChoices() — callers pick the endpoint
    * explicitly instead of this method inferring it from prompt content.
    */
-  async generateContent(prompt: string): Promise<AIResponse> {
+  async generateContent(prompt: string, options?: AIGenerateOptions): Promise<AIResponse> {
     const data = await this.postJson<{ content: string; finishReason?: string; promptTokens?: number; completionTokens?: number }>(
       '/api/narrative/generate',
       { prompt, config: { temperature: 0.7, maxTokens: 1024 } },
-      'generation'
+      'generation',
+      // The route makes a single 30s Gemini attempt (makeGeminiRequest), so
+      // the wait ceiling is that budget + headroom, not the retry worst case.
+      { signal: options?.signal, timeoutMs: SINGLE_ATTEMPT_TEXT_TIMEOUT_MS }
     );
     return this.toAIResponse(data);
   }
@@ -77,11 +91,12 @@ export class ClientGeminiClient implements AIClient {
    * Generate choices via server-side API route
    * This method is used specifically for choice generation
    */
-  async generateChoices(prompt: string): Promise<AIResponse> {
+  async generateChoices(prompt: string, options?: AIGenerateOptions): Promise<AIResponse> {
     const data = await this.postJson<{ content: string; finishReason?: string; promptTokens?: number; completionTokens?: number }>(
       '/api/narrative/choices',
       { prompt, config: { temperature: 0.7, maxTokens: 1024 } },
-      'choice generation'
+      'choice generation',
+      { signal: options?.signal, timeoutMs: SINGLE_ATTEMPT_TEXT_TIMEOUT_MS }
     );
     return this.toAIResponse(data);
   }

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -1,6 +1,7 @@
 // src/lib/ai/config.ts
 
 import { AIConfig, GenerationConfig, SafetySetting } from './types';
+import { GEMINI_ATTEMPT_TIMEOUT_MS } from '@/lib/constants/aiTimeouts';
 
 /**
  * Gets AI configuration from environment variables.
@@ -15,7 +16,7 @@ export const getAIConfig = (): AIConfig => {
     modelName: 'gemini-2.5-flash',
     imageModelName: 'gemini-2.5-flash-image',
     maxRetries: 3,
-    timeout: 30000
+    timeout: GEMINI_ATTEMPT_TIMEOUT_MS
   };
 };
 

--- a/src/lib/ai/narrativeGenerator.ts
+++ b/src/lib/ai/narrativeGenerator.ts
@@ -54,6 +54,18 @@ import {
   enhancePromptWithContinuityExpectations,
 } from './narrativeGenerator.continuity';
 
+/**
+ * Stop an abandoned generation before its side effects run. Callers that race
+ * generation against a UI timeout abort this signal on race loss; without the
+ * check, a generation that loses the race would still write lore, inventory,
+ * and NPC state minutes after the UI took the fallback path.
+ */
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new Error('Narrative generation aborted by caller');
+  }
+}
+
 export class NarrativeGenerator {
   private staticContentCache: NarrativeStaticContentCache = {
     toneSettings: new Map(),
@@ -62,7 +74,8 @@ export class NarrativeGenerator {
   constructor(private geminiClient: AIClient) {}
 
   async generateSegment(
-    request: NarrativeGenerationRequest
+    request: NarrativeGenerationRequest,
+    options?: { signal?: AbortSignal }
   ): Promise<NarrativeGenerationResult> {
     try {
       const world = this.getWorld(request.worldId);
@@ -140,7 +153,10 @@ export class NarrativeGenerator {
         continuityContract
       );
 
-      const response = await this.geminiClient.generateContent(finalPrompt);
+      const response = await this.geminiClient.generateContent(finalPrompt, {
+        signal: options?.signal,
+      });
+      throwIfAborted(options?.signal);
       recordRequestCalibration(budget, finalPrompt, response);
 
       let result = await formatNarrativeResponse(
@@ -158,6 +174,9 @@ export class NarrativeGenerator {
         worldId: request.worldId,
         sessionId: request.sessionId,
       });
+      // Re-check before the store-mutating tail (lore extraction, item
+      // acquisition/loss, NPC sync) in case the caller aborted mid-pipeline.
+      throwIfAborted(options?.signal);
 
       // Lore extraction runs on the final (possibly corrected) prose so a
       // contradicted draft never pollutes the lore store.
@@ -302,7 +321,7 @@ export class NarrativeGenerator {
     worldId: string,
     characterIds: string[],
     sessionId?: string,
-    options?: { generationParameters?: GenerationParameters }
+    options?: { generationParameters?: GenerationParameters; signal?: AbortSignal }
   ): Promise<NarrativeGenerationResult> {
     try {
       const world = this.getWorld(worldId);
@@ -379,7 +398,10 @@ export class NarrativeGenerator {
         characterInventory
       );
 
-      const response = await this.geminiClient.generateContent(fullyEnhancedPrompt);
+      const response = await this.geminiClient.generateContent(fullyEnhancedPrompt, {
+        signal: options?.signal,
+      });
+      throwIfAborted(options?.signal);
       recordRequestCalibration(budget, fullyEnhancedPrompt, response);
 
       if (response.content) {

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -75,14 +75,23 @@ export interface AIImageResponse {
 }
 
 /**
+ * Per-call options for AI clients. `signal` lets a caller cancel the
+ * underlying request (e.g. when a UI-level timeout races the generation);
+ * implementations that can't cancel may ignore it.
+ */
+export interface AIGenerateOptions {
+  signal?: AbortSignal;
+}
+
+/**
  * Interface for AI clients (both real and mock)
  */
 export interface AIClient {
-  generateContent(prompt: string): Promise<AIResponse>;
+  generateContent(prompt: string, options?: AIGenerateOptions): Promise<AIResponse>;
   // Choice generation is a distinct endpoint on the browser path; callers that
   // need it (choiceGenerator) prefer this over generateContent so routing is
   // explicit rather than inferred from prompt content.
-  generateChoices?(prompt: string): Promise<AIResponse>;
+  generateChoices?(prompt: string, options?: AIGenerateOptions): Promise<AIResponse>;
   generateImage?(prompt: string): Promise<AIImageResponse>;
   generateStructuredContent?<T = unknown>(prompt: string, schema: unknown): Promise<T>;
   isAvailable?(): Promise<boolean>;

--- a/src/lib/constants/aiTimeouts.ts
+++ b/src/lib/constants/aiTimeouts.ts
@@ -14,9 +14,10 @@ export const GEMINI_ATTEMPT_TIMEOUT_MS = 30_000;
 
 /**
  * Headroom the browser grants on top of the server budget it's waiting on:
- * transport, serverless cold start, queuing, and JSON handling.
+ * transport, serverless cold start, queuing, and JSON handling. Module-local —
+ * only used to derive the single-attempt ceiling below.
  */
-export const AI_CLIENT_HEADROOM_MS = 15_000;
+const AI_CLIENT_HEADROOM_MS = 15_000;
 
 /**
  * Browser ceiling for single-attempt text routes (/api/narrative/generate,

--- a/src/lib/constants/aiTimeouts.ts
+++ b/src/lib/constants/aiTimeouts.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared AI request budgets (milliseconds), importable from both the browser
+ * and API-route code. The invariant: a browser-side ceiling must be derived
+ * from the server-side budget of the route it calls (server budget + headroom),
+ * never sized independently — otherwise the two drift and the client ends up
+ * waiting on a response the server gave up on long ago.
+ */
+
+/**
+ * Server budget for a single Gemini attempt: makeGeminiRequest's
+ * AbortController timeout and GeminiClient's per-attempt abort signal.
+ */
+export const GEMINI_ATTEMPT_TIMEOUT_MS = 30_000;
+
+/**
+ * Headroom the browser grants on top of the server budget it's waiting on:
+ * transport, serverless cold start, queuing, and JSON handling.
+ */
+export const AI_CLIENT_HEADROOM_MS = 15_000;
+
+/**
+ * Browser ceiling for single-attempt text routes (/api/narrative/generate,
+ * /api/narrative/choices). Those routes make exactly one Gemini attempt via
+ * makeGeminiRequest — no retries — so the client budget is one attempt plus
+ * headroom, not the retry-loop worst case.
+ */
+export const SINGLE_ATTEMPT_TEXT_TIMEOUT_MS =
+  GEMINI_ATTEMPT_TIMEOUT_MS + AI_CLIENT_HEADROOM_MS;
+
+/**
+ * Browser ceiling for routes that run GeminiClient's retry loop server-side
+ * (3 attempts x 30s + exponential backoff ≈ 93s worst case) or image
+ * generation. Also aiFetch's default when no tighter budget is given.
+ */
+export const RETRYING_ROUTE_TIMEOUT_MS = 120_000;

--- a/src/utils/__tests__/apiHelpers.test.ts
+++ b/src/utils/__tests__/apiHelpers.test.ts
@@ -17,6 +17,7 @@ jest.mock('../rateLimiter', () => ({
 
 import { getSafetySettingsFromPrompt, makeGeminiRequest } from '../apiHelpers';
 import { getAIConfig } from '../../lib/ai/config';
+import { GEMINI_ATTEMPT_TIMEOUT_MS } from '../../lib/constants/aiTimeouts';
 
 describe('getSafetySettingsFromPrompt', () => {
   it('returns BLOCK_MEDIUM_AND_ABOVE for G-rated content', () => {
@@ -153,5 +154,32 @@ describe('makeGeminiRequest', () => {
     await makeGeminiRequest(endpoint, 'test-key', {});
 
     expect(global.fetch).toHaveBeenCalledWith(endpoint, expect.any(Object));
+  });
+
+  it('rejects at the shared single-attempt budget when the upstream hangs', async () => {
+    jest.useFakeTimers();
+    try {
+      // Hang forever, but honor the abort signal like a real fetch would.
+      (global.fetch as jest.Mock).mockImplementation(
+        (_endpoint: string, init: RequestInit) =>
+          new Promise((_, reject) => {
+            init.signal?.addEventListener('abort', () =>
+              reject(Object.assign(new Error('The operation was aborted'), { name: 'AbortError' }))
+            );
+          })
+      );
+
+      const pending = makeGeminiRequest('https://example.test/gemini', 'test-key', {});
+      const outcome = expect(pending).rejects.toThrow('Request timeout - please try again');
+
+      // Still in-flight just before the 30s budget…
+      jest.advanceTimersByTime(GEMINI_ATTEMPT_TIMEOUT_MS - 1);
+      // …and aborted the moment it elapses.
+      jest.advanceTimersByTime(1);
+
+      await outcome;
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -5,6 +5,7 @@ import { globalRateLimiter, RateLimiter, type RateLimitResult } from './rateLimi
 import { getAIConfig } from '../lib/ai/config';
 import { resolveApiKey } from '../lib/ai/resolveApiKey';
 import { createAPIErrorResponse } from '../lib/utils/errorUtils';
+import { GEMINI_ATTEMPT_TIMEOUT_MS } from '../lib/constants/aiTimeouts';
 
 import Logger from '@/lib/utils/logger';
 const logger = new Logger('ApiHelpers');
@@ -139,7 +140,7 @@ export async function makeGeminiRequest(
   endpoint: string,
   apiKey: string,
   payload: object,
-  timeoutMs: number = 30000
+  timeoutMs: number = GEMINI_ATTEMPT_TIMEOUT_MS
 ): Promise<Response> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);


### PR DESCRIPTION
## Description
Fixes two related defects in the narrative-generation timeout stack (left behind around PR #1506):

**1. Orphaned uncancellable requests (the player-facing bug).** `NarrativeController` raced `generateInitialScene`/`generateSegment` against `AI_GENERATION_TIMEOUT_MS` with a bare `Promise.race`. On race loss the losing promise was abandoned but never aborted — no `AbortSignal` was threaded through `NarrativeGenerator → ClientGeminiClient → aiFetch` — so the fetch kept running until `aiFetch`'s 120s ceiling. Reproduced in a real browser (Playwright stalling `/api/narrative/generate` at the network layer): request out at +9.1s, UI fallback at +23.1s, request death at **+129.1s** (`TimeoutError: signal timed out`) — ~105s decoupled from the UI, wasting Gemini spend, and the zombie's tail (lore extraction, item acquisition/loss, NPC sync) still mutated stores when it settled.

Fix: both race sites now create an `AbortController` and abort it when the timeout wins; the signal is threaded through `NarrativeGenerator.generateInitialScene/generateSegment` → `AIClient.generateContent(prompt, { signal })` → `ClientGeminiClient.postJson` → `aiFetch` (which now **composes** a caller signal with its timeout ceiling via a guarded `AbortSignal.any` helper instead of letting the caller signal replace the ceiling). `NarrativeGenerator` also short-circuits its store-mutating tail when the signal aborted mid-pipeline. Timers are cleared in `finally` on both paths.

**2. Timeout budget drift.** `aiFetch`'s 120s ceiling was justified by `GeminiClient` retry math (3×30s + backoff ≈ 93s), but `/api/narrative/generate` and `/choices` go through `makeGeminiRequest`: a single attempt with a 30s `AbortController` and zero retries — the client budget was sized for a path the main loop doesn't use. Budgets now derive from shared constants in `src/lib/constants/aiTimeouts.ts`:
- `GEMINI_ATTEMPT_TIMEOUT_MS = 30_000` — shared by `makeGeminiRequest`'s default and `GeminiClient`'s per-attempt config.
- `SINGLE_ATTEMPT_TEXT_TIMEOUT_MS = 45_000` (server budget + headroom) — the browser ceiling for the two single-attempt narrative text routes.
- `RETRYING_ROUTE_TIMEOUT_MS = 120_000` — retained only for routes that genuinely run the retry loop or image generation, and as `aiFetch`'s default.
- Explicit `maxDuration = 60` on the single-attempt AI routes (`narrative/generate`, `narrative/choices`, `ai/validate-provider`) so deployed functions don't ride a plan default shorter than the 30s attempt. The retry-loop/image routes are deliberately left unpinned: their ~93s+ worst case exceeds the 60s `maxDuration` cap of legacy Hobby plans, so pinning them risks either failing the deploy (120) or breaking the retry path (60).

## Related Issue
Follow-up to the timeout work in #1429 / #1506 (no standalone issue).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation — the defect was first reproduced end-to-end in a real browser (see below), and the new regression assertions fail against the pre-fix code (`generateSegment` received no options argument, so `options?.signal` was `undefined`)
- [x] All new code is tested
- [x] All tests pass locally — 86 suites / 549 tests across `src/components/Narrative`, `src/lib/ai`, `src/utils`
- [x] Test coverage maintained or improved

## User Stories Addressed
Players whose generation stalls get the fallback at ~15s without a hidden request continuing to burn quota for another 105s or clobbering lore/inventory/NPC state minutes later.

## Flow Diagrams
N/A — the abort now travels the same path as the request: `NarrativeController` race → `NarrativeGenerator` → `ClientGeminiClient` → `aiFetch` → `fetch`.

## Component Development
N/A — no UI changes; `NarrativeController` changes are orchestration-only.

## Implementation Notes
- `anySignal()` (in `lib/ai/abortTimeout.ts`) uses native `AbortSignal.any` when available with a manual listener fallback for jsdom.
- `AIClient.generateContent/generateChoices` gained an optional `options?: { signal? }` parameter; implementations that ignore it (server `GeminiClient`, mocks) still satisfy the interface unchanged.
- `maxDuration` values are static literals (Next.js segment-config requirement) with comments pointing at the shared constants they mirror.

## Screenshots
N/A.

## Code Review Summary (if applicable)
Verified all three analyses against the code before editing; both defects confirmed exactly as described (race sites at NarrativeController ~440/~681, no signal threading, single-attempt 30s server path vs 120s client ceiling, zero `maxDuration` exports).

## Chrome DevTools MCP Verification Summary (if applicable)
Playwright against `next dev`, stalling `/api/narrative/generate` at the network layer:
- **Before:** request out +9.1s → UI fallback +23.1s → request still in-flight until **+129.1s** (`net::ERR_ABORTED` at aiFetch's 120s ceiling, decoupled console errors).
- **After:** request out +8.3s → race loss at +22.5s aborts the request **immediately** (`AbortError`, `net::ERR_ABORTED` at +22.5s) → UI fallback +22.7s. No zombie remains.

## Quality Checks (if applicable)
- [x] Linting passed (`next lint` clean on all touched files)
- [x] Type checking passed (`tsc --noEmit`)
- [ ] Security audit passed (not run — no dependency changes)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npx jest --config=jest.config.cjs src/components/Narrative src/lib/ai src/utils`
2. Regression specifics: `NarrativeController.timeout.test.tsx` (“aborts the losing generation when the race times out”), `apiHelpers.test.ts` (“rejects at the shared single-attempt budget when the upstream hangs”), `aiFetch.test.ts` (signal composition + per-call budget).
3. Browser verification: run `npm run dev`, stall `POST /api/narrative/generate` (devtools request blocking or a Playwright route), start a session — the fallback appears at ~15s and the network panel shows the original request cancelled at that same moment rather than at 120s.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) — N/A
- [x] No new warnings generated
- [x] Accessibility considerations addressed — N/A (no UI changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UQcajxoz12u3jibjw81oE

---
_Generated by [Claude Code](https://claude.ai/code/session_014UQcajxoz12u3jibjw81oE)_