### PR TITLE
fix: stop story-summary retry loop, log write-path failures, surface errors

### DIFF
--- a/src/components/GameSession/StorySummarySection.tsx
+++ b/src/components/GameSession/StorySummarySection.tsx
@@ -16,7 +16,7 @@ export const StorySummarySection: React.FC<StorySummarySectionProps> = ({
   sessionId,
   characterId,
 }) => {
-  useStoryCheckpointManager({ worldId, sessionId, characterId });
+  const { status, error } = useStoryCheckpointManager({ worldId, sessionId, characterId });
   const worldState = useWorldStore((state) =>
     worldId ? state.worldStates[worldId] : undefined
   );
@@ -44,6 +44,8 @@ export const StorySummarySection: React.FC<StorySummarySectionProps> = ({
         .filter(Boolean)
     : [];
 
+  const showFailedState = summaryParagraphs.length === 0 && status === 'error';
+
   return (
     <section
       data-testid="story-summary-section"
@@ -55,6 +57,10 @@ export const StorySummarySection: React.FC<StorySummarySectionProps> = ({
             <p key={`${paragraph.slice(0, 32)}-${index}`} className="manuscript-story-summary-paragraph">{paragraph}</p>
           ))}
         </div>
+      ) : showFailedState ? (
+        <p className="manuscript-story-summary-error">
+          {error ?? 'Story summary failed to generate.'}
+        </p>
       ) : (
         <p className="manuscript-story-summary-empty">
           Your story will appear here once major events occur.

--- a/src/components/GameSession/__tests__/ActiveGameSession.manuscriptLayout.test.tsx
+++ b/src/components/GameSession/__tests__/ActiveGameSession.manuscriptLayout.test.tsx
@@ -20,10 +20,10 @@ jest.mock('@/state/characterStore');
 jest.mock('@/state/inventoryStore');
 jest.mock('@/state/journalStore');
 jest.mock('@/state/worldStore');
-// StorySummaryDrawerContent mounts the checkpoint manager; its return value is
-// unused there, so a no-op keeps the drawer test focused on the header.
+// StorySummaryDrawerContent mounts the checkpoint manager; this test only
+// exercises the drawer header, so a default idle/no-error shape is enough.
 jest.mock('../hooks/useStoryCheckpointManager', () => ({
-  useStoryCheckpointManager: jest.fn(),
+  useStoryCheckpointManager: jest.fn(() => ({ status: 'idle', error: null })),
 }));
 jest.mock('@/hooks/useAutoSave');
 jest.mock('@/components/TutorialProvider');

--- a/src/components/GameSession/__tests__/StorySummarySection.test.tsx
+++ b/src/components/GameSession/__tests__/StorySummarySection.test.tsx
@@ -52,6 +52,15 @@ describe('StorySummarySection', () => {
     expect(screen.getByText(/Your story will appear here once major events occur/i)).toBeInTheDocument();
   });
 
+  it('shows a distinct failure message instead of the empty placeholder when the checkpoint request errored', () => {
+    setupHook({ status: 'error', error: 'Checkpoint API is down' });
+    setupWorldStore([]);
+    render(<StorySummarySection worldId="world-1" sessionId="session-1" />);
+
+    expect(screen.getByText('Checkpoint API is down')).toBeInTheDocument();
+    expect(screen.queryByText(/Your story will appear here once major events occur/i)).not.toBeInTheDocument();
+  });
+
   it('renders checkpoint segment from a single checkpoint', () => {
     const checkpoint: StoryCheckpoint = {
       id: 'checkpoint-1',

--- a/src/components/GameSession/hooks/__tests__/useStoryCheckpointManager.test.ts
+++ b/src/components/GameSession/hooks/__tests__/useStoryCheckpointManager.test.ts
@@ -1,0 +1,123 @@
+import { renderHook, act } from '@testing-library/react';
+import { useStoryCheckpointManager } from '../useStoryCheckpointManager';
+import { useWorldStore } from '@/state/worldStore';
+import { useCharacterStore } from '@/state/characterStore';
+import { aiFetch } from '@/lib/ai/aiFetch';
+
+jest.mock('@/lib/ai/aiFetch', () => ({
+  aiFetch: jest.fn(),
+}));
+
+jest.mock('@/state/worldStore', () => ({
+  useWorldStore: Object.assign(jest.fn(), { getState: jest.fn() }),
+}));
+
+jest.mock('@/state/characterStore', () => ({
+  useCharacterStore: jest.fn(),
+}));
+
+jest.mock('@/state/narrativeStore', () => ({
+  useNarrativeStore: {
+    getState: jest.fn(() => ({
+      getSessionDecisions: jest.fn(() => []),
+      getSessionSegments: jest.fn(() => []),
+    })),
+  },
+}));
+
+const mockAiFetch = aiFetch as jest.MockedFunction<typeof aiFetch>;
+const mockUseWorldStore = useWorldStore as unknown as jest.Mock & { getState: jest.Mock };
+const mockUseCharacterStore = useCharacterStore as unknown as jest.Mock;
+const mockUpdateWorldState = jest.fn();
+
+const pendingEvent = {
+  id: 'event-1',
+  description: 'Something happened',
+  timestamp: '2026-01-01T00:00:00.000Z',
+  sessionId: 'session-1',
+  characterId: 'char-1',
+};
+
+const setupWorldState = (majorEvents = [pendingEvent]) => {
+  mockUseWorldStore.mockImplementation((selector) =>
+    selector({
+      worldStates: {
+        'world-1': { majorEvents, storyCheckpoints: [] },
+      },
+      worlds: {
+        'world-1': { toneSettings: undefined },
+      },
+    })
+  );
+  mockUseWorldStore.getState.mockReturnValue({ updateWorldState: mockUpdateWorldState });
+};
+
+describe('useStoryCheckpointManager', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    setupWorldState();
+    mockUseCharacterStore.mockImplementation((selector) => selector({ characters: {} }));
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('does not re-fire createCheckpoint after a failure without new pending events', async () => {
+    mockAiFetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: 'Checkpoint API is down' }),
+    } as unknown as Response);
+
+    const { result } = renderHook(() =>
+      useStoryCheckpointManager({ worldId: 'world-1', sessionId: 'session-1' })
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(mockAiFetch).toHaveBeenCalledTimes(1);
+    expect(result.current.status).toBe('error');
+
+    // Same pending events, no new major event since the failure — the old bug
+    // re-armed the debounce timer on every status change and retried forever.
+    await act(async () => {
+      jest.advanceTimersByTime(10000);
+    });
+
+    expect(mockAiFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries once a new major event arrives after a failure', async () => {
+    mockAiFetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: 'Checkpoint API is down' }),
+    } as unknown as Response);
+
+    const { rerender } = renderHook(
+      ({ majorEvents }) => {
+        setupWorldState(majorEvents);
+        return useStoryCheckpointManager({ worldId: 'world-1', sessionId: 'session-1' });
+      },
+      { initialProps: { majorEvents: [pendingEvent] } }
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(mockAiFetch).toHaveBeenCalledTimes(1);
+
+    const newEvent = { ...pendingEvent, id: 'event-2', timestamp: '2026-01-01T00:05:00.000Z' };
+    rerender({ majorEvents: [pendingEvent, newEvent] });
+
+    await act(async () => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(mockAiFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/GameSession/hooks/useStoryCheckpointManager.ts
+++ b/src/components/GameSession/hooks/useStoryCheckpointManager.ts
@@ -285,19 +285,30 @@ export const useStoryCheckpointManager = ({ worldId, sessionId, characterId }: U
     }
   }, [characterId, characterNameLookup, pendingEvents, sessionId, worldId, worldState?.storyCheckpoints, world?.toneSettings]);
 
-  // Auto-trigger checkpoint creation when there's at least 1 pending event
+  // Auto-trigger checkpoint creation when there's at least 1 pending event.
+  // Gated on the actual event-id set (not just status) so a failed attempt
+  // doesn't re-arm the timer every render — it only retries once genuinely
+  // new events arrive, instead of retrying the same failed batch forever.
+  const lastAttemptedEventIdsRef = React.useRef<string | null>(null);
+
   React.useEffect(() => {
     if (pendingEvents.length === 0 || status === 'loading') {
       return;
     }
 
+    const currentEventIds = pendingEvents.map((event) => event.id).join(',');
+    if (currentEventIds === lastAttemptedEventIdsRef.current) {
+      return;
+    }
+
     // Debounce: wait 3 seconds after the last event before creating checkpoint
     const timeoutId = setTimeout(() => {
+      lastAttemptedEventIdsRef.current = currentEventIds;
       createCheckpoint();
     }, 3000);
 
     return () => clearTimeout(timeoutId);
-  }, [pendingEvents.length, status, createCheckpoint]);
+  }, [pendingEvents, status, createCheckpoint]);
 
   // Listen for session end event to capture final checkpoint
   React.useEffect(() => {

--- a/src/lib/narrative/applyWorldStateThreadUpdates.ts
+++ b/src/lib/narrative/applyWorldStateThreadUpdates.ts
@@ -224,6 +224,10 @@ export async function applyWorldStateThreadUpdates({
     }
 
     worldStore.updateWorldState(effectiveWorldId, updatePayload, sessionId);
-  } catch {
+  } catch (error) {
+    logger.error('[NarrativeStore]', 'Failed to apply world state thread updates', {
+      error: error instanceof Error ? error.message : 'Unknown error',
+      sessionId,
+    });
   }
 }

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -1007,6 +1007,14 @@ body.manuscript-overlay-open {
   letter-spacing: 0.05em;
 }
 
+.manuscript-story-summary-error {
+  font-family: var(--font-system);
+  font-size: 0.75rem;
+  color: var(--color-danger);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
 /* Mobile Stack Layouts */
 .manuscript-main-stage-mobile-stack {
   display: grid;


### PR DESCRIPTION
## Description
Three compounding bugs kept the story-summary panel useless whenever a checkpoint request failed, and the retry logic made that worse: a failed request retried every 3 seconds forever, burning the player's own Gemini quota for the rest of the session.

1. `applyWorldStateThreadUpdates.ts` ended in a bare `catch {}` — any exception in the write path that persists major events into world state disappeared with no log and no rethrow.
2. `useStoryCheckpointManager`'s auto-trigger effect re-armed its debounce timer on every `status` change, including to `'error'`. Since a failed checkpoint doesn't clear `pendingEvents`, the guard never blocked the retry, so it fired again, failed again, forever.
3. `StorySummarySection` called the hook only for its side effects and never read `status`/`error`, so even a properly surfaced error still rendered the generic "Your story will appear here" placeholder.

Fix: log the write-path exception instead of swallowing it, gate the auto-retry on the actual pending-event-id set (not just a status flip) so it only retries once genuinely new events arrive, and branch the summary panel on `status === 'error'` to show a distinct failure message.

## Related Issue
Closes #1575

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — bug fix, not new functionality.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [x] Visual consistency verified

`StorySummarySection` already has a story covering empty/with-content states; neither seeds pending events, so both remain valid unchanged. Didn't add an error-state story — reproducing it needs a failing MSW-mocked checkpoint call, which is more machinery than this fix warrants; the new unit test covers the branch directly.

## Implementation Notes
The retry guard tracks the last-attempted event-id set in a ref and compares it against the current `pendingEvents` on each effect run, rather than gating on `status` alone. That's the part worth flagging: gating on `status === 'idle'` alone would've also blocked *legitimate* retries after the first successful checkpoint, since `status` never resets to `'idle'` once it's fired. The event-id comparison is what lets a genuinely new major event re-trigger after a prior failure, without looping on the same failed batch.

This worktree branch turned out to be based on `main` instead of `develop` (missing 5 commits, including the sharp/libvips override and the token-budget bugfix PR this plan cites as bundling precedent). Fast-forwarded onto `origin/develop` before starting — no local commits were lost since the branch had none yet.

## Screenshots
N/A — no visual change; the new error state is text-only using an existing CSS pattern (`--color-danger`, mirroring the sibling `-empty` rule).

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A — logic/hook fix, not verified via browser; covered by unit tests instead.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed (not run for this change)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm test` — full suite green (359 suites / 2394 tests).
2. `npm run type-check`, `npm run lint`, `npm run lint:css` — all green.
3. New tests specifically exercising this fix:
   - `src/components/GameSession/hooks/__tests__/useStoryCheckpointManager.test.ts` — asserts a failed checkpoint doesn't re-fire without new pending events, and does retry once a new major event arrives.
   - `src/components/GameSession/__tests__/StorySummarySection.test.tsx` — asserts the error state renders instead of the generic empty placeholder.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) — none needed, no public docs reference this internal hook behavior
- [x] No new warnings generated
- [ ] Accessibility considerations addressed — N/A, no markup/a11y change
