### PR TITLE
fix: ending-screen a11y/gap/eyebrow, hero margin, card clamp, HUD portrait, dead CSS

### DIFF
--- a/src/app/__tests__/workshop.css.test.ts
+++ b/src/app/__tests__/workshop.css.test.ts
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import path from 'path';
+
+const workshopCss = fs.readFileSync(path.join(__dirname, '../workshop.css'), 'utf-8');
+
+describe('workshop.css static checks', () => {
+  it('does not use the literal placeholder word "Section" in a section eyebrow (#1577)', () => {
+    expect(workshopCss).not.toMatch(/content:\s*"•\s*Section"/);
+  });
+
+  it('does not carry the dead three-design-system theme-menu-* rules (#1583)', () => {
+    expect(workshopCss).not.toMatch(/\.theme-menu-item-text/);
+    expect(workshopCss).not.toMatch(/\.theme-menu-mode/);
+    expect(workshopCss).not.toMatch(/\.theme-menu \.header-dropdown-menu\s*\{\s*width:\s*15rem/);
+  });
+});

--- a/src/app/workshop.css
+++ b/src/app/workshop.css
@@ -861,32 +861,6 @@
   display: inline-flex;
 }
 
-/* Bound the appearance dropdown so it fits the narrow workshop rail (which
-   clips overflow) and let the skin descriptions wrap instead of forcing the
-   menu wider than its container. */
-.theme-menu .header-dropdown-menu {
-  width: 15rem;
-}
-
-.theme-menu-item-text {
-  min-width: 0;
-}
-
-.theme-menu-item-text > div {
-  white-space: normal;
-}
-
-/* Color-mode section inside the appearance dropdown, below the theme list. */
-.theme-menu-mode {
-  margin-top: var(--space-1);
-  padding-top: var(--space-2);
-  border-top: 1px solid var(--color-border);
-}
-
-.theme-menu-mode .dark-mode-toggle {
-  margin-top: var(--space-1);
-}
-
 /* In the workshop rail the trigger sits at the bottom-left, so the default
    top-right dropdown placement clips off the bottom and left edges. Flip it to
    open upward and align to the trigger's left edge. */
