### PR TITLE
Defer lore extraction and ending detection off the per-turn path

### DIFF
--- a/src/components/GameSession/EndingScreen.tsx
+++ b/src/components/GameSession/EndingScreen.tsx
@@ -27,8 +27,6 @@ import {
 import { Button } from '@/components/ui/button';
 import Image from 'next/image';
 import { buildStoryFromCheckpoints } from '@/lib/narrative/storyCheckpointHelpers';
-import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
-import { isStorybookEnv } from '@/lib/utils/isStorybookEnv';
 import { generateEndingImage as requestEndingImage } from '@/lib/api/endingImageApi';
 import { capitalize } from '@/lib/utils/formatters';
 
@@ -160,25 +158,10 @@ export function EndingScreen() {
     updateCurrentEnding,
   ]);
 
-  // Load ending image when ending is available (but not in Storybook or test environment)
-  useEffect(() => {
-    // Skip image generation in Storybook or test environment
-    const isStorybook = isStorybookEnv();
-    const isTest = process.env.NODE_ENV === 'test';
-    const isPlaywright = isPlaywrightEnv();
-
-    if (
-      currentEnding &&
-      !endingImage &&
-      !isGeneratingImage &&
-      !isStorybook &&
-      !isTest &&
-      !isPlaywright &&
-      generatedForEndingRef.current !== currentEnding.id
-    ) {
-      generateEndingImage();
-    }
-  }, [currentEnding, endingImage, isGeneratingImage, generateEndingImage]); // Include all dependencies
+  // Ending image generation is purely decorative and manually triggered
+  // (placeholder "Generate Image" button / error-state "Try Again") rather
+  // than auto-firing on mount — it's an extra Gemini round-trip the player
+  // hasn't asked for.
 
   // Note: Removed automatic cleanup to prevent clearing ending during development re-renders
   // The ending should be cleared manually when navigating away
@@ -359,6 +342,14 @@ export function EndingScreen() {
           >
             <div className="component-ending-screen-hero-placeholder">
               <p>Ending image</p>
+              <Button
+                onClick={generateEndingImage}
+                variant="link"
+                size="sm"
+                aria-label="Generate ending image"
+              >
+                Generate Image
+              </Button>
             </div>
             <div className="component-ending-screen-hero-overlay">
               <header className="component-ending-screen-hero-header">

--- a/src/components/GameSession/__tests__/EndingScreen.yourStory.test.tsx
+++ b/src/components/GameSession/__tests__/EndingScreen.yourStory.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { EndingScreen } from '../EndingScreen';
 import { useNarrativeStore } from '@/state/narrativeStore';
 import { useCharacterStore } from '@/state/characterStore';
@@ -8,12 +8,16 @@ import { useSessionStore } from '@/state/sessionStore';
 import { useRouter } from 'next/navigation';
 import { StoryCheckpoint } from '@/types/world-state.types';
 import { StoryEnding } from '@/types/narrative.types';
+import { generateEndingImage as requestEndingImage } from '@/lib/api/endingImageApi';
 
 jest.mock('next/navigation');
 jest.mock('@/state/narrativeStore');
 jest.mock('@/state/characterStore');
 jest.mock('@/state/worldStore');
 jest.mock('@/state/sessionStore');
+jest.mock('@/lib/api/endingImageApi');
+
+const mockRequestEndingImage = requestEndingImage as jest.MockedFunction<typeof requestEndingImage>;
 
 const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
 const mockUseNarrativeStore = useNarrativeStore as jest.MockedFunction<typeof useNarrativeStore>;
@@ -272,6 +276,31 @@ describe('EndingScreen - Your Story Section', () => {
     // Expand and check updated ARIA attributes
     fireEvent.click(button);
     expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+});
+
+// The ending image is decorative and should never auto-fire an AI call on
+// mount — only a player clicking a manual trigger requests it.
+describe('EndingScreen - Ending image is manually triggered', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequestEndingImage.mockResolvedValue({ imageUrl: 'https://example.com/ending.png' });
+  });
+
+  it('does not request an ending image on mount', () => {
+    setupStores([]);
+    render(<EndingScreen />);
+
+    expect(mockRequestEndingImage).not.toHaveBeenCalled();
+  });
+
+  it('requests an ending image when the placeholder button is clicked', async () => {
+    setupStores([]);
+    render(<EndingScreen />);
+
+    fireEvent.click(screen.getByRole('button', { name: /generate ending image/i }));
+
+    await waitFor(() => expect(mockRequestEndingImage).toHaveBeenCalledTimes(1));
   });
 });
 

