### PR TITLE
fix(game-session): prevent stacked active-play confirmation dialogs (#1536)

### DIFF
--- a/src/components/GameSession/ActiveGameSession.tsx
+++ b/src/components/GameSession/ActiveGameSession.tsx
@@ -287,6 +287,20 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
     createJournalEntryFromSegment,
   });
 
+  // One modal decision at a time (#1536): the End Story confirmation renders
+  // without a focus trap, so the HUD Close/Reset controls stay reachable while
+  // it is open. Those controls hand off to page-level confirmation dialogs, so
+  // close the End Story confirmation first or both dialogs mount at once.
+  const handleHudBack = React.useCallback(() => {
+    handleCloseEndStory();
+    onBack?.();
+  }, [handleCloseEndStory, onBack]);
+
+  const handleHudStartNew = React.useCallback(() => {
+    handleCloseEndStory();
+    onStartNew?.();
+  }, [handleCloseEndStory, onStartNew]);
+
   // If we have an ending, show the ending screen instead
   if (currentEnding) {
     return <EndingScreen />;
@@ -369,8 +383,8 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
             setActiveDrawer(drawerType as DrawerType);
             setIsCharacterSummaryExpanded(false);
           }}
-          onStartNew={onStartNew}
-          onBack={onBack}
+          onStartNew={handleHudStartNew}
+          onBack={handleHudBack}
           onEndStory={handleEndStoryClick}
           saveIndicator={
             <SaveIndicator

--- a/src/components/GameSession/ActiveGameSessionControls.tsx
+++ b/src/components/GameSession/ActiveGameSessionControls.tsx
@@ -31,6 +31,27 @@ const ActiveGameSessionControls: React.FC<ActiveGameSessionControlsProps> = ({
   onOpenJournal,
   isProgressiveDisclosureEnabled = false,
 }) => {
+  const cancelButtonRef = React.useRef<HTMLButtonElement>(null);
+
+  // Escape/focus parity with the shared ConfirmationDialog (#1536): Escape
+  // dismisses, and initial focus lands on Cancel because ending the story is
+  // irreversible - the same choice the shared dialog makes for destructive
+  // confirmations.
+  React.useEffect(() => {
+    if (!showEndConfirmation) return;
+
+    cancelButtonRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onCloseEndStory();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [showEndConfirmation, onCloseEndStory]);
+
   return (
     <div className="manuscript-support-sections">
       {/* Inventory Display - hidden when progressive disclosure is enabled */}
@@ -104,6 +125,7 @@ const ActiveGameSessionControls: React.FC<ActiveGameSessionControlsProps> = ({
             
             <div className="manuscript-end-story-footer">
               <button
+                ref={cancelButtonRef}
                 type="button"
                 className="manuscript-end-story-cancel"
                 onClick={onCloseEndStory}

--- a/src/components/GameSession/__tests__/ActiveGameSession.dialogExclusion.test.tsx
+++ b/src/components/GameSession/__tests__/ActiveGameSession.dialogExclusion.test.tsx
@@ -1,0 +1,200 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ActiveGameSession from '../ActiveGameSession';
+import { useNarrativeStore } from '@/state/narrativeStore';
+import { useSessionStore } from '@/state/sessionStore';
+import { useCharacterStore } from '@/state/characterStore';
+import { useInventoryStore } from '@/state/inventoryStore';
+import { useJournalStore } from '@/state/journalStore';
+import { useTutorial } from '@/components/TutorialProvider';
+import { useRouter } from 'next/navigation';
+import { useAutoSave } from '@/hooks/useAutoSave';
+import { isFeatureEnabled } from '@/lib/featureFlags';
+
+// Only one active-play confirmation may be mounted at a time (#1536): the
+// End Story confirmation has no focus trap, so the HUD Close/Reset controls
+// stay reachable while it is open. Triggering either must dismiss End Story
+// before the page-level confirmation opens.
+
+jest.mock('@/state/narrativeStore');
+jest.mock('@/state/sessionStore');
+jest.mock('@/state/characterStore');
+jest.mock('@/state/inventoryStore');
+jest.mock('@/state/journalStore');
+jest.mock('@/hooks/useAutoSave');
+jest.mock('@/components/TutorialProvider');
+jest.mock('@/lib/featureFlags');
+jest.mock('@/lib/theme/ThemeProvider', () => ({
+  useTheme: () => ({ theme: 'ds3', colorScheme: 'light', resolvedColorScheme: 'light', setTheme: jest.fn(), setColorScheme: jest.fn() }),
+}));
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+
+// Stub the heavy columns; keep the REAL ActiveGameSessionControls so the
+// End Story confirmation dialog actually mounts. The choices column is
+// emptied so the HUD's "End Story" button is the only one in the tree.
+jest.mock('../ActiveGameSessionNarrativeColumn', () => ({
+  __esModule: true,
+  default: () => <div data-testid="narrative-column" />,
+}));
+
+jest.mock('../ActiveGameSessionChoicesColumn', () => ({
+  __esModule: true,
+  default: () => <div data-testid="choices-column" />,
+}));
+
+jest.mock('../GameSessionSkeleton', () => ({
+  GameSessionSkeleton: () => <div data-testid="game-session-skeleton" />,
+}));
+
+jest.mock('@/components/Narrative/NarrativeController', () => ({
+  NarrativeController: () => <div data-testid="narrative-controller" />,
+}));
+
+jest.mock('../ManuscriptActionRail', () => ({
+  ManuscriptActionRail: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="manuscript-action-rail">{children}</div>
+  ),
+}));
+
+jest.mock('@/components/ui/SaveIndicator', () => ({
+  SaveIndicator: () => <div data-testid="save-indicator" />,
+}));
+
+// ActiveGameSessionControls' support sections pull their own store data;
+// stub them so only the confirmation dialog behavior is under test.
+jest.mock('../StorySummarySection', () => ({
+  StorySummarySection: () => <div data-testid="story-summary" />,
+}));
+
+jest.mock('../ChoiceHistorySection', () => ({
+  ChoiceHistorySection: () => <div data-testid="choice-history" />,
+}));
+
+jest.mock('@/components/ui/CollapsibleSection', () => ({
+  CollapsibleSection: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="collapsible-section">{children}</div>
+  ),
+}));
+
+jest.mock('@/components/inventory/InventoryList', () => ({
+  InventoryList: () => <div data-testid="inventory-list" />,
+}));
+
+describe('ActiveGameSession confirmation dialog exclusion (#1536)', () => {
+  const mockWorldId = 'world-1';
+  const mockSessionId = 'session-1';
+  const mockCharacterId = 'char-1';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    const mockNarrativeState = {
+      segments: {
+        'seg-1': { id: 'seg-1', content: 'Story starts...', characterIds: [] },
+      },
+      sessionSegments: { [mockSessionId]: ['seg-1'] },
+      currentEnding: null,
+      isGeneratingEnding: false,
+      isSessionEnded: () => false,
+      generateEnding: jest.fn(),
+      generationError: null,
+      getSessionSegments: (sid: string) => {
+        const segments = mockNarrativeState.segments as Record<string, unknown>;
+        const ids = (mockNarrativeState.sessionSegments as Record<string, string[]>)[sid] ?? [];
+        return ids.map((id) => segments[id]).filter(Boolean);
+      },
+      getSessionDecisions: () => [],
+    };
+    (useNarrativeStore as unknown as jest.Mock).mockImplementation((selector) =>
+      selector ? selector(mockNarrativeState) : mockNarrativeState
+    );
+    (useNarrativeStore as unknown as { getState: jest.Mock }).getState = jest.fn(() => mockNarrativeState);
+    (useNarrativeStore as unknown as { subscribe: jest.Mock }).subscribe = jest.fn(() => jest.fn());
+
+    (useSessionStore as unknown as jest.Mock).mockImplementation((selector) =>
+      selector({ characterId: mockCharacterId, shouldShowTutorialPhase: () => false })
+    );
+
+    (useCharacterStore as unknown as jest.Mock).mockImplementation((selector) =>
+      selector({ characters: { [mockCharacterId]: { id: mockCharacterId, name: 'Hero', worldId: mockWorldId, skills: [] } } })
+    );
+
+    (useInventoryStore as unknown as jest.Mock).mockImplementation((selector) =>
+      selector({
+        getCharacterItems: () => [],
+        characterInventories: {},
+        itemsObject: {},
+      })
+    );
+
+    (useJournalStore as unknown as jest.Mock).mockImplementation((selector) => {
+      const state = {
+        getSessionEntries: () => [],
+        addEntry: jest.fn(),
+      };
+      return selector ? selector(state) : state;
+    });
+
+    (useTutorial as jest.Mock).mockReturnValue({
+      startTour: jest.fn(),
+      isTourActive: false,
+    });
+
+    (useRouter as jest.Mock).mockReturnValue({
+      push: jest.fn(),
+    });
+
+    (useAutoSave as jest.Mock).mockReturnValue({
+      isSaving: false,
+      lastSaved: null,
+      saveError: null,
+    });
+
+    (isFeatureEnabled as jest.Mock).mockReturnValue(false);
+  });
+
+  const renderSession = (handlers: { onBack?: jest.Mock; onStartNew?: jest.Mock }) =>
+    render(
+      <ActiveGameSession
+        worldId={mockWorldId}
+        sessionId={mockSessionId}
+        onChoiceSelected={jest.fn()}
+        onBack={handlers.onBack}
+        onStartNew={handlers.onStartNew}
+      />
+    );
+
+  it('closes the End Story confirmation when the HUD Close control is used', async () => {
+    const onBack = jest.fn();
+    renderSession({ onBack });
+
+    await screen.findByTestId('manuscript-session-shell');
+
+    fireEvent.click(screen.getByRole('button', { name: 'End Story' }));
+    expect(screen.getByRole('dialog', { name: /end story/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+    // The exit flow proceeds, and the End Story confirmation is gone - the
+    // page-level Leave Story dialog is the only modal decision left.
+    expect(onBack).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('closes the End Story confirmation when the HUD Reset Session control is used', async () => {
+    const onStartNew = jest.fn();
+    renderSession({ onStartNew });
+
+    await screen.findByTestId('manuscript-session-shell');
+
+    fireEvent.click(screen.getByRole('button', { name: 'End Story' }));
+    expect(screen.getByRole('dialog', { name: /end story/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset Session' }));
+
+    expect(onStartNew).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/GameSession/__tests__/ActiveGameSessionControls.test.tsx
+++ b/src/components/GameSession/__tests__/ActiveGameSessionControls.test.tsx
@@ -100,4 +100,36 @@ describe('ActiveGameSessionControls', () => {
     expect(cancelButton).toHaveClass('manuscript-end-story-cancel');
     expect(confirmButton).toHaveClass('manuscript-end-story-confirm');
   });
+
+  // Escape/focus parity with the shared ConfirmationDialog (#1536).
+  it('closes the end-story confirmation on Escape', () => {
+    const onCloseEndStory = jest.fn();
+
+    render(
+      <ActiveGameSessionControls
+        {...baseProps}
+        onCloseEndStory={onCloseEndStory}
+        showEndConfirmation={true}
+        character={undefined}
+        characterId={undefined}
+      />
+    );
+
+    fireEvent.keyDown(window, { key: 'Escape', code: 'Escape' });
+
+    expect(onCloseEndStory).toHaveBeenCalledTimes(1);
+  });
+
+  it('moves focus to Cancel when the end-story confirmation opens', () => {
+    render(
+      <ActiveGameSessionControls
+        {...baseProps}
+        showEndConfirmation={true}
+        character={undefined}
+        characterId={undefined}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /cancel/i })).toHaveFocus();
+  });
 });


### PR DESCRIPTION
## Description

On the active play screen you could open the End Story confirmation, then hit the HUD Close control and get the Leave Story confirmation stacked on top of it — two modal decisions at once, with focus ownership split across two different dialog systems.

Root cause: the two confirmations have different owners with zero coordination. The exit and start-new confirmations live at the page level and go through the shared `ConfirmationDialog` (a real Radix modal with a focus trap), while the End Story confirmation is a bespoke dialog owned by `useActiveGameSessionEnding` inside `ActiveGameSession` — and it has no focus trap, so the HUD stays reachable while it's open.

The fix is state-level, at the one component that can see both sides: `ActiveGameSession` now wraps the HUD's Back and Reset Session callbacks so they clear the End Story confirmation before handing off to the page, which opens its own dialog. The reverse direction can't stack — the shared dialog's focus trap and overlay make the HUD unreachable while it's open.

Also brings the End Story dialog up to parity with the shared confirmations (the issue's second success criterion): Escape now dismisses it, and initial focus lands on Cancel — same choice the shared dialog makes for destructive confirmations, since ending a story is irreversible.

Deliberately stayed out of `ConfirmationDialog` / `SimpleModal` / `GameSessionConfirmationDialog` internals — #1531/#1533 are touching those.

## Related Issue

Closes #1536

Part of the v1.0 launch gate checklist (#1320). Heads up: merging to `develop` won't auto-close the issue, so it needs a manual close.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Fix and tests landed in the same pass rather than strictly test-first. New coverage: a repro-shaped suite (`ActiveGameSession.dialogExclusion.test.tsx`) that opens End Story via the HUD, triggers Close (and separately Reset Session), and asserts the End Story dialog unmounts while the page handler fires — plus Escape-dismiss and initial-focus tests in `ActiveGameSessionControls.test.tsx`.

## User Stories Addressed

N/A — bug fix. The player-facing behavior: only one modal decision is ever active during play.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

No prop or visual changes — `ActiveGameSessionControls`' existing stories still hold. The change is coordination logic plus keyboard/focus behavior.

## Implementation Notes

- `ActiveGameSession.tsx`: `handleHudBack` / `handleHudStartNew` wrap the page-provided `onBack` / `onStartNew`, calling `handleCloseEndStory()` first. That's the whole mutual-exclusion guarantee — the issue's "explicitly clear `showEndConfirmation` when the exit confirmation opens" suggestion, implemented at the only layer that sees both dialog owners.
- `ActiveGameSessionControls.tsx`: `useEffect` keyed on `showEndConfirmation` adds a window `keydown` listener for Escape and focuses the Cancel button on open.
- Didn't move End Story onto the shared confirmation path (the issue's other suggested option) — that'd mean touching shared dialog components that in-flight sibling PRs are already editing, for no extra behavioral win.

## Screenshots

N/A — no visual change.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks (if applicable)

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit not run — no dependency or API surface changes. Local gate: full jest suite, `type-check`, and `lint` all exit 0.

## Testing Instructions

1. Start or resume a session with narrative progress.
2. Click the HUD End Story control — the End Story confirmation opens.
3. Without answering it, click the HUD Close control.
4. Before: both End Story and Leave the Story? dialogs mounted. After: End Story closes and only the Leave Story confirmation shows.
5. Same holds for the HUD Reset Session control (start-new confirmation).
6. With the End Story dialog open, press Escape — it dismisses; on open, focus lands on Cancel.

## Checklist

- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

`ActiveGameSession.tsx` already sat past the 300-line limit before this change; this adds ~14 lines at the coordination point rather than splitting the file, which would collide with sibling PRs in the same area. Docs untouched — behavior matches what the issue describes as expected.
