### PR TITLE
ci: add a gating internal-link checker and an advisory symbol-resolution prototype

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,39 @@ jobs:
       - name: Run CSS audit
         run: npm run audit:css
 
+  docs-check:
+    name: Docs Check
+    runs-on: ubuntu-latest
+    needs: [setup]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Restore node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-modules-
+
+      # Blocking: a relative link or anchor either resolves or it doesn't --
+      # no judgment call, so unlike the symbol check below it's safe to gate
+      # (#1651, follow-up to the #1638 docs correctness sweep).
+      - name: Check internal doc links
+        run: npm run docs:check-links
+
+      # Advisory prototype, not a gate: whether a backticked span is a code
+      # reference or plain English is a judgment call, so this exits 0 on
+      # findings (same failure ergonomics as `audit-css` above) and prints a
+      # worklist instead. Review the output and expand the tolerance list in
+      # scripts/check-docs-symbols.mjs as false positives show up.
+      - name: Check doc symbol references (advisory)
+        run: npm run docs:check-symbols
+
   test:
     name: Unit & Integration Tests
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "lint:css": "stylelint \"**/*.css\"",
     "lint:css:fix": "stylelint \"**/*.css\" --fix",
     "audit:css": "node scripts/audit-css.mjs",
+  "docs:check-links": "node scripts/check-docs-links.js",
+  "docs:check-symbols": "node scripts/check-docs-symbols.mjs",
     "validate:routes": "node scripts/validate-routes.js",
     "type-check": "tsc --noEmit",
     "knip": "knip --no-config-hints",

--- a/scripts/__tests__/docs-link-checker.test.js
+++ b/scripts/__tests__/docs-link-checker.test.js
@@ -34,6 +34,11 @@ describe('extractHeadingSlugs', () => {
       new Set(['real-heading'])
     );
   });
+
+  it('suffixes repeated headings the way GitHub does (-1, -2, ...)', () => {
+    const content = '## Usage\n\ntext\n\n## Usage\n\nmore text\n\n## Usage\n';
+    expect(extractHeadingSlugs(content)).toEqual(new Set(['usage', 'usage-1', 'usage-2']));
+  });
 });
 
 describe('findBrokenLinks', () => {
@@ -94,5 +99,25 @@ describe('findBrokenLinks', () => {
     const content = '![alt text](missing.png)';
     const broken = findBrokenLinks(content, fakeFs(), '/docs/self.md');
     expect(broken).toEqual([{ target: 'missing.png', reason: 'target does not exist' }]);
+  });
+
+  it('resolves a link with a title, ignoring the title text', () => {
+    const content = '[see this](exists.md "read more")';
+    expect(findBrokenLinks(content, fakeFs(), '/docs/self.md')).toEqual([]);
+  });
+
+  it('flags a broken link even when it carries a title', () => {
+    const content = "[broken](missing.md 'read more')";
+    const broken = findBrokenLinks(content, fakeFs(), '/docs/self.md');
+    expect(broken).toEqual([{ target: "missing.md 'read more'", reason: 'target does not exist' }]);
+  });
+
+  it('resolves an anchor into the second occurrence of a repeated heading', () => {
+    const broken = findBrokenLinks(
+      '[jump](target.md#usage-1)',
+      fakeFs({ headings: new Set(['usage', 'usage-1']) }),
+      '/docs/self.md'
+    );
+    expect(broken).toEqual([]);
   });
 });

