### PR TITLE
fix(ui): add branded not-found page with recovery actions (#1535)

### DIFF
--- a/src/app/__tests__/not-found.test.tsx
+++ b/src/app/__tests__/not-found.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useRouter } from 'next/navigation';
+import NotFound from '../not-found';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+
+describe('NotFound page (#1535)', () => {
+  const push = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useRouter as jest.Mock).mockReturnValue({ push });
+  });
+
+  it('renders branded copy with a single h1', () => {
+    render(<NotFound />);
+
+    const headings = screen.getAllByRole('heading', { level: 1 });
+    expect(headings).toHaveLength(1);
+    expect(headings[0]).toHaveTextContent('Page Not Found');
+    // Branded copy, not the framework fallback.
+    expect(screen.queryByText('This page could not be found.')).not.toBeInTheDocument();
+  });
+
+  it('offers a recovery action back to worlds', () => {
+    render(<NotFound />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to Worlds' }));
+    expect(push).toHaveBeenCalledWith('/worlds');
+  });
+});

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from 'next';
+import { NotFoundState } from '@/components/shared/NotFoundState';
+
+export const metadata: Metadata = {
+  title: 'Page Not Found | Narraitor',
+};
+
+/**
+ * Global not-found page for unknown routes (#1535).
+ *
+ * Renders inside the app shell via the root layout, so a stale bookmark or a
+ * typo lands on branded copy with a way back into the player flow instead of
+ * the framework-default 404.
+ */
+export default function NotFound() {
+  return (
+    <NotFoundState
+      title="Page Not Found"
+      message="This path doesn't lead anywhere — the page may have moved, or the link is stale. Head back to your worlds and pick up the story."
+      backUrl="/worlds"
+      backLabel="Back to Worlds"
+    />
+  );
+}

--- a/src/components/shared/NotFoundState.css
+++ b/src/components/shared/NotFoundState.css
@@ -1,0 +1,37 @@
+/* NotFoundState — styles for src/components/shared/NotFoundState.tsx (#1535)
+ *
+ * The shared not-found treatment (unknown routes via src/app/not-found.tsx, plus
+ * the world/character detail fallbacks) lost its classes in the Tailwind removal
+ * (#1051) and rendered as bare top-left text. Mirrors the EmptyState treatment
+ * (#1479): centered, comfortable measure, token-driven so the active theme and
+ * surface CSS brand it. Heading size comes from the surface h1 rules, not here.
+ */
+
+.component-not-found-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-6);
+  max-width: 32rem;
+  margin: 0 auto;
+  padding: var(--space-8) var(--space-4);
+  text-align: center;
+}
+
+.not-found-state-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.not-found-state-content h1 {
+  margin: 0;
+}
+
+.not-found-state-content p {
+  margin: 0;
+  font-family: var(--font-interface);
+  font-size: 1rem;
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+}

--- a/src/components/shared/NotFoundState.tsx
+++ b/src/components/shared/NotFoundState.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { useRouter } from 'next/navigation';
 import { ActionButtonGroup } from './ActionButtonGroup';
+import './NotFoundState.css';
 
 interface NotFoundStateProps {
   title: string;
@@ -13,23 +14,20 @@ interface NotFoundStateProps {
 
 export function NotFoundState({ title, message, backUrl, backLabel }: NotFoundStateProps) {
   const router = useRouter();
-  
+
   return (
-    <div>
-      <div>
-        <div>
-          <h1>{title}</h1>
-          <p>{message}</p>
-          <ActionButtonGroup
-            actions={[{
-              label: backLabel,
-              onClick: () => router.push(backUrl),
-              variant: 'primary'
-            }]}
-            
-          />
-        </div>
+    <div className="component-not-found-state">
+      <div className="not-found-state-content">
+        <h1>{title}</h1>
+        <p>{message}</p>
       </div>
+      <ActionButtonGroup
+        actions={[{
+          label: backLabel,
+          onClick: () => router.push(backUrl),
+          variant: 'primary'
+        }]}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Description
Unknown routes were falling through to Next's default `404 / This page could not be found.` inside the app shell — technically fine, but it reads as unowned, especially on mobile. This adds a global `src/app/not-found.tsx` so a stale bookmark or typo lands on branded copy with a clear way back into the player flow.

The root cause ran a little deeper than a missing file: the shared `NotFoundState` component (already used by the world/character detail fallbacks) lost all its classes in the Tailwind clean-slate removal (#1051) and has been rendering as bare top-left text ever since — same story EmptyState had before #1479. So rather than introduce a one-off 404 design, this styles the shared component once (identifying classes + co-located token CSS mirroring the EmptyState treatment) and builds the new page on it. The world/character not-found fallbacks pick up the same fix for free.

Heading size deliberately comes from the surface cascade (`.app-surface-* h1` in workshop.css), not the component CSS, so each surface brands it without a specificity fight.

## Related Issue
Closes #1535

Part of the v1.0 launch-gate checklist (#1320). Heads up: since this merges to `develop`, the `Closes` keyword won't auto-close — the issue needs a manual close after merge.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Being honest on the first box: the page, styling, and spec were written in one pass, not test-first. The new spec covers the single-h1 rule, the branded copy (and asserts the framework fallback string is gone), and that the recovery CTA routes to `/worlds`.

## User Stories Addressed
N/A — bug fix, scoped to the acceptance criteria in #1535.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

`NotFoundState` already has a canon story (`02-Molecules/ui-components/NotFoundState`) and its API didn't change, so the existing story picks up the new styling as-is. Visual consistency wasn't browser-verified in this lane (no dev server per the parallel-PR setup) — the treatment mirrors EmptyState's shipped CSS and uses only proven tokens, but it's worth a quick look at `/any-missing-route` at mobile and desktop widths before merge.

## Implementation Notes
- `src/app/not-found.tsx` is a server component (exports `metadata` with a proper title) rendering the client `NotFoundState`. It renders inside the root layout, so the header/nav shell stays put.
- Unknown top-level routes resolve to the `default` surface via `getSurfaceMode`, which already styles `h1` — the component CSS only handles layout, measure, and the secondary text color.
- Copy stays in-world ("head back to your worlds and pick up the story") without naming any tech.
- Shared-surface blast radius: `NotFoundState` is also rendered by `worlds/[id]`, `characters/[id]`, and `characters/[id]/edit` fallbacks. Those states were unstyled bare text before, so this is strictly an upgrade, but if any visual baseline frames them it'll shift.

## Screenshots
N/A — no dev server in this lane. Repro from the issue: visit `/visual-crawl-missing-route` at 390x844 and 1440x900.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Ran locally in the worktree, exit codes checked directly: `npm test -- --maxWorkers=2` (351 suites / 2358 tests, exit 0), `npm run type-check` (exit 0), `npm run lint` (exit 0), `npm run lint:css` (exit 0). Security audit wasn't run — nothing here touches dependencies or inputs.

## Testing Instructions
1. `npm run dev`, then visit any route that doesn't exist (e.g. `/visual-crawl-missing-route`).
2. Expect: branded "Page Not Found" h1, friendly copy, a primary "Back to Worlds" button that routes to `/worlds`, all centered inside the normal app shell.
3. Check mobile (390x844) and desktop (1440x900) — no horizontal overflow.
4. Bonus: visit `/worlds/does-not-exist` — the world-not-found fallback now renders with the same centered treatment instead of bare text.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

Docs: nothing to update — no architectural change. Accessibility: exactly one page-level `h1`, the CTA is a real focusable `<button>` via the shared `Button`, and text colors come from the token pairs that already clear AA in both modes.
