### PR TITLE
fix: align @types/node with runtime version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.5.2",
         "@types/jest": "^29.5.14",
-        "@types/node": "^20",
+        "@types/node": "^24",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@typescript-eslint/eslint-plugin": "^8.41.0",
@@ -6836,11 +6836,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.17.32",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/parse-json": {
@@ -19861,7 +19863,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.5.2",
     "@types/jest": "^29.5.14",
-    "@types/node": "^20",
+    "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@typescript-eslint/eslint-plugin": "^8.41.0",


### PR DESCRIPTION
## Description
Bumps `@types/node` from `^20` to `^24`, closing the version gap flagged in #798 so newer Node APIs stop tripping type errors. Type-only `devDependency` change — no runtime code touched.

## Related Issue
Closes #798

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## TDD Compliance
N/A — dependency version bump, no new code to test.
- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [ ] Test coverage maintained or improved

## User Stories Addressed
N/A

## Flow Diagrams
N/A

## Component Development
N/A — no UI change.

## Implementation Notes
Straight `@types/node` version bump. The docs the issue pointed to (`docs/security/dependency-upgrade-plan.md`, `docs/security/issues/align-node-types.md`) don't exist in the repo, so that reference in #798 looks stale — nothing to update there.

## Screenshots
N/A

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm ci`
2. `npm run type-check`
3. `npm test`

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic — N/A, no logic changed
- [ ] Documentation updated (if required) — N/A
- [x] No new warnings generated
- [ ] Accessibility considerations addressed — N/A
