### PR TITLE
docs: add model-power label family for AI-reasoning triage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,5 +32,12 @@ labels: bug
 - OS:
 - Device:
 
+## Estimated Model Power
+<!-- Select the reasoning/judgment level this work requires — a different axis from Estimated Complexity (time/scope). See .github/labels.md. -->
+- [ ] Light (mechanical, narrow, unambiguous — rename, copy tweak, dependency bump)
+- [ ] Standard (typical well-scoped work, follows an existing pattern — default tier)
+- [ ] Advanced (cross-cutting or judgment-heavy — several viable approaches, real tradeoffs)
+- [ ] Frontier (high-ambiguity, architecture-level or creative-judgment work)
+
 ## Additional Context
 <!-- Add any other context about the problem here -->

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -35,5 +35,12 @@ assignees: ''
 ## Alternatives Considered
 <!-- Have you considered any alternative solutions? -->
 
+## Estimated Model Power
+<!-- Select the reasoning/judgment level this work requires — a different axis from Estimated Complexity (time/scope). See .github/labels.md. -->
+- [ ] Light (mechanical, narrow, unambiguous — rename, copy tweak, dependency bump)
+- [ ] Standard (typical well-scoped work, follows an existing pattern — default tier)
+- [ ] Advanced (cross-cutting or judgment-heavy — several viable approaches, real tradeoffs)
+- [ ] Frontier (high-ambiguity, architecture-level or creative-judgment work)
+
 ## Additional Context
 <!-- Add any other context or screenshots about the enhancement here -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -23,5 +23,12 @@ labels: enhancement
 ## Implementation Notes
 <!-- Any ideas or suggestions for implementation -->
 
+## Estimated Model Power
+<!-- Select the reasoning/judgment level this work requires — a different axis from Estimated Complexity (time/scope). See .github/labels.md. -->
+- [ ] Light (mechanical, narrow, unambiguous — rename, copy tweak, dependency bump)
+- [ ] Standard (typical well-scoped work, follows an existing pattern — default tier)
+- [ ] Advanced (cross-cutting or judgment-heavy — several viable approaches, real tradeoffs)
+- [ ] Frontier (high-ambiguity, architecture-level or creative-judgment work)
+
 ## Additional Context
 <!-- Add any other context or screenshots about the feature request here -->

--- a/.github/ISSUE_TEMPLATE/user-story.md
+++ b/.github/ISSUE_TEMPLATE/user-story.md
@@ -32,6 +32,13 @@ As a [type of user], I want [goal/need] so that [benefit/value].
 - [ ] Medium (3-5 days)
 - [ ] Large (1+ week)
 
+## Estimated Model Power
+<!-- Select the reasoning/judgment level this work requires — a different axis from Estimated Complexity (time/scope). See .github/labels.md. -->
+- [ ] Light (mechanical, narrow, unambiguous — rename, copy tweak, dependency bump)
+- [ ] Standard (typical well-scoped work, follows an existing pattern — default tier)
+- [ ] Advanced (cross-cutting or judgment-heavy — several viable approaches, real tradeoffs)
+- [ ] Frontier (high-ambiguity, architecture-level or creative-judgment work)
+
 ## Priority
 <!-- Select the priority level -->
 - [ ] High (MVP)

--- a/.github/labels.md
+++ b/.github/labels.md
@@ -43,6 +43,29 @@ This file documents the labels used in the Narraitor repository. You can use a t
 - `complexity:medium` - Medium complexity (3-5 days of effort)
 - `complexity:large` - Large complexity (1+ week of effort)
 
