### PR TITLE
fix(a11y): expose dialog descriptions in shared modals (#1533)

### DIFF
--- a/src/components/shared/SimpleModal.tsx
+++ b/src/components/shared/SimpleModal.tsx
@@ -1,4 +1,4 @@
-import React, { useId } from 'react';
+import React from 'react';
 import { X } from 'lucide-react';
 import { clsx } from 'clsx';
 
@@ -7,6 +7,7 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
+  DialogDescription,
   DialogTitle,
 } from '@/components/ui/dialog';
 
@@ -55,10 +56,15 @@ export function SimpleModal({
   scrollBehavior = 'overlay',
   stickyFooter,
 }: SimpleModalProps) {
-  const fallbackDescriptionId = useId();
-  const resolvedDescriptionId =
-    ariaDescribedBy ||
-    (description ? `${fallbackDescriptionId}-description` : undefined);
+  // Radix wires DialogContent's aria-describedby to the DialogDescription we
+  // render below. Only override that default to point at a caller-owned
+  // element (ariaDescribedBy), or to opt out explicitly when the dialog has
+  // no descriptive text at all -- a dangling aria-describedby makes Radix
+  // warn about a missing Description.
+  const describedByOverride =
+    description && !ariaDescribedBy
+      ? {}
+      : { 'aria-describedby': ariaDescribedBy };
   const hasHeaderContent = Boolean(title || showCloseButton || description);
 
   return (
@@ -67,7 +73,7 @@ export function SimpleModal({
       onOpenChange={(open) => (open ? undefined : onClose())}
     >
       <DialogContent
-        aria-describedby={resolvedDescriptionId}
+        {...describedByOverride}
         showCloseButton={false}
         overlayScroll={scrollBehavior === 'overlay'}
         overlayClassName={overlayClassName}
@@ -93,10 +99,13 @@ export function SimpleModal({
           <div>
             <div>
               {title && <DialogTitle>{title}</DialogTitle>}
+              {/* asChild keeps this a div: description accepts arbitrary
+                  nodes (some callers pass <p> blocks), which the default
+                  Radix <p> element could not legally contain. */}
               {description && (
-                <div id={ariaDescribedBy ? undefined : resolvedDescriptionId}>
-                  {description}
-                </div>
+                <DialogDescription asChild>
+                  <div className="dialog-description">{description}</div>
+                </DialogDescription>
               )}
             </div>
             {showCloseButton && (

--- a/src/components/shared/__tests__/LoadingOverlay.test.tsx
+++ b/src/components/shared/__tests__/LoadingOverlay.test.tsx
@@ -21,13 +21,33 @@ describe('LoadingOverlay', () => {
 
     it('should display custom message when provided', () => {
       render(
-        <LoadingOverlay 
-          isVisible={true} 
-          message="Loading your world..." 
+        <LoadingOverlay
+          isVisible={true}
+          message="Loading your world..."
         />
       );
-      
+
       expect(screen.getByText('Loading your world...')).toBeInTheDocument();
+    });
+
+    it('exposes the message as the dialog accessible description without Radix warnings', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      render(
+        <LoadingOverlay
+          isVisible={true}
+          message="Loading Playwright Test World..."
+        />
+      );
+
+      expect(screen.getByRole('dialog')).toHaveAccessibleDescription(
+        'Loading Playwright Test World...',
+      );
+      const missingDescriptionWarnings = warnSpy.mock.calls.filter((call) =>
+        String(call[0]).includes('Missing `Description`'),
+      );
+      expect(missingDescriptionWarnings).toHaveLength(0);
+      warnSpy.mockRestore();
     });
   });
 

--- a/src/components/shared/__tests__/SimpleModal.test.tsx
+++ b/src/components/shared/__tests__/SimpleModal.test.tsx
@@ -62,6 +62,63 @@ describe('SimpleModal', () => {
     expect(document.querySelector('[data-scroll-container="overlay"]')).toBeNull();
   });
 
+  it('exposes description as the dialog accessible description', () => {
+    render(
+      <SimpleModal
+        isOpen={true}
+        onClose={jest.fn()}
+        title="Please wait"
+        description="Loading Test World..."
+      />,
+    );
+
+    expect(screen.getByRole('dialog')).toHaveAccessibleDescription(
+      'Loading Test World...',
+    );
+  });
+
+  it('does not trigger the Radix missing-description warning when description is set', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    render(
+      <SimpleModal
+        isOpen={true}
+        onClose={jest.fn()}
+        title="Please wait"
+        description="Loading Test World..."
+      />,
+    );
+
+    const missingDescriptionWarnings = warnSpy.mock.calls.filter((call) =>
+      String(call[0]).includes('Missing `Description`'),
+    );
+    expect(missingDescriptionWarnings).toHaveLength(0);
+    warnSpy.mockRestore();
+  });
+
+  it('lets ariaDescribedBy point the dialog at a caller-owned element', () => {
+    // Radix cannot see caller-owned aria-describedby wiring and still logs
+    // its missing-description heuristic warning for this path; silence it so
+    // test output stays clean. The accessible description itself resolves.
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    render(
+      <SimpleModal
+        isOpen={true}
+        onClose={jest.fn()}
+        title="Generate World"
+        ariaDescribedBy="caller-desc"
+      >
+        <p id="caller-desc">Caller supplied description.</p>
+      </SimpleModal>,
+    );
+
+    expect(screen.getByRole('dialog')).toHaveAccessibleDescription(
+      'Caller supplied description.',
+    );
+    warnSpy.mockRestore();
+  });
+
   it('supports overlay scrolling with a footer', () => {
     render(
       <SimpleModal

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -132,13 +132,8 @@ DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 export {
   Dialog,
-  
-  
   DialogClose,
-  
   DialogContent,
-  
-  
+  DialogDescription,
   DialogTitle,
-  
 };


### PR DESCRIPTION
## Description
Every shared modal that passes a `description` — the navigation loading overlay, ConfirmationDialog, NoProviderModal, and friends — was logging Radix's `Missing Description or aria-describedby={undefined}` warning. The aria wiring itself worked (SimpleModal pointed `aria-describedby` at a plain div), but Radix's check only accepts an element rendered through its own `Description` primitive, which `dialog.tsx` defined and never exported.

This exports `DialogDescription` from the shared primitive and has SimpleModal render `description` through it as an `asChild` div, letting Radix own the id wiring. Same DOM shape as before (still a div — some callers pass `<p>` blocks, which the default Radix `<p>` couldn't legally contain), so visible copy and layout don't move. The no-description opt-out (`aria-describedby={undefined}`) and caller-owned `ariaDescribedBy` overrides behave exactly as they did.

Before: 12 missing-description warnings across the SimpleModal/LoadingOverlay/DeleteConfirmationDialog jest suites. After: 0 from the description path.

## Related Issue
Closes #1533

Part of the v1.0 launch-gate checklist in #1320 ("shared modals expose dialog descriptions"). Since this merges to `develop`, the Closes keyword won't auto-close — needs a manual close after merge.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Fix landed first, tests right behind it in the same change — four new specs cover the description path (accessible description resolves, no Radix warning), the caller-owned `ariaDescribedBy` path, and the LoadingOverlay repro from the issue.

## User Stories Addressed
N/A — accessibility bug fix.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

Existing SimpleModal/LoadingOverlay stories still apply unchanged. There's no visual delta to verify: the description element stays a div in the same spot, and the new `dialog-description` class has no CSS rules — this PR is deliberately markup/aria only (dialog CSS belongs to #1531).

## Implementation Notes
Root cause: Radix's `DescriptionWarning` checks `document.getElementById(context.descriptionId)` — its own context id, which only a rendered `DialogPrimitive.Description` receives. Hand-rolled `aria-describedby` wiring can never satisfy it, no matter how valid the reference is for assistive tech. So the `useId` plumbing in SimpleModal is gone; when a `description` exists and no override is passed, we don't set `aria-describedby` at all and Radix wires content to description itself.

Known residual: dialogs that pass only `ariaDescribedBy` pointing at an element in their children (GenerateCharacterDialog, the worlds-page generate modal) still trip Radix's heuristic, since there's no description content to route through the primitive. Their AT wiring is real — the new test asserts the accessible description resolves — it's just invisible to Radix's check. Rewiring those callers would move copy out of the modal body, which this issue explicitly avoids ("keep current visible copy and layout").

Coordination: markup/aria changes only, no dialog CSS or layout touched — kept disjoint from #1531 (shared dialog mobile overflow CSS) on purpose.

## Screenshots
N/A — no visual change.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A — verified via jest (Radix's warning fires in the same effect path under jsdom; the suites that warned before are clean now).

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npx jest src/components/shared src/components/DeleteConfirmationDialog --maxWorkers=2` — 4 new specs pass, and the missing-description warnings that used to spam this output are gone.
2. In the app: open a world with at least one character, go to `/worlds/<world id>`, click the primary play action, and watch the console while the "Please wait" overlay is up — no Radix warning.
3. Inspect the overlay: the dialog content's `aria-describedby` resolves to the `dialog-description` element carrying the loading message.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
