### PR TITLE
Write the v1.0.0 release notes and bump the package version

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,36 @@
 # Releases
 
-Narraitor is pre-1.0, so releases get tagged manually from `develop` and fast-forwarded to `main`. Each entry below covers what's in the tag, what's known to still be in flight, and what's lined up next. The full release process lives in [release-process.md](public_docs/development/release-process.md).
+Releases get tagged manually from `develop` and fast-forwarded to `main`. Each entry below covers what's in the tag, what's known to still be in flight, and what's lined up next. The full release process lives in [release-process.md](public_docs/development/release-process.md).
+
+---
+
+## v1.0.0 - 2026-08-04
+
+This is 1.0, and what makes it 1.0 is that the whole loop holds together now: describe a world, create a character who fits it, play a story that responds to what you choose, and reach an ending that reads like an ending. Narraitor started from wanting tabletop RPG sessions without coordinating four schedules, and this is the first tag where a stranger can open the app and get that without a walkthrough. The v1.0 milestone closed 60 issues across 554 commits since [v0.5.0](https://github.com/jerseycheese/narraitor/releases/tag/v0.5.0-design-system), most of them about making pieces that already existed work together in someone else's browser.
+
+**What's in this release**
+
+- Bring your own key. Generation runs on a Google Gemini key entered once under Settings, then Providers. It's encrypted in the browser and sent per request, so there's no server-held key, no account, and no sign-up ([#891](https://github.com/jerseycheese/narraitor/issues/891), [#892](https://github.com/jerseycheese/narraitor/issues/892), [#893](https://github.com/jerseycheese/narraitor/issues/893)).
+- A public front door: a landing page ([#1365](https://github.com/jerseycheese/narraitor/issues/1365)), an About page with copy that says what this actually is rather than describing a generic storyteller chatbot ([#1421](https://github.com/jerseycheese/narraitor/issues/1421)), a privacy note and terms ([#1366](https://github.com/jerseycheese/narraitor/issues/1366)), cookieless funnel analytics ([#1367](https://github.com/jerseycheese/narraitor/issues/1367)), and share metadata so a pasted link previews properly ([#1636](https://github.com/jerseycheese/narraitor/issues/1636)).
+- One design system. DS1, DS2, and DS3 collapsed down to DS3 alone under [ADR-013](https://github.com/jerseycheese/narraitor/pull/1526), which supersedes ADR-011. Light and dark is the only switch left. The legacy shadcn token layer went with it ([#1527](https://github.com/jerseycheese/narraitor/pull/1527)), theme selectors got flattened ([#1546](https://github.com/jerseycheese/narraitor/issues/1546)), and the app shell collapsed to a single chrome ([#1655](https://github.com/jerseycheese/narraitor/issues/1655)).
+- Storybook is the single canon surface ([#1488](https://github.com/jerseycheese/narraitor/issues/1488), [ADR-012](https://github.com/jerseycheese/narraitor/issues/1484)). The old `/dev/design-system` living style guide is retired, and the stories run backend-free on MSW plus store decorators.
+- The play loop got the attention it needed: inventory with generated item images, lore dedup that catches role aliases, decisions weighted Minor / Major / Critical with alignment and trust tracking, story summaries that stop retrying forever ([#1575](https://github.com/jerseycheese/narraitor/issues/1575)), epilogues that close a story instead of teasing another one ([#1578](https://github.com/jerseycheese/narraitor/issues/1578), [#1605](https://github.com/jerseycheese/narraitor/pull/1605)), lethality rebalanced so one bad roll doesn't end a run ([#1426](https://github.com/jerseycheese/narraitor/issues/1426)), and generation failures that surface instead of hanging the session ([#1429](https://github.com/jerseycheese/narraitor/issues/1429), [#1478](https://github.com/jerseycheese/narraitor/issues/1478)).
+- Less surface to maintain. The world and character template systems came out entirely ([#1454](https://github.com/jerseycheese/narraitor/issues/1454), [#1455](https://github.com/jerseycheese/narraitor/issues/1455)), archetype generation went with them, and knip, skott, and a CSS audit now run in CI so dead code doesn't pile up quietly.
+- Two QA passes fed the punch lists in [#1423](https://github.com/jerseycheese/narraitor/issues/1423)-[#1438](https://github.com/jerseycheese/narraitor/issues/1438) and [#1574](https://github.com/jerseycheese/narraitor/issues/1574)-[#1590](https://github.com/jerseycheese/narraitor/issues/1590), every one of which closed before this tag.
+
+The last four issues ahead of the tag were about docs rather than code: a README rewrite that had been advertising a template system which no longer exists ([#1637](https://github.com/jerseycheese/narraitor/issues/1637)), a correctness sweep across `public_docs` ([#1638](https://github.com/jerseycheese/narraitor/issues/1638)), an archive pass over stale branches and dead config ([#1639](https://github.com/jerseycheese/narraitor/issues/1639)), and the share metadata above. The release tracking issues are [#1320](https://github.com/jerseycheese/narraitor/issues/1320) and [#1417](https://github.com/jerseycheese/narraitor/issues/1417).
+
+**Known incomplete**
+
+The bolder DS3 redesign is deferred to v1.1. What ships here is DS3 as it landed during the collapse, which is coherent but deliberately restrained. Epic [#1543](https://github.com/jerseycheese/narraitor/issues/1543) and its children cover the real accent treatment, the dot grid, a proper type scale, drafting marks, and the brand-versus-product surface split. DESIGN.md still carries type-scale numbers from the old DS1, which [#1626](https://github.com/jerseycheese/narraitor/issues/1626) fixes once that work lands.
+
+Two accessibility gaps are known and named rather than discovered. Full keyboard control with visible focus indicators is [#276](https://github.com/jerseycheese/narraitor/issues/276), and touch targets under the 44px WCAG 2.5.5 threshold are [#1477](https://github.com/jerseycheese/narraitor/issues/1477). Both are open, both are real, and both are deferred to v1.1.
+
+There's no client-side error reporting, so a production failure in someone else's browser is invisible from here ([#1641](https://github.com/jerseycheese/narraitor/issues/1641)). Vercel Analytics is wired up for the launch funnel only and doesn't capture errors. That's a deliberate call for 1.0 rather than something that got missed.
+
+**What's next**
+
+- `v1.1` - the bolder DS3 work from [#1543](https://github.com/jerseycheese/narraitor/issues/1543), plus the two deferred accessibility items ([#276](https://github.com/jerseycheese/narraitor/issues/276), [#1477](https://github.com/jerseycheese/narraitor/issues/1477)) and error reporting ([#1641](https://github.com/jerseycheese/narraitor/issues/1641)).
 
 ---
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -24,9 +24,9 @@ The last four issues ahead of the tag were about docs rather than code: a README
 
 The bolder DS3 redesign is deferred to v1.1. What ships here is DS3 as it landed during the collapse, which is coherent but deliberately restrained. Epic [#1543](https://github.com/jerseycheese/narraitor/issues/1543) and its children cover the real accent treatment, the dot grid, a proper type scale, drafting marks, and the brand-versus-product surface split. DESIGN.md still carries type-scale numbers from the old DS1, which [#1626](https://github.com/jerseycheese/narraitor/issues/1626) fixes once that work lands.
 
-Two accessibility gaps are known and named rather than discovered. Full keyboard control with visible focus indicators is [#276](https://github.com/jerseycheese/narraitor/issues/276), and touch targets under the 44px WCAG 2.5.5 threshold are [#1477](https://github.com/jerseycheese/narraitor/issues/1477). Both are open, both are real, and both are deferred to v1.1.
+Two accessibility gaps are worth naming up front. Full keyboard control with visible focus indicators is [#276](https://github.com/jerseycheese/narraitor/issues/276), and touch targets under the 44px WCAG 2.5.5 threshold are [#1477](https://github.com/jerseycheese/narraitor/issues/1477). Both are open, both are real, and both are deferred to v1.1.
 
-There's no client-side error reporting, so a production failure in someone else's browser is invisible from here ([#1641](https://github.com/jerseycheese/narraitor/issues/1641)). Vercel Analytics is wired up for the launch funnel only and doesn't capture errors. That's a deliberate call for 1.0 rather than something that got missed.
+There's no client-side error reporting, so a production failure in someone else's browser is invisible from here ([#1641](https://github.com/jerseycheese/narraitor/issues/1641)). Vercel Analytics is wired up for the launch funnel only and doesn't capture errors. That was a deliberate call for 1.0, not an oversight.
 
 **What's next**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "narraitor",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "narraitor",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "narraitor",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/public_docs/development/release-process.md
+++ b/public_docs/development/release-process.md
@@ -10,7 +10,9 @@ Rule of thumb: if there's a clean story to tell about what's in this slice of wo
 
 ## Version naming
 
-Tags follow `vMAJOR.MINOR.PATCH[-suffix]`. Pre-1.0 the version numbers are loose — they signal scope, not a stability promise. The optional suffix is for tags that benefit from a one-word label, like `v0.4.0-pre-design-system` or `v0.5.0-design-system` (the two tags that exist so far). Skip the suffix when the version is self-explanatory, which `v1.0.0` is.
+Tags follow `vMAJOR.MINOR.PATCH[-suffix]`. The two pre-1.0 tags used loose numbers that signalled scope rather than a stability promise. The optional suffix is for tags that benefit from a one-word label, like `v0.4.0-pre-design-system` or `v0.5.0-design-system`. Skip the suffix when the version is self-explanatory, which `v1.0.0` was.
+
+`package.json` tracks the tag from 1.0.0 onward. Bump it with `npm version X.Y.Z --no-git-tag-version` in the same commit as the `RELEASES.md` entry, so the lockfile stays in sync and no stray tag gets created.
 
 ## Cutting the release
 
@@ -28,6 +30,12 @@ The process has three moving parts: write the release notes, tag the commit, and
    git pull --ff-only
    git merge --ff-only vX.Y.Z
    git push origin main
+   ```
+   The `Protected branches` ruleset covers `main` with a pull-request requirement, so this push only works because the Repository admin role is a bypass actor on that ruleset. Deletion and non-fast-forward stay blocked for everyone. If the push gets rejected, check that the bypass is still there before reaching for anything else.
+
+   From a worktree, `git checkout main` will collide with whichever checkout already has it. Push the ref directly instead:
+   ```
+   git push origin vX.Y.Z^{commit}:refs/heads/main
    ```
 4. **Publish the GitHub release.** Either paste the matching section from `RELEASES.md` or pipe it in:
    ```


### PR DESCRIPTION
## Description

Writes the `v1.0.0` section of `RELEASES.md`, which is step 1 of the four-step process in `release-process.md`. Tagging, the fast-forward to `main`, and publishing the GitHub release all happen after this merges, off the resulting `develop` HEAD.

The notes cover what shipped since `v0.5.0` (BYO-key, the public launch surfaces, the DS collapse to DS3-only, the play-loop work, the template rip-outs, the two QA punch lists), and they name what's deliberately incomplete rather than leaving it to be discovered: the bolder DS3 redesign (#1543), keyboard control (#276), sub-44px touch targets (#1477), and the absence of client-side error reporting (#1641).

Two smaller things ride along:

`package.json` has said `0.1.0` through both prior tags. It moves to 1.0.0 here via `npm version --no-git-tag-version`, and `release-process.md` now documents that the field tracks the tag from 1.0.0 onward.

`release-process.md` step 3 was wrong in two ways that would have bitten during this release. The `Protected branches` ruleset covers `main` with a pull-request requirement, so `git push origin main` gets rejected unless the Repository admin role is a bypass actor on that ruleset. And `git checkout main` collides with whichever checkout already holds it, so the doc now shows the ref-to-ref push for worktree use.

## Related Issue

Part of #1635 (the issue stays open until the tag, the fast-forward, and the GitHub release are done).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

N/A beyond the pass/coverage boxes. No source changes, so there's nothing to write a test against. The full gate gets run against the exact SHA being tagged after this merges, which is what #1635 asks for.

## User Stories Addressed

N/A. Release mechanics, not a user-facing change.

## Flow Diagrams

N/A.

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A. No components touched.

## Implementation Notes

The `RELEASES.md` section follows the `v0.5.0-design-system` shape exactly: version and date heading, framing prose, `What's in this release` bullets, `Known incomplete` as prose paragraphs, `What's next` as bullets. Links are full inline URLs the way the v0.5.0 entry does them, not bare `#NNNN` like the older v0.4.0 entry.

The file's intro line said "Narraitor is pre-1.0," which stops being true the moment this tag lands, so it's reworded.

## Screenshots

N/A.

## Code Review Summary (if applicable)

N/A.

## Chrome DevTools MCP Verification Summary (if applicable)

N/A.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit unchecked because nothing was run for it here; the diff is markdown and two version fields, with no dependency change.

## Testing Instructions

Read the `v1.0.0` section at the top of `RELEASES.md` and check the claims against the v1.0 milestone (60 closed issues) and the open v1.1 milestone. The four "known incomplete" items should each match an open issue: #1543, #276, #1477, #1641.

Confirm `package.json` and `package-lock.json` both read `1.0.0`, and that no `v1.0.0` tag was created by the version bump.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed

Comments and accessibility are N/A for a markdown and version-field diff. The accessibility gaps that exist in the product are named in the release notes rather than fixed here.
