### PR TITLE
fix(a11y): add page-level h1s to the active play flow (#1532)

### DIFF
--- a/src/app/worlds/[id]/play/__tests__/page.test.tsx
+++ b/src/app/worlds/[id]/play/__tests__/page.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
 import PlayPage from '../page';
 import { notFound, useParams } from 'next/navigation';
+import { useWorldStore } from '@/state/worldStore';
+import { useNarrativeStore } from '@/state/narrativeStore';
+import type { World } from '@/types/world.types';
+import type { StoryEnding } from '@/types/narrative.types';
 
 // Mock dependencies
 jest.mock('next/navigation', () => ({
@@ -104,5 +108,44 @@ describe('Play Page', () => {
 
     // Assert — GameSession is loaded via next/dynamic, so await its appearance
     expect(await screen.findByTestId('mock-game-session')).toHaveTextContent(`Game Session for ${testWorldId}`);
+  });
+
+  // The immersive play route is chrome-free (no PageLayout), so the page
+  // renders its own screen-reader-only h1 (#1532). No React.useState spy
+  // here: the real mount effect flips isClient under act(), and the spy
+  // breaks hook order once store updates re-render the page.
+  describe('page-level heading', () => {
+    afterEach(() => {
+      // Unmount before resetting stores so the real narrativeStore doesn't
+      // re-render a mounted page outside act().
+      cleanup();
+      useNarrativeStore.setState({ currentEnding: null });
+      (useWorldStore as unknown as { __resetMocks: () => void }).__resetMocks();
+    });
+
+    test('active play exposes exactly one sr-only h1 naming the world', () => {
+      // worldStore is globally mocked (jest.setup.ts); seed via its own API.
+      const worldId = useWorldStore
+        .getState()
+        .createWorld({ name: 'Neo-Tokyo' } as Omit<World, 'id' | 'createdAt' | 'updatedAt'>);
+      (useParams as jest.Mock).mockReturnValue({ id: worldId });
+
+      render(<PlayPage />);
+
+      const headings = screen.getAllByRole('heading', { level: 1 });
+      expect(headings).toHaveLength(1);
+      expect(headings[0]).toHaveTextContent('Playing in Neo-Tokyo');
+      expect(headings[0]).toHaveClass('sr-only');
+    });
+
+    test('h1 switches to Story Complete when an ending is active', () => {
+      useNarrativeStore.setState({
+        currentEnding: { id: 'ending-1' } as StoryEnding,
+      });
+
+      render(<PlayPage />);
+
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Story Complete');
+    });
   });
 });

--- a/src/app/worlds/[id]/play/page.tsx
+++ b/src/app/worlds/[id]/play/page.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic';
 import { notFound, useParams, useSearchParams, useRouter } from 'next/navigation';
 import { useSessionStore } from '@/state/sessionStore';
 import { useNarrativeStore } from '@/state/narrativeStore';
+import { useWorldStore } from '@/state/worldStore';
 import { GameSessionConfirmationDialog } from '@/components/GameSession/GameSessionConfirmationDialog';
 import { ProviderGate } from '@/components/ai/ProviderGate';
 
@@ -37,6 +38,10 @@ export default function PlayPage() {
   // Always call hooks and use persisted store data
   const currentSessionId = useSessionStore((state) => state.id);
   const { getSessionSegments } = useNarrativeStore();
+  const worldName = useWorldStore((state) => state.worlds[worldId]?.name);
+  // ActiveGameSession swaps to the ending screen whenever currentEnding is
+  // set, so the page heading tracks the same store field to stay in sync.
+  const currentEnding = useNarrativeStore((state) => state.currentEnding);
 
   // Check if this should be a fresh session (from "Start New Session" button)
   const disableAutoResume = searchParams?.get('fresh') === 'true';
@@ -94,8 +99,18 @@ export default function PlayPage() {
     notFound();
   }
 
+  const pageHeading = currentEnding
+    ? 'Story Complete'
+    : worldName
+      ? `Playing in ${worldName}`
+      : 'Game Session';
+
   return (
     <div className="manuscript-play-page">
+      {/* The immersive play shell is deliberately chrome-free, so the
+          page-level heading is screen-reader-only (#1532). */}
+      <h1 className="sr-only manuscript-play-page-title">{pageHeading}</h1>
+
       <ProviderGate />
 
       <GameSession

--- a/src/components/GameSession/EndingScreen.tsx
+++ b/src/components/GameSession/EndingScreen.tsx
@@ -328,9 +328,12 @@ export function EndingScreen() {
               />
               <div className="component-ending-screen-hero-overlay">
                 <header className="component-ending-screen-hero-header">
-                  <h1 className="component-ending-screen-hero-title">
+                  {/* h2 in every hero branch: the page-level h1 belongs to the
+                      route (sr-only "Story Complete", #1532), and this was the
+                      only branch still rendering the hero title as an h1. */}
+                  <h2 className="component-ending-screen-hero-title">
                     The End
-                  </h1>
+                  </h2>
                   <p className="component-ending-screen-hero-meta">
                     {`${character?.name || 'Unknown Hero'} • ${world?.name || 'Unknown Realm'}${currentEnding.playTime ? ` • Play Time: ${formatPlayTime(currentEnding.playTime)}` : ''}`}
                   </p>

--- a/src/components/GameSession/__tests__/EndingScreen.yourStory.test.tsx
+++ b/src/components/GameSession/__tests__/EndingScreen.yourStory.test.tsx
@@ -38,7 +38,7 @@ const mockEnding: StoryEnding = {
   updatedAt: '2025-11-24T10:00:00Z',
 };
 
-const setupStores = (checkpoints: StoryCheckpoint[] = []) => {
+const setupStores = (checkpoints: StoryCheckpoint[] = [], ending: StoryEnding = mockEnding) => {
   mockUseRouter.mockReturnValue({
     push: jest.fn(),
     back: jest.fn(),
@@ -49,7 +49,7 @@ const setupStores = (checkpoints: StoryCheckpoint[] = []) => {
   } as ReturnType<typeof useRouter>);
 
   mockUseNarrativeStore.mockReturnValue({
-    currentEnding: mockEnding,
+    currentEnding: ending,
     isGeneratingEnding: false,
     endingError: null,
     getSessionSegments: jest.fn(() => []),
@@ -272,5 +272,29 @@ describe('EndingScreen - Your Story Section', () => {
     // Expand and check updated ARIA attributes
     fireEvent.click(button);
     expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+});
+
+// The page-level h1 belongs to the play route, so the ending screen itself
+// must only contribute subordinate headings (#1532).
+describe('EndingScreen - Heading hierarchy', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders The End as an h2 with no h1 of its own (placeholder hero)', () => {
+    setupStores([]);
+    render(<EndingScreen />);
+
+    expect(screen.getByRole('heading', { level: 2, name: 'The End' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 1 })).toBeNull();
+  });
+
+  it('keeps The End subordinate when the ending image renders', () => {
+    setupStores([], { ...mockEnding, imageUrl: 'data:image/png;base64,abc' });
+    render(<EndingScreen />);
+
+    expect(screen.getByRole('heading', { level: 2, name: 'The End' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 1 })).toBeNull();
   });
 });


### PR DESCRIPTION
## Description
The immersive play route had no page-level `<h1>` in its active and ending states, so screen-reader heading navigation had no main heading to land on. The manuscript shell is deliberately chrome-free (no `PageLayout`), which means the route has to own its heading: `/worlds/[id]/play` now renders a screen-reader-only `h1` that follows the session state — "Playing in {world}" during play (falling back to "Game Session" if the world isn't loaded), switching to "Story Complete" once an ending exists. It reads the same `narrativeStore.currentEnding` field `ActiveGameSession` keys on to swap in the ending screen, so heading and content can't drift.

On top of that, the ending hero title was inconsistent: "The End" rendered as `h1` only when the ending image loaded, but `h2` in the placeholder and error branches. It's `h2` in all three now, which keeps it subordinate to the page heading — and as a side effect drops a second `h1` from the standalone `/play` route, which wraps the session in `PageLayout` (that route already had its own page title, per the issue).

No visual shift expected: the new `h1` uses the existing `.sr-only` utility, and `.component-ending-screen-hero-title` pins its own font-size/weight/family/line-height (the manuscript surface has no per-tag heading rules), so the `h1`-to-`h2` retag renders identically. Playwright baselines never capture the with-image branch anyway — ending-image generation is gated off under Playwright.

One known edge left alone: if ending *generation* fails, `EndingScreen` renders `ErrorDisplay variant="page"`, which brings its own `h1`, so that rare error state can briefly show two h1s. Switching the variant would change its layout, so it stays out of scope here.

## Related Issue
Closes #1532

Also on the v1.0 launch-gate checklist (#1320). Heads up: this branch merges to `develop`, so the Closes keyword won't auto-close — close #1532 manually after merge.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation (implementation and assertions landed in the same pass — tests came right after the code, not before)
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — accessibility bug fix; the acceptance criteria live in #1532.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated — N/A, no new component; heading-level change only
- [ ] Components developed in isolation first — N/A
- [x] Visual consistency verified (sr-only h1 is invisible by design; hero title typography is pinned by its class, not its tag)

## Implementation Notes
- `worldStore` is globally mocked in `jest.setup.ts` and isn't reactive, so the page spec seeds it through the mock's own `createWorld` API. The new tests also skip the file's legacy `React.useState` spy hack — it breaks hook order as soon as a real store update re-renders the page — and let the real mount effect flip `isClient` under `act()`.
- The `EndingScreen` spec's `setupStores` grew an optional ending override so the with-image hero branch (the retagged one) is actually covered.

## Screenshots
N/A — the only visible-DOM change is the `h1`-to-`h2` retag, whose typography is pinned by `.component-ending-screen-hero-title`.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A — semantic markup change, covered by unit specs.

## Quality Checks (if applicable)
- [x] Linting passed (`npm run lint`, exit 0)
- [x] Type checking passed (`npm run type-check`, exit 0)
- [ ] Security audit passed — N/A, not run for this change
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. Seed or create an active session and open `/worlds/<world id>/play`.
2. In DevTools, run `document.querySelectorAll('h1')` — exactly one match, `sr-only`, reading "Playing in <world name>".
3. Click End Story and confirm. Once `[data-testid="ending-screen"]` renders, the same query returns exactly one `h1` ("Story Complete"), and "The End" is an `h2` alongside the section-level `h2`s (Epilogue, Character Legacy, etc.).
4. Unit: `npx jest "src/app/worlds/\[id\]/play/__tests__/page.test.tsx" src/components/GameSession/__tests__/EndingScreen.yourStory.test.tsx`
5. Full gate run locally: 350 suites / 2360 tests passed, type-check and lint clean. No `.css` touched, so `lint:css` wasn't in play.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) — N/A
- [x] No new warnings generated
- [x] Accessibility considerations addressed
