### PR TITLE
fix(a11y): add page-level h1s to populated dashboard and character list (#1530)

### DIFF
--- a/src/app/characters/__tests__/page.h1.test.tsx
+++ b/src/app/characters/__tests__/page.h1.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useRouter } from 'next/navigation';
+import CharactersPage from '../page';
+import { useCharacterStore } from '@/state/characterStore';
+import { useWorldStore } from '@/state/worldStore';
+import { useSessionStore } from '@/state/sessionStore';
+import { useNarrativeStore } from '@/state/narrativeStore';
+
+// Heavy children are irrelevant to the heading hierarchy under test.
+jest.mock('@/components/CharacterCard', () => ({
+  CharacterCard: () => <div data-testid="character-card" />,
+}));
+
+jest.mock('@/components/character/CharacterTable', () => ({
+  CharacterTable: () => <div data-testid="character-table" />,
+}));
+
+jest.mock('@/components/GenerateCharacterDialog', () => ({
+  GenerateCharacterDialog: () => null,
+}));
+
+jest.mock('@/services/characterDeletionService', () => ({
+  deleteCharacterWithCleanup: jest.fn(),
+}));
+
+jest.mock('@/lib/api/generatePortrait', () => ({
+  generatePortrait: jest.fn(),
+}));
+
+jest.mock('@/lib/api/characterApi', () => ({
+  characterApi: { generateCharacter: jest.fn() },
+}));
+
+jest.mock('@/state/characterStore', () => ({
+  useCharacterStore: jest.fn(),
+}));
+
+jest.mock('@/state/worldStore', () => ({
+  useWorldStore: jest.fn(),
+}));
+
+jest.mock('@/state/sessionStore', () => ({
+  useSessionStore: jest.fn(),
+}));
+
+jest.mock('@/state/narrativeStore', () => ({
+  useNarrativeStore: jest.fn(),
+}));
+
+const mockCharacter = {
+  id: 'char-1',
+  name: 'Aria',
+  worldId: 'world-1',
+};
+
+const mockWorldWithImage = {
+  id: 'world-1',
+  name: 'Fantasy Realm',
+  genre: 'fantasy',
+  // A world image suppresses the visible PageLayout header — the populated
+  // state that previously rendered with no page-level <h1> (#1530).
+  image: { url: 'https://example.test/world.png', type: 'ai-generated' },
+};
+
+function mockStores({ populated }: { populated: boolean }) {
+  (useCharacterStore as unknown as jest.Mock).mockReturnValue({
+    characters: populated ? { 'char-1': mockCharacter } : {},
+    currentCharacterId: null,
+    setCurrentCharacter: jest.fn(),
+    createCharacter: jest.fn(),
+    updateCharacter: jest.fn(),
+  });
+  (useWorldStore as unknown as jest.Mock).mockReturnValue({
+    worlds: populated ? { 'world-1': mockWorldWithImage } : {},
+    currentWorldId: populated ? 'world-1' : null,
+    worldStates: {},
+  });
+  (useSessionStore as unknown as jest.Mock).mockImplementation((selector) =>
+    selector ? selector({ id: null }) : { id: null }
+  );
+  (useNarrativeStore as unknown as jest.Mock).mockReturnValue({
+    getSessionSegments: jest.fn(() => []),
+  });
+}
+
+describe('CharactersPage heading hierarchy (#1530)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+  });
+
+  it('renders exactly one page-level h1 when populated with a world hero', async () => {
+    mockStores({ populated: true });
+
+    render(<CharactersPage />);
+
+    const h1s = await screen.findAllByRole('heading', { level: 1 });
+    expect(h1s).toHaveLength(1);
+    expect(h1s[0]).toHaveTextContent('My Characters');
+
+    // The world hero stays a section heading under the page heading.
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Fantasy Realm' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders exactly one page-level h1 in the empty no-world state', async () => {
+    mockStores({ populated: false });
+
+    render(<CharactersPage />);
+
+    const h1s = await screen.findAllByRole('heading', { level: 1 });
+    expect(h1s).toHaveLength(1);
+    expect(h1s[0]).toHaveTextContent('My Characters');
+  });
+});

