### PR TITLE
fix(navigation): fix mobile-nav-menu breakpoint mismatch at 768px

### DIFF
--- a/src/app/workshop.css
+++ b/src/app/workshop.css
@@ -1086,7 +1086,11 @@
   border-top: 1px solid var(--color-border);
 }
 
-@media (width >= 768px) {
+/* Hidden above 768px to match the header hamburger's `<= 768px` boundary
+   (useMobileNavigation.ts). A `>= 768px` gate here disagreed with that
+   boundary by one pixel, so opening the menu at exactly 768px rendered
+   nothing — same off-by-one class as the workshop shell fix in #1557. */
+@media (width > 768px) {
   .mobile-nav-menu {
     display: none;
   }


### PR DESCRIPTION
## Description

On default-surface routes, the header hamburger opens at `<= 768px` (`useMobileNavigation.ts` uses `matchMedia('(max-width: 768px)')`), but `.mobile-nav-menu` was force-hidden at `>= 768px` in `src/app/workshop.css`. At exactly 768px both conditions were true simultaneously, so opening the menu rendered nothing — an invisible overlay.

`workshop.css`, despite its name, is the single global stylesheet imported in the root `layout.tsx`, so this rule applies to every route, not just the workshop surface. `.mobile-nav-menu` is the only class in the codebase using this hide rule.

This is the same off-by-one boundary-disagreement class of bug fixed for the workshop shell in #1557 (closing #1540) — that PR's description explicitly flagged this exact default-surface case as a known follow-up ("worth its own issue").

Fix: change the hide rule from `@media (width >= 768px)` to `@media (width > 768px)`, matching the hamburger's `<= 768px` boundary. One boundary changed, nothing else.

## Related Issue
N/A — no issue was filed for this specific case; it was called out directly in #1557's PR description as a known follow-up to the workshop-shell fix for #1540.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

No new spec, matching the precedent set in #1557 for this same bug class: a trivial one-boundary CSS fix doesn't get a pinning test. I checked for existing specs asserting the old boundary — `MobileNavigationMenu.test.tsx` and `Navigation.test.tsx` don't reference 768px at all, and the one Playwright spec that asserts header-collapse behavior at a breakpoint (`tests/visual/mobile-overflow.spec.ts`, for #1381) only exercises 320px/375px viewports and never opens or asserts `.mobile-nav-menu` visibility, so it's unaffected by this change.

## User Stories Addressed
N/A — bug fix.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

CSS-only change to an existing global media query; no component code touched, so no story changes.

## Implementation Notes
- Selector touched: `.mobile-nav-menu`'s hide media query only. No other rule in `workshop.css` was changed (the neighboring `.breadcrumbs-desktop`/`.breadcrumbs-mobile` toggle at the same `>= 768px` boundary is intentionally left alone — out of scope for this fix).
- Added a short comment explaining the boundary rationale, in the same spirit as the explanation #1557 added for the workshop shell's boundary move.

## Screenshots
N/A — no visual redesign. Behavior at 767px and below, and 769px and above, is unchanged. The only affected width is exactly 768px, where the menu now renders instead of nothing.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed (`npm run lint:css`)
- [ ] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

(Type checking and security audit N/A — CSS-only diff, no JS/TS touched. Full suite run: `npm test` → 353 suites / 2379 tests passed.)

## Testing Instructions
1. Open any default-surface route (e.g. `/worlds`) at exactly 768×1024 viewport.
2. Tap the header hamburger.
3. Before: the overlay opens but renders invisible (`.mobile-nav-menu` was `display: none` at `>= 768px`). After: the full-screen nav overlay renders correctly.
4. At 767px and below, and 769px and above, behavior is unchanged (menu already worked at 767px; hamburger and menu are both absent at 769px+).

## Checklist
- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

(`workshop.css` is a pre-existing ~4k-line file predating this change; this is a 4-line net addition to an existing rule, not a new file, so it doesn't fit the 300-line cap and splitting it isn't this PR's job. Accessibility: this restores the mobile nav's accessible overlay — `role="navigation"`, focus management, swipe-to-close — at exactly 768px, where it was previously open but invisible.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AgKX5a5gh5sU77ULnMh1Kd)_