### PR TITLE
Copy local env files into linked worktrees on dev start

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -12,6 +12,8 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+"scripts/sync-local-env.sh"
+
 port="$(node scripts/worktree-port.js)"
 
 bash scripts/kill-port.sh "$port"

--- a/scripts/sync-local-env.sh
+++ b/scripts/sync-local-env.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Copy ignored local env files from the primary checkout into a linked worktree.
+# These files are intentionally untracked, but local dev worktrees need the same
+# server-side keys and feature flags as the main checkout.
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$repo_root" ]; then
+  exit 0
+fi
+
+current_root="$(cd "$repo_root" && pwd -P)"
+primary_root="$(
+  git worktree list --porcelain |
+    awk '/^worktree / { print substr($0, 10); exit }'
+)"
+
+if [ -z "$primary_root" ]; then
+  exit 0
+fi
+
+primary_root="$(cd "$primary_root" && pwd -P)"
+if [ "$primary_root" = "$current_root" ]; then
+  exit 0
+fi
+
+shopt -s nullglob
+for source_env in "$primary_root"/.env*.local; do
+  env_name="$(basename "$source_env")"
+  target_env="$current_root/$env_name"
+
+  if [ -e "$target_env" ]; then
+    continue
+  fi
+
+  if ! git -C "$current_root" check-ignore -q "$env_name"; then
+    echo "Skipping $env_name because it is not ignored by git"
+    continue
+  fi
+
+  cp -p "$source_env" "$target_env"
+  echo "Copied $env_name from primary checkout"
+done


### PR DESCRIPTION
## Description

Worktrees don't inherit the primary checkout's `.env*.local` files. They're untracked on purpose, so `git worktree add` doesn't bring them along, and a fresh worktree comes up missing the server-side keys and feature flags the main checkout has. You usually find out when an AI route 500s for no obvious reason and you go hunting for a config bug that isn't there.

`scripts/dev.sh` now runs a sync step before picking the port. The script is deliberately timid:

- no-ops entirely when you're already in the primary checkout
- only copies files git already ignores (`git check-ignore` gate), so it can't quietly start tracking a secret
- never overwrites an existing target, so a worktree with its own tweaked env keeps it
- exits 0 and stays quiet if it can't work out the repo layout

This was originally bundled into #1592 alongside a marginalia CSS fix. Split out so each diff reads as one change.

## Related Issue

No issue — this came out of reviewing #1592 rather than a filed bug.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

N/A — dev tooling, no app code. The script's behaviour is verified by running it (see Testing Instructions) rather than by a suite; adding a shell-script harness for 44 lines of copy-with-guards would cost more than it's worth.

- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed

N/A — developer environment, not product behaviour.

## Flow Diagrams

N/A

## Component Development

N/A — no UI.

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes

The `git check-ignore` gate is the part worth looking at. Without it, a repo whose `.gitignore` stopped covering `.env.local` would start copying a secrets file into a directory where the next `git add -A` would happily stage it. With it, the script refuses and says why.

It reads the primary checkout from `git worktree list --porcelain` and takes the first entry, which is always the main working tree. Comparing resolved paths (`pwd -P`) rather than the raw strings avoids a symlinked `/tmp` reading as a different directory than it is.

`shopt -s nullglob` matters — without it, a checkout with no `.env*.local` files at all would iterate over the literal unmatched glob and try to copy a file named `.env*.local`.

## Screenshots

N/A

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks (if applicable)

- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

Three-stage:

1. **Primary checkout** — run `npm run dev` from `~/Projects/personal/narraitor`. The script should print nothing and change nothing; it detects it's in the primary tree and exits.
2. **Fresh worktree** — make one without env files, run `npm run dev`, and confirm it prints `Copied .env.local from primary checkout` (and any other `.env*.local` you have) and that the files land.
3. **Worktree with its own env** — put a modified `.env.local` in a worktree, run `npm run dev` again, and confirm it's left alone rather than clobbered.

For the ignore gate: temporarily drop `.env.local` out of `.gitignore` and confirm the script skips it with `Skipping .env.local because it is not ignored by git` instead of copying.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
