### PR TITLE
fix: require epilogue closure for every ending tone, not just tragic

### DIFF
--- a/src/lib/promptTemplates/templates/__tests__/endingTemplates.closureRequirement.test.ts
+++ b/src/lib/promptTemplates/templates/__tests__/endingTemplates.closureRequirement.test.ts
@@ -1,0 +1,38 @@
+// src/lib/promptTemplates/templates/__tests__/endingTemplates.closureRequirement.test.ts
+//
+// Template-level regression guard for #1578: the epilogue's closure
+// requirement must apply to every tone, not just tragic. This can't assert
+// on generated prose (that's how a test gets rigged) — it pins the template
+// TEXT itself, so a future edit that re-scopes closure back to tragic-only
+// fails loudly here instead of silently reintroducing cliffhangers.
+
+import { endingTemplate } from '../endingTemplates';
+
+describe('endingTemplates - epilogue closure requirement (#1578)', () => {
+  const content = endingTemplate.content;
+
+  it('states a closure requirement in the EPILOGUE block that is not gated by tone', () => {
+    const epilogueBlockStart = content.indexOf('2. EPILOGUE');
+    const tragicSubBlockStart = content.indexOf('For TRAGIC endings');
+    expect(epilogueBlockStart).toBeGreaterThan(-1);
+    expect(tragicSubBlockStart).toBeGreaterThan(epilogueBlockStart);
+
+    const globalEpilogueInstructions = content.slice(epilogueBlockStart, tragicSubBlockStart);
+    expect(globalEpilogueInstructions).toMatch(/REQUIRED FOR EVERY TONE/i);
+    expect(globalEpilogueInstructions).toMatch(/MYSTERIOUS/);
+  });
+
+  it('does not ask the model to leave narrative room for imagination', () => {
+    expect(content).not.toMatch(/leaving room for imagination/i);
+  });
+
+  it('does not tell MYSTERIOUS endings to leave the plot itself unresolved', () => {
+    const mysteriousStart = content.indexOf('MYSTERIOUS:');
+    const tragicStart = content.indexOf('TRAGIC:');
+    expect(mysteriousStart).toBeGreaterThan(-1);
+    expect(tragicStart).toBeGreaterThan(mysteriousStart);
+
+    const mysteriousBlock = content.slice(mysteriousStart, tragicStart);
+    expect(mysteriousBlock).not.toMatch(/the ending raises new questions/i);
+  });
+});

--- a/src/lib/promptTemplates/templates/endingTemplates.ts
+++ b/src/lib/promptTemplates/templates/endingTemplates.ts
@@ -45,8 +45,10 @@ Generate a complete story ending with the following components:
    - HOPEFUL: Use when results are mixed, there's potential for future success, or the outcome
      is bittersweet but optimistic. Not complete victory, but progress was made.
 
-   - MYSTERIOUS: Use when there are unresolved questions, ambiguous outcomes, enigmatic events,
-     or the story leaves mysteries unsolved. The ending raises new questions.
+   - MYSTERIOUS: Use when enigmatic events color the outcome, even though the character's
+     immediate situation still resolves. The plot concludes — what happened is clear — but
+     deeper questions about meaning, truth, or consequence linger unanswered. Only the larger
+     "why" may stay open; the character's immediate fate must not.
 
    - TRAGIC: Use when the character DIED, was INCAPACITATED, or suffered catastrophic failure.
      The character's story has ENDED—they cannot continue. Use past tense. Focus on their
@@ -61,6 +63,10 @@ Generate a complete story ending with the following components:
    - Reference specific events from their journey
    - Match the chosen tone throughout
    - Provide narrative closure while respecting the ending type
+   - REQUIRED FOR EVERY TONE: the immediate story arc must resolve by the end of the epilogue —
+     this session's central conflict or situation is answered. A cliffhanger that leaves the
+     character's present circumstances unresolved is not acceptable for any tone, including
+     MYSTERIOUS — ambiguity belongs to meaning or theme, never to what just happened.
 
    For TRAGIC endings where the character died:
    * Describe their final moments with weight and dignity
@@ -101,7 +107,7 @@ Remember to:
 - Make the ending feel earned and satisfying
 - Reference specific story events, not generic fantasy tropes
 - Match your chosen tone throughout all sections
-- Provide closure while leaving room for imagination
+- Resolve the immediate story arc fully — closure is required, not optional, regardless of tone
 - Keep the language evocative and engaging
 
 DO NOT (especially for tragic/fatal endings):


### PR DESCRIPTION
## :warning: NOT auto-merged — needs a human live-AI evaluation pass before merge

This PR changes a live prompt template. Per this repo's own `narraitor-prompt-template-governance` and `narraitor-ai-quality-discipline` skills, that requires a real Gemini API key and a >=2 world x >=2 character x 3+ generation evaluation matrix, plus an arc check and a failure drill — recorded in an eval log. I don't have a Gemini API key available in this automated session (and correctly can't read `.env.local` to look for one), so **I could not run that evaluation**. Everything else in this PR (the template edit itself, the template-level regression test, the full quality gate) is done and green — but the actual "does this read better across worlds/tones" question is unverified pending your own pass. Please run the eval matrix (or spot-check a few generations) before merging.

## Description
Endings could finish on a cliffhanger for 3 of 4 tones. Only `tragic` got an explicit "the story has ended" closure requirement (`endingTemplates.ts`); the global closing checklist actively undercut closure with "leaving room for imagination," and the `MYSTERIOUS` tone asked for open-endedness outright ("The ending raises new questions"). The playtest that surfaced this drew `mysterious` and got exactly the cliffhanger the prompt asked for.

Fix, in `src/lib/promptTemplates/templates/endingTemplates.ts`:
1. Added a closure requirement to the EPILOGUE block that applies to every tone, not just tragic.
2. Reframed `MYSTERIOUS` so ambiguity lives at the level of meaning/theme rather than plot — the character's immediate situation still has to resolve; only the larger "why" can stay open.
3. Reworded the "leaving room for imagination" line in the global checklist, since it directly undercut the new requirement.
4. Left the tragic-only guardrail block untouched — it already does the right thing.

## Related Issue
Closes #1578

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The new test is a template-level static check (see below) — it pins the template TEXT, not generated prose (asserting on generated prose is how this class of test gets rigged, per the issue's own Definition of Done).

## User Stories Addressed
N/A — bug fix.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A — prompt template, not a component.

## Implementation Notes
The template-level test (`endingTemplates.closureRequirement.test.ts`) asserts three things directly on `endingTemplate.content`:
1. The closure requirement text appears in the EPILOGUE block *before* the tragic-only sub-block starts (i.e., it's global, not tone-scoped) — this guards against someone re-scoping it back to tragic-only later.
2. The "leaving room for imagination" phrase is gone.
3. The MYSTERIOUS tone's own description no longer contains "the ending raises new questions" (the literal cliffhanger-permitting phrase).

This is a regression guard, not evidence the prompt change actually improves output — that's exactly what the missing eval pass would provide. See the governance skill's G4 gate for what that pass needs to cover (2 worlds x 2 characters x 3 generations minimum, an arc check, a failure drill).

## Screenshots
N/A

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed (not applicable to this change)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm test` — 360/360 suites, 2397/2397 tests green, including the new template-level guard and the pre-existing `endingTemplates.fatalContext.test.ts` (confirms the tragic-tone injection logic is untouched).
2. `npm run type-check`, `npm run lint`, `npm run lint:css` — all green.
3. **Before merging**: run the live-AI evaluation matrix per `narraitor-ai-quality-discipline` — at minimum, generate a few `mysterious`-tone endings across 2+ contrasting worlds and confirm the immediate story situation resolves (no cliffhanger) while thematic ambiguity is still allowed to linger.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic — n/a, prompt text change
- [ ] Documentation updated (if required) — none needed
- [x] No new warnings generated
- [ ] Accessibility considerations addressed — N/A
