### PR TITLE
fix: consolidate world-created tracking into store chokepoint

### DIFF
--- a/src/components/WorldCreationWizard/WorldCreationWizard.tsx
+++ b/src/components/WorldCreationWizard/WorldCreationWizard.tsx
@@ -33,7 +33,6 @@ import { analyzeWorldDescriptionClient } from '@/lib/ai/worldAnalyzerClient';
 import { ensureWorldNpcRoster } from '@/lib/services/worldCreationService';
 import { useTutorial } from '@/components/TutorialProvider';
 import { tourStepToWizardStep } from '@/lib/tutorial/worldCreationTour';
-import { trackFunnelStep } from '@/lib/analytics/trackFunnelStep';
 
 import Logger from '@/lib/utils/logger';
 const logger = new Logger('WorldCreationWizard');
@@ -342,9 +341,6 @@ export default function WorldCreationWizard({
         reference: data.reference, // Include reference for character generation
         relationship: data.relationship, // Include relationship for character generation
       });
-
-      // Track the world-created funnel step for analytics
-      trackFunnelStep('world-created');
 
       // Set the newly created world as the active world
       const { setCurrentWorld } = useWorldStore.getState();

--- a/src/state/__tests__/worldStore.tracking.test.ts
+++ b/src/state/__tests__/worldStore.tracking.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Tests for the world-created funnel event wired into worldStore's createWorld
+ * alias (#1619 follow-up). createWorld is the single chokepoint every
+ * production world-creation path converges on, so the tracking call lives
+ * there instead of in each caller.
+ *
+ * jest.setup.ts globally auto-mocks '@/state/worldStore' for component tests;
+ * unmock it here so these tests exercise the real store.
+ */
+
+// Don't mock the store - we want to test the real one
+jest.unmock('../worldStore');
+
+import { track } from '@vercel/analytics';
+import { useWorldStore } from '../worldStore';
+import { createTestWorldData } from './worldStore.testHelpers';
+
+const mockTrack = track as jest.Mock;
+
+describe('useWorldStore - world-created funnel tracking', () => {
+  beforeEach(() => {
+    useWorldStore.getState().reset();
+    mockTrack.mockClear();
+  });
+
+  test('createWorld fires the world-created funnel event exactly once', () => {
+    useWorldStore.getState().createWorld(createTestWorldData());
+
+    expect(mockTrack).toHaveBeenCalledTimes(1);
+    expect(mockTrack).toHaveBeenCalledWith('world-created');
+  });
+
+  test('calling create directly does not fire analytics', () => {
+    useWorldStore.getState().create(createTestWorldData());
+
+    expect(mockTrack).not.toHaveBeenCalled();
+  });
+});

--- a/src/state/worldStore.ts
+++ b/src/state/worldStore.ts
@@ -13,6 +13,7 @@ import { applyWorldStateUpdate, getActiveWorldState, mergeState } from '@/lib/wo
 import Logger from '@/lib/utils/logger';
 import { storeEvents, StoreEventTypes, type WorldDeletedEvent } from '@/lib/state/storePubSub';
 import { useSessionStore } from './sessionStore';
+import { trackFunnelStep } from '@/lib/analytics/trackFunnelStep';
 
 const logger = new Logger('WorldStore');
 
@@ -255,7 +256,11 @@ export const useWorldStore = create<WorldStore>()(
         },
 
         // Domain-specific method aliases
-        createWorld: (worldData) => get().create(worldData),
+        createWorld: (worldData) => {
+          const worldId = get().create(worldData);
+          trackFunnelStep('world-created');
+          return worldId;
+        },
         updateWorld: (id, updates) => get().update(id, updates),
         deleteWorld: (id) => get().delete(id),
         setCurrentWorld: (id) => get().setCurrent(id),


### PR DESCRIPTION
## Description
PR #1619 added `trackFunnelStep('world-created')` directly inside `WorldCreationWizard`'s `handleComplete`. A reviewer bot flagged that this only covers the wizard's own creation path — it missed the other production world-creation flows. This PR moves the tracking call into `worldStore`'s `createWorld` alias, the single chokepoint every production creation path already funnels through, so the event fires no matter which UI created the world.

Previously-uncovered production paths that now fire the event:
- `src/app/worlds/page.tsx` creating a world via `worldCreationService.createWorldFromGeneration(...)`
- `GuidedFirstTimeExperience` (reached from `DashboardHome` for first-run users), which creates worlds the same way

Both of these call into `worldCreationService.ts`, which calls `useWorldStore.getState().createWorld(...)` — previously a bare passthrough to the `create` primitive with no tracking. The `create` primitive itself stays untouched so the ~30 existing tests that call it directly remain side-effect-free.

## Related Issue
N/A - addresses review feedback on PR #1619, no standalone tracked issue.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A - no UI change, only where the tracking call lives.

## Implementation Notes
- `worldStore.createWorld` now wraps `create` and fires `trackFunnelStep('world-created')` after a successful creation, then returns the new world's ID.
- Removed the now-redundant `trackFunnelStep('world-created')` call (and its import) from `WorldCreationWizard.tsx`.
- Added `src/state/__tests__/worldStore.tracking.test.ts`, which unmocks the global `@/state/worldStore` auto-mock (see `jest.setup.ts`) so it exercises the real store. It pins: `createWorld` fires `track` exactly once with `'world-created'`, and calling `create` directly fires no tracking at all.

## Screenshots
N/A - no visual change.

## Code Review Summary (if applicable)
Addresses reviewer feedback from PR #1619: the wizard-only tracking call didn't cover the AI-generation creation paths (`/worlds` page, first-run onboarding).

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npx jest src/state/__tests__/worldStore.crud.test.ts src/state/__tests__/worldStore.tracking.test.ts src/lib/analytics src/components/WorldCreationWizard --silent` - all pass.
2. `npm test -- --silent` - full suite green (361 suites, 2388 tests).
3. `npm run lint` - 0 errors (148 pre-existing warnings, unrelated to this change).

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed