### PR TITLE
refactor(design-system): unify onboarding tour onto --color-* tokens, remove legacy shadcn layer (#1474)

### DIFF
--- a/public_docs/architecture/ADR-013-collapse-to-single-design-system-ds3.md
+++ b/public_docs/architecture/ADR-013-collapse-to-single-design-system-ds3.md
@@ -70,7 +70,10 @@ Also deferred, on purpose, and separately from each other:
 
 - **A bolder DS3** — deeper ink-blue accent, a louder dot grid, drafting marks, a real type scale, a brand-vs-product surface split. A design pass, not a code cleanup, and it changes token values again, which is exactly why this PR doesn't try to update `DESIGN.md`'s numbers yet (see the note added there).
 - **The `DESIGN.md` rewrite** that follows the bolder-DS3 pass, once there are real DS3 numbers worth documenting as canon instead of DS1's leftover values.
-- **Removing the legacy shadcn HSL token layer** (`--primary`, `--background`, etc. in [ds3.css](../../src/lib/theme/themes/ds3.css)) — the tour and some dialogs still read those tokens, so it stays until that's untangled.
+
+Since resolved:
+
+- **Removing the legacy shadcn HSL token layer** (`--primary`, `--background`, etc. in [ds3.css](../../src/lib/theme/themes/ds3.css)) — done in #1474. The onboarding tour was the last consumer once the shadcn `ui/*` primitives were re-skinned onto `--color-*`; it now reads the `--color-*` family too, and the legacy block was removed from ds3.css.
 
 ## Related Decisions
 

--- a/public_docs/design-system/design-tokens.md
+++ b/public_docs/design-system/design-tokens.md
@@ -4,7 +4,7 @@ type: design-system
 category: tokens
 tags: [design-tokens, colors, architecture, theming, dark-mode]
 created: 2025-01-09
-updated: 2025-06-15
+updated: 2026-07-12
 ---
 
 # Design Token System
@@ -119,35 +119,16 @@ These map intent and context onto the global foundation. Status feedback, storyt
 }
 ```
 
-### Tier 3: Component Tokens (shadcn-derived)
+### Tier 3: Extended Status Tokens (HSL)
 
-HSL-based tokens carried over from the shadcn/ui component foundation. They're consumed via
-`var()` in component CSS (typically wrapped in `hsl()`, e.g. `background: hsl(var(--primary))`).
-These predate the Tailwind removal, so despite the `bg-primary`-style naming there are no
-matching Tailwind utility classes — the values are reached through `var()` like every other token.
+A few status tokens are still stored as raw HSL channels and consumed via `hsl(var())`
+(e.g. `background: hsl(var(--success-background))`), because they carry background/border
+variants that predate the `--color-*` family. Everything else reaches color through the
+`--color-*` tokens (Tiers 1–2).
 
 ```css
 [data-theme="ds3"] {
-  --background: 36 24% 95%;
-  --foreground: 25 20% 14%;
-  --card: 38 100% 98%;
-  --card-foreground: 25 20% 14%;
-  --popover: 38 100% 98%;
-  --popover-foreground: 25 20% 14%;
-  --primary: 200 21% 45%;
-  --primary-foreground: 0 0% 100%;
-  --secondary: 25 14% 40%;
-  --secondary-foreground: 0 0% 100%;
-  --muted: 30 16% 92%;
-  --muted-foreground: 25 14% 46%;
-  --accent: 30 16% 92%;
-  --accent-foreground: 25 20% 14%;
-  --border: 29 16% 85%;
-  --input: 29 16% 85%;
-  --ring: 200 21% 45%;
-  --radius: 0.375rem;
-
-  /* Extended status tokens with background/border/muted variants */
+  /* Status tokens with background/border variants (HSL channels) */
   --success: 138 25% 40%;
   --success-background: 138 25% 90%;
   --success-border: 138 25% 75%;
@@ -160,7 +141,7 @@ matching Tailwind utility classes — the values are reached through `var()` lik
 }
 ```
 
-Note: there's no `--destructive` / `--destructive-foreground` pair — `--color-danger` (Tier 2, above) covers that semantic need instead.
+Note: there's no `--destructive` / `--destructive-foreground` pair — `--color-danger` (Tier 2, above) covers that semantic need instead. The old shadcn base tokens (`--primary`, `--background`, `--card`, `--popover`, `--border`, `--input`, `--ring`, `--radius`, …) were removed once the app unified on the `--color-*` family — see [ADR-013](../architecture/ADR-013-collapse-to-single-design-system-ds3.md).
 
 ## Using Design Tokens
 
@@ -197,8 +178,8 @@ const WarningAlert = () => (
 
 ```css
 .btn-primary {
-  background: hsl(var(--primary));
-  color: hsl(var(--primary-foreground));
+  background: var(--color-accent);
+  color: var(--color-on-accent);
   padding: var(--space-2) var(--space-4);
   border-radius: var(--radius-md);
 }

