### PR TITLE
fix(world): wire wizard form labels to their controls (#1529)

### DIFF
--- a/src/components/WorldCreationWizard/steps/BasicInfoStep.test.tsx
+++ b/src/components/WorldCreationWizard/steps/BasicInfoStep.test.tsx
@@ -29,6 +29,26 @@ describe('BasicInfoStep', () => {
     expect(screen.getByTestId('world-genre-select')).toBeInTheDocument();
   });
 
+  // #1529: the visible WizardFormGroup labels must be programmatically wired
+  // to the controls they describe, or screen readers announce them unlabeled.
+  test('associates visible labels with their form controls', () => {
+    render(
+      <BasicInfoStep
+        worldData={mockWorldData}
+        errors={{}}
+        onUpdate={mockOnUpdate}
+      />
+    );
+
+    expect(screen.getByLabelText('World Name (optional)')).toBe(
+      screen.getByTestId('world-name-input')
+    );
+    // The Genre label renders a trailing required marker, so match by prefix
+    expect(screen.getByLabelText(/^genre/i)).toBe(
+      screen.getByTestId('world-genre-select')
+    );
+  });
+
   test('displays error for world name when provided', () => {
     // Since BasicInfoStep no longer handles validation directly,
     // we test that errors passed in are displayed correctly

--- a/src/components/shared/wizard/components/FormComponents.tsx
+++ b/src/components/shared/wizard/components/FormComponents.tsx
@@ -5,6 +5,13 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 
+// Associates a WizardFormGroup's visible label with the wizard control it
+// wraps (#1529). The group generates an id, points its Label at it, and the
+// wizard field components below pick the id up from context - so every
+// existing WizardFormGroup + WizardTextField/WizardSelect/WizardTextArea
+// pairing gets an accessible name without call-site changes.
+const WizardFieldIdContext = React.createContext<string | undefined>(undefined);
+
 interface WizardFormGroupProps {
   label: string;
   error?: string;
@@ -20,9 +27,11 @@ export const WizardFormGroup: React.FC<WizardFormGroupProps> = ({
   helpText,
   children,
 }) => {
+  const fieldId = React.useId();
+
   return (
     <div>
-      <Label>
+      <Label htmlFor={fieldId}>
         {label}
         {required && <span>*</span>}
       </Label>
@@ -34,7 +43,9 @@ export const WizardFormGroup: React.FC<WizardFormGroupProps> = ({
           {helpText}
         </p>
       )}
-      {children}
+      <WizardFieldIdContext.Provider value={fieldId}>
+        {children}
+      </WizardFieldIdContext.Provider>
       {error && <p className={errorStyles.message}>{error}</p>}
     </div>
   );
@@ -65,8 +76,11 @@ export const WizardTextField: React.FC<WizardTextFieldProps> = ({
   testId,
   dataTutorial,
 }) => {
+  const fieldId = React.useContext(WizardFieldIdContext);
+
   return (
     <Input
+      id={fieldId}
       type="text"
       value={value}
       onChange={(e) => onChange(e.target.value)}
@@ -107,8 +121,11 @@ export const WizardTextArea: React.FC<WizardTextAreaProps> = ({
   testId,
   dataTutorial,
 }) => {
+  const fieldId = React.useContext(WizardFieldIdContext);
+
   return (
     <Textarea
+      id={fieldId}
       value={value}
       onChange={(e) => onChange(e.target.value)}
       onBlur={onBlur}
@@ -146,8 +163,11 @@ export const WizardSelect: React.FC<WizardSelectProps> = ({
   testId,
   dataTutorial,
 }) => {
+  const fieldId = React.useContext(WizardFieldIdContext);
+
   return (
     <select
+      id={fieldId}
       value={value}
       onChange={(e) => onChange(e.target.value)}
       onBlur={onBlur}


### PR DESCRIPTION
## Description

The first step of the world-creation wizard showed labels for World Name and Genre, but the actual controls weren't wired to them — `WizardFormGroup` rendered a bare `Label` with no `htmlFor`, and `WizardTextField`/`WizardSelect` never got an `id`. Visually fine, but a screen reader hits unlabeled controls right at the first creation step.

The fix lives entirely in the shared wizard form components: `WizardFormGroup` now generates an id with `useId`, points its `Label` at it, and hands it down via a module-private context that `WizardTextField`, `WizardTextArea`, and `WizardSelect` pick up as their `id`. That means every existing `WizardFormGroup` + wizard-control pairing (BasicInfoStep, DescriptionStep, AttributeReviewStep, SkillReviewStep) gets an accessible name with zero call-site changes — which is why no step files needed touching.

## Related Issue

Closes #1529

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The test landed alongside the fix rather than strictly before it, but I verified it red-green: with the `FormComponents` change stashed, the new assertion fails with "Found a label with the text of: World Name (optional), however no form control was found associated to that label" — exactly the bug — and passes with the fix in place.

## User Stories Addressed

N/A — QA-audit accessibility finding, no user story attached.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

No story changes needed — the existing `FormComponents` stories render the same components and now get the wiring for free. There's no visual delta; the change is attribute-only (`id`/`htmlFor`).

## Implementation Notes

- Context over per-call-site ids: threading explicit `id` props through every step would've meant touching every usage and hoping nobody forgets one. The context approach makes labeling the default behavior of the shared pattern, which is what the issue's acceptance criteria asked for.
- Groups that wrap non-wizard children (the World Type radio group, the Starting Value number input, the Linked Attributes checkbox grid) end up with a group label whose `htmlFor` points at nothing. That's behaviorally identical to today's unassociated label — browsers and screen readers ignore a dangling `for` — and those inner controls already carry their own labels or `aria-label`.
- `useId` is already the house pattern here (`SimpleModal`), and it's hydration-safe for SSR.

## Screenshots

N/A — no visual change.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks (if applicable)

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit not run — attribute-only accessibility change, no new dependencies or inputs. `lint:css` N/A (no CSS touched).

## Testing Instructions

1. `npm test -- --maxWorkers=2` — full suite green (350 suites / 2357 tests locally), including the new "associates visible labels with their form controls" test in `BasicInfoStep.test.tsx`.
2. Manual check: open `/worlds/create`, inspect the World Name input and Genre select — both now have an `id` matched by their label's `for`. Clicking the visible label focuses the control.
3. Screen reader spot check (VoiceOver): the first-step controls announce "World Name (optional)" and "Genre" instead of nothing.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

Docs untouched — nothing documents the wizard form internals.
