### PR TITLE
fix(design-system): readable workshop tablet layout at 768px (#1540)

### DIFF
--- a/src/app/workshop.css
+++ b/src/app/workshop.css
@@ -610,7 +610,16 @@
   .default-surface-inner {
     padding: var(--space-3);
   }
+}
 
+/* Workshop drawer boundary is `<= 768px` (not `< 768px`) so exactly 768px —
+   iPad Mini portrait — gets the drawer shell, matching the header hamburger's
+   `<= 768px` boundary (#1381). With the old `< 768px` gate the desktop shell
+   survived at exactly 768px: the 18rem rail pinned next to a 479px workspace
+   and the breadcrumb trail wrapped the sticky header to 144px tall (#1540).
+   `.default-surface-inner` stays in the `< 768px` block above — its gutter is
+   synced with `.header-nav-inner`'s space-3 (<768) / space-4 (768-1024) map. */
+@media (width <= 768px) {
   .app-surface-workshop {
     display: block;
   }


### PR DESCRIPTION
## Description

At exactly 768px (iPad Mini portrait) the workshop shell still rendered the desktop layout: the 18rem sidebar rail stayed pinned, leaving a 479px workspace, and the breadcrumb trail wrapped the sticky context header into a 144px-tall block before any content started.

The root cause is a media-query gap in `src/app/workshop.css`. The workshop shell's mobile block was gated at `@media (width < 768px)`, so the drawer layout ended at 767px and the desktop rail assumptions started at exactly 768px. Meanwhile the app header's hamburger boundary in the same file is `<= 768px` (#1381), with a comment spelling out that exactly 768px should get the mobile treatment. The two boundaries disagreed by one pixel, and the workshop shell was on the wrong side of it.

The fix moves the workshop shell rules to `@media (width <= 768px)`, so 768px gets the drawer shell (hamburger trigger, off-canvas sidebar, full-width workspace) — same boundary convention as the header. No new rules, no shell redesign: the existing mobile block just starts one pixel later. Everything in that block was already CSS-gated (`AppSurfaceShell` renders the trigger, drawer, and backdrop unconditionally), so no JS changed.

One deliberate exclusion: `.default-surface-inner` stayed in its original `< 768px` block. Its gutter is documented as synced with `.header-nav-inner`'s space-3 (<768) / space-4 (768–1024) map, and dragging it along would have desynced the default surface's header and content gutters at exactly 768px.

## Related Issue

Closes #1540

Also one of the v1.0 launch-gate items on #1320 ("workshop shell uses a readable tablet layout at 768px"). Heads up: merging to `develop` won't auto-close the issue — needs a manual close.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

No new spec — this is a one-boundary CSS fix, and the house rule is not to pin trivial layout fixes with tests. I did check for existing specs asserting the old boundary: no jest or Playwright spec pins the workshop shell at 768px (the old rail-width assertion was removed in #1526, and the only 768x1024 visual specs target the manuscript surface, which doesn't use these rules). The jest hamburger test (`Navigation.test.tsx`) asserts the toggle is always in the DOM regardless of breakpoint, which this change relies on and doesn't disturb.

## User Stories Addressed

N/A — bug fix under the #1320 launch gate.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

CSS-only change to an existing app-shell media query; no component code touched, so no story changes.

## Implementation Notes

- Constraint chain: `.workshop-sidebar` is `width: 18rem; min-width: 18rem` in the base (desktop) rules; `.app-surface-workshop` is `display: flex`. At 768px viewport that leaves `768 - 288 - 1px border = 479px` for `.workshop-workspace`, which matches the measured `.workshop-context-header` width in the issue.
- Selectors touched: none renamed or restyled. The existing mobile rules for `.app-surface-workshop`, `.workshop-sidebar`, `.workshop-sidebar.workshop-sidebar-open`, `.workshop-sidebar-backdrop`, `.workshop-context-header`, `.workshop-context-header-mobile-trigger`, `.workshop-context-header-mobile-title`, `.workshop-context-header .workshop-context-header-breadcrumbs`, `.workshop-context-header .workshop-context-header-recent`, `.workshop-context-header .tutorial-menu`, `.workshop-workspace-main`, and `.workshop-workspace-inner` moved verbatim from the `< 768px` block into a new `<= 768px` block.
- None of the moved rules are `[data-theme="ds3"]`-prefixed, so the #1546 selector flatten shouldn't collide with this diff.
- Visual-baseline impact: the only affected viewport width is exactly 768px. Desktop baselines (1280) and mobile baselines (320/375/390) render identically; the 768x1024 tablet specs in the suite are manuscript-surface only. I expect zero baseline churn.
- Spotted while verifying the header interaction, out of scope here: on default-surface routes the header hamburger shows at `<= 768px` but `.mobile-nav-menu` is force-hidden at `>= 768px`, so at exactly 768px the hamburger opens an invisible menu. Same off-by-one class of bug, different surface — worth its own issue.

## Screenshots

N/A — no UI redesign; the drawer shell at 768px is the same one that already renders at 767px.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks (if applicable)

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

(Security audit N/A — CSS-only diff. The console.log/promises boxes reflect that no JS was touched.)

## Testing Instructions

1. Seed a few worlds and characters (a long world name makes the old breakpoint failure obvious).
2. Open `/characters` at exactly 768x1024.
3. Before: 18rem rail + 479px workspace, breadcrumb header wrapped ~144px tall. After: drawer shell — hamburger in the context header, full-width workspace, compact header.
4. At 769px and up, the desktop rail layout is unchanged; at 767px the drawer shell was already active and is unchanged.

## Checklist

- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

(`workshop.css` is a pre-existing ~4k-line file; this adds a net ~10 lines to it rather than respecting the 300-line cap, and splitting it is not this PR's job. Docs: nothing to update. Accessibility: the drawer + aria-labeled toggle now activate at 768px, replacing a layout that squeezed content to 94px-wide description columns.)
