### PR TITLE
fix(settings): confirm before removing saved providers (#1537)

### DIFF
--- a/src/app/settings/providers/__tests__/page.test.tsx
+++ b/src/app/settings/providers/__tests__/page.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 // The jest alias mapper resolves @/-form CSS imports before the CSS stub rule
@@ -46,6 +46,7 @@ jest.mock('@/components/DeleteConfirmationDialog/DeleteConfirmationDialog', () =
     description,
     itemName,
     confirmButtonText,
+    isDeleting,
   }: {
     isOpen: boolean;
     onClose: () => void;
@@ -54,14 +55,19 @@ jest.mock('@/components/DeleteConfirmationDialog/DeleteConfirmationDialog', () =
     description: string;
     itemName: string;
     confirmButtonText?: string;
+    isDeleting?: boolean;
   }) => {
     if (!isOpen) return null;
     return (
       <div role="dialog" aria-label={title}>
         <p>{description}</p>
         <p>{itemName}</p>
-        <button onClick={onClose}>Cancel</button>
-        <button onClick={onConfirm}>{confirmButtonText || 'Delete'}</button>
+        <button onClick={onClose} disabled={isDeleting}>
+          Cancel
+        </button>
+        <button onClick={onConfirm} disabled={isDeleting}>
+          {confirmButtonText || 'Delete'}
+        </button>
       </div>
     );
   },
@@ -163,5 +169,55 @@ describe('ProvidersSettingsPage — remove confirmation', () => {
     expect(useProviderStore.getState().providers['p1']).toBeUndefined();
     expect(useProviderStore.getState().activeProviderId).toBe('p2');
     expect(clearEncryptionKey).not.toHaveBeenCalled();
+  });
+
+  test('double-clicking confirm only starts one removal', async () => {
+    seedProviders([makeProvider('p1', 'Visual QA Gemini')], 'p1');
+    let resolveRemoval!: () => void;
+    removeSpy = jest.fn(
+      () => new Promise<void>((resolve) => { resolveRemoval = resolve; })
+    );
+    useProviderStore.setState({ removeProvider: removeSpy });
+    const user = userEvent.setup();
+    render(<ProvidersSettingsPage />);
+
+    await user.click(screen.getByRole('button', { name: /remove/i }));
+    const dialog = screen.getByRole('dialog', { name: /remove provider/i });
+    const confirmButton = within(dialog).getByRole('button', { name: /^remove$/i });
+
+    await user.click(confirmButton);
+    await user.click(confirmButton);
+
+    expect(confirmButton).toBeDisabled();
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+
+    await act(async () => resolveRemoval());
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+
+  test('cancel is inert while removal is in flight, and removal still completes', async () => {
+    seedProviders([makeProvider('p1', 'Visual QA Gemini')], 'p1');
+    let resolveRemoval!: () => void;
+    removeSpy = jest.fn(
+      () => new Promise<void>((resolve) => { resolveRemoval = resolve; })
+    );
+    useProviderStore.setState({ removeProvider: removeSpy });
+    const user = userEvent.setup();
+    render(<ProvidersSettingsPage />);
+
+    await user.click(screen.getByRole('button', { name: /remove/i }));
+    const dialog = screen.getByRole('dialog', { name: /remove provider/i });
+    await user.click(within(dialog).getByRole('button', { name: /^remove$/i }));
+
+    // Once confirmed, removal runs to completion: cancel must neither close
+    // the dialog early nor stop the removal.
+    const cancelButton = within(dialog).getByRole('button', { name: /cancel/i });
+    expect(cancelButton).toBeDisabled();
+    await user.click(cancelButton);
+    expect(screen.getByRole('dialog', { name: /remove provider/i })).toBeInTheDocument();
+
+    await act(async () => resolveRemoval());
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(removeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/settings/providers/__tests__/page.test.tsx
+++ b/src/app/settings/providers/__tests__/page.test.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// The jest alias mapper resolves @/-form CSS imports before the CSS stub rule
+// can catch them, so stub the page's stylesheet import here.
+jest.mock('@/components/ai/provider-config.css', () => ({}));
+
+// crypto.subtle isn't available in jsdom — mock the encryption layer so the
+// store's removeProvider can run (it clears the key after the last removal).
+jest.mock('@/lib/storage/encryption', () => ({
+  encryptSecret: jest.fn(async (plaintext: string) => ({ ciphertext: `ct:${plaintext}`, iv: 'iv' })),
+  decryptSecret: jest.fn(async (p: { ciphertext: string }) => p.ciphertext.replace(/^ct:/, '')),
+  clearEncryptionKey: jest.fn(async () => {}),
+}));
+
+jest.mock('@/components/shared/PageLayout', () => ({
+  PageLayout: function MockPageLayout({
+    title,
+    actions,
+    children,
+  }: {
+    title: string;
+    actions?: React.ReactNode;
+    children: React.ReactNode;
+  }) {
+    return (
+      <main>
+        <h1>{title}</h1>
+        {actions}
+        {children}
+      </main>
+    );
+  },
+}));
+
+// Lightweight stand-in so the test exercises the page wiring, not Radix
+// internals (same convention as WorldListScreen's tests).
+jest.mock('@/components/DeleteConfirmationDialog/DeleteConfirmationDialog', () => ({
+  __esModule: true,
+  default: ({
+    isOpen,
+    onClose,
+    onConfirm,
+    title,
+    description,
+    itemName,
+    confirmButtonText,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    onConfirm: () => void;
+    title: string;
+    description: string;
+    itemName: string;
+    confirmButtonText?: string;
+  }) => {
+    if (!isOpen) return null;
+    return (
+      <div role="dialog" aria-label={title}>
+        <p>{description}</p>
+        <p>{itemName}</p>
+        <button onClick={onClose}>Cancel</button>
+        <button onClick={onConfirm}>{confirmButtonText || 'Delete'}</button>
+      </div>
+    );
+  },
+}));
+
+import ProvidersSettingsPage from '../page';
+import { useProviderStore } from '@/state/providerStore';
+import { clearEncryptionKey } from '@/lib/storage/encryption';
+import type { ProviderConfig } from '@/types/provider.types';
+
+const makeProvider = (id: string, name: string): ProviderConfig => ({
+  id,
+  type: 'gemini',
+  name,
+  endpoint: 'https://example.test',
+  encryptedApiKey: 'ct:key',
+  model: 'gemini-2.5-flash',
+  capabilities: { text: true, images: false, streaming: true },
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+});
+
+let removeSpy: jest.Mock;
+
+const seedProviders = (providers: ProviderConfig[], activeProviderId: string | null) => {
+  useProviderStore.setState({
+    providers: Object.fromEntries(providers.map((p) => [p.id, p])),
+    activeProviderId,
+  });
+  // Wrap the real implementation so calls are observable and removal still happens.
+  removeSpy = jest.fn(useProviderStore.getState().removeProvider);
+  useProviderStore.setState({ removeProvider: removeSpy });
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  useProviderStore.getState().reset();
+  jest.clearAllMocks();
+});
+
+describe('ProvidersSettingsPage — remove confirmation', () => {
+  test('clicking Remove opens a confirmation instead of removing immediately', async () => {
+    seedProviders([makeProvider('p1', 'Visual QA Gemini')], 'p1');
+    const user = userEvent.setup();
+    render(<ProvidersSettingsPage />);
+
+    await user.click(screen.getByRole('button', { name: /remove/i }));
+
+    expect(screen.getByRole('dialog', { name: /remove provider/i })).toBeInTheDocument();
+    expect(removeSpy).not.toHaveBeenCalled();
+    expect(useProviderStore.getState().providers['p1']).toBeDefined();
+  });
+
+  test('cancel keeps the provider untouched', async () => {
+    seedProviders([makeProvider('p1', 'Visual QA Gemini')], 'p1');
+    const user = userEvent.setup();
+    render(<ProvidersSettingsPage />);
+
+    await user.click(screen.getByRole('button', { name: /remove/i }));
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(removeSpy).not.toHaveBeenCalled();
+    expect(useProviderStore.getState().providers['p1']).toBeDefined();
+    expect(screen.getByText('Visual QA Gemini')).toBeInTheDocument();
+  });
+
+  test('confirming the last provider removes it, warns about the key, and clears it', async () => {
+    seedProviders([makeProvider('p1', 'Visual QA Gemini')], 'p1');
+    const user = userEvent.setup();
+    render(<ProvidersSettingsPage />);
+
+    await user.click(screen.getByRole('button', { name: /remove/i }));
+    const dialog = screen.getByRole('dialog', { name: /remove provider/i });
+    expect(within(dialog).getByText(/clears the encryption key/i)).toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole('button', { name: /^remove$/i }));
+
+    await waitFor(() => expect(removeSpy).toHaveBeenCalledWith('p1'));
+    await screen.findByText(/no provider yet/i);
+    expect(useProviderStore.getState().providers['p1']).toBeUndefined();
+    await waitFor(() => expect(clearEncryptionKey).toHaveBeenCalled());
+  });
+
+  test('removing the active provider (with others saved) warns about the switch', async () => {
+    seedProviders([makeProvider('p1', 'Primary'), makeProvider('p2', 'Backup')], 'p1');
+    const user = userEvent.setup();
+    render(<ProvidersSettingsPage />);
+
+    const card = screen.getByText('Primary').closest('.component-provider-card') as HTMLElement;
+    await user.click(within(card).getByRole('button', { name: /remove/i }));
+
+    const dialog = screen.getByRole('dialog', { name: /remove provider/i });
+    expect(within(dialog).getByText(/currently in use/i)).toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole('button', { name: /^remove$/i }));
+
+    await waitFor(() => expect(removeSpy).toHaveBeenCalledWith('p1'));
+    expect(useProviderStore.getState().providers['p1']).toBeUndefined();
+    expect(useProviderStore.getState().activeProviderId).toBe('p2');
+    expect(clearEncryptionKey).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/settings/providers/page.tsx
+++ b/src/app/settings/providers/page.tsx
@@ -5,6 +5,7 @@ import { PageLayout } from '@/components/shared/PageLayout';
 import { Button } from '@/components/ui/button';
 import { ProviderCard } from '@/components/ai/ProviderCard';
 import { ProviderWizard } from '@/components/ai/ProviderWizard';
+import DeleteConfirmationDialog from '@/components/DeleteConfirmationDialog/DeleteConfirmationDialog';
 import { useProviderStore } from '@/state/providerStore';
 import '@/components/ai/provider-config.css';
 
@@ -23,6 +24,7 @@ export default function ProvidersSettingsPage() {
 
   const [showWizard, setShowWizard] = useState(false);
   const [validatingId, setValidatingId] = useState<string | null>(null);
+  const [providerToRemoveId, setProviderToRemoveId] = useState<string | null>(null);
 
   const list = Object.values(providers);
 
@@ -34,6 +36,26 @@ export default function ProvidersSettingsPage() {
       setValidatingId(null);
     }
   };
+
+  const handleCloseRemoveDialog = () => setProviderToRemoveId(null);
+
+  const handleConfirmRemove = async () => {
+    if (providerToRemoveId) {
+      await removeProvider(providerToRemoveId);
+    }
+    setProviderToRemoveId(null);
+  };
+
+  // Removal is destructive: the key is gone for good, and removing the last
+  // provider also clears the stored encryption key. Spell out the stakes.
+  const providerToRemove = providerToRemoveId ? providers[providerToRemoveId] : undefined;
+  const removeMessage = !providerToRemove
+    ? ''
+    : list.length === 1
+      ? "Removing your only provider also clears the encryption key stored in this browser. You'll need to set up a provider again before playing."
+      : providerToRemove.id === activeProviderId
+        ? 'This provider is currently in use. Another saved provider will take over.'
+        : 'Are you sure you want to remove this provider? Its saved key will be deleted from this browser.';
 
   return (
     <PageLayout
@@ -66,12 +88,22 @@ export default function ProvidersSettingsPage() {
                 validation={validationStatus[provider.id]}
                 onSetActive={setActiveProvider}
                 onValidate={handleValidate}
-                onDelete={removeProvider}
+                onDelete={setProviderToRemoveId}
                 isValidating={validatingId === provider.id}
               />
             ))}
           </div>
         )}
+
+        <DeleteConfirmationDialog
+          isOpen={providerToRemoveId !== null}
+          onClose={handleCloseRemoveDialog}
+          onConfirm={handleConfirmRemove}
+          title="Remove Provider"
+          description={removeMessage}
+          itemName={providerToRemove?.name || 'this provider'}
+          confirmButtonText="Remove"
+        />
       </div>
     </PageLayout>
   );

--- a/src/app/settings/providers/page.tsx
+++ b/src/app/settings/providers/page.tsx
@@ -25,6 +25,7 @@ export default function ProvidersSettingsPage() {
   const [showWizard, setShowWizard] = useState(false);
   const [validatingId, setValidatingId] = useState<string | null>(null);
   const [providerToRemoveId, setProviderToRemoveId] = useState<string | null>(null);
+  const [isRemoving, setIsRemoving] = useState(false);
 
   const list = Object.values(providers);
 
@@ -37,13 +38,22 @@ export default function ProvidersSettingsPage() {
     }
   };
 
-  const handleCloseRemoveDialog = () => setProviderToRemoveId(null);
+  // Once confirmed, removal runs to completion: cancel/escape are inert while
+  // the await is in flight, and the dialog closes when it settles.
+  const handleCloseRemoveDialog = () => {
+    if (isRemoving) return;
+    setProviderToRemoveId(null);
+  };
 
   const handleConfirmRemove = async () => {
-    if (providerToRemoveId) {
+    if (!providerToRemoveId || isRemoving) return;
+    setIsRemoving(true);
+    try {
       await removeProvider(providerToRemoveId);
+    } finally {
+      setIsRemoving(false);
+      setProviderToRemoveId(null);
     }
-    setProviderToRemoveId(null);
   };
 
   // Removal is destructive: the key is gone for good, and removing the last
@@ -103,6 +113,7 @@ export default function ProvidersSettingsPage() {
           description={removeMessage}
           itemName={providerToRemove?.name || 'this provider'}
           confirmButtonText="Remove"
+          isDeleting={isRemoving}
         />
       </div>
     </PageLayout>


### PR DESCRIPTION
## Description
Remove on `/settings/providers` was a one-click destructive action — the provider disappeared immediately, and if it was the last one the store also cleared the encryption key with no warning. This routes provider removal through the existing `DeleteConfirmationDialog` (the same pattern `WorldListScreen` uses for worlds): the page holds the pending-removal id, `ProviderCard` stays dumb, cancel leaves everything untouched, and `removeProvider` only runs on confirm. The dialog copy adapts to the risky cases — removing your only provider warns that the stored encryption key gets cleared, and removing the active provider (with others saved) says another one takes over.

Part of the v1.0 launch-gate checklist (#1320).

## Related Issue
Closes #1537

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The page had no spec at all before this; the new one covers the wiring the issue asked for (remove opens the dialog, cancel doesn't call `removeProvider`, confirm does).

## User Stories Addressed
As a player, I want a confirmation before a saved provider is removed, so one stray click can't delete my key — especially when it's the active or only provider.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A — no component changed. `ProviderCard` and `DeleteConfirmationDialog` are untouched; the fix is page-level wiring between two existing pieces.

## Implementation Notes
- `src/app/settings/providers/page.tsx` now tracks `providerToRemoveId`, and `onDelete` on the card sets it instead of calling `removeProvider` directly. The store method is unchanged, so the encryption key is still only cleared after the last provider goes — now behind an explicit confirm.
- Dialog message picks the sharpest warning: last provider > active provider > plain remove.
- One test-infra note: `@/`-alias CSS imports resolve through the jest alias mapper before the CSS stub rule can catch them, so the new spec stubs the page's stylesheet import. Pre-existing quirk — this page just never had a spec to trip over it.
- Per the Codex review finding: the page tracks an `isRemoving` flag and passes it through the dialog's existing `isDeleting` prop, with re-entry guards in both handlers. In-flight semantics: once confirmed, removal runs to completion — Cancel and Escape are inert while the await is running, both buttons are disabled, and the dialog closes when it settles. Double-clicking Confirm starts exactly one removal.

## Screenshots
N/A — the dialog is the existing `DeleteConfirmationDialog` in its destructive variant.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit not run separately — CI covers it. No `.css` touched, so no stylelint-relevant changes.

## Testing Instructions
1. `npm test -- src/app/settings/providers` — 4 specs: remove opens the dialog, cancel keeps the provider, confirming the last provider removes it and clears the key, removing the active provider warns about the switch.
2. Manually: open `/settings/providers` with a saved provider, click Remove — you get a confirmation instead of an instant delete. Cancel keeps the card; confirm shows the empty state.
3. With two providers, remove the active one — the dialog notes the other takes over, and it becomes active after confirm.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

Docs: nothing to update — behavior now matches the existing destructive-action pattern. Accessibility rides on `ConfirmationDialog`'s existing focus handling (destructive variant focuses Cancel first).
