### PR TITLE
fix: wait for font swap before dashboard empty-state screenshots

### DIFF
--- a/tests/visual/main-pages.spec.ts
+++ b/tests/visual/main-pages.spec.ts
@@ -36,6 +36,14 @@ test.describe('Main Pages Visual Tests', () => {
 
     await page.goto('/dashboard');
     await waitForContentStable(page);
+    // Empty state routes to GuidedFirstTimeExperience, whose "First time?"
+    // title renders in the italic Newsreader webfont (--font-narrative,
+    // next/font with display: 'swap'). Without waiting for the swap, an
+    // occasional slow font fetch leaves fallback-font glyphs painted at
+    // screenshot time, producing a few thousand pixels of diff right at
+    // maxDiffPixels — the same wait other specs already do (e.g.
+    // world-creation.spec.ts, landing-page.spec.ts).
+    await page.evaluate(() => document.fonts.ready);
     await hideDynamicContent(page);
 
     // Verify page loaded with expected content

--- a/tests/visual/tutorials/intro-onboarding.spec.ts
+++ b/tests/visual/tutorials/intro-onboarding.spec.ts
@@ -27,6 +27,13 @@ test('Guided first-time experience snapshots (steps 0-2)', async ({ page }) => {
       )
     )
     .toBe(true);
+  // The "First time?" title renders in the italic Newsreader webfont
+  // (--font-narrative, next/font with display: 'swap'). Without waiting for
+  // the swap, an occasional slow font fetch (cold CI dev-server compile)
+  // leaves the fallback-font glyphs painted at screenshot time, producing a
+  // few thousand pixels of diff right at maxDiffPixels — the same wait other
+  // specs already do (e.g. world-creation.spec.ts, landing-page.spec.ts).
+  await page.evaluate(() => document.fonts.ready);
 
   // Step 0: Welcome
   await expect(page).toHaveScreenshot(`tutorial-intro-onboarding-step${zeroPad(0)}.png`, {
@@ -39,6 +46,7 @@ test('Guided first-time experience snapshots (steps 0-2)', async ({ page }) => {
   await nextButton.click();
   await page.waitForTimeout(500);
   await waitForContentStable(page);
+  await page.evaluate(() => document.fonts.ready);
   await expect(page).toHaveScreenshot(`tutorial-intro-onboarding-step${zeroPad(1)}.png`, {
     fullPage: false,
   });
@@ -47,6 +55,7 @@ test('Guided first-time experience snapshots (steps 0-2)', async ({ page }) => {
   await nextButton.click();
   await page.waitForTimeout(500);
   await waitForContentStable(page);
+  await page.evaluate(() => document.fonts.ready);
   await expect(page).toHaveScreenshot(`tutorial-intro-onboarding-step${zeroPad(2)}.png`, {
     fullPage: false,
   });


### PR DESCRIPTION
## Description
Fixes a pre-existing, intermittent visual-regression flake on `/dashboard`'s empty state. Surfaced while working PR #1627 (issue #1456), but confirmed unrelated to it and pre-existing on the branch.

Two specs screenshot `GuidedFirstTimeExperience`'s "First time?" heading, which renders in the italic Newsreader webfont (`--font-narrative`, loaded via `next/font` with `display: 'swap'`). Neither waited for `document.fonts.ready` before capturing, so an occasional slow font fetch leaves fallback-font glyphs painted at screenshot time — producing a pixel diff that intermittently lands right at `maxDiffPixels`. Nine other specs in this codebase already guard this exact font this way (`world-creation.spec.ts`, `landing-page.spec.ts`, etc.); these two were just missing it.

## Related Issue
Closes #
N/A — discovered as a side effect of PR #1627, not filed as its own tracked issue.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — test-infrastructure fix, no user-facing behavior change.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified
N/A — no component changes; test-only fix.

## Implementation Notes
Added `await page.evaluate(() => document.fonts.ready)` at each screenshot point in the two affected specs, matching the existing pattern used elsewhere in the suite for this same font. No production code touched, no baseline PNGs regenerated (the fix doesn't change intended rendered output, only when the screenshot is taken).

Caveat for reviewers: I confirmed the underlying race is real (forcing a stalled font fetch reproduces `document.fonts.status === 'loading'` at screenshot time), but I could not force an actual `maxDiffPixels`-exceeding failure locally on macOS/Chromium — likely because the local fallback serif renders close enough to Newsreader-italic to stay under threshold. CI runs Linux, whose fallback serif differs more sharply, which is consistent with the flake being CI-only. The fix itself is low-risk and matches an established codebase pattern regardless.

## Screenshots
N/A — test-only change, no rendered UI differs.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm run dev` (or the worktree's port script) to start the app.
2. `PLAYWRIGHT_BASE_URL=http://localhost:<port> npx playwright test tests/visual/tutorials/intro-onboarding.spec.ts --project=tutorials --repeat-each=5`
3. `PLAYWRIGHT_BASE_URL=http://localhost:<port> npx playwright test tests/visual/main-pages.spec.ts --project=chromium -g "empty state" --repeat-each=5`
4. Both should pass consistently (verified 8/8 and 10/10 across repeated local runs).

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed
N/A — test-only change.
