### PR TITLE
docs: drop stale 'bittersweet' tone, document desiredTone is advisory

### DIFF
--- a/src/app/api/generate-ending-image/README.md
+++ b/src/app/api/generate-ending-image/README.md
@@ -64,7 +64,7 @@ Comprehensive testing through:
    - JSON parsing robustness validated
 
 3. **Coverage:**
-   - All ending tones tested (triumphant, bittersweet, mysterious, tragic, hopeful)
+   - All ending tones tested (triumphant, mysterious, tragic, hopeful)
    - Both AI success and fallback scenarios verified
    - Error conditions thoroughly exercised
 

--- a/src/app/api/narrative/ending/README.md
+++ b/src/app/api/narrative/ending/README.md
@@ -13,10 +13,12 @@ This API endpoint generates AI-powered story endings for completed game sessions
   "characterId": "string (required)", 
   "worldId": "string (required)",
   "endingType": "player-choice | story-complete | session-limit | character-retirement (required)",
-  "desiredTone": "triumphant | bittersweet | mysterious | tragic | hopeful (optional)",
+  "desiredTone": "triumphant | mysterious | tragic | hopeful (optional)",
   "customPrompt": "string (optional)"
 }
 ```
+
+`desiredTone` is advisory except for `tragic`, which forces explicit fatal-outcome framing (character death, past tense, no continuation language). For the other three values, the model chooses whichever tone actually fits the narrative content — the prompt text doesn't change based on what's requested, so the response's own `tone` field may differ from what was sent.
 
 **Response (200):**
 ```json


### PR DESCRIPTION
## Description
The ending route's README documents `desiredTone: 'bittersweet'` as a valid value, but the actual `EndingTone` type / `validTones` array never included it — a client following the docs and sending it gets a 400. Also documents the thing that actually tripped up the #1578 eval: `desiredTone` only branches the prompt for `tragic`; the other three values are advisory, and the model self-selects the tone from the narrative content regardless of what's requested.

## Related Issue
No linked issue — flagged as a background-task follow-up during the #1578 eval (`task_d3b9fd1f`), too small to warrant its own GitHub issue.

## Type of Change
- [x] Documentation update

## TDD Compliance
N/A — docs-only change, no code/type/behavior change.

## User Stories Addressed
N/A

## Flow Diagrams
N/A

## Component Development
N/A — no component changes.

## Implementation Notes
Investigated whether `'bittersweet'` should instead become a real 5th supported tone — the DS3 theme has a full `--ending-bittersweet` color token + `.ending-bittersweet` CSS class, and a Storybook story literally titled "Bittersweet". Concluded no: `EndingImageDebugSection`'s real `toneOptions` array only lists 4 tones, the Storybook "Bittersweet" story actually sets `tone: 'mysterious'` under the hood (the name is just story-title flavor text, not a real tone value), and HOPEFUL's own prompt definition already explicitly absorbs "bittersweet but optimistic" phrasing. Reads as a tone that was consolidated into `hopeful` at some point, leaving orphaned CSS behind — not a planned-but-unbuilt feature worth un-consolidating. Flagged that CSS/Storybook dead-code cluster as a separate follow-up rather than bundling it into this docs fix.

## Screenshots
N/A

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed — N/A, no dependency changes
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
Docs-only change. Read both READMEs and confirm the tone lists now match `src/types/narrative.types.ts`'s `EndingTone` union (`triumphant | mysterious | tragic | hopeful`), and that the new advisory note in `src/app/api/narrative/ending/README.md` reads clearly.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic — N/A, docs change
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed — N/A
