### PR TITLE
fix(settings): keep provider setup actions in the first mobile viewport (#1539)

### DIFF
--- a/src/components/ai/provider-config.css
+++ b/src/components/ai/provider-config.css
@@ -159,6 +159,29 @@
   font-size: 0.875rem;
 }
 
+/* Mobile wizard fit (#1539): at phone widths the auto-fill preset grid
+   collapses to a single 12rem column, so seven stacked presets (six of them
+   "Coming soon") push the custom-endpoint toggle and the Cancel/Next row
+   ~270px past a 667px-tall first viewport. Two-up compact presets halve that
+   wall so the usable path fits the first screen, and the sticky action row
+   keeps Cancel/Next reachable however long the step content grows. */
+@media (width < 768px) {
+  .component-provider-presets {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .provider-preset {
+    padding: var(--space-2);
+  }
+
+  .component-provider-wizard .wizard-nav-container {
+    position: sticky;
+    bottom: 0;
+    padding-bottom: var(--space-3);
+    background: var(--color-surface);
+  }
+}
+
 /* Verify step */
 .provider-verify {
   display: flex;


### PR DESCRIPTION
## Description
On a 375x667 viewport, opening provider setup on `/settings/providers` buries the primary actions. The constraint chain: the preset grid uses `repeat(auto-fill, minmax(12rem, 1fr))`, and at phone width the content column only fits one 12rem track — so all seven presets (six of them "Coming soon") stack into a ~510px single column. That pushes the "Use a custom endpoint" toggle to y=873 and the Cancel/Next row to y=933, both well past the 667px fold. The provider wizard had no mobile treatment at all — the DS3 command-strip mobile rules in `wizard.css` only target the world/character creation wizards.

The fix is one media block in the co-located `provider-config.css`, scoped to the provider surface:

- below 768px the presets go two-up with tighter padding, which halves the wall and pulls the usable path (Gemini card, custom-endpoint toggle) into the first viewport
- the wizard action row gets `position: sticky; bottom: 0`, so Cancel/Next stay visible however long the step content grows — including when the custom-endpoint form expands

No DOM changes, no redesign. This is one of the v1.0 launch-gate items (#1320, "provider setup actions stay discoverable on mobile").

## Related Issue
Closes #1539

Heads-up: this merges to `develop`, so the keyword won't auto-close — needs a manual close after merge, per repo convention.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
CSS-only layout fix with no DOM or behavior change, so no new spec (house rule for trivial layout fixes — the constraint chain above is the evidence instead).
- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved (no code paths changed)

## User Stories Addressed
N/A — bug fix. The underlying journey is a first-time player completing provider setup on a phone.

## Flow Diagrams
N/A

## Component Development
No component code touched; the wizard shell and presets grid already exist. There are no Storybook stories for ProviderWizard to update.
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes
- The sticky bar needs an opaque background to float over scrolled content; it uses `var(--color-surface)`, which matches the workshop workspace behind it in all three themes and both color modes.
- Scoped to `.component-provider-wizard .wizard-nav-container` so the world/character creation wizards (which have their own DS3 mobile grid treatment) are untouched.
- `repeat(2, minmax(0, 1fr))` rather than bare `1fr` so long model names can't force the grid past the viewport.
- Visual-baseline risk is nil: the only spec covering this page (`tests/visual/providers-page.spec.ts`) captures the desktop empty state, and everything here sits inside `@media (width < 768px)`.

## Screenshots
Before shots are in the issue (proof-pass captures at 375x667).

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A — verified by arithmetic against the issue's measured proof-pass numbers: the preset wall drops from ~511px to ~256px, the custom-endpoint toggle lands around y=636 (above the 667px fold), and the action row pins to the viewport bottom regardless of content height.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed (N/A — CSS only)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm run dev`, open `/settings/providers` in a 375x667 viewport (iPhone SE preset in devtools).
2. Click "Set up a provider".
3. The preset grid should be two columns, "Use a custom endpoint" visible without scrolling, and Cancel/Next pinned at the bottom of the viewport.
4. Tap "Use a custom endpoint" — the action row stays reachable while the form expands.
5. Widen past 768px — everything renders exactly as before.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) — N/A
- [x] No new warnings generated
- [x] Accessibility considerations addressed (preset cards stay ~55px tall at the tighter mobile padding, above the 44px tap-target floor)
