### PR TITLE
Rename the shared wizard hook to useWizardFlow

### DIFF
--- a/public_docs/technical-guides/components/shared-wizard-system.md
+++ b/public_docs/technical-guides/components/shared-wizard-system.md
@@ -88,8 +88,10 @@ interface ToggleButtonProps {
 
 ## Hooks & Utilities
 
-### useWizardState
-There are two, neither re-exported from `@/components/shared/wizard`. Import from the specific path.
+### Wizard state hooks
+There are two, neither re-exported from `@/components/shared/wizard`. Import from the specific
+path. `useWizardState` is step state on its own; `useWizardFlow` wraps that in persistence, a
+submit lifecycle, and cancel-routing.
 
 **`@/hooks/useWizardState`** — used by world creation and character creation. Note that
 `canGoNext` is defined as `!isLastStep && isCurrentStepValid && !isProcessing`, so it's always
@@ -115,11 +117,11 @@ interface UseWizardStateOptions<TData> {
 Note `state.data` rather than a top-level `data`, and `goNext`/`goBack` rather than
 `nextStep`/`previousStep`.
 
-**`@/components/shared/wizard/hooks/useWizardState`** — router-aware, used by `ProviderWizard`.
+**`@/components/shared/wizard/hooks/useWizardFlow`** — router-aware, used by `ProviderWizard`.
 Adds localStorage persistence and a completion callback:
 
 ```typescript
-interface WizardConfig<T> {
+interface WizardFlowConfig<T> {
   steps: WizardStep[];
   initialData: T;
   onComplete: (data: T) => void | Promise<void>;
@@ -228,8 +230,8 @@ function MyWizard() {
 ## Best Practices
 
 ### State Management
-- Use `useWizardState` for wizard state, but check which of the two you want first
-- Enable persistence (the `shared/wizard` variant's `persistKey`) when losing progress would hurt
+- Use `useWizardState` for step state, `useWizardFlow` when you also want the flow around it
+- Enable persistence (`useWizardFlow`'s `persistKey`) when losing progress would hurt
 - Implement proper validation rules per step
 
 ### Styling

--- a/src/components/GuidedFirstTimeExperience/GuidedFirstTimeExperience.tsx
+++ b/src/components/GuidedFirstTimeExperience/GuidedFirstTimeExperience.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useSessionStore } from '@/state/sessionStore';
 import { useWorldStore } from '@/state/worldStore';
 import { WizardContainer } from '@/components/shared/wizard/WizardContainer';
-import { useWizardState } from '@/components/shared/wizard/hooks/useWizardState';
+import { useWizardFlow } from '@/components/shared/wizard/hooks/useWizardFlow';
 import {
   validators,
   validateField,
@@ -146,7 +146,7 @@ export function GuidedFirstTimeExperience() {
   }, [updateTutorialProgress, router]);
 
   // Initialize wizard state
-  const wizard = useWizardState({
+  const wizard = useWizardFlow({
     steps: GUIDED_STEPS,
     initialData: {
       name: '',

--- a/src/components/GuidedFirstTimeExperience/README.md
+++ b/src/components/GuidedFirstTimeExperience/README.md
@@ -45,7 +45,7 @@ export function QuickPlay() {
 
 ## How It's Built
 
-**Reuses existing wizard infrastructure** - Built on the same `useWizardState` hook that powers the full world creation wizard, so it handles step navigation, validation, and persistence automatically.
+**Reuses existing wizard infrastructure** - Built on the shared `useWizardFlow` hook, so it handles step navigation, validation, and persistence automatically.
 
 **Smart user detection** - Hooks into the session store to detect first-time users and track when they've completed onboarding.
 

--- a/src/components/ai/ProviderWizard.tsx
+++ b/src/components/ai/ProviderWizard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { useWizardState } from '@/components/shared/wizard/hooks/useWizardState';
+import { useWizardFlow } from '@/components/shared/wizard/hooks/useWizardFlow';
 import { WizardContainer } from '@/components/shared/wizard/WizardContainer';
 import { WizardStep } from '@/components/shared/wizard/WizardStep';
 import { WizardNavigation } from '@/components/shared/wizard/WizardNavigation';
@@ -69,7 +69,7 @@ export function ProviderWizard({ onComplete, onCancel }: ProviderWizardProps) {
   const [verifyState, setVerifyState] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
   const [verifyResult, setVerifyResult] = useState<ValidationResult | null>(null);
 
-  // Memoized so useWizardState's validation effect has a stable dependency —
+  // Memoized so useWizardFlow's validation effect has a stable dependency —
   // an inline function would change identity each render and loop the effect.
   const validateStep = useCallback((step: number, data: ProviderWizardData) => {
     if (step === 0) {
@@ -98,7 +98,7 @@ export function ProviderWizard({ onComplete, onCancel }: ProviderWizardProps) {
     [addProvider, onComplete]
   );
 
-  const wizard = useWizardState<ProviderWizardData>({
+  const wizard = useWizardFlow<ProviderWizardData>({
     steps: STEPS,
     initialData: INITIAL_DATA,
     // No persistKey: the wizard holds a plaintext key in memory only — it must

--- a/src/components/shared/wizard/README.md
+++ b/src/components/shared/wizard/README.md
@@ -12,11 +12,11 @@ import {
   WizardProgress,
   WizardNavigation,
   WizardStep,
-  useWizardState
 } from '@/components/shared/wizard';
+import { useWizardFlow } from '@/components/shared/wizard/hooks/useWizardFlow';
 
 function MyWizard() {
-  const wizard = useWizardState({
+  const wizard = useWizardFlow({
     initialData: { /* your data */ },
     totalSteps: 3,
     persistKey: 'my-wizard-session', // automatically saves progress
@@ -52,7 +52,7 @@ function MyWizard() {
 - **ToggleButton** - Styled toggle switches that actually look good
 
 - ### Hooks & Utilities
-- **useWizardState** - Complete state management (saves you from prop drilling hell)
+- **useWizardFlow** - Complete state management with persistence, submit, and cancel (saves you from prop drilling hell). For step state without any of that, there's `useWizardState` in `@/hooks`.
 - **Validation helpers** - `createWizardValidator`, `validateFields`, and friends for building per-step rules
 
 ## Why Use This Instead of Rolling Your Own

--- a/src/components/shared/wizard/hooks/__tests__/useWizardFlow.migration.test.ts
+++ b/src/components/shared/wizard/hooks/__tests__/useWizardFlow.migration.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { createElement } from 'react';
-import { useWizardState } from '../useWizardState';
+import { useWizardFlow } from '../useWizardFlow';
 
 // Mock localStorage
 const localStorageMock = {
@@ -24,7 +24,7 @@ interface TestData {
   };
 }
 
-describe('useWizardState - localStorage migration', () => {
+describe('useWizardFlow - localStorage migration', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -56,7 +56,7 @@ describe('useWizardState - localStorage migration', () => {
     };
 
     const { result } = renderHook(() =>
-      useWizardState({
+      useWizardFlow({
         steps: [{ id: 'test', label: 'Test' }],
         initialData,
         onComplete: () => {},
@@ -91,7 +91,7 @@ describe('useWizardState - localStorage migration', () => {
     };
 
     const { result } = renderHook(() =>
-      useWizardState({
+      useWizardFlow({
         steps: [{ id: 'test', label: 'Test' }],
         initialData,
         onComplete: () => {},
@@ -117,7 +117,7 @@ describe('useWizardState - localStorage migration', () => {
     };
 
     const { result } = renderHook(() =>
-      useWizardState({
+      useWizardFlow({
         steps: [{ id: 'test', label: 'Test' }],
         initialData,
         onComplete: () => {},
@@ -149,7 +149,7 @@ describe('useWizardState - localStorage migration', () => {
     };
 
     const { result } = renderHook(() =>
-      useWizardState({
+      useWizardFlow({
         steps: [{ id: 'test', label: 'Test' }],
         initialData,
         onComplete: () => {},
@@ -192,7 +192,7 @@ describe('useWizardState - localStorage migration', () => {
     };
 
     const { result } = renderHook(() =>
-      useWizardState({
+      useWizardFlow({
         steps: [{ id: 'test', label: 'Test' }],
         initialData,
         onComplete: () => {},
@@ -227,7 +227,7 @@ describe('useWizardState - localStorage migration', () => {
     }));
 
     const WizardTest = () => {
-      const wizard = useWizardState({
+      const wizard = useWizardFlow({
         steps: [{ id: 'test', label: 'Test' }],
         initialData,
         onComplete: () => {},

--- a/src/components/shared/wizard/hooks/useWizardFlow.ts
+++ b/src/components/shared/wizard/hooks/useWizardFlow.ts
@@ -2,12 +2,16 @@ import { useState, useCallback, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { safeJsonParse } from '@/lib/safeJsonParse';
 
+// Wizard state plus the surrounding flow: optional localStorage persistence,
+// a submit lifecycle, and cancel-routing. For step state with none of that,
+// use `useWizardState` in @/hooks instead.
+
 interface WizardStep {
   id: string;
   label: string;
 }
 
-export interface WizardState<T> {
+export interface WizardFlowState<T> {
   currentStep: number;
   data: T;
   errors: Record<string, string>;
@@ -21,7 +25,7 @@ interface ValidationState {
   touched: boolean;
 }
 
-export interface WizardConfig<T> {
+export interface WizardFlowConfig<T> {
   steps: WizardStep[];
   initialData: T;
   onComplete: (data: T) => void | Promise<void>;
@@ -31,7 +35,7 @@ export interface WizardConfig<T> {
   debug?: boolean;
 }
 
-export interface WizardHandlers<T> {
+export interface WizardFlowHandlers<T> {
   handleNext: () => void;
   handleBack: () => void;
   handleCancel: () => void;
@@ -41,7 +45,7 @@ export interface WizardHandlers<T> {
   clearError: (field: string) => void;
 }
 
-export function useWizardState<T>(config: WizardConfig<T>) {
+export function useWizardFlow<T>(config: WizardFlowConfig<T>) {
   const router = useRouter();
   const { 
     steps, 
@@ -54,7 +58,7 @@ export function useWizardState<T>(config: WizardConfig<T>) {
   } = config;
 
   // Initialize state from localStorage if persist key provided
-  const [state, setState] = useState<WizardState<T>>(() => {
+  const [state, setState] = useState<WizardFlowState<T>>(() => {
     if (persistKey && typeof window !== 'undefined') {
       const parsed = safeJsonParse<unknown>(
         localStorage.getItem(persistKey),
@@ -63,17 +67,17 @@ export function useWizardState<T>(config: WizardConfig<T>) {
 
       // Only restore if the persisted value is actually a wizard state.
       // localStorage under a persistKey is untrusted input — it can hold
-      // a value that isn't a WizardState (foreign writer, manual edit,
+      // a value that isn't a WizardFlowState (foreign writer, manual edit,
       // corruption). Spreading that produced a state missing required
       // fields like `errors`, which crashed downstream consumers.
-      const isWizardState =
+      const isWizardFlowState =
         parsed !== null &&
         typeof parsed === 'object' &&
         typeof (parsed as { currentStep?: unknown }).currentStep === 'number' &&
         typeof (parsed as { data?: unknown }).data === 'object';
 
-      if (isWizardState) {
-        const persisted = parsed as Partial<WizardState<T>> & {
+      if (isWizardFlowState) {
+        const persisted = parsed as Partial<WizardFlowState<T>> & {
           currentStep: number;
           data: Partial<T>;
         };
@@ -81,7 +85,7 @@ export function useWizardState<T>(config: WizardConfig<T>) {
         // This ensures new fields in initialData are present even if not
         // in the saved state. Each top-level field is rebuilt explicitly
         // so a partial persisted state can never yield an undefined field.
-        const initialState: WizardState<T> = {
+        const initialState: WizardFlowState<T> = {
           currentStep: persisted.currentStep,
           data: { ...initialData, ...persisted.data },
           errors: persisted.errors ?? {},
@@ -259,7 +263,7 @@ export function useWizardState<T>(config: WizardConfig<T>) {
     });
   }, []);
 
-  const handlers: WizardHandlers<T> = {
+  const handlers: WizardFlowHandlers<T> = {
     handleNext,
     handleBack,
     handleCancel,

--- a/src/hooks/useWizardState.ts
+++ b/src/hooks/useWizardState.ts
@@ -1,5 +1,9 @@
 import { useState, useCallback, useMemo } from 'react';
 
+// In-memory step/data/validation state only. If you also want localStorage
+// persistence, a submit lifecycle, and cancel-routing, use `useWizardFlow`
+// in @/components/shared/wizard/hooks instead.
+
 export interface WizardStep {
   id: string;
   label: string;


### PR DESCRIPTION
## Description

Two live hooks were both named `useWizardState` with incompatible shapes, so autocomplete on the name was a coin flip between two APIs — and `WorldCreationWizard` imports one of them alongside the other's directory in the same file.

The naming call: **the one under `components/shared/wizard` does more than hold state.** It persists to localStorage, runs a submit lifecycle (`onComplete`, error capture, clearing persisted state), and routes on cancel. So it becomes `useWizardFlow`, in `useWizardFlow.ts`. `@/hooks/useWizardState` keeps its name because in-memory step/data/validation state is exactly what it is — nothing about that name is wrong once the other one stops shadowing it.

Its exported types moved to match: `WizardState` -> `WizardFlowState`, `WizardConfig` -> `WizardFlowConfig`, `WizardHandlers` -> `WizardFlowHandlers`. None of the three had an importer outside the hook, so that rename is free.

Both hooks picked up a short header comment pointing at the other, so the next person picking one doesn't have to read both to tell them apart.

Consumers updated: `GuidedFirstTimeExperience.tsx`, `ai/ProviderWizard.tsx`, and the migration test (renamed to `useWizardFlow.migration.test.ts`).

Docs that named the hook were fixed rather than find-replaced. `GuidedFirstTimeExperience/README.md` claimed it shared a hook with the world creation wizard — it never did; those are the two different hooks. The shared-wizard technical guide's `### useWizardState` section is now `### Wizard state hooks` with a one-line "which one do I want" split. The shared/wizard README's example imported the hook from the barrel, which doesn't export it and never did, so that import now points at the real path.

## Related Issue

Closes #1612

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

Pure rename with no behavior change, so there's no new behavior to write a test for first. The existing coverage is the safety net — it renamed with the hook and still passes unchanged.

- [ ] Tests written before implementation — N/A, no behavior change
- [ ] All new code is tested — N/A, no new code
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed

N/A — internal naming cleanup, no user-facing change.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated — N/A, no component changed
- [ ] Components developed in isolation first — N/A
- [ ] Visual consistency verified — N/A, nothing renders differently

## Implementation Notes

Not a merge of the two hooks, deliberately. They solve different problems (an options-object step machine vs. a config-object persisted flow) and forcing one API over both would just trade one confusion for another. Naming was the whole fix.

`useWizardState`'s `WizardStep` type still collides by name with the `WizardStep` *component* from `@/components/shared/wizard`, which is why `WorldCreationWizard` aliases it as `WizardStepType`. That's a separate footgun from the one #1612 describes, so it's left alone here.

## Screenshots

N/A — no UI change.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A — no browser-observable change.

## Quality Checks

- [x] Linting passed — `npm run lint`, exit 0, 0 errors (144 pre-existing warnings, unchanged)
- [x] Type checking passed — `npm run type-check`, exit 0
- [ ] Security audit passed — not run, no dependency or input-handling change
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

1. `npm run type-check` — exit 0.
2. `npm test` — 370 suites, 2437 tests, all passing.
3. `grep -rn "useWizardState" src/` — every remaining hit is `@/hooks/useWizardState`; nothing points at the old shared path.
4. Exercise either wizard in the browser (provider setup, or the guided first-time experience) — behavior is identical, including localStorage persistence across a reload.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed — N/A, no rendered output changed
