### PR TITLE
fix: stop discarding portrait-enhancement AI calls for populated fields

### DIFF
--- a/src/lib/ai/__tests__/portraitGenerator.test.ts
+++ b/src/lib/ai/__tests__/portraitGenerator.test.ts
@@ -168,6 +168,78 @@ describe('portraitGenerator', () => {
     });
   });
 
+  describe('enhanceKnownCharacter (invoked internally by generatePortrait for known figures)', () => {
+    const knownFigureCharacter = (background: {
+      physicalDescription?: string;
+      personality?: string;
+      history?: string;
+    }): Character => ({
+      ...mockCharacter,
+      name: 'Nathan Fielder',
+      background: {
+        ...mockCharacter.background,
+        physicalDescription: '',
+        personality: '',
+        history: '',
+        ...background,
+      },
+    });
+
+    const enhancementPromptMarkers = [
+      'Provide an accurate physical description',
+      'Enhance this physical description',
+      'personality in 15 words',
+      'Enhance this personality description',
+      'Provide a one-sentence background',
+      'Enhance this background',
+    ];
+
+    beforeEach(() => {
+      (mockAIClient.generateImage as jest.Mock).mockResolvedValue({
+        image: 'data:image/png;base64,abc123',
+        prompt: 'portrait',
+      });
+    });
+
+    it('does not enhance background fields that are already populated (#1588)', async () => {
+      // history is left blank so enhancement still runs, but physicalDescription
+      // and personality are already set and must not fire their own AI calls
+      const character = knownFigureCharacter({
+        physicalDescription: 'Tall with a beard and glasses',
+        personality: 'Deadpan and awkward',
+      });
+
+      await generatePortrait(mockAIClient, character);
+
+      const prompts = (mockAIClient.generateContent as jest.Mock).mock.calls.map(
+        (call) => call[0]
+      );
+
+      expect(prompts.some((p) => p.includes('Enhance this physical description'))).toBe(false);
+      expect(prompts.some((p) => p.includes('Enhance this personality description'))).toBe(false);
+    });
+
+    it('fires zero enhancement calls when all three background fields are already populated', async () => {
+      const character = knownFigureCharacter({
+        physicalDescription: 'Tall with a beard and glasses',
+        personality: 'Deadpan and awkward',
+        history: 'Star of Nathan For You',
+      });
+
+      await generatePortrait(mockAIClient, character);
+
+      const prompts = (mockAIClient.generateContent as jest.Mock).mock.calls.map(
+        (call) => call[0]
+      );
+
+      const firedEnhancementCall = prompts.some((p) =>
+        enhancementPromptMarkers.some((marker) => p.includes(marker))
+      );
+
+      expect(firedEnhancementCall).toBe(false);
+    });
+  });
+
   describe('buildPortraitPrompt', () => {
     it('should create detailed prompt from character data', async () => {
       const prompt = await buildPortraitPrompt(mockAIClient,mockCharacter);

--- a/src/lib/ai/portraitGenerator.ts
+++ b/src/lib/ai/portraitGenerator.ts
@@ -206,27 +206,12 @@ async function enhanceKnownCharacter(
       description = capitalize(description);
 
       enhancements.physicalDescription = description.replace(/\.+$/, '.');
-    } else {
-      const prompt = `Enhance this physical description of ${character.name} (the ${contextHint}) with accurate details: "${character?.background?.physicalDescription}"
-        ${detection.figureType === 'fictional' && detection.actorName ? `As portrayed by ${detection.actorName} in the film/show.` : ''}
-        Keep the user's description but add missing details like specific hair length/style/color, facial features, or typical clothing if not specified.
-        Maximum 40 words. Answer with just the enhanced description, no extra text.`;
-
-      const response = await aiClient.generateContent(prompt);
-      enhancements.physicalDescription = normalizeText(response.content, NORM_DESC).replace(/\.+$/, '.');
     }
 
     if (!character?.background?.personality || safeTrim(character?.background?.personality ?? '').length === 0) {
       const prompt = `Describe ${character.name}'s (the ${contextHint}) personality in 15 words or less.
         Focus on their key character traits.
         Answer with just the description, no extra text.`;
-
-      const response = await aiClient.generateContent(prompt);
-      enhancements.personality = normalizeText(response.content, NORM_DESC).replace(/\.+$/, '.');
-    } else {
-      const prompt = `Enhance this personality description of ${character.name} (the ${contextHint}): "${character?.background?.personality}"
-        Keep the user's description but add accurate character traits if missing or expand on provided traits.
-        Maximum 20 words. Answer with just the enhanced description, no extra text.`;
 
       const response = await aiClient.generateContent(prompt);
       enhancements.personality = normalizeText(response.content, NORM_DESC).replace(/\.+$/, '.');
@@ -237,14 +222,6 @@ async function enhanceKnownCharacter(
         ${detection.figureType === 'videogame' ? 'MUST include the specific video game title they are from (e.g., "from Red Dead Redemption 2", "from The Legend of Zelda", etc.).' : ''}
         ${detection.figureType === 'fictional' ? 'MUST include the specific movie or TV show title they are from.' : ''}
         Answer with just one sentence, no extra text.`;
-
-      const response = await aiClient.generateContent(prompt);
-      enhancements.history = normalizeText(response.content, NORM_DESC).replace(/\.+$/, '.');
-    } else {
-      const prompt = `Enhance this background for ${character.name} (the ${contextHint}): "${character?.background?.history}"
-        ${detection.figureType === 'videogame' ? 'Add the specific video game title if missing.' : ''}
-        ${detection.figureType === 'fictional' ? 'Add the specific movie or TV show title if missing.' : ''}
-        Keep the user's content but add missing context or details. One sentence maximum. Answer with just the enhanced background, no extra text.`;
 
       const response = await aiClient.generateContent(prompt);
       enhancements.history = normalizeText(response.content, NORM_DESC).replace(/\.+$/, '.');


### PR DESCRIPTION
## Description
`enhanceKnownCharacter` in `src/lib/ai/portraitGenerator.ts` fired an AI call to "enhance" every background field (physical description, personality, history), even when that field was already filled in. The result landed in `enhancements.X`, but the return block picks `character.background.X || enhancements.X` — so a populated field always wins and the enhancement call's result never reached the output. Worst case was two wasted Gemini calls per portrait, and on a bring-your-own-key product that's the player's own quota spent on nothing.

The fix is exactly what the issue lays out: delete the three `else` branches. Only a field that's actually empty fires an AI call now, and the visible output is unchanged (the discarded calls' results were never used anyway).

Searched the rest of the open backlog for anything else sharing this file or this discarded-call pattern — nothing did. #1575 (the same pattern in the story-checkpoint retry loop) is already closed. #1299 (preset avatars / custom upload) is an unrelated post-MVP feature request that just happens to mention "portrait." So this PR is scoped to #1588 alone.

## Related Issue
Closes #1588

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Wrote the fix first, then the tests, so this wasn't strict red-green-refactor. Verified the regression coverage is real by temporarily reverting just the source fix and confirming the new "does not enhance background fields that are already populated" test fails against the old code, then passes again once the fix is restored.

## User Stories Addressed
N/A — bug fix, not a new user story.

## Flow Diagrams
N/A

## Component Development
N/A — no UI or component changes, this is AI-generation logic only.

## Implementation Notes
Two tests added to `src/lib/ai/__tests__/portraitGenerator.test.ts`, both driven through the public `generatePortrait` entry point since `enhanceKnownCharacter` isn't exported:
- Reproduces the issue's exact repro (physical description and personality populated, history blank) and asserts the two populated fields never fire their "enhance this..." prompts.
- The issue's literal Definition of Done: a character with all three fields populated fires zero enhancement calls.

One pre-existing thing worth flagging rather than quietly fixing: `portraitGenerator.ts` is 643 lines, well past this repo's 300-line file guideline. That predates this PR (it was 667 lines before this fix trimmed dead branches) and splitting it is out of scope for a minimal bug fix — flagging here rather than folding a refactor into a one-line-of-reasoning bug PR.

## Screenshots
N/A

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A — no browser-observable surface for this change.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed (not run — no security-sensitive surface touched)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npx jest src/lib/ai/__tests__/portraitGenerator.test.ts` — all 10 tests pass.
2. `npm test`, `npm run type-check`, `npm run lint` — full gate is green.
3. To see the new tests actually catch the bug: `git stash push -- src/lib/ai/portraitGenerator.ts`, re-run the portrait test file (the new "does not enhance background fields that are already populated" test fails), then `git stash pop` to restore the fix.

## Checklist
- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file) — pre-existing violation (643 lines), not introduced by this PR; out of scope here, see Implementation Notes.
- [x] Self-review of code performed
- [ ] Comments added for complex logic — n/a, this PR only deletes dead branches, no new logic added
- [ ] Documentation updated (if required) — not required, no public docs reference this internal function
- [x] No new warnings generated
- [ ] Accessibility considerations addressed — n/a, no UI surface
