### PR TITLE
feat(analytics): track world-created funnel step

### DIFF
--- a/__mocks__/@vercel/analytics.js
+++ b/__mocks__/@vercel/analytics.js
@@ -1,0 +1,8 @@
+// __mocks__/@vercel/analytics.js
+// Real package is ESM-only (dist/index.mjs), which ts-jest's CJS transform
+// can't parse. Manual mock keeps trackFunnelStep's transitive import
+// test-safe, same pattern as __mocks__/@google/genai.js.
+
+module.exports = {
+  track: jest.fn(),
+};

--- a/src/components/WorldCreationWizard/WorldCreationWizard.tsx
+++ b/src/components/WorldCreationWizard/WorldCreationWizard.tsx
@@ -33,6 +33,7 @@ import { analyzeWorldDescriptionClient } from '@/lib/ai/worldAnalyzerClient';
 import { ensureWorldNpcRoster } from '@/lib/services/worldCreationService';
 import { useTutorial } from '@/components/TutorialProvider';
 import { tourStepToWizardStep } from '@/lib/tutorial/worldCreationTour';
+import { trackFunnelStep } from '@/lib/analytics/trackFunnelStep';
 
 import Logger from '@/lib/utils/logger';
 const logger = new Logger('WorldCreationWizard');
@@ -341,7 +342,10 @@ export default function WorldCreationWizard({
         reference: data.reference, // Include reference for character generation
         relationship: data.relationship, // Include relationship for character generation
       });
-      
+
+      // Track the world-created funnel step for analytics
+      trackFunnelStep('world-created');
+
       // Set the newly created world as the active world
       const { setCurrentWorld } = useWorldStore.getState();
       setCurrentWorld(worldId);

--- a/src/lib/analytics/trackFunnelStep.ts
+++ b/src/lib/analytics/trackFunnelStep.ts
@@ -5,7 +5,7 @@ import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
  * The funnel steps we measure. Names only — this union is the entire
  * vocabulary that ever leaves the browser.
  */
-type FunnelStep = 'landing' | 'session-started' | 'return-visit';
+type FunnelStep = 'landing' | 'session-started' | 'return-visit' | 'world-created';
 
 /**
  * Fire an anonymous funnel-step event to Vercel Web Analytics.


### PR DESCRIPTION
## Description
Adds a `world-created` funnel step to the analytics vocabulary and fires it right after a world finishes creation, alongside the existing `landing`/`session-started`/`return-visit` steps. Also adds a manual mock for `@vercel/analytics` (its dist is ESM-only, which ts-jest's CJS transform can't parse) so `trackFunnelStep`'s transitive import doesn't break tests that render `WorldCreationWizard` — same pattern as the existing `__mocks__/@google/genai.js`.

Found this sitting uncommitted directly on `develop` in a separate session; verified it, fixed the test breakage it introduced, and split it out onto its own branch.

## Related Issue
Closes #
N/A — no tracked issue, opportunistic find.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## TDD Compliance
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A

## Flow Diagrams
N/A

## Component Development
N/A — no new UI component.

## Implementation Notes
`WorldCreationWizard.tsx` now imports `trackFunnelStep` and calls it with `'world-created'` right after the world is persisted and set as current. The `@vercel/analytics` mock is scoped narrowly (just `track: jest.fn()`) and lives at the repo-root `__mocks__/` the same way `@google/genai` already does, so Jest auto-applies it without any per-test `jest.mock()` call.

## Screenshots
N/A — no UI change.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npx jest --config=jest.config.cjs src/lib/analytics/trackFunnelStep src/components/WorldCreationWizard` — 5 suites / 40 tests pass (previously 1 suite failed with `SyntaxError: Unexpected token 'export'` from `@vercel/analytics`'s ESM dist, before the mock was added).
2. `npm run type-check` / `npm run lint` — clean.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic — none needed, change is small and self-explanatory
- [x] Documentation updated (if required) — N/A
- [x] No new warnings generated
- [x] Accessibility considerations addressed — N/A, no UI change
