### PR TITLE
docs(skills): fix stale Tailwind/shadcn refs and drop emoji markers

### DIFF
--- a/.claude/skills/narraitor-architecture/SKILL.md
+++ b/.claude/skills/narraitor-architecture/SKILL.md
@@ -22,7 +22,7 @@ Do NOT invoke for: small bug fixes, copy changes, config tweaks, or test-only ch
 
 ## Place code in the right module
 - Put routes and API handlers in `src/app/` and `src/app/api/` (Next.js 15 App Router).
-- Put UI in `src/components/`, grouped by domain/feature; use `src/components/ui` for shadcn primitives and `src/components/shared` for cross-domain UI.
+- Put UI in `src/components/`, grouped by domain/feature; use `src/components/shared` for cross-domain UI.
 - Put state in `src/state/` with domain stores; use persistence helpers in `src/state/persistence.ts` when needed.
 - Put types in `src/types/*.types.ts`; keep `src/types/index.ts` type-only (no runtime imports).
 - Put hooks in `src/hooks/` and services in `src/services/` unless an existing `src/lib/*` module already owns the behavior.
@@ -43,8 +43,8 @@ Do NOT invoke for: small bug fixes, copy changes, config tweaks, or test-only ch
 - Never expose API keys or AI clients in client components.
 
 ## Use design tokens
-- Avoid hardcoded colors; use Tailwind tokens or `hsl(var(--...))` variables.
-- Prefer shadcn/ui components for form controls and primitives.
+- Avoid hardcoded colors; use `hsl(var(--color-*))` design tokens.
+- Style components with plain CSS + design tokens (removed: Tailwind, shadcn/ui, cva); use `clsx` for conditional classes.
 
 ## Validate with tests and dev harnesses
 - Add tests in `__tests__/` or `*.test.ts(x)`; add stories in `src/stories/`.

--- a/.claude/skills/narraitor-pattern-alignment-skill/SKILL.md
+++ b/.claude/skills/narraitor-pattern-alignment-skill/SKILL.md
@@ -25,8 +25,8 @@ Do NOT invoke for: documentation-only edits, config changes, or trivial one-line
 - Report issues first (ordered by severity) with file:line and concrete fixes.
 
 ## Core alignment areas
-- Components and structure (naming, file size, shadcn/ui usage)
-- Design tokens and color usage (no hardcoded colors)
+- Components and structure (naming, file size, DOM clarity)
+- Design tokens and color usage (no hardcoded colors; use `hsl(var(--color-*))` and design-token CSS)
 - Error handling and user-friendly errors
 - State management and persistence patterns
 - Type safety and domain types

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -8,6 +8,6 @@ description: Use when reviewing Narraitor code or PR changes for bugs, regressio
 1. Fetch the latest diff from the remote PR branch (never use cached data)
 2. Analyze all changed files for bugs, logic errors, missing edge cases, and style issues
 3. Run `npm run lint` and `npm run test` against the branch
-4. Present findings as: 🔴 Blocking, 🟡 Suggestions, 🟢 Praise
+4. Present findings as: BLOCKING, SUGGESTION, PRAISE (ordered by severity)
 5. Do NOT enter plan mode or create plan files
 6. End with a clear MERGE / NEEDS CHANGES verdict

--- a/.claude/skills/style-port/SKILL.md
+++ b/.claude/skills/style-port/SKILL.md
@@ -10,7 +10,7 @@ Port inline styles from a reference source (demo component, Figma spec, screensh
 ## Hard Rules
 
 - **No `!important`** -- fix specificity at the selector level.
-- **No raw pixel values** when a design token exists (`--space-*`, `--radius-*`, `--font-*`). Token definitions live in `src/lib/theme/design-tokens.css`.
+- **No raw pixel values** when a design token exists (`--space-*`, `--radius-*`, `--font-*`). Token definitions live in `src/lib/theme/themes/_shared-tokens.css`.
 - **No demo-only UI** -- do not port components that only exist in the reference scaffold (state switchers, mock data chrome, debug panels).
 - **No dark-mode changes** -- theme overrides target `[data-theme="dsN"]` only. Do not touch `.dark` variants unless the plan explicitly calls for it.
 - **No new inline styles** -- the point is moving styles into CSS. Never add `style={{}}` to fix a gap.


### PR DESCRIPTION
## Description
Fixes stale references in four `SKILL.md` docs: Tailwind/shadcn/ui mentions left over from before they were removed from the app (#1097), a `design-tokens.css` path that's now `themes/_shared-tokens.css`, and a `src/components/ui` shadcn-primitives callout that no longer applies. Also swaps the `review` skill's emoji severity markers (🔴🟡🟢) for plain text, per the repo's no-emoji convention.

Found this sitting uncommitted directly on `develop` in a separate session; verified the diffs against current code and split it out onto its own branch.

## Related Issue
Closes #
N/A — no tracked issue, opportunistic find.

## Type of Change
- [x] Documentation update

## TDD Compliance
N/A — doc-only change, no code paths affected.

## User Stories Addressed
N/A

## Flow Diagrams
N/A

## Component Development
N/A

## Implementation Notes
Confirmed each stale reference against current code before editing: Tailwind/shadcn are gone repo-wide (`#1097`), `_shared-tokens.css` is the real token-file path (`src/lib/theme/themes/_shared-tokens.css`), and `src/components/ui` isn't a real directory anymore. No behavior change — these docs only steer future agent sessions.

## Screenshots
N/A

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
Docs only — read-diff review is the verification. `npm run lint` / `npm run type-check` pass (untouched by this change, run for completeness).

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic — N/A, prose-only diffs
- [x] Documentation updated (if required) — this PR is the update
- [x] No new warnings generated
- [x] Accessibility considerations addressed — N/A