--- a/scripts/__tests__/docs-link-checker.test.js
+++ b/scripts/__tests__/docs-link-checker.test.js
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for the pure doc-link-checking logic (issue #1651). Fixture-based
+ * and deterministic -- no real fs, so it stays green in CI.
+ */
+
+import { slugify, extractHeadingSlugs, findBrokenLinks } from '../docs-link-checker.js';
+
+describe('slugify', () => {
+  it('lowercases and hyphenates a plain heading', () => {
+    expect(slugify('Getting Started')).toBe('getting-started');
+  });
+
+  it('strips punctuation GitHub would also strip', () => {
+    expect(slugify('What is Narraitor?')).toBe('what-is-narraitor');
+  });
+
+  it('keeps existing hyphens', () => {
+    expect(slugify('ADR-013: Collapse to DS3')).toBe('adr-013-collapse-to-ds3');
+  });
+});
+
+describe('extractHeadingSlugs', () => {
+  it('collects every heading level as a slug', () => {
+    const content = '# Title\n\nSome text.\n\n## A Section\n\n### A Subsection\n';
+    expect(extractHeadingSlugs(content)).toEqual(
+      new Set(['title', 'a-section', 'a-subsection'])
+    );
+  });
+
+  it('ignores non-heading lines', () => {
+    expect(extractHeadingSlugs('Not a heading\n# Real Heading')).toEqual(
+      new Set(['real-heading'])
+    );
+  });
+});
+
+describe('findBrokenLinks', () => {
+  // A minimal fs stub: only /docs/exists.md and /docs/target.md "exist".
+  function fakeFs({ headings = new Set() } = {}) {
+    const existing = new Set(['/docs/exists.md', '/docs/target.md', '/docs/self.md']);
+    return {
+      exists: (p) => existing.has(p),
+      isMarkdownFile: (p) => p.endsWith('.md') && existing.has(p),
+      headingSlugs: () => headings,
+      resolve: (fromFile, target) =>
+        target.startsWith('/') ? target : `/docs/${target.replace(/^\.\//, '')}`,
+    };
+  }
+
+  it('passes a link to a file that exists', () => {
+    const content = '[see this](exists.md)';
+    expect(findBrokenLinks(content, fakeFs(), '/docs/self.md')).toEqual([]);
+  });
+
+  it('flags a link to a file that does not exist', () => {
+    const content = '[broken](missing.md)';
+    const broken = findBrokenLinks(content, fakeFs(), '/docs/self.md');
+    expect(broken).toEqual([{ target: 'missing.md', reason: 'target does not exist' }]);
+  });
+
+  it('flags an anchor with no matching heading', () => {
+    const content = '[jump](target.md#nope)';
+    const broken = findBrokenLinks(content, fakeFs({ headings: new Set(['real-heading']) }), '/docs/self.md');
+    expect(broken).toEqual([
+      { target: 'target.md#nope', reason: 'no heading matches anchor "#nope"' },
+    ]);
+  });
+
+  it('passes an anchor that matches a heading', () => {
+    const content = '[jump](target.md#real-heading)';
+    const broken = findBrokenLinks(content, fakeFs({ headings: new Set(['real-heading']) }), '/docs/self.md');
+    expect(broken).toEqual([]);
+  });
+
+  it('resolves a bare #anchor against the doc itself', () => {
+    const content = '[jump](#real-heading)';
+    const broken = findBrokenLinks(content, fakeFs({ headings: new Set(['real-heading']) }), '/docs/self.md');
+    expect(broken).toEqual([]);
+  });
+
+  it('ignores absolute URLs', () => {
+    const content = '[external](https://example.com/nope)';
+    expect(findBrokenLinks(content, fakeFs(), '/docs/self.md')).toEqual([]);
+  });
+
+  it('ignores links inside fenced code blocks', () => {
+    const content = '```md\n[example](missing.md)\n```';
+    expect(findBrokenLinks(content, fakeFs(), '/docs/self.md')).toEqual([]);
+  });
+
+  it('checks image targets the same as links', () => {
+    const content = '![alt text](missing.png)';
+    const broken = findBrokenLinks(content, fakeFs(), '/docs/self.md');
+    expect(broken).toEqual([{ target: 'missing.png', reason: 'target does not exist' }]);
+  });
+});

--- a/scripts/check-docs-links.js
+++ b/scripts/check-docs-links.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+/**
+ * Internal doc link checker -- CLI (issue #1651).
+ *
+ * Checks every relative markdown link and in-page anchor reachable from
+ * `public_docs/` and the root docs (README.md, DESIGN.md, PRODUCT.md,
+ * RELEASES.md, CLAUDE.md), and fails if any target doesn't resolve.
+ *
+ * What it checks:
+ *  - Relative link/image targets (`[text](path)`, `![alt](path)`) resolve to
+ *    a file or directory on disk.
+ *  - `#anchor` targets (bare, or appended to a relative path) resolve to a
+ *    heading in the target markdown file, using GitHub's heading-slug rules.
+ *
+ * What it skips:
+ *  - Absolute URLs (anything with a `scheme:` prefix, e.g. `https://`).
+ *  - Fenced code blocks, since docs often show link syntax as an example
+ *    rather than a real link.
+ *
+ * Exit codes: 0 = all links resolve, 1 = broken links found.
+ * The pure logic lives in ./docs-link-checker.js (unit-tested in isolation).
+ *
+ * Run: npm run docs:check-links
+ */
+
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { glob } from 'glob';
+import { findBrokenLinks, extractHeadingSlugs } from './docs-link-checker.js';
+
+const REPO_ROOT = process.cwd();
+const DOC_GLOBS = ['public_docs/**/*.md', '*.md'];
+
+async function findDocs() {
+  const files = await glob(DOC_GLOBS, {
+    cwd: REPO_ROOT,
+    nodir: true,
+    ignore: ['node_modules/**'],
+  });
+  return files.sort();
+}
+
+function makeFsAdapter() {
+  const slugCache = new Map();
+  return {
+    exists: (absPath) => existsSync(absPath),
+    isMarkdownFile: (absPath) =>
+      absPath.endsWith('.md') && existsSync(absPath) && statSync(absPath).isFile(),
+    headingSlugs: (absPath) => {
+      if (!slugCache.has(absPath)) {
+        slugCache.set(absPath, extractHeadingSlugs(readFileSync(absPath, 'utf8')));
+      }
+      return slugCache.get(absPath);
+    },
+    resolve: (fromFile, relativeTarget) => path.resolve(path.dirname(fromFile), relativeTarget),
+  };
+}
+
+async function main() {
+  const docs = await findDocs();
+  const fs = makeFsAdapter();
+  let brokenCount = 0;
+
+  for (const relPath of docs) {
+    const absPath = path.join(REPO_ROOT, relPath);
+    const content = readFileSync(absPath, 'utf8');
+    const broken = findBrokenLinks(content, fs, absPath);
+    if (broken.length === 0) continue;
+
+    brokenCount += broken.length;
+    console.error(`\n${relPath}`);
+    for (const { target, reason } of broken) {
+      console.error(`  broken link "${target}" -- ${reason}`);
+    }
+  }
+
+  if (brokenCount > 0) {
+    console.error(`\n${brokenCount} broken link(s) across ${docs.length} doc(s) checked.`);
+    process.exit(1);
+  }
+
+  console.log(`docs:check-links: ${docs.length} doc(s) checked, no broken links.`);
+}
+
+main();

--- a/scripts/check-docs-symbols.mjs
+++ b/scripts/check-docs-symbols.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+// Doc symbol-resolution PROTOTYPE (issue #1651, part 2 of the docs-check pair).
+//
+// The link checker (scripts/check-docs-links.mjs) catches broken paths and
+// anchors, but not the defect that actually mattered in the #1638 sweep: docs
+// that confidently describe a type, hook, or file that doesn't exist in
+// `src/` anymore (or never did) -- e.g. `api/types-reference.md` documenting
+// ten types that were never real. This is a first pass at automating that.
+//
+// Deliberately ADVISORY, not gating (unlike check-docs-links.mjs): telling
+// code references apart from plain English inside backticks is a judgment
+// call, so this is a warn-only report, same failure ergonomics as
+// scripts/audit-css.mjs -- it never fails CI, only prints a worklist for
+// human review. Promoting it to a gate is a possible follow-up once the
+// tolerance list has proven itself against real docs.
+//
+// Approach: regex-extract every top-level `export` declaration under `src/`
+// into a symbol table, then scan backticked spans in `public_docs/` for
+// things that *look like* code references (PascalCase types, `camelCase()`
+// calls, `useThing` hooks, or `src/...`-style paths) and flag any that don't
+// resolve. Plain English backticked words (most of them) never match these
+// shapes and are left alone.
+//
+// Run: npm run docs:check-symbols
+
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { glob } from 'glob';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+
+const EXPORT_DECL_RE =
+  /export\s+(?:default\s+)?(?:abstract\s+)?(?:class|interface|type|enum|function)\s+([A-Za-z_$][\w$]*)/g;
+const EXPORT_VAR_RE = /export\s+(?:const|let|var)\s+([A-Za-z_$][\w$]*)/g;
+const EXPORT_LIST_RE = /export\s+\{([^}]+)\}/g;
+// The dominant component pattern here is `function Foo() {...}` declared
+// earlier in the file, then `export default Foo;` at the bottom -- catch the
+// bare-identifier default export too, not just `export default function Foo`.
+const EXPORT_DEFAULT_IDENT_RE = /export\s+default\s+([A-Za-z_$][\w$]*)\s*;/g;
+
+// Common built-ins and generic type params that read as PascalCase/camelCase
+// but were never going to be exported from src/. Keeps the report focused on
+// genuine drift instead of noise -- expand as real false positives show up.
+const TOLERANCE = new Set([
+  'T', 'K', 'V', 'U', 'E', 'P', 'S',
+  'Promise', 'Array', 'Map', 'Set', 'Date', 'Error', 'JSON', 'Object',
+  'String', 'Number', 'Boolean', 'RegExp', 'Function', 'Infinity', 'NaN',
+  'React', 'ReactNode', 'ReactElement', 'JSX', 'HTMLElement', 'HTMLDivElement',
+  'Record', 'Partial', 'Required', 'Readonly', 'Omit', 'Pick',
+  'useEffect', 'useState', 'useMemo', 'useCallback', 'useRef', 'useContext', 'useReducer',
+  // CSS/env, not project symbols, but shaped like a call/identifier.
+  'var', 'NODE_ENV',
+]);
+
+const CODE_DIR_PREFIXES = ['src/', 'public_docs/', 'scripts/', '.github/'];
+
+function extractExports(sourceDir) {
+  const names = new Set();
+  const files = glob.sync('**/*.{ts,tsx}', {
+    cwd: sourceDir,
+    ignore: ['**/*.test.*', '**/*.stories.*', '**/__tests__/**'],
+    absolute: true,
+  });
+
+  for (const file of files) {
+    const content = readFileSync(file, 'utf8');
+    for (const re of [EXPORT_DECL_RE, EXPORT_VAR_RE, EXPORT_DEFAULT_IDENT_RE]) {
+      for (const match of content.matchAll(re)) names.add(match[1]);
+    }
+    for (const match of content.matchAll(EXPORT_LIST_RE)) {
+      for (const entry of match[1].split(',')) {
+        const name = entry.trim().split(/\s+as\s+/).pop().trim();
+        if (/^[A-Za-z_$][\w$]*$/.test(name)) names.add(name);
+      }
+    }
+  }
+  return names;
+}
+
+function extractBacktickSpans(content) {
+  const withoutFences = content.replace(/```[\s\S]*?```/g, (block) => block.replace(/[^\n]/g, ' '));
+  const spans = [];
+  for (const match of withoutFences.matchAll(/`([^`\n]+)`/g)) spans.push(match[1]);
+  return spans;
+}
+
+function classify(span) {
+  if (span.includes('/')) {
+    const looksLikeRepoPath = CODE_DIR_PREFIXES.some((prefix) => span.startsWith(prefix));
+    return looksLikeRepoPath ? { kind: 'path', value: span } : null;
+  }
+  const call = /^([a-z][\w$]*)\(\)$/.exec(span);
+  if (call) return { kind: 'symbol', value: call[1] };
+
+  const type = /^([A-Z][\w$]*)(<[^`]*>)?$/.exec(span);
+  if (type) return { kind: 'symbol', value: type[1] };
+
+  const hook = /^(use[A-Z][\w$]*)$/.exec(span);
+  if (hook) return { kind: 'symbol', value: hook[1] };
+
+  return null;
+}
+
+async function main() {
+  const exportedNames = extractExports(path.join(rootDir, 'src'));
+  const docFiles = (
+    await glob('public_docs/**/*.md', { cwd: rootDir, ignore: ['node_modules/**'] })
+  ).sort();
+
+  let flaggedCount = 0;
+
+  for (const relPath of docFiles) {
+    const content = readFileSync(path.join(rootDir, relPath), 'utf8');
+    const flagged = [];
+    const seen = new Set();
+
+    for (const span of extractBacktickSpans(content)) {
+      const ref = classify(span);
+      if (!ref || seen.has(span)) continue;
+
+      if (ref.kind === 'symbol') {
+        if (TOLERANCE.has(ref.value) || exportedNames.has(ref.value)) continue;
+        flagged.push(`\`${span}\` -- no export named "${ref.value}" found in src/`);
+      } else if (ref.kind === 'path') {
+        if (existsSync(path.join(rootDir, ref.value))) continue;
+        flagged.push(`\`${span}\` -- path does not exist`);
+      }
+      seen.add(span);
+    }
+
+    if (flagged.length === 0) continue;
+    flaggedCount += flagged.length;
+    console.log(`\n${relPath}`);
+    for (const line of flagged) console.log(`  ${line}`);
+  }
+
+  console.log(
+    `\ndocs:check-symbols (advisory): ${docFiles.length} doc(s) scanned, ${flaggedCount} unresolved reference(s).`,
+  );
+  console.log('Review manually -- this is a prototype and does not fail CI. False positives go in TOLERANCE.');
+}
+
+main();

