### PR TITLE
fix(test): reorder jest CSS mapper before @/ alias, drop manual stub

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -5,8 +5,10 @@ const config = {
   maxWorkers: '50%',
   workerIdleMemoryLimit: '512MB',
   moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/src/$1',
+    // CSS stub must come first: mappers match in order, and the @/ alias would
+    // otherwise resolve @/-form stylesheet imports to real files.
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+    '^@/(.*)$': '<rootDir>/src/$1',
   },
   testMatch: [
     '<rootDir>/src/**/*.test.{ts,tsx}',

--- a/src/app/settings/providers/__tests__/page.test.tsx
+++ b/src/app/settings/providers/__tests__/page.test.tsx
@@ -2,10 +2,6 @@ import React from 'react';
 import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-// The jest alias mapper resolves @/-form CSS imports before the CSS stub rule
-// can catch them, so stub the page's stylesheet import here.
-jest.mock('@/components/ai/provider-config.css', () => ({}));
-
 // crypto.subtle isn't available in jsdom — mock the encryption layer so the
 // store's removeProvider can run (it clears the key after the last removal).
 jest.mock('@/lib/storage/encryption', () => ({


### PR DESCRIPTION
## Description
`jest.config.cjs`'s `moduleNameMapper` checks patterns in insertion order. With the `^@/(.*)$` alias rule listed before the CSS → `identity-obj-proxy` rule, any `@/`-form stylesheet import (e.g. `import '@/components/ai/provider-config.css'`) matched the alias first and resolved to the real CSS file instead of being stubbed — breaking any suite that loaded such a component, since ts-jest can't parse CSS as a module.

This PR reorders the two mapper entries so the CSS stub rule matches first, then removes the manual `jest.mock('@/components/ai/provider-config.css', ...)` workaround this branch's new spec (`src/app/settings/providers/__tests__/page.test.tsx`) had added to route around the bug.

**Stacked on #1552**: the spec file this touches only exists on that branch, so this PR targets `fix/1537-provider-remove-confirm` rather than `develop`. Once #1552 merges, this should be retargeted to `develop` — at that point the diff will just be the two changes described above.

## Related Issue
N/A — test-infrastructure fix noted as a workaround in #1552's PR description.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — internal test-infrastructure fix, no user-facing behavior change.

## Flow Diagrams
N/A

## Component Development
N/A — no component changed.

## Implementation Notes
- `jest.config.cjs`: swapped the order of the two `moduleNameMapper` entries so `\.(css|less|scss|sass)$` → `identity-obj-proxy` is checked before `^@/(.*)$` → `<rootDir>/src/$1`, with a comment explaining why the order matters.
- `src/app/settings/providers/__tests__/page.test.tsx`: removed the now-unnecessary `jest.mock('@/components/ai/provider-config.css', () => ({}))` stub and its explanatory comment.
- Confirmed no other spec in the tree carries a similar manual CSS-alias stub, so this was the only workaround to remove.

## Screenshots
N/A

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm test -- src/app/settings/providers` — 4 specs still pass with the manual stub removed, proving the mapper reorder alone stubs the `@/`-aliased CSS import.
2. `npm test` — full suite: 354 suites / 2383 tests pass.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed


---
_Generated by [Claude Code](https://claude.ai/code/session_01SZuXUcetY2Egy4hEmRMCiT)_