### PR TITLE
feat: add world-created funnel event to analytics

### DIFF
--- a/src/components/WorldCreationWizard/WorldCreationWizard.tsx
+++ b/src/components/WorldCreationWizard/WorldCreationWizard.tsx
@@ -33,6 +33,7 @@ import { analyzeWorldDescriptionClient } from '@/lib/ai/worldAnalyzerClient';
 import { ensureWorldNpcRoster } from '@/lib/services/worldCreationService';
 import { useTutorial } from '@/components/TutorialProvider';
 import { tourStepToWizardStep } from '@/lib/tutorial/worldCreationTour';
+import { trackFunnelStep } from '@/lib/analytics/trackFunnelStep';
 
 import Logger from '@/lib/utils/logger';
 const logger = new Logger('WorldCreationWizard');
@@ -341,7 +342,10 @@ export default function WorldCreationWizard({
         reference: data.reference, // Include reference for character generation
         relationship: data.relationship, // Include relationship for character generation
       });
-      
+
+      // Track the world creation in the funnel
+      trackFunnelStep('world-created');
+
       // Set the newly created world as the active world
       const { setCurrentWorld } = useWorldStore.getState();
       setCurrentWorld(worldId);

--- a/src/components/WorldCreationWizard/__tests__/worldCreationWizard.cancel-confirmation.test.tsx
+++ b/src/components/WorldCreationWizard/__tests__/worldCreationWizard.cancel-confirmation.test.tsx
@@ -45,6 +45,14 @@ jest.mock('@/components/TutorialProvider', () => ({
   })),
 }));
 
+jest.mock('@vercel/analytics', () => ({
+  track: jest.fn(),
+}));
+
+jest.mock('@/lib/utils/isPlaywrightEnv', () => ({
+  isPlaywrightEnv: jest.fn(() => false),
+}));
+
 // Test data constants
 const TEST_WORLD_DATA = {
   name: 'Test World Name',

--- a/src/lib/analytics/__tests__/trackFunnelStep.test.ts
+++ b/src/lib/analytics/__tests__/trackFunnelStep.test.ts
@@ -36,4 +36,11 @@ describe('trackFunnelStep (#1367)', () => {
 
     expect(mockTrack).not.toHaveBeenCalled();
   });
+
+  it('tracks world-created step', () => {
+    trackFunnelStep('world-created');
+
+    expect(mockTrack).toHaveBeenCalledTimes(1);
+    expect(mockTrack).toHaveBeenCalledWith('world-created');
+  });
 });

--- a/src/lib/analytics/trackFunnelStep.ts
+++ b/src/lib/analytics/trackFunnelStep.ts
@@ -5,7 +5,7 @@ import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
  * The funnel steps we measure. Names only — this union is the entire
  * vocabulary that ever leaves the browser.
  */
-type FunnelStep = 'landing' | 'session-started' | 'return-visit';
+type FunnelStep = 'landing' | 'session-started' | 'return-visit' | 'world-created';
 
 /**
  * Fire an anonymous funnel-step event to Vercel Web Analytics.


### PR DESCRIPTION
Resolves #1382. Added world-created funnel step to track conversion from opening the creation wizard to successfully creating a world.