--- a/scripts/docs-link-checker.js
+++ b/scripts/docs-link-checker.js
@@ -29,14 +29,37 @@ export function slugify(heading) {
     .replace(/\s+/g, '-');
 }
 
-/** Extract the set of heading-derived anchor slugs from markdown content. */
+/**
+ * Extract the set of heading-derived anchor slugs from markdown content.
+ *
+ * GitHub suffixes repeated headings with `-1`, `-2`, ... (first occurrence
+ * keeps the bare slug), so duplicate headings must be counted, not just
+ * collected into a Set of unique slugs.
+ */
 export function extractHeadingSlugs(content) {
+  const counts = new Map();
   const slugs = new Set();
   for (const line of content.split('\n')) {
     const match = /^#{1,6}\s+(.+)$/.exec(line);
-    if (match) slugs.add(slugify(match[1]));
+    if (!match) continue;
+    const base = slugify(match[1]);
+    const count = counts.get(base) ?? 0;
+    counts.set(base, count + 1);
+    slugs.add(count === 0 ? base : `${base}-${count}`);
   }
   return slugs;
+}
+
+/**
+ * Split a markdown link target into its href and an optional title, e.g.
+ * `target.md "read more"` -> `{ href: 'target.md', title: 'read more' }`.
+ * GitHub (and the spec) treats the quoted suffix as a title, not part of the
+ * path -- checking the raw string as a path would look for a file literally
+ * named "target.md \"read more\"".
+ */
+function splitLinkTitle(target) {
+  const match = /^(\S+)\s+(?:"[^"]*"|'[^']*'|\([^)]*\))$/.exec(target);
+  return match ? match[1] : target;
 }
 
 /**
@@ -60,7 +83,8 @@ export function findBrokenLinks(content, fs, selfPath) {
     const target = match[1].trim();
     if (!target || SCHEME_RE.test(target) || target.startsWith('mailto:')) continue;
 
-    const [rawPath, anchor] = target.split('#');
+    const href = splitLinkTitle(target);
+    const [rawPath, anchor] = href.split('#');
     const targetPath = rawPath ? fs.resolve(selfPath, rawPath) : selfPath;
 
     if (rawPath && !fs.exists(targetPath)) {

--- a/scripts/docs-link-checker.js
+++ b/scripts/docs-link-checker.js
@@ -1,0 +1,80 @@
+/**
+ * Internal doc link checker -- pure logic (issue #1651).
+ *
+ * Walks every relative markdown link (and in-page anchor) in a doc's content
+ * and reports any that don't resolve. This is the automated version of the
+ * manual link walk from the #1638 correctness sweep -- that sweep found real
+ * drift and had no way to re-run itself, so nothing caught the next round of
+ * rot. This does.
+ *
+ * Deliberately gating (unlike scripts/audit-css.mjs): a broken relative link
+ * or anchor is unambiguous -- there's no judgment call and no false-positive
+ * risk the way there is with "unused" CSS selectors, so it's safe to block CI.
+ *
+ * Fixture-based and deterministic -- no fs, no live codebase scan, so it
+ * stays green in CI. The CLI wrapper (./check-docs-links.js) supplies real
+ * filesystem access.
+ */
+
+const LINK_RE = /!?\[[^\]]*\]\(([^)]+)\)/g;
+const SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+const FENCE_RE = /```[\s\S]*?```/g;
+
+/** GitHub's heading-to-anchor-slug algorithm. */
+export function slugify(heading) {
+  return heading
+    .trim()
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-');
+}
+
+/** Extract the set of heading-derived anchor slugs from markdown content. */
+export function extractHeadingSlugs(content) {
+  const slugs = new Set();
+  for (const line of content.split('\n')) {
+    const match = /^#{1,6}\s+(.+)$/.exec(line);
+    if (match) slugs.add(slugify(match[1]));
+  }
+  return slugs;
+}
+
+/**
+ * Find broken links in a doc's markdown content.
+ *
+ * @param {string} content - the raw markdown source.
+ * @param {object} fs - injected filesystem access, so this stays pure/testable:
+ *   - exists(absPath): boolean
+ *   - isMarkdownFile(absPath): boolean -- true if absPath is a real .md file
+ *   - headingSlugs(absPath): Set<string> -- anchor slugs for that file
+ *   - resolve(fromContentPath, relativeTarget): string -- resolves a link
+ *     target to an absolute path
+ * @param {string} selfPath - absolute path of the doc being checked, used to
+ *   resolve bare `#anchor` links against itself.
+ */
+export function findBrokenLinks(content, fs, selfPath) {
+  const stripped = content.replace(FENCE_RE, (block) => block.replace(/[^\n]/g, ' '));
+  const broken = [];
+
+  for (const match of stripped.matchAll(LINK_RE)) {
+    const target = match[1].trim();
+    if (!target || SCHEME_RE.test(target) || target.startsWith('mailto:')) continue;
+
+    const [rawPath, anchor] = target.split('#');
+    const targetPath = rawPath ? fs.resolve(selfPath, rawPath) : selfPath;
+
+    if (rawPath && !fs.exists(targetPath)) {
+      broken.push({ target, reason: 'target does not exist' });
+      continue;
+    }
+
+    if (anchor !== undefined && fs.isMarkdownFile(targetPath)) {
+      const slugs = fs.headingSlugs(targetPath);
+      if (!slugs.has(slugify(decodeURIComponent(anchor)))) {
+        broken.push({ target, reason: `no heading matches anchor "#${anchor}"` });
+      }
+    }
+  }
+
+  return broken;
+}


