### PR TITLE
chore: document NEXT_PUBLIC_SITE_URL and drop a dead feature flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,4 +12,11 @@ NEXT_PUBLIC_ENABLE_TOKEN_BUDGET_MANAGER=false
 # Feature flags for migration safety (default off)
 NEXT_PUBLIC_FEATURE_BUFFERED_STREAMING=false
 NEXT_PUBLIC_FEATURE_PROGRESSIVE_DISCLOSURE=false
-NEXT_PUBLIC_FEATURE_VIRTUALIZATION=false
+
+# Public site origin, used for metadataBase, robots.txt, and the sitemap.
+# Leave unset for local development - getSiteUrl() falls back to
+# http://localhost:$PORT, which is what you want so a local build doesn't
+# generate canonicals pointing at production. Vercel supplies its own host
+# automatically. Required only for a production build off Vercel, which
+# throws without it rather than publish a localhost URL to crawlers.
+# NEXT_PUBLIC_SITE_URL=https://narraitor-six.vercel.app

--- a/.env.production.example
+++ b/.env.production.example
@@ -13,6 +13,12 @@ GITHUB_TOKEN=your-github-token-here
 # Debug settings (usually false in production)
 NEXT_PUBLIC_DEBUG_LOGGING=false
 
+# Public site origin, used for metadataBase, robots.txt, and the sitemap.
+# On Vercel this is optional - VERCEL_PROJECT_PRODUCTION_URL covers it.
+# Anywhere else the build throws without it rather than publish a localhost
+# URL to crawlers. Set it to the real origin you serve from.
+NEXT_PUBLIC_SITE_URL=https://narraitor-six.vercel.app
+
 # Security Notes:
 # - Never use NEXT_PUBLIC_ prefix for sensitive data like API keys
 # - API keys are accessed server-side only through API routes


### PR DESCRIPTION
## Description

`getSiteUrl()` ([`src/lib/constants/site.ts:29-52`](https://github.com/jerseycheese/Narraitor/blob/develop/src/lib/constants/site.ts#L29-L52)) resolves the public origin from `NEXT_PUBLIC_SITE_URL`, then `VERCEL_PROJECT_PRODUCTION_URL`, then `VERCEL_URL` — and if none are set under `NODE_ENV=production` it throws on purpose, rather than let robots.txt, the sitemap, and every canonical publish a localhost URL to crawlers. That's the right call (#1636 added it deliberately).

The gap was that neither env template mentioned the variable. On Vercel one of the `VERCEL_*` hosts is always set, so the deploy has always sailed through — which is exactly why nobody noticed. Anywhere else (self-hosted, a container, a contributor running a production build on a fresh clone) the fallback chain runs out and the build dies on a variable that appears in no template they'd think to read.

**`.env.production.example`** gets it set outright — that file is a production template, so a real origin is the correct value.

**`.env.example`** gets it commented out, with the reasoning inline. This one's worth being deliberate about: that file gets copied to `.env.local` for local development, so pinning it to the production URL would make local builds generate canonicals and a sitemap pointing at prod. Left unset, `getSiteUrl()` falls back to `http://localhost:$PORT`, which is what you want locally. It reads `PORT` rather than assuming 3000 because worktrees each run their own — there's a comment at `site.ts:49-51` about precisely that.

Also drops `NEXT_PUBLIC_FEATURE_VIRTUALIZATION`. It's referenced nowhere in the repo — not in `src/`, not in `scripts/`, not in `FEATURE_FLAGS` — so setting it did nothing. A flag that silently does nothing is worse than no flag, since someone will eventually flip it and lose an afternoon.

## Related Issue

Closes #1647

Targets `develop`, so the `Closes` keyword won't auto-close on merge — `post-merge` handles it.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

N/A — env templates only, no code paths changed. Neither file is read by application code, tests, or CI (verified by grep across `*.ts/tsx/js/mjs/sh/yml/yaml`), so there's nothing to write a test against.

- [ ] Tests written before implementation
- [ ] All new code is tested
- [ ] All tests pass locally
- [ ] Test coverage maintained or improved

## User Stories Addressed

Not user-story-driven. The driver is a contributor cloning the repo and hitting a build failure on an undocumented variable.

## Flow Diagrams

N/A

## Component Development

N/A — no components touched.

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes

Left the stale `# - Maximum 50 requests per hour per IP address` line in `.env.production.example` alone even though this PR touches that file. It's the same wrong claim #1646 just corrected in the README — the real behavior is 50/hour in production only (500/10min in dev) and it covers 2 of 19 API routes — but fixing it here would widen a config PR into a doc-accuracy pass. It belongs with #1638's sweep.

Both files were also missing trailing newlines; that's fixed as a side effect of the rewrite.

## Screenshots

N/A

## Code Review Summary

N/A

## Chrome DevTools MCP Verification Summary

N/A

## Quality Checks

Env templates aren't linted, type-checked, or executed. Verification is below.

- [ ] Linting passed
- [ ] Type checking passed
- [ ] Security audit passed
- [ ] No console.log statements in production code
- [ ] No unhandled promises

## Testing Instructions

1. **The dead flag really is dead** — `grep -rn "VIRTUALIZATION" .` across `*.ts/tsx/js/mjs/sh/json/md` (excluding `node_modules` and `.next`) returns nothing.
2. **Neither template is consumed by anything** — grep for `env.example` / `env.production.example` across code and CI configs returns nothing, so removing a line can't break a build step. `scripts/sync-local-env.sh` only copies `.env*.local` files, not the examples.
3. **The throw is real and the fallback is real** — read `getSiteUrl()` at `src/lib/constants/site.ts:29-52`. Note the throw is only reachable off Vercel; on Vercel `VERCEL_PROJECT_PRODUCTION_URL` short-circuits it. I did not execute a production build to watch it throw — the claim here is from reading the resolution chain, not from reproducing the failure.
4. **Local default still sensible** — with `NEXT_PUBLIC_SITE_URL` commented out, `getSiteUrl()` returns `http://localhost:$PORT`, so `npm run dev` and a local sitemap stay pointed at localhost.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed
