### PR TITLE
fix: bump postcss to 8.5.23 to clear high-severity path-traversal CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "msw": "^2.14.6",
         "msw-storybook-addon": "^2.0.7",
         "playwright": "^1.56.1",
-        "postcss": "^8.5.10",
+        "postcss": "^8.5.23",
         "postcss-load-config": "^6.0.1",
         "postcss-nested": "^7.0.2",
         "prettier": "^3.5.3",
@@ -15444,9 +15444,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -16369,9 +16369,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -16388,7 +16388,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "msw": "^2.14.6",
     "msw-storybook-addon": "^2.0.7",
     "playwright": "^1.56.1",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.23",
     "postcss-load-config": "^6.0.1",
     "postcss-nested": "^7.0.2",
     "prettier": "^3.5.3",


### PR DESCRIPTION
## Description
`npm audit` started flagging `postcss <=8.5.17` (GHSA-r28c-9q8g-f849, high-severity path traversal in source-map auto-loading, leading to arbitrary `.map` file disclosure), pulled in transitively via `next` -> `@vercel/analytics`. This is currently failing `develop`'s own CI (confirmed via `gh run list --branch develop` — the latest run there already shows `conclusion: failure` for Security Scan, from right after PR #1605 merged), so it's inherited, not caused by any in-flight change — just a newly-flagged advisory against a version that was already installed.

npm's own suggested fix (`npm audit fix --force`) wants to downgrade `next` to `9.3.3` (from 15.x), which isn't viable. The `overrides` block already pins every nested `postcss` to `"$postcss"` (added in the earlier sharp/libvips fix, PR #1600), so bumping the root devDependency from `^8.5.10` to `^8.5.23` is the whole fix — it cascades through the override to the copy `next` pulls in too.

## Related Issue
No linked issue — found while checking CI on an unrelated small docs PR (#1606); this one's genuinely blocking (Security Scan is a required check) so it gets its own fix rather than just a flag.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## TDD Compliance
N/A — dependency version bump, no application code changed.

## User Stories Addressed
N/A

## Flow Diagrams
N/A

## Component Development
N/A

## Implementation Notes
Verified with the exact command CI's Security Scan job runs: `npm audit --omit=dev --audit-level=moderate` now reports 0 vulnerabilities (was 3 high). A plain `npm audit` (no `--omit=dev`) still shows unrelated devDependency-only findings — out of scope, not part of this repo's CI gate, and not touched here.

## Screenshots
N/A

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed — `npm audit --omit=dev --audit-level=moderate`: 0 vulnerabilities
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm install` after pulling this branch.
2. `npm audit --omit=dev --audit-level=moderate` -> 0 vulnerabilities.
3. Full quality gate run locally: `npm test` (362/362 suites, 2406/2406 tests), `npm run type-check`, `npm run lint`, `npm run lint:css`, `npm run build` — all green (postcss sits inside Next's CSS pipeline, so the build run specifically matters here).

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic — N/A, dependency bump
- [ ] Documentation updated (if required) — N/A
- [x] No new warnings generated
- [ ] Accessibility considerations addressed — N/A