### PR DESCRIPTION
## Description
CI never reads the docs. The #1638 correctness sweep found six real defects in `public_docs/` with 18/18 green checks — a review bot caught them, not the pipeline, and none of the sweep's four manual verification passes could re-run itself.

This adds the two checks the issue scoped:

- **Link checker (gating).** `scripts/check-docs-links.js` walks every relative markdown link and anchor in `public_docs/` and the root docs, and fails CI if any target doesn't resolve. Safe to gate — a broken link is unambiguous, no judgment call involved. Pure logic lives in `docs-link-checker.js` and is unit tested.
- **Symbol resolution (advisory prototype).** `scripts/check-docs-symbols.mjs` extracts exported names from `src/` and flags backticked doc references (PascalCase types, `camelCase()` calls, hook names, repo paths) that don't resolve. Warn-only, same failure ergonomics as `audit-css.mjs` — telling a code reference apart from plain English is a judgment call, so it reports rather than gates. Ships with a small tolerance list for the obvious false positives (generics, JS/React builtins); expect that list to grow as it runs against real docs.

Both run in a new `Docs Check` CI job, same shape as the existing CSS-audit and Knip jobs.

## Related Issue
Related to #1651 (targets `develop`, not the default branch, so this won't auto-close — closing it is handled post-merge)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement
<!-- Closest fit: this is CI tooling, not app code -- it adds automated checks over the existing docs. -->

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved
<!-- The gating link checker (docs-link-checker.js) is unit tested with fixtures. The advisory symbol prototype (check-docs-symbols.mjs) follows the existing audit-css.mjs precedent, which also ships untested -- it's a report generator, not gating logic. -->