@@ -1403,6 +1377,10 @@
   font-size: 0.9375rem;
   line-height: 1.5;
   margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .world-card-type-badge {
@@ -1597,7 +1575,7 @@
 }
 
 :root .world-detail-section h2::before {
-  content: "• Section";
+  content: "• ";
   display: block;
   margin-bottom: var(--space-1);
   font-family: var(--font-system);
@@ -1730,7 +1708,7 @@
 
 :root .component-collapsible-section
   [data-testid="collapsible-section-title"]::before {
-  content: "• Section";
+  content: "• ";
   display: block;
   margin-bottom: var(--space-1);
   font-family: var(--font-system);
@@ -2045,6 +2023,10 @@
 
 /* ─── Character Detail Page ─── */
 
+.character-detail-hero {
+  margin-bottom: var(--space-3);
+}
+
 .character-detail-body {
   display: flex;
   flex-direction: column;
@@ -2151,7 +2133,7 @@
 }
 
 :root .character-detail-section h2::before {
-  content: "• Section";
+  content: "• ";
   display: block;
   margin-bottom: var(--space-1);
   font-family: var(--font-system);
@@ -2415,7 +2397,7 @@
 }
 
 :root .settings-section h2::before {
-  content: "• Section";
+  content: "• ";
   display: block;
   margin-bottom: var(--space-1);
   font-family: var(--font-system);

--- a/src/components/GameSession/ActiveGameSession.tsx
+++ b/src/components/GameSession/ActiveGameSession.tsx
@@ -378,6 +378,7 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
           characterSummaryPanel={character && <CharacterSnapshot character={character} />}
           drawerTriggers={isProgressiveDisclosureEnabled}
           characterName={character?.name}
+          characterPortrait={character?.portrait}
           onOpenDrawer={(drawerType) => {
             drawerTriggerRef.current = document.activeElement as HTMLElement;
             setActiveDrawer(drawerType as DrawerType);

--- a/src/components/GameSession/ActiveGameSession.tsx
+++ b/src/components/GameSession/ActiveGameSession.tsx
@@ -309,7 +309,7 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
   // If generating ending, show loading state
   if (isGeneratingEnding) {
     return (
-      <div>
+      <div className="manuscript-loading-shell">
         <LoadingState
           message={isFatalEnding ? "Game Over" : "Writing your story's ending..."}
         />

--- a/src/components/GameSession/EndingScreen.tsx
+++ b/src/components/GameSession/EndingScreen.tsx
@@ -30,6 +30,7 @@ import { buildStoryFromCheckpoints } from '@/lib/narrative/storyCheckpointHelper
 import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
 import { isStorybookEnv } from '@/lib/utils/isStorybookEnv';
 import { generateEndingImage as requestEndingImage } from '@/lib/api/endingImageApi';
+import { capitalize } from '@/lib/utils/formatters';
 
 import Logger from '@/lib/utils/logger';
 const logger = new Logger('EndingScreen');
@@ -290,11 +291,6 @@ export function EndingScreen() {
 
   return (
     <>
-      {/* Screen reader announcement */}
-      <div role="status" aria-live="polite" aria-label="story complete">
-        Story Complete: {currentEnding.tone} ending
-      </div>
-
       <div className="component-ending-screen" data-testid="ending-screen">
         {/* Hero Section: Combined Header with Image */}
         <section
@@ -321,7 +317,7 @@ export function EndingScreen() {
               <Image
                 className="component-ending-screen-hero-image"
                 src={endingImage}
-                alt={`${currentEnding.tone} ending for ${character?.name || 'the hero'}'s story`}
+                alt={`${capitalize(currentEnding.tone)} ending for ${character?.name || 'the hero'}'s story`}
                 width={1280}
                 height={720}
                 priority
@@ -397,60 +393,58 @@ export function EndingScreen() {
             </SectionWrapper>
           </section>
 
-          <div>
-            {/* Character Legacy */}
-            <section>
-              <SectionWrapper title="Character Legacy">
-                <div className="manuscript-ending-prose">
-                  {currentEnding.characterLegacy}
-                </div>
-              </SectionWrapper>
-            </section>
+          {/* Character Legacy */}
+          <section>
+            <SectionWrapper title="Character Legacy">
+              <div className="manuscript-ending-prose">
+                {currentEnding.characterLegacy}
+              </div>
+            </SectionWrapper>
+          </section>
 
-            {/* Achievements */}
-            {currentEnding.achievements &&
-              currentEnding.achievements.length > 0 && (
-                <section aria-label="Story achievements">
-                  <SectionWrapper title="Achievements">
-                    <ul
-                      className="component-ending-screen-achievements"
-                      role="list"
-                    >
-                      {currentEnding.achievements.map((achievement, index) => {
-                        // Split achievement into title and description
-                        const colonIndex = achievement.indexOf(':');
-                        const title =
-                          colonIndex > 0
-                            ? achievement.substring(0, colonIndex)
-                            : achievement;
-                        const description =
-                          colonIndex > 0
-                            ? achievement.substring(colonIndex + 1).trim()
-                            : '';
+          {/* Achievements */}
+          {currentEnding.achievements &&
+            currentEnding.achievements.length > 0 && (
+              <section aria-label="Story achievements">
+                <SectionWrapper title="Achievements">
+                  <ul
+                    className="component-ending-screen-achievements"
+                    role="list"
+                  >
+                    {currentEnding.achievements.map((achievement, index) => {
+                      // Split achievement into title and description
+                      const colonIndex = achievement.indexOf(':');
+                      const title =
+                        colonIndex > 0
+                          ? achievement.substring(0, colonIndex)
+                          : achievement;
+                      const description =
+                        colonIndex > 0
+                          ? achievement.substring(colonIndex + 1).trim()
+                          : '';
 
-                        return (
-                          <li
-                            key={index}
-                            className="component-ending-screen-achievement"
-                          >
-                            <div className="component-ending-screen-achievement-body">
-                              <span className="component-ending-screen-achievement-title">
-                                {title}
+                      return (
+                        <li
+                          key={index}
+                          className="component-ending-screen-achievement"
+                        >
+                          <div className="component-ending-screen-achievement-body">
+                            <span className="component-ending-screen-achievement-title">
+                              {title}
+                            </span>
+                            {description && (
+                              <span className="component-ending-screen-achievement-description">
+                                {description}
                               </span>
-                              {description && (
-                                <span className="component-ending-screen-achievement-description">
-                                  {description}
-                                </span>
-                              )}
-                            </div>
-                          </li>
-                        );
-                      })}
-                    </ul>
-                  </SectionWrapper>
-                </section>
-              )}
-          </div>
+                            )}
+                          </div>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </SectionWrapper>
+              </section>
+            )}
 
           {/* World Impact */}
           <section>

--- a/src/components/GameSession/ManuscriptFloatingHud.tsx
+++ b/src/components/GameSession/ManuscriptFloatingHud.tsx
@@ -3,6 +3,8 @@
 import React from 'react';
 import { BookOpen, Backpack, FileText, RotateCcw, LogOut, History } from 'lucide-react';
 import { HudCloseButton } from './HudCloseButton';
+import { CharacterPortrait } from '@/components/CharacterPortrait';
+import type { GeneratedImage } from '@/types/common.types';
 
 interface ManuscriptFloatingHudProps {
   onToggleCharacterSummary: () => void;
@@ -11,6 +13,7 @@ interface ManuscriptFloatingHudProps {
   characterSummaryPanel?: React.ReactNode;
   drawerTriggers?: boolean;
   characterName?: string;
+  characterPortrait?: GeneratedImage;
   onOpenDrawer?: (drawerType: string) => void;
   onStartNew?: () => void;
   onBack?: () => void;
@@ -25,6 +28,7 @@ export const ManuscriptFloatingHud: React.FC<ManuscriptFloatingHudProps> = ({
   isCharacterSummaryExpanded,
   characterSummaryPanel,
   characterName,
+  characterPortrait,
   drawerTriggers,
   onOpenDrawer,
   onStartNew,
@@ -50,7 +54,13 @@ export const ManuscriptFloatingHud: React.FC<ManuscriptFloatingHudProps> = ({
             className="manuscript-hud-character-pill"
           >
             <span className="manuscript-hud-character-pill-avatar" aria-hidden="true">
-              {/* Avatar placeholder — CSS handles sizing */}
+              {characterPortrait && (
+                <CharacterPortrait
+                  portrait={characterPortrait}
+                  characterName={characterName || 'Character'}
+                  size="small"
+                />
+              )}
             </span>
             <span>{characterName || 'Character'}</span>
           </button>

--- a/src/components/GameSession/__tests__/EndingScreen.yourStory.test.tsx
+++ b/src/components/GameSession/__tests__/EndingScreen.yourStory.test.tsx
@@ -297,4 +297,39 @@ describe('EndingScreen - Heading hierarchy', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'The End' })).toBeInTheDocument();
     expect(screen.queryByRole('heading', { level: 1 })).toBeNull();
   });
+
+  it('does not render a redundant visible "Story Complete" announcement (#1577)', () => {
+    setupStores([]);
+    render(<EndingScreen />);
+
+    expect(screen.queryByText(/Story Complete/i)).not.toBeInTheDocument();
+  });
+});
+
+// The unclassed wrapper div previously grouping Character Legacy and
+// Achievements broke the parent flex `gap` between them (#1577) — the fix
+// is structural (no wrapper), so the regression guard is structural too.
+describe('EndingScreen - Legacy/Achievements layout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders Character Legacy and Achievements as direct siblings under the flex content container', () => {
+    setupStores([]);
+    render(<EndingScreen />);
+
+    // SectionWrapper renders its own inner <section class="component-section-wrapper">;
+    // EndingScreen wraps each in a second, outer <section> with no class of its own.
+    // The bug was an extra <div> around that outer pair, so what matters here is
+    // that pair's shared parent, not the inner SectionWrapper markup.
+    const legacyOuterSection = screen.getByText('Character Legacy').closest('section')
+      ?.parentElement;
+    const achievementsOuterSection = screen.getByText('Achievements').closest('section')
+      ?.parentElement;
+
+    expect(legacyOuterSection?.tagName).toBe('SECTION');
+    expect(achievementsOuterSection?.tagName).toBe('SECTION');
+    expect(legacyOuterSection?.parentElement).toBe(achievementsOuterSection?.parentElement);
+    expect(legacyOuterSection?.parentElement).toHaveClass('component-ending-screen-content');
+  });
 });

--- a/src/components/GameSession/__tests__/ManuscriptFloatingHud.a11y.test.tsx
+++ b/src/components/GameSession/__tests__/ManuscriptFloatingHud.a11y.test.tsx
@@ -62,4 +62,24 @@ describe('ManuscriptFloatingHud accessibility', () => {
     );
     expect(button).toHaveAttribute('aria-expanded', 'true');
   });
+
+  it('renders the active character portrait in the avatar pill when one exists (#1581)', () => {
+    render(
+      <ManuscriptFloatingHud
+        {...baseProps}
+        characterName="Finn"
+        characterPortrait={{ type: 'ai-generated', url: 'data:image/png;base64,abc' }}
+      />
+    );
+
+    const avatar = document.querySelector('.manuscript-hud-character-pill-avatar');
+    expect(avatar?.querySelector('img')).not.toBeNull();
+  });
+
+  it('leaves the avatar pill empty when the character has no portrait', () => {
+    render(<ManuscriptFloatingHud {...baseProps} characterName="Finn" />);
+
+    const avatar = document.querySelector('.manuscript-hud-character-pill-avatar');
+    expect(avatar?.querySelector('img')).toBeNull();
+  });
 });

--- a/src/components/ui/LoadingState/LoadingState.css
+++ b/src/components/ui/LoadingState/LoadingState.css
@@ -1,0 +1,93 @@
+/* LoadingState — global semantic styles for src/components/ui/LoadingState/LoadingState.tsx (#1576)
+ *
+ * The `pulse`, `dots`, and `skeleton` variants rendered bare unclassed <div> elements
+ * with no CSS backing anywhere in the repo — a Tailwind-removal regression (#1051) that
+ * stripped `animate-pulse` and friends — so every screen using them showed only floating
+ * text on a blank page. `spinner` was repaired in #1467; this finishes the other three.
+ * Token-based per the active `data-theme` scope; no hardcoded colors.
+ */
+
+@keyframes component-loading-pulse-fade {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+@keyframes component-loading-dot-fade {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 1; }
+}
+
+/* Pulse variant */
+.component-loading-pulse {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  width: 100%;
+}
+
+.component-loading-pulse-avatar-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.component-loading-pulse-avatar-circle {
+  flex-shrink: 0;
+  width: 3rem;
+  height: 3rem;
+  border-radius: var(--radius-full);
+  background: var(--color-surface-hover);
+  animation: component-loading-pulse-fade 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+.component-loading-pulse-avatar-lines {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.component-loading-pulse-avatar-line,
+.component-loading-pulse-line {
+  height: 1rem;
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-hover);
+  animation: component-loading-pulse-fade 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+/* Dots variant */
+.component-loading-dots {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.component-loading-dot {
+  width: 0.625rem;
+  height: 0.625rem;
+  border-radius: var(--radius-full);
+  background: var(--color-text-secondary);
+  animation: component-loading-dot-fade 1.4s ease-in-out infinite;
+}
+
+/* Skeleton variant */
+.component-loading-skeleton {
+  width: 100%;
+}
+
+.component-loading-skeleton-lines {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.component-loading-skeleton-line {
+  height: 1rem;
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-hover);
+  animation: component-loading-pulse-fade 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+.component-loading-skeleton-line:last-child {
+  width: 80%;
+}

--- a/src/components/ui/LoadingState/LoadingState.css
+++ b/src/components/ui/LoadingState/LoadingState.css
@@ -37,7 +37,7 @@
   height: 3rem;
   border-radius: var(--radius-full);
   background: var(--color-surface-hover);
-  animation: component-loading-pulse-fade 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  animation: component-loading-pulse-fade 2s ease-in-out infinite;
 }
 
 .component-loading-pulse-avatar-lines {
@@ -52,7 +52,7 @@
   height: 1rem;
   border-radius: var(--radius-sm);
   background: var(--color-surface-hover);
-  animation: component-loading-pulse-fade 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  animation: component-loading-pulse-fade 2s ease-in-out infinite;
 }
 
 /* Dots variant */
@@ -85,7 +85,7 @@
   height: 1rem;
   border-radius: var(--radius-sm);
   background: var(--color-surface-hover);
-  animation: component-loading-pulse-fade 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  animation: component-loading-pulse-fade 2s ease-in-out infinite;
 }
 
 .component-loading-skeleton-line:last-child {

--- a/src/components/ui/LoadingState/LoadingState.tsx
+++ b/src/components/ui/LoadingState/LoadingState.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import './LoadingState.css';
 
 export type LoadingVariant = 'spinner' | 'pulse' | 'dots' | 'skeleton';
 type LoadingSize = 'sm' | 'md' | 'lg' | 'xl';
@@ -72,28 +73,29 @@ export const LoadingState: React.FC<LoadingStateProps> = ({
 
       case 'pulse':
         return (
-          <div role="status" aria-label="Loading">
+          <div role="status" aria-label="Loading" className="component-loading-pulse">
             {showAvatar && (
-              <div>
-                <div />
-                <div>
-                  <div />
-                  <div />
+              <div className="component-loading-pulse-avatar-row">
+                <div className="component-loading-pulse-avatar-circle" />
+                <div className="component-loading-pulse-avatar-lines">
+                  <div className="component-loading-pulse-avatar-line" />
+                  <div className="component-loading-pulse-avatar-line" />
                 </div>
               </div>
             )}
             {Array.from({ length: skeletonLines }).map((_, i) => (
-              <div key={i} />
+              <div key={i} className="component-loading-pulse-line" />
             ))}
           </div>
         );
 
       case 'dots':
         return (
-          <div role="status" aria-label="Loading">
+          <div role="status" aria-label="Loading" className="component-loading-dots">
             {[0, 1, 2].map((i) => (
               <div
                 key={i}
+                className="component-loading-dot"
                 style={{ animationDelay: `${i * 150}ms` }}
               />
             ))}
@@ -103,10 +105,10 @@ export const LoadingState: React.FC<LoadingStateProps> = ({
 
       case 'skeleton':
         return (
-          <div role="status" aria-label="Loading">
-            <div>
+          <div role="status" aria-label="Loading" className="component-loading-skeleton">
+            <div className="component-loading-skeleton-lines">
               {Array.from({ length: skeletonLines }).map((_, i) => (
-                <div key={i} />
+                <div key={i} className="component-loading-skeleton-line" />
               ))}
             </div>
           </div>

--- a/src/components/ui/LoadingState/__tests__/LoadingState.test.tsx
+++ b/src/components/ui/LoadingState/__tests__/LoadingState.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { LoadingState } from '../LoadingState';
+
+describe('LoadingState', () => {
+  it('renders the pulse variant with styled, classed elements', () => {
+    render(<LoadingState variant="pulse" />);
+
+    const status = screen.getByRole('status');
+    expect(status.className).not.toBe('');
+    expect(status.querySelectorAll('.component-loading-pulse-line').length).toBeGreaterThan(0);
+  });
+
+  it('renders the dots variant with styled, classed elements', () => {
+    render(<LoadingState variant="dots" />);
+
+    const status = screen.getByRole('status');
+    expect(status.className).not.toBe('');
+    expect(status.querySelectorAll('.component-loading-dot').length).toBe(3);
+  });
+
+  it('renders the skeleton variant with styled, classed elements', () => {
+    render(<LoadingState variant="skeleton" skeletonLines={5} />);
+
+    const status = screen.getByRole('status');
+    expect(status.className).not.toBe('');
+    expect(status.querySelectorAll('.component-loading-skeleton-line').length).toBe(5);
+  });
+});

--- a/src/stories/01-atoms/feedback/LoadingState.stories.tsx
+++ b/src/stories/01-atoms/feedback/LoadingState.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { LoadingState } from '@/components/ui/LoadingState/LoadingState';
+
+const meta: Meta<typeof LoadingState> = {
+  title: '01-Atoms/feedback/LoadingState',
+  component: LoadingState,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: 'Loading indicator with four variants: spinner, pulse, dots, skeleton.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['spinner', 'pulse', 'dots', 'skeleton'],
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg', 'xl'],
+    },
+    message: {
+      control: 'text',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Spinner: Story = {
+  args: {
+    variant: 'spinner',
+    message: 'Loading...',
+  },
+};
+
+export const Pulse: Story = {
+  args: {
+    variant: 'pulse',
+    message: 'Loading your worlds...',
+  },
+};
+
+export const PulseWithAvatar: Story = {
+  args: {
+    variant: 'pulse',
+    showAvatar: true,
+    message: 'Loading profile...',
+  },
+};
+
+export const Dots: Story = {
+  args: {
+    variant: 'dots',
+    message: 'Writing your story...',
+  },
+};
+
+export const Skeleton: Story = {
+  args: {
+    variant: 'skeleton',
+    skeletonLines: 4,
+  },
+};

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -2843,6 +2843,15 @@ body.manuscript-overlay-open {
   object-fit: cover;
 }
 
+/* CharacterPortrait's own size variant sets an intrinsic square size that
+   would overflow this 20-24px pill; force it to fill the wrapper instead,
+   matching the equivalent override for every other sized consumer. */
+:root .manuscript-hud-character-pill-avatar .component-character-portrait {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
 /* Icon-only buttons for DS3 HUD right side */
 :root .manuscript-hud-icon-button {
   display: inline-flex;


### PR DESCRIPTION
## Description
Bundle of five small, independent CSS/markup fixes from the v1.0 gate punch list — #1576, #1577, #1579, #1580, #1581, #1583. All low-risk, no behavioral changes, bundled per the repo's own precedent (#1593 → PR #1599) for exactly this class of fix.

- **#1576** — `LoadingState`'s `pulse`, `dots`, and `skeleton` variants rendered bare unclassed `<div>`s with zero CSS anywhere in the repo (a Tailwind-removal regression, #1051) — any screen using them, including the ending-generation screen, showed only floating text on a blank page. Added classNames + a co-located `LoadingState.css` (mirroring the `EmptyState` component's identical fix for the identical bug pattern), wrapped the `isGeneratingEnding` branch in `ActiveGameSession.tsx` with `manuscript-loading-shell` to match its sibling, and added the story + unit test this component never had.
- **#1577** — Ending screen: deleted the redundant *visible* "Story Complete: {tone} ending" status div (the route already renders a proper `sr-only` h1 for this); fixed the raw `EndingTone` enum leaking into image alt text (now uses the existing `capitalize()` helper); removed the unclassed wrapper div that broke the flex `gap` between Character Legacy and Achievements; fixed the literal "SECTION" eyebrow text at all 4 affected sites (world-detail, character-detail, settings, the shared `CollapsibleSection` component) to match the generic bullet convention already used everywhere else.
- **#1579** — Added the missing `.character-detail-hero` `margin-bottom` rule, mirroring its two structural siblings (`world-detail-hero`, `journal-hero`) exactly.
- **#1580** — Line-clamped world card descriptions at 2 lines, matching `CharacterCard`'s existing pattern in the same list idiom. Confirmed "description" (not "teaser," per the issue's own sanity-check note) is the correct target — that word doesn't appear anywhere in the codebase.
- **#1581** — Threaded the active character's portrait through `ManuscriptFloatingHud` and render it in the HUD pill's avatar span (previously always empty, just a comment). Added the wrapper-scoped CSS override `CharacterPortrait`'s sized variants need to fill a small parent — this codebase already has the identical override for every other "sized consumer" (`CharacterSnapshot`, `CharacterCard`), so this just extends the established pattern.
- **#1583** — Deleted the 5 dead `.theme-menu-*` CSS rules left over from the three-design-system era (DS1/DS2/DS3 collapsed to DS3-only). Verified against the issue's own precise line-level breakdown, and confirmed via grep that none of the 5 selectors appear in any `.tsx`/`.ts` consumer. Kept the 2 rules that are still genuinely live (`.theme-menu` positioning, the sidebar-rail placement flip) — those aren't part of the dead set despite superficially similar selectors.

## Related Issue
Closes #1576, Closes #1577, Closes #1579, Closes #1580, Closes #1581, Closes #1583

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — bug fixes, not new functionality.

## Flow Diagrams
N/A

## Component Development
- [x] Storybook stories created/updated
- [x] Components developed in isolation first
- [x] Visual consistency verified

Added `LoadingState.stories.tsx` (all 4 variants) since it had none. See Implementation Notes for how visual consistency was verified for the geometry-only fixes.

## Implementation Notes
**Playwright visual baseline regeneration could not be completed in this session** — `npx playwright install chromium` hung indefinitely mid-extraction (stuck at `Chromium.app/Contents`, never progressing), a known sandboxed-environment limitation with this tooling. Rather than skip verification, I ran the dev server directly and verified every geometry/rendering-dependent fix with real browser measurements via injected JS (not jsdom, not a guess):

- **#1577 gap**: measured `Character Legacy` and `Achievements` sections' actual `getBoundingClientRect()` on the live ending screen (mysterious-tone harness) — 20px gap, confirmed both share the same flex parent (`component-ending-screen-content`). Also confirmed no "Story Complete" text renders anywhere, and the epilogue/legacy/achievements/impact eyebrows all render "• " correctly instead of "• SECTION".
- **#1579 gap**: injected a world image into the store to force the hero banner to render (the seeded dev data has no image), then measured hero-bottom to header-top — 12px gap, matching the sibling rules' `var(--space-3)`.
- **#1580 clamp**: the seeded world's description was too short to visually overflow, so I temporarily injected a much longer string into the live DOM node and re-measured — height stayed pinned at exactly 2 line-heights (45px = 22.5px × 2) regardless of content length, confirming the clamp is genuinely active, not just present in the stylesheet.
- **#1581 portrait**: injected a portrait onto the seeded character and confirmed via a live `/dev/game-session` harness that the HUD pill now renders `CharacterPortrait` (showing initials, since the harness's own portrait is a placeholder) sized correctly at 24×24 inside the 26×26 pill — the wrapper CSS override is doing its job, not letting the component's own 48px "small" variant bleed out.

I'd recommend running `npx playwright install chromium && npm run test:visual` locally (outside this sandboxed environment) to regenerate the local `.png` baselines for `ending-screen.spec.ts` (all 4 tone variants), `main-pages.spec.ts` (`character-detail`, `worlds-list`), and `mobile-layouts.spec.ts` (`mobile-character-detail`, `mobile-worlds-list`) before/after merge, per the repo's regenerate-together convention — I did not want to guess at pixel diffs I couldn't actually produce.

## Screenshots
N/A — see Implementation Notes for the real-browser measurements taken in place of screenshots/baselines.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A (used the in-app browser tooling directly, not Chrome DevTools MCP) — see Implementation Notes.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed (`npm audit --omit=dev --audit-level=moderate` clean)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm test` — 361/361 suites, 2403/2403 tests green.
2. `npm run type-check`, `npm run lint`, `npm run lint:css`, `npm run build` (incl. Storybook build) — all green.
3. `npm run knip`, `npm run deps:validate`, `npm run audit:css`, `npm run skott:check` — all green.
4. New/updated tests specifically exercising these fixes:
   - `src/components/ui/LoadingState/__tests__/LoadingState.test.tsx` (new)
   - `src/components/GameSession/__tests__/EndingScreen.yourStory.test.tsx` (2 new cases: no redundant status text, Legacy/Achievements are direct flex siblings)
   - `src/app/__tests__/workshop.css.test.ts` (new — static checks for the SECTION eyebrow and the dead theme-menu rules)
   - `src/components/GameSession/__tests__/ManuscriptFloatingHud.a11y.test.tsx` (2 new cases: portrait renders when present, avatar stays empty when absent)
5. See Implementation Notes above for the live-browser geometry verification on #1577/#1579/#1580/#1581.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) — none needed
- [x] No new warnings generated
- [x] Accessibility considerations addressed — #1577 removes a redundant/confusing screen-reader announcement