--- a/src/app/workshop.css
+++ b/src/app/workshop.css
@@ -350,7 +350,7 @@
   padding: var(--space-2) var(--space-3);
   text-align: left;
   border: 1px solid transparent;
-  border-radius: var(--radius);
+  border-radius: var(--radius-md);
 }
 
 .workshop-sidebar-world-item[data-active="true"] {

--- a/src/lib/theme/themes/ds3.css
+++ b/src/lib/theme/themes/ds3.css
@@ -34,27 +34,6 @@
   --color-accent-hover: rgb(74 105 120);
   --color-accent-soft: rgb(91 122 140 / 10%);
 
-  /* shadcn/ui HSL tokens */
-  --background: 36 24% 95%;
-  --foreground: 25 20% 14%;
-  --card: 38 100% 98%;
-  --card-foreground: 25 20% 14%;
-  --popover: 38 100% 98%;
-  --popover-foreground: 25 20% 14%;
-
-  --primary: 200 21% 45%;
-  --primary-foreground: 0 0% 100%;
-  --secondary: 25 14% 40%;
-  --secondary-foreground: 0 0% 100%;
-  --muted: 30 16% 92%;
-  --muted-foreground: 25 14% 46%;
-  --accent: 30 16% 92%;
-  --accent-foreground: 25 20% 14%;
-  --border: 29 16% 85%;
-  --input: 29 16% 85%;
-  --ring: 200 21% 45%;
-  --radius: 0.375rem;
-
   /* Extended semantic tokens */
   --success: 138 25% 40%;
   --success-foreground: 210 40% 98%;
@@ -169,25 +148,6 @@
    * mode — white-on-hover ~5.4:1. Base-state contrast tracked separately (#1379). */
   --color-accent-hover: rgb(80 110 128);
   --color-accent-soft: rgb(123 160 180 / 12%);
-
-  --background: 20 18% 8%;
-  --foreground: 33 17% 90%;
-  --card: 20 15% 10%;
-  --card-foreground: 33 17% 90%;
-  --popover: 20 15% 10%;
-  --popover-foreground: 33 17% 90%;
-
-  --primary: 200 19% 59%;
-  --primary-foreground: 0 0% 100%;
-  --secondary: 20 10% 28%;
-  --secondary-foreground: 0 0% 100%;
-  --muted: 20 12% 14%;
-  --muted-foreground: 25 10% 52%;
-  --accent: 20 12% 14%;
-  --accent-foreground: 33 17% 90%;
-  --border: 20 15% 16%;
-  --input: 20 15% 16%;
-  --ring: 200 19% 59%;
 
   --success: 138 20% 48%;
   --success-foreground: 222 84% 5%;

--- a/src/lib/tutorial/tutorialConfig.ts
+++ b/src/lib/tutorial/tutorialConfig.ts
@@ -2,18 +2,18 @@ import type { Placement } from '@popperjs/core';
 
 export const joyrideStyles = {
   options: {
-    primaryColor: 'hsl(var(--primary))',
-    backgroundColor: 'hsl(var(--background))',
-    textColor: 'hsl(var(--foreground))',
-    arrowColor: 'hsl(var(--card))',
+    primaryColor: 'var(--color-accent)',
+    backgroundColor: 'var(--color-canvas)',
+    textColor: 'var(--color-text-primary)',
+    arrowColor: 'var(--color-overlay-surface-strong)',
     // eslint-disable-next-line design-tokens/no-hardcoded-colors
     overlayColor: 'rgba(0, 0, 0, 0.5)',
     zIndex: 10000,
   },
   tooltip: {
-    backgroundColor: 'hsl(var(--card))',
-    borderRadius: 'var(--radius)',
-    color: 'hsl(var(--card-foreground))',
+    backgroundColor: 'var(--color-overlay-surface-strong)',
+    borderRadius: 'var(--radius-md)',
+    color: 'var(--color-text-primary)',
     textAlign: 'left' as const,
     pointerEvents: 'auto' as const,
   },
@@ -38,18 +38,17 @@ export const joyrideStyles = {
     // app's stacking context, so the tour never showed a backdrop (#1431).
     backgroundColor: 'transparent',
     mixBlendMode: 'normal' as const,
-    // eslint-disable-next-line design-tokens/no-hardcoded-colors
     boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.45)',
   },
   buttonNext: {
-    backgroundColor: 'hsl(var(--primary))',
-    color: 'hsl(var(--primary-foreground))',
+    backgroundColor: 'var(--color-accent)',
+    color: 'var(--color-on-accent)',
   },
   buttonBack: {
-    color: 'hsl(var(--muted-foreground))',
+    color: 'var(--color-text-muted)',
   },
   buttonSkip: {
-    color: 'hsl(var(--primary))',
+    color: 'var(--color-accent)',
     textDecoration: 'underline',
     backgroundColor: 'transparent',
     padding: 0,


### PR DESCRIPTION
## Description

Two parallel token systems were left in `ds3.css` after the Tailwind removal (#1097): the canonical `--color-*` family, and a legacy shadcn-style HSL family (`--primary`, `--background`, `--card`, `--radius`, …) read via `hsl(var(--token))`. #1474 flagged them for drifting apart.

Most of that drift is already gone — the DS3 collapse (#1526) deleted `ds1.css`/`ds2.css`, and in DS3 the two accents are nearly identical in light mode and only mildly apart in dark. What was left is the structural half: the legacy layer had exactly **one** runtime consumer, the onboarding tour, plus a single stray `var(--radius)`. That's the footgun — the layer looks unused, so someone deletes it and silently breaks the tour, while the two systems keep drifting.

This points the tour at `--color-*` directly and removes the legacy layer, so there's one token system. It's the item ADR-013 named as deferred ("removing the legacy shadcn HSL token layer").

- **`tutorialConfig.ts`** — the joyride tour's reads move onto `--color-*`: `hsl(var(--primary))` → `var(--color-accent)`, `--primary-foreground` → `--color-on-accent`, `--background` → `--color-canvas`, `--foreground`/`--card-foreground` → `--color-text-primary`, `--muted-foreground` → `--color-text-muted`. The tooltip/arrow background goes to the opaque `--color-overlay-surface-strong` (95/96%) rather than the 80% `--color-surface`, so it stays readable; radius → `--radius-md`.
- **`workshop.css`** — the one stray `var(--radius)` → `var(--radius-md)`.
- **`ds3.css`** — the `/* shadcn/ui HSL tokens */` block removed from both the light and dark blocks. Extended semantic HSL tokens (`--success*`/`--warning*`/`--info*`/`--ending-*`/`--lore-*`/`--alignment-*`) stay — they're still consumed.
- **Docs** — `design-tokens.md` Tier 3 and ADR-013's deferred list brought in line with the removal.

## Related Issue

Closes #1474
<!-- Targets develop, so GitHub won't auto-close on merge — will close manually post-merge. -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

Token-reference refactor — no new logic, so no new tests (per house style, trivial styling isn't pinned with a spec). The tour's rendering is already covered by the existing `TutorialProvider`/`tutorialConfig` suites, which stay green.

- [ ] Tests written before implementation — N/A (no new behavior)
- [ ] All new code is tested — N/A (no new code paths; tour render covered by existing tests)
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## Implementation Notes

The issue's original evidence is stale post-collapse: the dramatic blue-vs-indigo mismatch it describes was a DS1 artifact, and the "dialogs also read the legacy family" note no longer holds (the shadcn `ui/*` primitives were already re-skinned onto `--color-*`). The tour was the sole remaining consumer, which is why removing the whole layer is safe here.

Scope call: full removal of the legacy block rather than only re-pointing the accent tokens, so the codebase is left with one token system instead of a half-migrated two. That's what ADR-013 named.

Naming trap avoided: legacy `--accent` (a beige surface) is a different concept from `--color-accent` (the steel-blue brand) — it was unused, so it's just dropped, not mapped.

## Component Development

- [ ] Storybook stories created/updated — N/A (no component/markup change)
- [ ] Components developed in isolation first — N/A
- [x] Visual consistency verified (tour accent now matches the app accent in both modes — see below)

## Quality Checks

- [x] Linting passed (`lint` + `lint:css`)
- [x] Type checking passed
- [ ] Security audit passed — N/A (no security surface)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Chrome DevTools MCP Verification Summary

Verified live against the running dev server (in-app browser, computed styles), with a probe element using the exact token references the joyride button now carries, portaled into the same `html[data-theme="ds3"]` subtree:

| | Light | Dark |
|---|---|---|
| Button background (`--color-accent`) | `rgb(91, 122, 140)` | `rgb(123, 160, 180)` |
| Button text (`--color-on-accent`) | `rgb(255, 255, 255)` | `rgb(23, 19, 16)` |
| Tooltip bg (`--color-overlay-surface-strong`) | `rgba(255, 252, 246, 0.95)` | `rgba(30, 26, 22, 0.96)` |

The deleted tokens (`--primary`, `--background`, `--card`, `--radius`) resolve empty at runtime in both modes — the legacy layer is gone, nothing re-defines it. The button values match the app's own accent buttons.

## Testing Instructions

1. `npm run type-check` / `npm run lint` / `npm run lint:css` — all clean.
2. `npm test` — 350 suites / 2356 tests pass.
3. Live: start the dev server, open the app; `getComputedStyle` on an element using `var(--color-accent)` returns `rgb(91 122 140)` (light) / `rgb(123 160 180)` (dark), and `--primary`/`--background`/`--card`/`--radius` return empty.

Note: the tour's dark-mode accent shifts slightly (from the drifted `rgb(131 157 170)` to the app's `rgb(123 160 180)`) and the tooltip goes from 100% to 95% opaque, so the **non-required** macOS-only Tutorial Visual baselines may need a refresh — not a merge gate.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic — N/A (none warranted)
- [x] Documentation updated
- [x] No new warnings generated (removed one dead eslint-disable)
- [x] Accessibility considerations addressed (tour now uses the AA-audited `--color-accent`/`--color-on-accent` pair from #1480/#1483, in both modes)