## User Stories Addressed
N/A -- CI tooling, not a user-facing feature.

## Flow Diagrams
N/A

## Component Development
N/A -- no UI changes.

## Implementation Notes
- Link resolution matches the relative-path style already used across `public_docs/` (`../foo.md`, `./foo.md`, bare `foo.md`), and anchors are matched using GitHub's heading-slug algorithm.
- Symbol extraction is regex-based over `export` declarations in `src/**/*.{ts,tsx}`, including the codebase's dominant `function Foo() {...}; export default Foo;` pattern (not just `export default function Foo`).
- Ran both scripts against the current `public_docs/` tree: the link checker is clean (0 broken links across 91 docs). The symbol checker currently reports ~95 unresolved references across 86 docs — expected for a first pass (env var names, object-method calls like `getState()`, template placeholders like `ComponentA`), and it's advisory by design so none of it blocks CI. Worth a manual pass later to see if any of the 95 are real drift, same as the six #1638 found.

## Screenshots
N/A

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises
<!-- Security audit unchecked: not run as part of this change, same as any other PR here. -->

## Testing Instructions
1. `npm run docs:check-links` — should print `docs:check-links: 91 doc(s) checked, no broken links.` and exit 0.
2. `npm run docs:check-symbols` — prints a per-file worklist of unresolved backticked references, always exits 0.
3. `npx jest --config=jest.config.cjs scripts/__tests__/docs-link-checker.test.js` — 13 tests, all green.
4. To see the gate actually catch something: break a link in any `public_docs/*.md` file (e.g. point it at a nonexistent file) and re-run step 1 — it should exit 1 and print the broken target.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
<!-- Docs-updated unchecked: this PR adds tooling that checks docs, it doesn't change any doc content itself. Accessibility: N/A, no UI. -->
