### PR TITLE
Give detail-page action groups a single primary action

### DIFF
--- a/src/app/characters/[id]/page.tsx
+++ b/src/app/characters/[id]/page.tsx
@@ -59,7 +59,7 @@ export default function CharacterViewPage() {
     {
       label: 'Edit Character',
       onClick: () => router.push(`/characters/${characterId}/edit`),
-      variant: 'primary' as const,
+      variant: 'secondary' as const,
       icon: <Pencil aria-hidden="true" />,
     },
     {
@@ -74,7 +74,7 @@ export default function CharacterViewPage() {
     {
       label: 'Delete Character',
       onClick: () => setShowDeleteDialog(true),
-      variant: 'danger' as const,
+      variant: 'danger-outline' as const,
       icon: <Trash aria-hidden="true" />,
     },
   ];
@@ -87,8 +87,8 @@ export default function CharacterViewPage() {
         <ActionButtonGroup 
           actions={actionButtons.map(btn => ({
             ...btn,
-            flex: btn.variant === 'primary' || btn.variant === 'success'
-          }))} 
+            flex: btn.variant === 'success'
+          }))}
           layout="horizontal" 
           gap="sm" 
         />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -256,6 +256,20 @@ body > * {
   color: var(--color-text-inverse);
 }
 
+/* Variant: destructive-outline (demoted danger action — color carries the
+ * warning, fill stays reserved for the confirmation dialog's confirm button) */
+.button-destructive-outline {
+  background: transparent;
+  color: var(--color-danger);
+  border: 1px solid var(--color-danger);
+}
+
+.button-destructive-outline:hover {
+  background: color-mix(in srgb, var(--color-danger) 10%, transparent);
+  border-color: var(--color-danger-hover);
+  color: var(--color-danger-hover);
+}
+
 /* Variant: success */
 .button-success {
   background: var(--color-success);

--- a/src/app/worlds/[id]/page.tsx
+++ b/src/app/worlds/[id]/page.tsx
@@ -71,7 +71,7 @@ export default function WorldViewPage() {
     {
       label: 'View Characters',
       onClick: () => router.push(`/characters?worldId=${worldId}`),
-      variant: 'primary' as const,
+      variant: 'secondary' as const,
       icon: (
         <Users aria-hidden="true" />
       )
@@ -103,7 +103,7 @@ export default function WorldViewPage() {
         <ActionButtonGroup
           actions={actionButtons.map(btn => ({
             ...btn,
-            flex: btn.variant === 'primary' || btn.variant === 'success'
+            flex: btn.variant === 'success'
           }))}
           layout="horizontal"
           gap="sm"

--- a/src/components/shared/ActionButtonGroup.tsx
+++ b/src/components/shared/ActionButtonGroup.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 interface ActionButton {
   label: string;
   onClick: () => void;
-  variant?: 'default' | 'secondary' | 'outline' | 'ghost' | 'link' | 'destructive' | 'primary' | 'success' | 'danger';
+  variant?: 'default' | 'secondary' | 'outline' | 'ghost' | 'link' | 'destructive' | 'primary' | 'success' | 'danger' | 'danger-outline';
   size?: 'default' | 'sm' | 'lg' | 'icon';
   icon?: React.ReactNode;
   disabled?: boolean;
@@ -34,6 +34,7 @@ export function ActionButtonGroup({
       case 'secondary': return 'secondary';
       case 'success': return 'success';
       case 'danger': return 'destructive';
+      case 'danger-outline': return 'destructive-outline';
       default: return variant as 'default' | 'secondary' | 'outline' | 'ghost' | 'link' | 'destructive' | undefined;
     }
   };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -3,7 +3,7 @@ import { clsx } from 'clsx'
 
 interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'default' | 'secondary' | 'outline' | 'ghost' | 'link' | 'destructive' | 'success' | 'info' | 'warning'
+  variant?: 'default' | 'secondary' | 'outline' | 'ghost' | 'link' | 'destructive' | 'destructive-outline' | 'success' | 'info' | 'warning'
   size?: 'default' | 'sm' | 'lg' | 'icon'
 }
 


### PR DESCRIPTION
## Description
Both `/characters/[id]` and `/worlds/[id]` shipped two or three filled buttons in one action row, so nothing on the page signalled which action it actually wanted. Play now stays the one filled (green) button on each page and stretches to claim the visual weight; Edit Character / View Characters demote to `secondary`; Delete Character demotes to a new `danger-outline` variant that keeps the warning color as text/border instead of another fill. The confirmation dialog's Delete button keeps its red fill — that's the one place a destructive fill is earned.

## Related Issue
Closes #1657

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

None of these quite fit — it's a design-system hierarchy fix (variant swap), closest to a non-breaking bug fix.
- [x] Bug fix (non-breaking change which fixes an issue)

## TDD Compliance
- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

No new tests — this is a `variant` prop swap on existing action arrays plus one new CSS button variant, verified live in the browser rather than with new assertions (per project convention: trivial layout/variant changes are verified live, not harnessed).

## User Stories Addressed
N/A

## Flow Diagrams
N/A

## Component Development
- [x] Storybook stories created/updated
- [x] Components developed in isolation first
- [x] Visual consistency verified

`ButtonStyling.stories.tsx` already exercises `Button`'s variant prop generically, so the new `destructive-outline` variant renders there without a story change needed.

## Implementation Notes
- Added `Button`'s `destructive-outline` variant (transparent bg, danger-colored text/border, danger-tinted hover) — no existing variant matched "outline but danger-colored."
- `ActionButtonGroup`'s legacy `danger-outline` name maps to it, mirroring the existing `danger` -> `destructive` mapping.
- Left Play as `success` (green) rather than switching to accent — issue explicitly scopes that decision out (#1655 unified green-for-Play across the header, `CardActionGroup`, and the mobile drawer; reversing it is separate work).
- The `flex` prop on both pages keyed off `variant === 'primary' || variant === 'success'`. Neither array uses `primary` anymore, so I simplified the check to `variant === 'success'` — the one filled button is the one that stretches, which is the intended effect.
- Did not regenerate the `character-detail` / `world-detail` / `mobile-character-detail` Playwright visual baselines. Visual regression isn't a required CI check on this repo (only TypeScript, Lint, Unit tests, Build, Storybook Build, Knip, Skott, and CodeQL are gated), and per project convention this class of change gets verified live rather than through the visual harness. The baselines will show an expected diff next time `test:visual` runs against these two pages.

## Screenshots
Verified live via the local dev server (seeded a throwaway world + character, screenshotted both detail pages, deleted the seed data after):
- `/worlds/[id]`: Play in World is the sole filled (green) button and stretches; Make Active, View Characters, Edit World are all `secondary`.
- `/characters/[id]`: Play with Character is the sole filled (green) button and stretches; Edit Character is `secondary`; Delete Character is outline with danger-red text/border, no fill.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm run dev`, open a character detail page (`/characters/[id]`) — Play with Character should be the only filled button; Edit Character is secondary/outline-gray; Delete Character is outline with red text/border.
2. Open a world detail page (`/worlds/[id]`) — Play in World should be the only filled button; Make Active, View Characters, Edit World are all secondary.
3. `npm test`, `npm run type-check`, `npm run lint`, `npx stylelint 'src/app/globals.css'` all green.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