+## Model Power Labels
+
+Model Power measures a **different axis than Complexity**. Complexity estimates
+*time/scope* (how many days, how many files). Model Power estimates *reasoning
+difficulty* — how much ambiguity, judgment, and tradeoff-weighing the work
+requires, independent of how long it takes or how many files it touches.
+
+The two are orthogonal: a `complexity:large` issue can be `model-power:light`
+if it's mechanical repetition across many files (a bulk rename, a
+well-specified dependency bump touching 30 files). A `complexity:small` issue
+can be `model-power:frontier` if it's one file but requires genuine
+architectural or creative judgment with no clear right answer. Assess them
+independently — don't infer one from the other.
+
+These tiers describe reasoning capability in the abstract, not any specific AI
+provider or model name. `model-power:frontier` means "needs the most capable
+model available," not "must use model X."
+
+- `model-power:light` - Mechanical, narrow, unambiguous (rename, copy tweak, dependency bump per changelog)
+- `model-power:standard` - Typical well-scoped fix/feature, follows an existing pattern (default tier)
+- `model-power:advanced` - Cross-cutting or judgment-heavy; several viable approaches, real tradeoffs
+- `model-power:frontier` - High-ambiguity, architecture-level or creative-judgment work, high blast radius
+
 ## Status Labels
 
 - `status:backlog` - In the backlog, not yet scheduled
@@ -63,4 +86,5 @@ For consistent visual styling, use these hex colors for labels:
 - Domain labels: `#5319e7` (purple)
 - Priority labels: `#f9d0c4` (salmon)
 - Complexity labels: `#bfd4f2` (light blue)
+- Model Power labels: `#fbca04` (gold)
 - Status labels: `#c2e0c6` (light green)


### PR DESCRIPTION
## Description
Adds a `model-power:*` label family (`light` / `standard` / `advanced` / `frontier`) that captures how much reasoning/judgment an issue needs to implement -- a different axis from `complexity:*`, which only estimates time/scope. Documents the distinction in `.github/labels.md` and adds an "Estimated Model Power" checklist to four issue templates (bug_report, enhancement, feature_request, user-story) so new issues capture it going forward. `epic.md` is intentionally untouched -- epics are tracking containers, not directly-implemented work.

The four labels themselves, and the retroactive triage pass across the current open queue, are applied live via `gh` CLI/API calls -- they're GitHub metadata, not repo files, so they aren't part of this diff.

## Related Issue
N/A -- requested directly in chat, not tied to a tracked issue.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
<!-- N/A -- markdown-only change, no application code -->
- [ ] Tests written before implementation
- [ ] All new code is tested
- [ ] All tests pass locally
- [ ] Test coverage maintained or improved

## User Stories Addressed
N/A -- repo/process maintenance (label taxonomy), not a user-facing story.

## Flow Diagrams
N/A

## Component Development
<!-- N/A -- no UI/Storybook change -->
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes
- House style for labels is `prefix:kebab-case-value`, one flat color per family (not a gradient per tier) -- `model-power:*` uses `#fbca04` (gold), unused elsewhere in the taxonomy.
- Checklist block placement mirrors the existing `## Estimated Complexity` pattern in `user-story.md` exactly (`- [ ] Label (short criterion)`); for the other three templates, which have no existing complexity/priority fields, it's inserted immediately before `## Additional Context`.
- `labels.md` explicitly calls out that Complexity and Model Power are orthogonal -- a `complexity:large` issue can be `model-power:light` if it's mechanical repetition across many files, and vice versa -- so the new axis doesn't read as a duplicate of the existing one.
- No GitHub Action parses these template checkboxes into applied labels (same as the existing Estimated Complexity/Priority fields today) -- this is filer-applied guidance, not automation.

## Screenshots
N/A -- markdown-only change, no UI.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
<!-- No application code touched -- lint/typecheck/build tooling doesn't target .github/*.md -->
- [ ] Linting passed
- [ ] Type checking passed
- [ ] Security audit passed
- [ ] No console.log statements in production code
- [ ] No unhandled promises

## Testing Instructions
No app code changed. To verify:
1. Read the diff on `.github/labels.md` and the four templates.
2. Open GitHub's "New issue" picker for Bug Report / Enhancement / Feature Request / User Story and confirm the "Estimated Model Power" checkboxes render where expected.
3. The `model-power:*` labels are already live: https://github.com/jerseycheese/Narraitor/labels?q=model-power

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed
