### PR TITLE
chore: remove orphaned bittersweet ending-tone CSS and fix misleading story name

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -409,10 +409,6 @@ body > * {
   background-color: hsl(var(--ending-triumphant));
 }
 
-.ending-bittersweet {
-  background-color: hsl(var(--ending-bittersweet));
-}
-
 .ending-mysterious {
   background-color: hsl(var(--ending-mysterious));
 }

--- a/src/lib/theme/themes/ds3.css
+++ b/src/lib/theme/themes/ds3.css
@@ -69,7 +69,6 @@
 
   /* Contextual colors for storytelling features */
   --ending-triumphant: 36 38% 50%;
-  --ending-bittersweet: 200 21% 50%;
   --ending-mysterious: 25 20% 14%;
   --ending-tragic: 0 59% 41%;
   --ending-hopeful: 138 25% 40%;
@@ -179,7 +178,6 @@
   --info-muted: 200 35% 12%;
 
   --ending-triumphant: 36 38% 55%;
-  --ending-bittersweet: 200 25% 55%;
   --ending-mysterious: 20 12% 12%;
   --ending-tragic: 0 50% 45%;
   --ending-hopeful: 138 20% 48%;

--- a/src/stories/00-foundation/DesignSystemShowcase.stories.tsx
+++ b/src/stories/00-foundation/DesignSystemShowcase.stories.tsx
@@ -492,7 +492,6 @@ export const CompleteShowcase: Story = {
             {[
               '--ending-triumphant',
               '--ending-hopeful',
-              '--ending-bittersweet',
               '--ending-mysterious',
               '--ending-tragic',
             ].map((token) => (

--- a/src/stories/03-organisms/game-session/EndingScreen.stories.tsx
+++ b/src/stories/03-organisms/game-session/EndingScreen.stories.tsx
@@ -27,11 +27,11 @@ export const Tragic: Story = {
   decorators: [withEndingScreenStores(mockStoryEndingTragic)],
 };
 
-export const Bittersweet: Story = {
+export const Mysterious: Story = {
   decorators: [
     withEndingScreenStores({
       ...mockStoryEndingTriumphant,
-      id: 'ending-bittersweet',
+      id: 'ending-mysterious',
       tone: 'mysterious',
       epilogue:
         'The truth, when it finally came, was smaller than expected. Not a revelation but a quiet acknowledgement that some questions were never meant to be answered.',


### PR DESCRIPTION
## Description
`'bittersweet'` isn't a real `EndingTone` value and never has been reachable at runtime, but the DS3 theme still carried a full `--ending-bittersweet` color token (light + dark) and `globals.css` a matching `.ending-bittersweet` class — leftovers from whenever this tone got folded into HOPEFUL (whose own prompt text already says "the outcome is bittersweet but optimistic"). Also fixes a Storybook story literally named `Bittersweet` that never actually exercised that tone — its mock data sets `tone: 'mysterious'`.

## Related Issue
No linked issue — found while fixing stale `desiredTone` docs on `/api/narrative/ending` (#1606), flagged and now fixed as its own small follow-up.

## Type of Change
- [x] Refactoring (code improvements without changing functionality)

## TDD Compliance
N/A — dead-code removal, no behavior change. Full suite re-run to confirm (362/362 suites, 2406/2406 tests, unchanged).

## User Stories Addressed
N/A

## Flow Diagrams
N/A

## Component Development
- [x] Storybook stories created/updated — renamed `Bittersweet` to `Mysterious` (its mock data already used `tone: 'mysterious'`; the name was the only thing wrong)
- [ ] Components developed in isolation first — N/A, no new component
- [x] Visual consistency verified — `npm run build-storybook` green

## Implementation Notes
Confirmed dead via the actual type system, not the repo's own CSS audit tool (which can't see this one): `EndingTone` is `'triumphant' | 'mysterious' | 'tragic' | 'hopeful'` (`src/types/narrative.types.ts:409`), and the real `toneOptions` array in `EndingImageDebugSection.tsx` matches. The CSS audit script excludes `src/lib/theme/themes/*.css` from its scan entirely (theme token files, by design — see the script's own comment), and covers the `.ending-*` class family under a greedy `/^ending-/` safelist entry for the legitimate `ending-${tone}` runtime pattern, so it silently keeps every `ending-*` selector regardless of whether that specific suffix is ever reachable. Manual verification was the only way to actually confirm this one.

Removed:
- `--ending-bittersweet` from both `ds3.css` theme blocks (light + dark)
- `.ending-bittersweet` from `globals.css`
- the `--ending-bittersweet` swatch entry from `DesignSystemShowcase.stories.tsx`'s "Ending Tones" showcase

Renamed (not removed) `EndingScreen.stories.tsx`'s `Bittersweet` export to `Mysterious` — still useful coverage for a quiet/resigned mysterious-tone rendering, just honestly labeled now.

## Screenshots
N/A — no visual change (the removed class/token were never applied by any reachable code path).

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed — N/A, no dependency changes
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm test` (362/362 suites, 2406/2406 tests), `npm run type-check`, `npm run lint`, `npm run lint:css`, `npm run build`, `npm run build-storybook` — all green.
2. `grep -rn "bittersweet" src/` — only remaining hit is the legitimate prose usage inside HOPEFUL's own tone description in `endingTemplates.ts`.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic — N/A, deletion only
- [ ] Documentation updated (if required) — N/A
- [x] No new warnings generated
- [ ] Accessibility considerations addressed — N/A
