### PR TITLE
fix(game-session): readable session labels in active play drawers (#1534)

### DIFF
--- a/src/components/GameSession/ActiveGameSession.tsx
+++ b/src/components/GameSession/ActiveGameSession.tsx
@@ -474,15 +474,18 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
                                     : ''
                           }
                           subtitle={
+                            // Session-scoped drawers show the world name as
+                            // readable context — never the raw persistence ID,
+                            // which truncated to "Session session-" (#1534).
+                            // No world name means no subtitle at all.
                             activeDrawer === 'character'
                               ? character?.name
                               : activeDrawer === 'inventory'
                                 ? `Items for ${character?.name}`
                                 : activeDrawer === 'story-summary' || activeDrawer === 'choice-history' || activeDrawer === 'journal'
-                                  ? `Session ${sessionId.slice(0, 8)}`
+                                  ? world?.name
                                   : undefined
                           }
-                
         >
           {activeDrawer === 'character' && character && (
             <CharacterDrawerContent character={character} />

--- a/src/components/GameSession/__tests__/ActiveGameSession.manuscriptLayout.test.tsx
+++ b/src/components/GameSession/__tests__/ActiveGameSession.manuscriptLayout.test.tsx
@@ -10,6 +10,8 @@ import { useTutorial } from '@/components/TutorialProvider';
 import { useRouter } from 'next/navigation';
 import { useAutoSave } from '@/hooks/useAutoSave';
 import { isFeatureEnabled } from '@/lib/featureFlags';
+import { useWorldStore } from '@/state/worldStore';
+import { createMockWorld } from '@/lib/test-utils';
 
 // Mock dependencies
 jest.mock('@/state/narrativeStore');
@@ -17,6 +19,12 @@ jest.mock('@/state/sessionStore');
 jest.mock('@/state/characterStore');
 jest.mock('@/state/inventoryStore');
 jest.mock('@/state/journalStore');
+jest.mock('@/state/worldStore');
+// StorySummaryDrawerContent mounts the checkpoint manager; its return value is
+// unused there, so a no-op keeps the drawer test focused on the header.
+jest.mock('../hooks/useStoryCheckpointManager', () => ({
+  useStoryCheckpointManager: jest.fn(),
+}));
 jest.mock('@/hooks/useAutoSave');
 jest.mock('@/components/TutorialProvider');
 jest.mock('@/lib/featureFlags');
@@ -74,6 +82,8 @@ describe('ActiveGameSession Manuscript Layout', () => {
         'seg-1': { id: 'seg-1', content: 'Story starts...', characterIds: [] },
       },
       sessionSegments: { [mockSessionId]: ['seg-1'] },
+      sessionDecisions: {},
+      decisions: {},
       currentEnding: null,
       isGeneratingEnding: false,
       isSessionEnded: () => false,
@@ -114,6 +124,10 @@ describe('ActiveGameSession Manuscript Layout', () => {
       };
       return selector ? selector(state) : state;
     });
+
+    (useWorldStore as unknown as jest.Mock).mockImplementation((selector) =>
+      selector({ worlds: {}, worldStates: {} })
+    );
 
     (useTutorial as jest.Mock).mockReturnValue({
       startTour: jest.fn(),
@@ -319,5 +333,56 @@ describe('ActiveGameSession Manuscript Layout', () => {
     expect(aside).toBeInTheDocument();
     expect(aside).toHaveClass('manuscript-characters-rail');
     expect(screen.getByText('Characters Present')).toBeInTheDocument();
+  });
+
+  describe('drawer subtitles use readable labels (#1534)', () => {
+    // mockSessionId ('session-1') slices to 'session-', so the old
+    // `sessionId.slice(0, 8)` subtitle rendered exactly "Session session-".
+    const worldWithName = createMockWorld({ id: mockWorldId, name: 'Cyberpunk Neo-Tokyo' });
+
+    beforeEach(() => {
+      (isFeatureEnabled as jest.Mock).mockImplementation(
+        (flag) => flag === 'PROGRESSIVE_DISCLOSURE'
+      );
+    });
+
+    // The three session-scoped drawers share one subtitle branch.
+    it.each(['Journal', 'Story Summary', 'Choice History'])(
+      'shows the world name instead of a truncated session ID in the %s drawer',
+      async (triggerLabel) => {
+        render(
+          <ActiveGameSession
+            worldId={mockWorldId}
+            sessionId={mockSessionId}
+            world={worldWithName}
+            onChoiceSelected={jest.fn()}
+          />
+        );
+
+        fireEvent.click(await screen.findByRole('button', { name: triggerLabel }));
+
+        const drawer = await screen.findByTestId('manuscript-drawer');
+        expect(drawer.querySelector('.manuscript-drawer-subtitle')).toHaveTextContent(
+          'Cyberpunk Neo-Tokyo'
+        );
+        expect(within(drawer).queryByText(/Session session-/)).not.toBeInTheDocument();
+      }
+    );
+
+    it('omits the subtitle entirely when no world name is available', async () => {
+      render(
+        <ActiveGameSession
+          worldId={mockWorldId}
+          sessionId={mockSessionId}
+          onChoiceSelected={jest.fn()}
+        />
+      );
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Journal' }));
+
+      const drawer = await screen.findByTestId('manuscript-drawer');
+      expect(within(drawer).queryByText(/Session session-/)).not.toBeInTheDocument();
+      expect(drawer.querySelector('.manuscript-drawer-subtitle')).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Description
The three session-scoped drawers in active play (Story So Far, Choice History, Journal Snapshot) shared one subtitle: `Session ${sessionId.slice(0, 8)}`. Generated session IDs all start with `session-`, so every drawer truncated to the same string — `Session session-` — which reads like scaffolding, not a finished game UI.

Session entities don't carry a display name (just id/worldId/characterId/status/lastActivity), so there's nothing session-specific to slice into a label. The play context already has the world, though, so the subtitle now uses `world?.name` (e.g. `Cyberpunk Neo-Tokyo` — one of the exact examples from the issue). No world name means no subtitle at all: `ManuscriptDrawer` already skips falsy subtitles, so nothing new was needed there. Drawer titles and the character/inventory drawer subtitles are untouched.

This is one of the checklist items on the v1.0 launch gate (#1320): "active play drawers use readable session labels".

## Related Issue
Closes #1534

Note: this targets `develop`, so the Closes keyword won't auto-close on merge — close manually.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation (fix landed first, tests right after — they fail against the old subtitle code)
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — visual-QA bug fix from the #1320 launch-gate checklist.

## Flow Diagrams
N/A

## Component Development
N/A — no new component and no Storybook change. `ManuscriptDrawer` already handled an absent subtitle; only the string `ActiveGameSession` feeds it changed.

## Implementation Notes
- The issue's safest-MVP suggestion was to omit the subtitle outright. Went one notch better since the data's already in hand: `world` is passed into `ActiveGameSession` by `GameSession`, so the world name gives the drawers readable context for free, with omission as the fallback.
- Test setup grew a couple of mocks because the drawers now actually open in the spec: `worldStore` (also needed by `CharacterSnapshot`, so the mock state carries `worlds` + `worldStates`), a no-op `useStoryCheckpointManager`, and `sessionDecisions`/`decisions` keys on the narrative mock for `ChoiceHistorySection`.
- The existing `mockSessionId` (`session-1`) slices to `session-`, so the specs reproduce the exact reported string against the old code.

## Screenshots
N/A — the before state is captured in #1534 (Journal drawer subtitle `Session session-` at 412x915).

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed (not run — no dependency or route changes)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npx jest src/components/GameSession/__tests__/ActiveGameSession.manuscriptLayout.test.tsx` — the new `drawer subtitles use readable labels (#1534)` block covers all three drawers plus the no-world fallback.
2. Manually: seed or create an active session with journal entries, open `/worlds/<world id>/play` (mobile viewport ~412x915 matches the report), open the HUD Journal / Story Summary / Choice History drawers. The subtitle should be the world name — never `Session session-` or any sliced ID. Same check with a world lacking a name: no subtitle line at all.

## Checklist
- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file) — `ActiveGameSession.tsx` was already past 300 lines before this change; net +5 lines here, no new file grew past the limit
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) — N/A
- [x] No new warnings generated
- [x] Accessibility considerations addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