--- a/src/app/characters/page.tsx
+++ b/src/app/characters/page.tsx
@@ -521,6 +521,10 @@ export default function CharactersPage() {
 
   return (
     <PageLayout title={headerTitle} description={headerDescription}>
+      {/* When the world hero replaces the visible page header, PageLayout
+          renders no h1, so keep a screen-reader page heading (#1530). */}
+      {!headerTitle && <h1 className="sr-only">My Characters</h1>}
+
       {mounted && currentWorld && (
         <Hero
           title={currentWorld.name}

--- a/src/components/Dashboard/DashboardHome.tsx
+++ b/src/components/Dashboard/DashboardHome.tsx
@@ -128,6 +128,10 @@ export function DashboardHome() {
 
   return (
     <main className="component-dashboard-home">
+      {/* The returning dashboard has no visible page title by design (cards
+          carry their own h2s), so keep a screen-reader page heading (#1530). */}
+      <h1 className="sr-only">Dashboard</h1>
+
       {/* Continue Card - Only for active session users */}
       {dashboardState === 'active-session' && mostRecentSession && (
         <DashboardContinueCard

--- a/src/components/Dashboard/__tests__/DashboardHome.test.tsx
+++ b/src/components/Dashboard/__tests__/DashboardHome.test.tsx
@@ -115,6 +115,14 @@ describe('DashboardHome', () => {
       expect(screen.getByRole('heading', { name: /your progress/i })).toBeInTheDocument();
     });
 
+    it('renders exactly one page-level h1 (#1530)', () => {
+      render(<DashboardHome />);
+
+      const h1s = screen.getAllByRole('heading', { level: 1 });
+      expect(h1s).toHaveLength(1);
+      expect(h1s[0]).toHaveTextContent('Dashboard');
+    });
+
     it('shows recent worlds section', () => {
       render(<DashboardHome />);
 
@@ -160,6 +168,14 @@ describe('DashboardHome', () => {
       render(<DashboardHome />);
 
       expect(screen.getAllByRole('button', { name: /continue/i }).length).toBeGreaterThan(0);
+    });
+
+    it('renders exactly one page-level h1 (#1530)', () => {
+      render(<DashboardHome />);
+
+      const h1s = screen.getAllByRole('heading', { level: 1 });
+      expect(h1s).toHaveLength(1);
+      expect(h1s[0]).toHaveTextContent('Dashboard');
     });
 
     it('shows progress card with session metrics', () => {


### PR DESCRIPTION
## Description

The July 12 populated-state visual crawl caught two views that render without any `<h1>`: the returning-player dashboard (`/`) and the populated `/characters` list. Empty states were fine — the gap only shows up once the stores hold a world, character, and session, because both views are built from cards and a hero that start at `<h2>`. Screen-reader heading navigation loses the page landmark, and it's easy to miss since the layout looks fine visually.

Root cause per view:

- **Dashboard**: `DashboardHome`'s returning-user branch renders cards ("Continue Your Game", "Your Progress", etc., all `<h2>`) with no page title at all — only the first-time wizard path has one.
- **Characters**: the page deliberately suppresses the visible `PageLayout` title once the world has a hero image (`headerTitle = undefined`), and the hero itself renders as `titleElement="h2"`. So the populated-with-image state has no `<h1>` anywhere.

The fix adds a screen-reader-only `<h1>` in each spot rather than re-tagging visible headings. That's intentional: `.app-surface-* h1/h2/h3` rules size headings per tag, so promoting an existing `<h2>` would change its rendered size and shift visual-regression baselines. The issue's acceptance criteria explicitly allow a "screen-reader-appropriate" page heading, and `.sr-only` + a single conditional keeps this the minimal fix. On `/characters` the sr-only heading only renders when the visible header is suppressed, so there's never a duplicate — same guardrail #1473 established in the other direction.

No visual change expected; visual baselines shouldn't move.

## Related Issue

Closes #1530

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Implementation landed first, tests right behind it in the same pass — both new h1s are pinned by focused assertions (populated dashboard in both returning states, populated + empty `/characters`).

## User Stories Addressed

N/A — this is a v1.0 QA-audit finding (sibling batch of the #1320 launch gate), not story work. The beneficiary is anyone navigating by screen-reader headings.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A — sr-only headings have no visual surface, so there's nothing for Storybook to show. Visual consistency is the point of the approach: nothing rendered changes.

## Implementation Notes

- `src/components/Dashboard/DashboardHome.tsx` — `<h1 className="sr-only">Dashboard</h1>` as the first child of the returning-user `<main>`. The first-time path (GuidedFirstTimeExperience) already gets its h1 from the wizard header, so this branch-local placement can't double up.
- `src/app/characters/page.tsx` — `{!headerTitle && <h1 className="sr-only">My Characters</h1>}` at the top of the `PageLayout` children. When the world has no hero image, `PageLayout` still renders the visible "My Characters" h1 exactly as before; the sr-only one only fills the suppressed case. It sits ahead of the hero in DOM order, so the h2 stays under the page heading.
- `.sr-only` already exists in `globals.css`; no CSS touched.

## Screenshots

N/A — no visual change.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A — the change is semantic markup only; verified via jest role queries rather than a browser pass.

## Quality Checks (if applicable)

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

(Security audit not run — no dependency or route surface in this diff. Remaining lint warnings in `characters/page.tsx` predate this PR.)

## Testing Instructions

1. `npx jest src/app/characters/__tests__/page.h1.test.tsx src/components/Dashboard/__tests__/DashboardHome.test.tsx`
2. In a populated app state (at least one world with an image, a character, and a saved session): on `/` and `/characters`, run `document.querySelectorAll('h1')` in the console — exactly one per page ("Dashboard" / "My Characters"), invisible on screen.
3. Confirm the empty states still show their visible headings as before.

## Checklist

- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

(`characters/page.tsx` already sat well past 300 lines before this change; this diff adds 4 lines to it rather than growing the problem meaningfully. Docs untouched — nothing to update.)