--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -496,8 +496,10 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
         onNarrativeGenerated(newSegment);
       }
 
-      // Check for ending indicators
-      await checkForEndingIndicators(newSegment);
+      // Check for ending indicators. Deferred off the per-turn path: it's
+      // an extra Gemini round-trip that only feeds onEndingSuggested, which
+      // choice generation below doesn't wait on.
+      void checkForEndingIndicators(newSegment);
 
       // Generate choices if enabled - skip when this segment already ends the session
       if (generateChoices && !isSessionEndingSegment(newSegment)) {
@@ -767,8 +769,10 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
         );
       }
 
-      // Check for ending indicators
-      await checkForEndingIndicators(newSegment);
+      // Check for ending indicators. Deferred off the per-turn path: it's
+      // an extra Gemini round-trip that only feeds onEndingSuggested, which
+      // choice generation below doesn't wait on.
+      void checkForEndingIndicators(newSegment);
 
       // Generate choices if enabled - skip when the session is ending
       // (fatal/ending segment or a fatal critical-decision failure).

--- a/src/lib/ai/__tests__/narrativeGenerator.skillContext.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.skillContext.test.ts
@@ -129,4 +129,62 @@ describe('NarrativeGenerator - Skill Context Integration', () => {
     expect(typeof calledPrompt).toBe('string');
     expect(calledPrompt.length).toBeGreaterThan(0);
   });
+
+  // Lore extraction is a full extra Gemini round-trip that only enriches
+  // later prompts — generateSegment must not block on it.
+  test('resolves before lore extraction settles, then stores lore once it does', async () => {
+    const mockResponse = {
+      content: 'You press onward through the fog.',
+      finishReason: 'stop' as const,
+      promptTokens: 50,
+      completionTokens: 50
+    };
+    mockAIClient.generateContent.mockResolvedValue(mockResponse);
+
+    let resolveLoreExtraction: (value: {
+      characters: never[];
+      locations: never[];
+      events: never[];
+      rules: never[];
+    }) => void = () => {};
+    (extractStructuredLore as jest.Mock).mockReturnValue(
+      new Promise((resolve) => {
+        resolveLoreExtraction = resolve;
+      })
+    );
+
+    const addStructuredLore = jest.fn();
+    (useLoreStore.getState as jest.Mock).mockReturnValue({
+      getLoreContext: jest.fn().mockReturnValue({ factIds: [] }),
+      recordLoreMentions: jest.fn(),
+      recordLoreUsage: jest.fn(),
+      addStructuredLore
+    });
+
+    await narrativeGenerator.generateSegment({
+      worldId: 'skill-world',
+      sessionId: 'session-1',
+      characterIds: ['char-1'],
+      narrativeContext: {
+        worldId: 'skill-world',
+        currentSceneId: 'scene-4',
+        characterIds: ['char-1'],
+        sessionId: 'session-1',
+        previousSegments: [],
+        currentTags: []
+      }
+    });
+
+    // The segment resolved even though lore extraction is still pending.
+    expect(addStructuredLore).not.toHaveBeenCalled();
+
+    resolveLoreExtraction({ characters: [], locations: [], events: [], rules: [] });
+    // Flush the microtask queue so the deferred .then() chain (which
+    // includes an `await import(...)`) has a chance to run.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(addStructuredLore).toHaveBeenCalled();
+  });
 });

--- a/src/lib/ai/narrativeGenerator.ts
+++ b/src/lib/ai/narrativeGenerator.ts
@@ -179,47 +179,46 @@ export class NarrativeGenerator {
       throwIfAborted(options?.signal);
 
       // Lore extraction runs on the final (possibly corrected) prose so a
-      // contradicted draft never pollutes the lore store.
+      // contradicted draft never pollutes the lore store. Deferred off the
+      // per-turn path — it's a full extra Gemini round-trip that only
+      // enriches later prompts, nothing in this turn's UI reads it.
       if (result.content) {
-        try {
-          if (process.env.NODE_ENV !== 'production') {
-            logger.info('[NarrativeGenerator] EXTRACTION: Post-segment', {
-              worldId: request.worldId,
-              sessionId: request.sessionId,
-              contentLength: result.content.length,
-            });
-          }
-
-          const existingLoreContext = getLoreContextForPrompt(request.worldId, request.sessionId, {
-            recordUsage: false,
+        if (process.env.NODE_ENV !== 'production') {
+          logger.info('[NarrativeGenerator] EXTRACTION: Post-segment', {
+            worldId: request.worldId,
+            sessionId: request.sessionId,
+            contentLength: result.content.length,
           });
-          const structuredLore = await extractStructuredLore(
-            result.content,
-            existingLoreContext
-          );
-
-          const { useLoreStore } = await import('@/state/loreStore');
-          const { addStructuredLore } = useLoreStore.getState();
-          addStructuredLore(structuredLore, request.worldId, request.sessionId);
-
-          if (process.env.NODE_ENV !== 'production') {
-            logger.info('[NarrativeGenerator] Extracted and stored lore:', {
-              worldId: request.worldId,
-              sessionId: request.sessionId,
-              factCount:
-                structuredLore.characters.length +
-                structuredLore.locations.length +
-                structuredLore.events.length +
-                structuredLore.rules.length,
-              characters: structuredLore.characters.map((c) => c.name),
-              locations: structuredLore.locations.map((l) => l.name),
-              events: structuredLore.events.length,
-              rules: structuredLore.rules.length,
-            });
-          }
-        } catch (error) {
-          logger.error('[NarrativeGenerator] Failed to extract lore:', error);
         }
+
+        const existingLoreContext = getLoreContextForPrompt(request.worldId, request.sessionId, {
+          recordUsage: false,
+        });
+        void extractStructuredLore(result.content, existingLoreContext)
+          .then(async (structuredLore) => {
+            const { useLoreStore } = await import('@/state/loreStore');
+            const { addStructuredLore } = useLoreStore.getState();
+            addStructuredLore(structuredLore, request.worldId, request.sessionId);
+
+            if (process.env.NODE_ENV !== 'production') {
+              logger.info('[NarrativeGenerator] Extracted and stored lore:', {
+                worldId: request.worldId,
+                sessionId: request.sessionId,
+                factCount:
+                  structuredLore.characters.length +
+                  structuredLore.locations.length +
+                  structuredLore.events.length +
+                  structuredLore.rules.length,
+                characters: structuredLore.characters.map((c) => c.name),
+                locations: structuredLore.locations.map((l) => l.name),
+                events: structuredLore.events.length,
+                rules: structuredLore.rules.length,
+              });
+            }
+          })
+          .catch((error) => {
+            logger.error('[NarrativeGenerator] Failed to extract lore:', error);
+          });
       }
 
       if (
@@ -404,52 +403,50 @@ export class NarrativeGenerator {
       throwIfAborted(options?.signal);
       recordRequestCalibration(budget, fullyEnhancedPrompt, response);
 
+      // Deferred off the per-turn path, same as generateSegment above.
       if (response.content) {
-        try {
-          if (process.env.NODE_ENV !== 'production') {
-            logger.info('[NarrativeGenerator] EXTRACTION: Initial scene', {
-              worldId,
-              sessionId,
-              contentLength: response.content.length,
-            });
-          }
-
-          const existingLoreContext = getLoreContextForPrompt(worldId, sessionId, {
-            recordUsage: false,
+        if (process.env.NODE_ENV !== 'production') {
+          logger.info('[NarrativeGenerator] EXTRACTION: Initial scene', {
+            worldId,
+            sessionId,
+            contentLength: response.content.length,
           });
-          const structuredLore = await extractStructuredLore(
-            response.content,
-            existingLoreContext
-          );
-
-          const { useLoreStore } = await import('@/state/loreStore');
-          const { addStructuredLore } = useLoreStore.getState();
-          addStructuredLore(structuredLore, worldId, sessionId);
-
-          if (process.env.NODE_ENV !== 'production') {
-            logger.info(
-              '[NarrativeGenerator] Extracted and stored lore from initial scene:',
-              {
-                worldId,
-                sessionId,
-                factCount:
-                  structuredLore.characters.length +
-                  structuredLore.locations.length +
-                  structuredLore.events.length +
-                  structuredLore.rules.length,
-                characters: structuredLore.characters.map((c) => c.name),
-                locations: structuredLore.locations.map((l) => l.name),
-                events: structuredLore.events.length,
-                rules: structuredLore.rules.length,
-              }
-            );
-          }
-        } catch (error) {
-          logger.error(
-            '[NarrativeGenerator] Failed to extract lore from initial scene:',
-            error
-          );
         }
+
+        const existingLoreContext = getLoreContextForPrompt(worldId, sessionId, {
+          recordUsage: false,
+        });
+        void extractStructuredLore(response.content, existingLoreContext)
+          .then(async (structuredLore) => {
+            const { useLoreStore } = await import('@/state/loreStore');
+            const { addStructuredLore } = useLoreStore.getState();
+            addStructuredLore(structuredLore, worldId, sessionId);
+
+            if (process.env.NODE_ENV !== 'production') {
+              logger.info(
+                '[NarrativeGenerator] Extracted and stored lore from initial scene:',
+                {
+                  worldId,
+                  sessionId,
+                  factCount:
+                    structuredLore.characters.length +
+                    structuredLore.locations.length +
+                    structuredLore.events.length +
+                    structuredLore.rules.length,
+                  characters: structuredLore.characters.map((c) => c.name),
+                  locations: structuredLore.locations.map((l) => l.name),
+                  events: structuredLore.events.length,
+                  rules: structuredLore.rules.length,
+                }
+              );
+            }
+          })
+          .catch((error) => {
+            logger.error(
+              '[NarrativeGenerator] Failed to extract lore from initial scene:',
+              error
+            );
+          });
       }
 
       let result = await formatNarrativeResponse(


### PR DESCRIPTION
## Description
Four calls were awaited inline on the per-turn narrative path even though two of them don't need to be there. Structured lore extraction (`narrativeGenerator.ts`, both `generateSegment` and `generateInitialScene`) is a full extra Gemini round-trip that only enriches later prompts — nothing in the current turn's UI reads it. Ending detection (`NarrativeController.tsx`, both the initial-narrative and regular-turn paths) blocks choice generation even though choice generation doesn't actually wait on its result. Both now fire-and-forget with `void ...then().catch()`, matching the pattern already used for goal extraction and journal summaries elsewhere in the store layer.

Also dropped the ending-image auto-fire on `EndingScreen` mount. It wasn't blocking render (the rest of the page — epilogue, legacy, achievements — already renders while the image loads), but it was spending an AI call the player never asked for just by landing on the ending screen. Added a manual "Generate Image" trigger to the placeholder state, alongside the error-state "Try Again" button that already existed.

Left the event-significance validator alone — it's already off the render path via `void` in `narrativeStore.segments.ts`, and folding it into the main prompt is a bigger, separate change per the issue.

## Related Issue
Closes #1586

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — internal performance change, no user-facing behavior change other than the ending image no longer generating itself unprompted.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A — no new components; the ending-image placeholder button reuses the existing `Button` component and styling already used by the error-state retry button.

## Implementation Notes
- `narrativeGenerator.ts`: both lore-extraction call sites (`generateSegment`, `generateInitialScene`) changed from `await extractStructuredLore(...)` inside a try/catch to `void extractStructuredLore(...).then(...).catch(...)`. The call itself still happens synchronously (so existing tests asserting `toHaveBeenCalledWith` are unaffected) — only the store write and logging move into the `.then()`.
- `NarrativeController.tsx`: both `await checkForEndingIndicators(newSegment)` call sites changed to `void checkForEndingIndicators(newSegment)`. The hook already handles its own errors internally and the choice-generation gate that follows depends on `isSessionEndingSegment`/fatal-tag metadata, not on this call's result, so nothing downstream needed to change.
- `EndingScreen.tsx`: removed the `useEffect` that auto-fired `generateEndingImage()` on mount (and the now-unused Storybook/test/Playwright env guards that existed only to suppress it in those environments). Added a "Generate Image" button to the placeholder (no-image-yet) hero state.
- Added a regression test in `narrativeGenerator.skillContext.test.ts` proving `generateSegment` resolves before a pending lore-extraction promise settles, and that lore is stored once it does. Added two tests in `EndingScreen.yourStory.test.tsx` proving no image request fires on mount, and that clicking the new button does request one.

## Screenshots
N/A — the only visual change is a small "Generate Image" text button in the ending-screen placeholder state, matching the existing "Try Again" link-style button next to it.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A — this is a non-visual timing change with no rendered surface to smoke-test beyond the ending-screen placeholder button covered by tests above.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm test` — full suite (365 suites / 2406 tests) passes.
2. `npm run type-check` and `npm run lint` — both clean.
3. `npm run deps:validate` — clean (no new cross-domain boundary issues).
4. Manually: play a turn and confirm narrative/choices still appear normally (lore/ending-detection deferral is invisible from the UI). Reach the ending screen and confirm no image request fires until the new "Generate Image" button is clicked.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
