### PR TITLE
fix: correct hsl() token guidance from #1620 review

### DIFF
--- a/.claude/skills/narraitor-architecture/SKILL.md
+++ b/.claude/skills/narraitor-architecture/SKILL.md
@@ -22,7 +22,7 @@ Do NOT invoke for: small bug fixes, copy changes, config tweaks, or test-only ch
 
 ## Place code in the right module
 - Put routes and API handlers in `src/app/` and `src/app/api/` (Next.js 15 App Router).
-- Put UI in `src/components/`, grouped by domain/feature; use `src/components/shared` for cross-domain UI.
+- Put UI in `src/components/`, grouped by domain/feature; use `src/components/ui` for shared primitives (Button, Input, Dialog, Card, etc.) and `src/components/shared` for cross-domain UI.
 - Put state in `src/state/` with domain stores; use persistence helpers in `src/state/persistence.ts` when needed.
 - Put types in `src/types/*.types.ts`; keep `src/types/index.ts` type-only (no runtime imports).
 - Put hooks in `src/hooks/` and services in `src/services/` unless an existing `src/lib/*` module already owns the behavior.
@@ -43,7 +43,7 @@ Do NOT invoke for: small bug fixes, copy changes, config tweaks, or test-only ch
 - Never expose API keys or AI clients in client components.
 
 ## Use design tokens
-- Avoid hardcoded colors; use `hsl(var(--color-*))` design tokens.
+- Avoid hardcoded colors; use `var(--color-*)` design tokens directly (already complete colors, never wrap in `hsl()`). Status/domain tokens (`--success`, `--warning`, `--ending-*`, `--alignment-*`, etc.) are raw HSL channels and DO need `hsl(var(--success))` — see `public_docs/design-system/design-tokens.md` for the full split.
 - Style components with plain CSS + design tokens (removed: Tailwind, shadcn/ui, cva); use `clsx` for conditional classes.
 
 ## Validate with tests and dev harnesses

--- a/.claude/skills/narraitor-architecture/resources/component-patterns.md
+++ b/.claude/skills/narraitor-architecture/resources/component-patterns.md
@@ -5,7 +5,7 @@ Follow existing component organization and keep UI code easy to discover.
 ## Organization
 - Domain/feature components live under `src/components/` (e.g., `world/`, `character/`, `narrative/`, `journal/`, `inventory/`).
 - Cross-domain components go in `src/components/shared/`.
-- UI primitives (shadcn/ui) live in `src/components/ui/` and use lowercase filenames.
+- UI primitives (Button, Input, Dialog, Card, etc.) live in `src/components/ui/` and use lowercase filenames.
 
 ## Naming
 - Use PascalCase for component files.
@@ -17,8 +17,8 @@ Follow existing component organization and keep UI code easy to discover.
 - Keep data-loading logic in server components or route handlers when possible.
 
 ## Form controls
-- Prefer shadcn/ui components over raw HTML form elements.
-- Use Tailwind design tokens or `hsl(var(--...))` CSS variables for styling.
+- Prefer existing `src/components/ui` primitives over raw HTML form elements.
+- Use `var(--color-*)`, `var(--space-*)`, etc. design tokens for styling — plain CSS, no Tailwind.
 
 ## Storybook
 - Place stories in `src/stories/` following existing folder patterns.

--- a/.claude/skills/narraitor-pattern-alignment-skill/SKILL.md
+++ b/.claude/skills/narraitor-pattern-alignment-skill/SKILL.md
@@ -26,7 +26,7 @@ Do NOT invoke for: documentation-only edits, config changes, or trivial one-line
 
 ## Core alignment areas
 - Components and structure (naming, file size, DOM clarity)
-- Design tokens and color usage (no hardcoded colors; use `hsl(var(--color-*))` and design-token CSS)
+- Design tokens and color usage (no hardcoded colors; use `var(--color-*)` directly, but wrap status/domain tokens like `--success`/`--alignment-*` in `hsl(var(--...))` — see `public_docs/design-system/design-tokens.md`)
 - Error handling and user-friendly errors
 - State management and persistence patterns
 - Type safety and domain types

--- a/.claude/skills/narraitor-pattern-alignment-skill/references/accessibility.md
+++ b/.claude/skills/narraitor-pattern-alignment-skill/references/accessibility.md
@@ -13,7 +13,7 @@ Use this when reviewing UI components.
 - Do not rely on placeholder-only labels.
 
 ## Dialogs and modals
-- Use shadcn/ui Dialog for focus trapping and escape handling.
+- Use the `Dialog` primitive from `src/components/ui/` for focus trapping and escape handling.
 - Ensure title/description are present.
 
 ## Keyboard support

--- a/.claude/skills/narraitor-pattern-alignment-skill/references/patterns.md
+++ b/.claude/skills/narraitor-pattern-alignment-skill/references/patterns.md
@@ -5,12 +5,12 @@ Use this checklist during reviews to keep Narraitor changes consistent with exis
 ## Component structure
 - Use PascalCase filenames for components.
 - Keep components focused; suggest splitting if files drift past ~300 lines.
-- Use shadcn/ui primitives from `src/components/ui/` for form controls and common UI.
-- Prefer `cn` from `src/lib/utils/classNames.ts` for class merging.
+- Use primitives from `src/components/ui/` for form controls and common UI.
+- Prefer `cssClasses` from `src/lib/utils/classNames.ts` for class merging.
 
 ## Design tokens
 - No hardcoded colors in TS/TSX or CSS.
