### PR TITLE
docs: sync CLAUDE.md design-system convention with ADR-013

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ npm run lint:css           # Stylelint over **/*.css — run after ANY .css edit
 - Style with design tokens, not hardcoded values. Stylelint enforces it: no hex, no named colors, no rgb/rgba in product CSS (theme files have scoped overrides). Avoid `!important`.
 - Put an identifying class attribute on components.
 - Look for an existing pattern/utility before adding a new one. One canon version per file — no `simple`/`enhanced` variants.
-- Three design systems coexist deliberately — that's ADR-011, not an accident. Storybook (`npm run storybook`) is the single canon surface — ADR-012; the old `/dev/design-system*` living style guide was retired. DESIGN.md is the map.
+- One design system: DS3 ("Mechanical Manuscript"). ADR-013 (PR #1526) collapsed the old three-system setup into DS3 and supersedes ADR-011 — the design system isn't switchable anymore, only light/dark is. Storybook (`npm run storybook`) is still the single canon surface (ADR-012, unaffected — it just renders the one theme now); the old `/dev/design-system*` living style guide stays retired. DESIGN.md is the map, though its type-scale numbers are still DS1's, pending the bolder-DS3 rewrite in #1543.
 - State: CRUD-style store methods; cross-store events via `storeEvents`/`StoreEventTypes`; static imports only (`eval(require())` was eradicated in #1206). Wizard step state goes through sessionStorage (`generated-world-data`); theme prefs through localStorage.
 - Current house style: no wrapper services (ExportService was removed on purpose), use `clsx` directly, extract hooks/helpers before things get clever.
 - Issue work runs the standard global pipeline: analyze-issue, then tdd-implement, then post-merge.
@@ -94,4 +94,4 @@ For truly automatic execution, select "Yes, and don't ask again this session" on
 ## Pointers
 
 - README.md — product overview.
-- DESIGN.md, ADR-011 (#1210), and ADR-012 (#1484) — design-system architecture and the Storybook-as-canon surface.
+- DESIGN.md, ADR-013 (PR #1526, supersedes ADR-011), and ADR-012 (#1484) — the single-design-system decision and the Storybook-as-canon surface.


### PR DESCRIPTION
## Description
CLAUDE.md's Conventions and Pointers sections still described three coexisting design systems under ADR-011 — but ADR-013 ([PR #1526](https://github.com/jerseycheese/Narraitor/pull/1526), merged 2026-07-12) collapsed DS1/DS2 into DS3-only and supersedes ADR-011 in full. A session reading the stale text would assume theme-switching still exists and go hunting for `ds1.css`/`ds2.css` and DS1/DS2 component branches that no longer exist.

Two lines changed:
- **Conventions:** "Three design systems coexist deliberately — that's ADR-011" → "One design system: DS3 (Mechanical Manuscript)", noting ADR-013 collapsed and superseded ADR-011, that the design system isn't switchable anymore (only light/dark is), and that ADR-012's Storybook-as-canon decision is unaffected (it just renders the one theme now). Kept the still-true "`/dev/design-system*` living style guide stays retired" note and flagged that DESIGN.md's type-scale numbers are still DS1's, pending the bolder-DS3 rewrite in #1543 — so nobody trusts them as DS3 canon.
- **Pointers:** repointed the design-system reference from ADR-011 to ADR-013 (noting the supersession), kept ADR-012.

Every claim is grounded: read ADR-013 directly for the framing, confirmed `/dev/design-system` is gone from the tree, and confirmed #1543 is the tracking issue for the DESIGN.md rewrite. This just syncs the instructions to the decision that already landed — no code or behavior change.

## Related Issue
No filed issue — this came out of the post-merge sweep for the DS1/DS2 collapse (same root cause as the issue edits/closes done alongside it). ADR-013 is the decision of record.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
N/A — documentation-only change to CLAUDE.md, no code to test-drive.
- [ ] Tests written before implementation
- [ ] All new code is tested
- [ ] All tests pass locally
- [ ] Test coverage maintained or improved

## User Stories Addressed
N/A — internal project-conventions doc.

## Flow Diagrams
N/A

## Component Development
N/A — no components touched.
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes
Deliberately kept scope to CLAUDE.md. The `narraitor-domain-reference` skill's description still says "the three-design-system theming model" and its body likely carries more DS1/DS2 detail — that's real adjacent rot, but it's a bigger, separate edit (and skill-doc staleness is already partly tracked in #1524), so it's flagged for follow-up rather than folded in here. Also left DESIGN.md itself alone — its rewrite is tracked in #1543 and ADR-013 deliberately deferred it.

## Screenshots
N/A

## Code Review Summary (if applicable)
Two-line diff to a markdown doc. The only judgment call was how much to say about DESIGN.md's known-stale numbers — landed on a short honest flag pointing at #1543 rather than silently trusting or silently dropping it.

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [ ] Linting passed <!-- N/A — markdown only, not covered by eslint globs -->
- [ ] Type checking passed <!-- N/A -->
- [ ] Security audit passed <!-- N/A -->
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
Nothing to run — it's a docs-only change to CLAUDE.md, outside the tsc/jest/eslint/stylelint surfaces. CI's standard gates will confirm nothing's disturbed.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic — N/A, but the doc text itself explains the why (why DS1's numbers can't be trusted yet)
- [x] Documentation updated (if required) — this IS the doc update
- [x] No new warnings generated
- [ ] Accessibility considerations addressed <!-- N/A -->