-- Use Tailwind color tokens or `hsl(var(--...))` variables.
+- Use `var(--color-*)` design tokens directly — complete colors, don't wrap in `hsl()`. Status/domain tokens (`--success`, `--warning`, `--ending-*`, `--alignment-*`, etc.) are raw HSL channels and must be wrapped: `hsl(var(--success))`. Full split in `public_docs/design-system/design-tokens.md`.
 - For JS-accessible tokens, use `src/lib/design-tokens`.
 
 ## Error handling

--- a/.claude/skills/narraitor-pattern-alignment-skill/references/patterns.md
+++ b/.claude/skills/narraitor-pattern-alignment-skill/references/patterns.md
@@ -6,7 +6,7 @@ Use this checklist during reviews to keep Narraitor changes consistent with exis
 - Use PascalCase filenames for components.
 - Keep components focused; suggest splitting if files drift past ~300 lines.
 - Use primitives from `src/components/ui/` for form controls and common UI.
-- Prefer `cssClasses` from `src/lib/utils/classNames.ts` for class merging.
+- Use `clsx` directly for conditional class merging (the repo's established pattern — 37+ components import it directly; `cssClasses` in `src/lib/utils/classNames.ts` is a thin wrapper only `ErrorDisplay` uses).
 
 ## Design tokens
 - No hardcoded colors in TS/TSX or CSS.

--- a/.claude/skills/narraitor-pattern-alignment-skill/references/utilities.md
+++ b/.claude/skills/narraitor-pattern-alignment-skill/references/utilities.md
@@ -10,7 +10,7 @@ Before adding new helpers, scan these areas for existing utilities:
 - `src/lib/utils/errorUtils.ts` — ErrorType, user-friendly errors, retryability, store errors
 - `src/lib/utils/formatters.ts` — date/time/string formatting helpers
 - `src/lib/utils/validationUtils.ts` — input and rules validation
-- `src/lib/utils/classNames.ts` — `cssClasses`, a `clsx`-based class merger
+- `src/lib/utils/classNames.ts` — `cssClasses`, a thin `clsx` wrapper (rarely used; prefer importing `clsx` directly, per repo convention)
 - `src/lib/utils/generateId.ts` — `generateUniqueId`
 - `src/lib/utils/logger.ts` — Logger utility
 - `src/lib/utils/timestamp.ts` — timestamp helpers

--- a/.claude/skills/narraitor-pattern-alignment-skill/references/utilities.md
+++ b/.claude/skills/narraitor-pattern-alignment-skill/references/utilities.md
@@ -10,7 +10,7 @@ Before adding new helpers, scan these areas for existing utilities:
 - `src/lib/utils/errorUtils.ts` — ErrorType, user-friendly errors, retryability, store errors
 - `src/lib/utils/formatters.ts` — date/time/string formatting helpers
 - `src/lib/utils/validationUtils.ts` — input and rules validation
-- `src/lib/utils/classNames.ts` — `cn` Tailwind class merger
+- `src/lib/utils/classNames.ts` — `cssClasses`, a `clsx`-based class merger
 - `src/lib/utils/generateId.ts` — `generateUniqueId`
 - `src/lib/utils/logger.ts` — Logger utility
 - `src/lib/utils/timestamp.ts` — timestamp helpers

--- a/.claude/skills/style-port/SKILL.md
+++ b/.claude/skills/style-port/SKILL.md
@@ -10,7 +10,7 @@ Port inline styles from a reference source (demo component, Figma spec, screensh
 ## Hard Rules
 
 - **No `!important`** -- fix specificity at the selector level.
-- **No raw pixel values** when a design token exists (`--space-*`, `--radius-*`, `--font-*`). Token definitions live in `src/lib/theme/themes/_shared-tokens.css`.
+- **No raw pixel values** when a design token exists (`--space-*`, `--radius-*`, `--font-*`). Token definitions live in `src/lib/theme/themes/`: spacing and `--radius-full` in `_shared-tokens.css`, `--font-*` and `--radius-sm/md/lg` in `ds3.css`.
 - **No demo-only UI** -- do not port components that only exist in the reference scaffold (state switchers, mock data chrome, debug panels).
 - **No dark-mode changes** -- theme overrides target `[data-theme="dsN"]` only. Do not touch `.dark` variants unless the plan explicitly calls for it.
 - **No new inline styles** -- the point is moving styles into CSS. Never add `style={{}}` to fix a gap.


### PR DESCRIPTION
## Description
Follow-up to PR #1620's review feedback (chatgpt-codex-connector bot, 4 confirmed P2 findings). Restores the `src/components/ui` pointer, swaps stale `cn`/Tailwind references for `cssClasses`/plain-CSS, names both token files in the style-port skill — and corrects an over-broad claim from my own #1620 edit that would've told future agents `hsl(var(--color-*))` is always invalid.

It isn't. `--color-*` tokens hold complete values and should be used bare, but a separate family (`--success`, `--warning`, `--info`, `--ending-*`, `--lore-*-bg`, `--alignment-*`) is stored as raw HSL channel triplets and genuinely needs the `hsl()` wrapper — there are 62 live, correct usages of that pattern in `src/`. The three affected docs now state both halves and point at `public_docs/design-system/design-tokens.md` for the full inventory instead of re-deriving it in three places.

## Related Issue
Follow-up to #1620 (merged; `develop` is not the default branch so it didn't auto-close on merge)

## Type of Change
- [x] Documentation update

## TDD Compliance
- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [ ] Test coverage maintained or improved

Docs-only change (7 `.md` files under `.claude/skills/`); no code or test surface.

## Implementation Notes
Ran `npx stylelint '**/*.css'` and `npm run type-check` — both exit 0, unaffected by this change (sanity check only, since nothing here touches CSS or TS).

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
No runtime behavior changes. Read the three edited files against `public_docs/design-system/design-tokens.md:124-125` to confirm the token-family split matches.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed