### PR TITLE
Prune and re-scope the dependency-cruiser baseline (51 -> 17)

### DIFF
--- a/.dependency-cruiser-known-violations.json
+++ b/.dependency-cruiser-known-violations.json
@@ -1,188 +1,71 @@
 [
   {
     "type": "dependency",
+    "from": "src/components/ai/ProviderPresets.tsx",
+    "to": "src/lib/ai/presets.ts",
+    "rule": {
+      "severity": "error",
+      "name": "components-no-direct-lib-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/ai/ProviderWizard.tsx",
+    "to": "src/lib/ai/presets.ts",
+    "rule": {
+      "severity": "error",
+      "name": "components-no-direct-lib-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/ai/ProviderWizard.tsx",
+    "to": "src/lib/ai/validateProviderClient.ts",
+    "rule": {
+      "severity": "error",
+      "name": "components-no-direct-lib-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/forms/WorldImageForm.tsx",
+    "to": "src/lib/ai/worldImageGenerator.ts",
+    "rule": {
+      "severity": "error",
+      "name": "components-no-direct-lib-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/WorldCreationWizard/steps/FinalizeStep.tsx",
+    "to": "src/lib/ai/worldImageGenerator.ts",
+    "rule": {
+      "severity": "error",
+      "name": "components-no-direct-lib-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/WorldCreationWizard/WorldCreationWizard.tsx",
+    "to": "src/lib/ai/worldAnalyzerClient.ts",
+    "rule": {
+      "severity": "error",
+      "name": "components-no-direct-lib-imports"
+    }
+  },
+  {
+    "type": "dependency",
+    "from": "src/components/WorldCreationWizard/WorldCreationWizard.tsx",
+    "to": "src/lib/ai/worldImageGenerator.ts",
+    "rule": {
+      "severity": "error",
+      "name": "components-no-direct-lib-imports"
+    }
+  },
+  {
+    "type": "dependency",
     "from": "src/state/__tests__/loreStore.testHelpers.ts",
     "to": "node_modules/@testing-library/react/dist/@testing-library/react.esm.js",
-    "rule": {
-      "severity": "error",
-      "name": "not-to-dev-dep"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/stories/01-atoms/feedback/ErrorDisplay.stories.tsx",
-    "to": "node_modules/@storybook/test/dist/index.d.ts",
-    "rule": {
-      "severity": "error",
-      "name": "not-to-dev-dep"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/stories/01-atoms/feedback/SaveIndicator.stories.tsx",
-    "to": "node_modules/@storybook/addon-actions/dist/index.d.ts",
-    "rule": {
-      "severity": "error",
-      "name": "not-to-dev-dep"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/stories/01-atoms/forms/controls/RangeSlider.stories.tsx",
-    "to": "node_modules/@storybook/react/dist/index.d.ts",
-    "rule": {
-      "severity": "error",
-      "name": "not-to-dev-dep"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/stories/02-molecules/forms/editors/SkillRangeEditor.stories.tsx",
-    "to": "node_modules/@storybook/react/dist/index.d.ts",
-    "rule": {
-      "severity": "error",
-      "name": "not-to-dev-dep"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/stories/02-molecules/forms/managers/ToneSettingsForm.stories.tsx",
-    "to": "node_modules/@storybook/test/dist/index.d.ts",
-    "rule": {
-      "severity": "error",
-      "name": "not-to-dev-dep"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/stories/02-molecules/narrative/FormattedNarrativeContent.stories.tsx",
-    "to": "node_modules/@storybook/test/dist/index.d.ts",
-    "rule": {
-      "severity": "error",
-      "name": "not-to-dev-dep"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/stories/02-molecules/ui-components/layout/CollapsibleSection.stories.tsx",
-    "to": "node_modules/@storybook/test/dist/index.d.ts",
-    "rule": {
-      "severity": "error",
-      "name": "not-to-dev-dep"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/stories/02-molecules/ui-components/layout/LoadingOverlay.stories.tsx",
-    "to": "node_modules/@storybook/addon-actions/dist/index.d.ts",
-    "rule": {
-      "severity": "error",
-      "name": "not-to-dev-dep"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/stories/03-organisms/editor-components/AttributeEditor.stories.tsx",
-    "to": "node_modules/@storybook/addon-actions/dist/index.d.ts",
-    "rule": {
-      "severity": "error",
-      "name": "not-to-dev-dep"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/stories/03-organisms/editor-components/SkillEditor.stories.tsx",
-    "to": "node_modules/@storybook/addon-actions/dist/index.d.ts",
-    "rule": {
-      "severity": "error",
-      "name": "not-to-dev-dep"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/stories/03-organisms/game-session/ActiveGameSessionChoicesColumn.stories.tsx",
-    "to": "node_modules/@storybook/test/dist/index.d.ts",
-    "rule": {
-      "severity": "error",
-      "name": "not-to-dev-dep"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/stories/03-organisms/game-session/ActiveGameSessionControls.stories.tsx",
-    "to": "node_modules/@storybook/test/dist/index.d.ts",
-    "rule": {
-      "severity": "error",
-      "name": "not-to-dev-dep"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/stories/03-organisms/game-session/EndingSuggestionBanner.stories.tsx",
-    "to": "node_modules/@storybook/test/dist/index.d.ts",
-    "rule": {
-      "severity": "error",
-      "name": "not-to-dev-dep"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/stories/03-organisms/game-session/GameSessionConfirmationDialog.stories.tsx",
-    "to": "node_modules/@storybook/test/dist/index.d.ts",
-    "rule": {
-      "severity": "error",
-      "name": "not-to-dev-dep"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/stories/03-organisms/game-session/GameSessionError.stories.tsx",
-    "to": "node_modules/@storybook/test/dist/index.d.ts",
-    "rule": {
-      "severity": "error",
-      "name": "not-to-dev-dep"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/stories/03-organisms/game-session/GameSessionResume.stories.tsx",
-    "to": "node_modules/@storybook/test/dist/index.d.ts",
-    "rule": {
-      "severity": "error",
-      "name": "not-to-dev-dep"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/stories/03-organisms/game-session/ManuscriptDrawerPanels.stories.tsx",
-    "to": "node_modules/@storybook/test/dist/index.d.ts",
-    "rule": {
-      "severity": "error",
-      "name": "not-to-dev-dep"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/stories/03-organisms/world/editor/WorldEditor.stories.tsx",
-    "to": "node_modules/@storybook/test/dist/index.d.ts",
-    "rule": {
-      "severity": "error",
-      "name": "not-to-dev-dep"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/stories/04-templates/layouts/WorldListScreen.stories.tsx",
-    "to": "node_modules/@storybook/test/dist/index.d.ts",
-    "rule": {
-      "severity": "error",
-      "name": "not-to-dev-dep"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/stories/04-templates/wizards/character/SkillsStep.stories.tsx",
-    "to": "node_modules/@storybook/addon-actions/dist/index.d.ts",
     "rule": {
       "severity": "error",
       "name": "not-to-dev-dep"
@@ -195,69 +78,6 @@
     "rule": {
       "severity": "error",
       "name": "not-to-dev-dep"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/types/global.d.ts",
-    "to": "src/state/characterStore.ts",
-    "rule": {
-      "severity": "error",
-      "name": "types-no-implementation-imports"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/types/global.d.ts",
-    "to": "src/state/inventoryStore.ts",
-    "rule": {
-      "severity": "error",
-      "name": "types-no-implementation-imports"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/types/global.d.ts",
-    "to": "src/state/journalStore.ts",
-    "rule": {
-      "severity": "error",
-      "name": "types-no-implementation-imports"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/types/global.d.ts",
-    "to": "src/state/narrativeStore.ts",
-    "rule": {
-      "severity": "error",
-      "name": "types-no-implementation-imports"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/types/global.d.ts",
-    "to": "src/state/npcStore.ts",
-    "rule": {
-      "severity": "error",
-      "name": "types-no-implementation-imports"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/types/global.d.ts",
-    "to": "src/state/sessionStore.ts",
-    "rule": {
-      "severity": "error",
-      "name": "types-no-implementation-imports"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/types/global.d.ts",
-    "to": "src/state/worldStore.ts",
-    "rule": {
-      "severity": "error",
-      "name": "types-no-implementation-imports"
     }
   },
   {
@@ -500,131 +320,5 @@
         ]
       }
     ]
-  },
-  {
-    "type": "module",
-    "from": "src/lib/ai/__mocks__/config.ts",
-    "to": "src/lib/ai/__mocks__/config.ts",
-    "rule": {
-      "severity": "warn",
-      "name": "no-orphans"
-    }
-  },
-  {
-    "type": "module",
-    "from": "src/lib/ai/__mocks__/geminiClient.ts",
-    "to": "src/lib/ai/__mocks__/geminiClient.ts",
-    "rule": {
-      "severity": "warn",
-      "name": "no-orphans"
-    }
-  },
-  {
-    "type": "module",
-    "from": "src/lib/storage/__mocks__/indexedDBAdapter.js",
-    "to": "src/lib/storage/__mocks__/indexedDBAdapter.js",
-    "rule": {
-      "severity": "warn",
-      "name": "no-orphans"
-    }
-  },
-  {
-    "type": "module",
-    "from": "src/lib/utils/__mocks__/logger.ts",
-    "to": "src/lib/utils/__mocks__/logger.ts",
-    "rule": {
-      "severity": "warn",
-      "name": "no-orphans"
-    }
-  },
-  {
-    "type": "module",
-    "from": "src/state/__mocks__/characterStore.ts",
-    "to": "src/state/__mocks__/characterStore.ts",
-    "rule": {
-      "severity": "warn",
-      "name": "no-orphans"
-    }
-  },
-  {
-    "type": "module",
-    "from": "src/state/__mocks__/narrativeStore.ts",
-    "to": "src/state/__mocks__/narrativeStore.ts",
-    "rule": {
-      "severity": "warn",
-      "name": "no-orphans"
-    }
-  },
-  {
-    "type": "module",
-    "from": "src/state/__mocks__/sessionStore.ts",
-    "to": "src/state/__mocks__/sessionStore.ts",
-    "rule": {
-      "severity": "warn",
-      "name": "no-orphans"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/components/WorldCreationWizard/WorldCreationWizard.tsx",
-    "to": "src/lib/ai/worldImageGenerator.ts",
-    "rule": {
-      "severity": "error",
-      "name": "components-no-direct-lib-imports"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/components/WorldCreationWizard/WorldCreationWizard.tsx",
-    "to": "src/lib/ai/worldAnalyzerClient.ts",
-    "rule": {
-      "severity": "error",
-      "name": "components-no-direct-lib-imports"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/components/WorldCreationWizard/steps/FinalizeStep.tsx",
-    "to": "src/lib/ai/worldImageGenerator.ts",
-    "rule": {
-      "severity": "error",
-      "name": "components-no-direct-lib-imports"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/components/forms/WorldImageForm.tsx",
-    "to": "src/lib/ai/worldImageGenerator.ts",
-    "rule": {
-      "severity": "error",
-      "name": "components-no-direct-lib-imports"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/components/ai/ProviderWizard.tsx",
-    "to": "src/lib/ai/validateProviderClient.ts",
-    "rule": {
-      "severity": "error",
-      "name": "components-no-direct-lib-imports"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/components/ai/ProviderWizard.tsx",
-    "to": "src/lib/ai/presets.ts",
-    "rule": {
-      "severity": "error",
-      "name": "components-no-direct-lib-imports"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/components/ai/ProviderPresets.tsx",
-    "to": "src/lib/ai/presets.ts",
-    "rule": {
-      "severity": "error",
-      "name": "components-no-direct-lib-imports"
-    }
   }
 ]

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -27,7 +27,11 @@ module.exports = {
           '(^|/)[.][^/]+[.](?:js|cjs|mjs|ts|cts|mts|json)$',                  // dot files
           '[.]d[.]ts$',                                                       // TypeScript declaration files
           '(^|/)tsconfig[.]json$',                                            // TypeScript config
-          '(^|/)(?:babel|webpack)[.]config[.](?:js|cjs|mjs|ts|cts|mts|json)$' // other configs
+          '(^|/)(?:babel|webpack)[.]config[.](?:js|cjs|mjs|ts|cts|mts|json)$', // other configs
+          // Jest manual mocks are reached through bare `jest.mock('path')` calls,
+          // which aren't import statements, so dependency-cruiser can't see the
+          // edge and reports every one of them as an orphan.
+          '(^|/)__mocks__/'
         ]
       },
       to: {},
@@ -186,13 +190,16 @@ module.exports = {
       severity: 'error',
       comment:
         'Type definition files should not import implementation code. ' +
-        'Types should be pure TypeScript interfaces and types only.',
+        'Types should be pure TypeScript interfaces and types only. ' +
+        'Type-only positions (`typeof import()`, `import type`) are fine: ' +
+        'they erase at compile time and pull in no implementation.',
       from: {
         path: '^src/types/.*\\.ts$'
       },
       to: {
         path: '^src/(?:state|components|lib)/',
-        pathNot: '^src/types/'
+        pathNot: '^src/types/',
+        dependencyTypesNot: ['type-only', 'type-import']
       }
     },
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,10 @@ jobs:
         run: npm run lint:ds-canon
       - name: Enforce dependency boundaries (no new cycles or dev-dep leaks)
         run: npm run deps:validate
+      # Blocking, and the other half of the ratchet: `deps:validate` stops new
+      # violations landing, this stops fixed ones lingering as dead suppressions.
+      - name: Enforce a shrinking dependency baseline
+        run: npm run deps:check
 
   knip:
     name: Knip (unused code)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ npm run lint:css           # Stylelint over **/*.css — run after ANY .css edit
 ```
 
 - `npm run build` — production build (includes a Storybook build step).
-- Structural changes (imports crossing domains): `npm run deps:validate` — dependency-cruiser against the known-violations baseline (`deps:validate:strict` shows everything; re-baseline only deliberately with `deps:baseline`).
+- Structural changes (imports crossing domains): `npm run deps:validate`, dependency-cruiser against the known-violations baseline (`deps:validate:strict` shows everything; re-baseline only deliberately with `deps:baseline`). `npm run deps:check` is the other half of the ratchet: it fails when a baseline entry no longer reproduces, so fixing a violation means re-baselining.
 - Visual work: `npm run test:visual` (Playwright, chromium). Update snapshots deliberately with `test:visual:update`; prune orphans with `test:visual:prune`.
 - If local jest runs out of memory, `npm run test:ci` exists for that (4GB Node heap).
 
@@ -90,6 +90,7 @@ For truly automatic execution, select "Yes, and don't ask again this session" on
 - Port 3000 taken → an orphan `next dev` or rcv-simulator-va's main checkout.
 - Stylelint color failures → a raw color landed outside a theme file; route it through tokens.
 - deps:validate failures → fix the boundary violation, or (rarely, deliberately) re-baseline.
+- deps:check failures → a violation got fixed but its baseline entry is still there; run `deps:baseline` and commit the smaller file.
 
 ## Pointers
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "deps:validate": "depcruise src --config --ignore-known .dependency-cruiser-known-violations.json",
     "deps:validate:strict": "depcruise src --config",
     "deps:baseline": "depcruise src --output-type baseline --output-to .dependency-cruiser-known-violations.json",
+    "deps:check": "node scripts/check-deps-baseline.mjs",
     "deps:diagram": "depcruise src --include-only '^src' --output-type mermaid --collapse '^src/[^/]+' > public_docs/architecture/dependency-graph-domains.mmd",
     "deps:diagram:archi": "command -v dot >/dev/null 2>&1 && depcruise src --config --output-type archi | dot -T svg -Grankdir=TD > public_docs/architecture/high-level.svg || echo 'Skipping archi diagram (requires: brew install graphviz)'",
     "deps:diagram:detailed": "depcruise src --include-only '^src' --output-type mermaid > public_docs/architecture/dependency-graph-detailed.mmd",

--- a/public_docs/architecture/dependency-analysis.md
+++ b/public_docs/architecture/dependency-analysis.md
@@ -94,15 +94,16 @@ npm run analyze
 
 The project uses **ignore-known violations** to manage the existing violations while preventing new ones:
 
-- **Baseline File:** `.dependency-cruiser-known-violations.json` (630 lines, tracked in git)
-- **Known Violations:** 51 total, as of 2026-08-01: 22 dev-dependency imports, 8 circular dependencies, 7 type-to-implementation imports, 7 orphans, 7 components importing lib directly
-- **Strategy:** Fix incrementally while preventing new violations
+- **Baseline File:** `.dependency-cruiser-known-violations.json`, tracked in git
+- **Known Violations:** 17 total, as of 2026-08-04: 8 circular dependencies, 7 components importing lib/ai directly, 2 dev-dependency imports
+- **Strategy:** a two-way ratchet. `deps:validate` stops new violations landing; `deps:check` stops fixed ones lingering as dead suppressions, so the number can only go down.
 
 **Daily Workflow:**
 ```bash
 npm run deps:validate         # Pass/fail on NEW violations only
 npm run deps:validate:strict  # Show all violations (for reference)
 npm run deps:baseline         # Update after fixes (tracks progress)
+npm run deps:check            # Fail if any baseline entry no longer reproduces
 ```
 
 ### Violation Categories
@@ -120,29 +121,32 @@ component-to-module loops in the world-creation wizard and the tutorial provider
 3. Apply pub-sub patterns for cross-store communication — this is what `storeEvents` in `src/lib/state/storePubSub.ts` already does for cascade deletes
 4. Break apart monolithic stores (the `loreStore` split into its `loreStore.*` family is an example of this)
 
-**Type Violations (23 errors)**
+**Components importing lib/ai directly (7 in the baseline)**
 
-Type files importing implementation:
-- Constants in type files
-- Type guards importing utils
-- Store types importing store implementations
+The world-creation wizard, the world image form, and the provider setup components reach
+`src/lib/ai/` without going through `lib/api` or a hook. Resolution is the `worldApi` pattern:
+put the call behind a service or a colocated `use*` hook.
 
-**Resolution:** Move or duplicate constants; relocate guards to utils.
+**Dev Dependency Issues (2 in the baseline)**
 
-**Dev Dependency Issues (Expected)**
+`src/types/jest.d.ts` pulls in `@testing-library/jest-dom` types, and a test helper under
+`src/state/__tests__/` imports `@testing-library/react`. Neither reaches production. The 20
+Storybook-file entries that used to sit here were stale: the `not-to-dev-dep` rule's own
+`from.pathNot` already excludes `*.stories.tsx`.
 
-Storybook/test files import dev dependencies - these are safe as they never reach production. Already ignored in baseline.
+**Not violations, by design**
+
+Two categories were rule-scoping noise rather than debt, and the rules now exclude them:
+
+- Jest manual mocks under `__mocks__/` are reached through bare `jest.mock('path')` calls, which
+  aren't import statements, so `no-orphans` saw every one of them as stranded.
+- `typeof import()` positions in `src/types/global.d.ts` erase at compile time, so
+  `types-no-implementation-imports` now skips `type-only`/`type-import` edges.
 
 ### Progress Tracking
 
-Monitor baseline file size over time:
-```bash
-wc -l .dependency-cruiser-known-violations.json
-# Current: 630 lines (51 violations)
-# Target: < 1000 lines (reduce by 60%)
-```
-
-Each fix shrinks the file, providing visible metrics.
+The baseline entry count is the metric, and `deps:check` enforces that it only shrinks. Fix a
+violation and CI fails until you re-baseline. Current: 17.
 
 ## Architecture Rules
 
@@ -161,7 +165,12 @@ Components importing AI/prompt services directly may indicate business logic tha
 Utility functions must be pure with no state dependencies.
 
 ### Rule: `types-no-implementation-imports` (error)
-Type definitions should not import implementation code.
+Type definitions should not import implementation code. Type-only edges (`import type`,
+`typeof import()`) are exempt, since they erase at compile time.
+
+### Rule: `no-orphans` (warning)
+Flags modules nothing imports. Jest manual mocks under `__mocks__/` are exempt, since
+`jest.mock('path')` isn't an import statement dependency-cruiser can follow.
 
 ## Available Commands
 
@@ -170,6 +179,7 @@ Type definitions should not import implementation code.
 npm run deps:validate              # Check for NEW violations only (ignores known)
 npm run deps:validate:strict       # Show ALL violations including known ones
 npm run deps:baseline              # Regenerate baseline after fixing violations
+npm run deps:check                 # Fail on baseline entries that no longer reproduce
 
 # Diagram Generation
 npm run deps:diagram               # Domain-level overview
@@ -204,29 +214,24 @@ Rules are defined in `.dependency-cruiser.cjs`. Key sections:
 3. Generate diagrams: `npm run deps:diagram:all`
 
 **Resolution Priority:**
-1. **High:** Fix type import violations (blocks clean architecture)
-2. **Medium:** Break circular dependencies (one store pair at a time)
-3. **Low:** Document expected dev-dependency violations
-4. **Ongoing:** Use `npm run deps:validate` to prevent new violations
-
-**Progress Tracking:**
-- Monitor baseline file line count over time
-- Celebrate when violations drop below thresholds (60, 40, 20)
-- Regenerate baseline after each fix: `npm run deps:baseline`
+1. **Medium:** Route the 7 direct `lib/ai` imports through `lib/api` services or hooks
+2. **Medium:** Break circular dependencies, starting with the barrel-file self-references
+3. **Low:** The 2 dev-dependency entries are test-only and can stay
+4. **Ongoing:** `npm run deps:validate` prevents new violations; `npm run deps:check` prevents stale ones
 
 ## Integration with CI
 
-Dependency validation runs in CI as the last step of the Lint Check job in
-`.github/workflows/ci.yml`, so a new violation fails the build:
+Both halves of the ratchet run in the Lint Check job in `.github/workflows/ci.yml`:
 
 ```yaml
 - name: Enforce dependency boundaries (no new cycles or dev-dep leaks)
   run: npm run deps:validate
+- name: Enforce a shrinking dependency baseline
+  run: npm run deps:check
 ```
 
-Fix the boundary, or re-baseline deliberately with `npm run deps:baseline`.
-
-That would fail the build on any NEW boundary violation while still tolerating the known ones
+A new boundary violation fails the build. So does a baseline entry that no longer reproduces:
+fix the boundary, then re-baseline with `npm run deps:baseline` and commit the smaller file.
 in the baseline file.
 
 ## Viewing Diagrams

--- a/scripts/check-deps-baseline.mjs
+++ b/scripts/check-deps-baseline.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// Ratchets the dependency-cruiser suppression baseline downward. `deps:validate`
+// already fails on violations that aren't in `.dependency-cruiser-known-violations.json`,
+// so new debt can't land. This covers the other direction: it fails when a
+// baseline entry no longer reproduces, forcing the list to shrink as violations
+// get fixed instead of quietly filling up with dead suppressions.
+//
+// Fix: run `npm run deps:baseline` and commit the smaller file.
+//
+// Same idea as `check-circular-count.mjs` / `.skott-baseline.json`, one level
+// more precise: it compares individual entries rather than a count.
+
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..');
+const baselinePath = resolve(repoRoot, '.dependency-cruiser-known-violations.json');
+
+const baseline = JSON.parse(readFileSync(baselinePath, 'utf8'));
+
+if (!Array.isArray(baseline)) {
+  console.error(`Invalid baseline in ${baselinePath}: expected an array of violations`);
+  process.exit(2);
+}
+
+const keyOf = (violation) =>
+  `${violation.type}|${violation.rule?.name}|${violation.from} -> ${violation.to}`;
+
+const child = spawn('npx', ['depcruise', 'src', '--config', '--output-type', 'json'], {
+  cwd: repoRoot,
+  stdio: ['ignore', 'pipe', 'inherit'],
+});
+
+let stdout = '';
+child.stdout.on('data', (chunk) => {
+  stdout += chunk.toString('utf8');
+});
+
+child.on('error', (err) => {
+  console.error('Failed to spawn depcruise:', err.message);
+  process.exit(2);
+});
+
+child.on('close', () => {
+  let current;
+  try {
+    current = JSON.parse(stdout).summary.violations ?? [];
+  } catch {
+    console.error('Could not parse depcruise JSON output.');
+    process.exit(2);
+  }
+
+  const reproducing = new Set(current.map(keyOf));
+  const stale = baseline.filter((violation) => !reproducing.has(keyOf(violation)));
+
+  if (stale.length > 0) {
+    console.error(
+      (stale.length === 1
+        ? '1 baseline entry no longer reproduces:\n'
+        : `${stale.length} baseline entries no longer reproduce:\n`) +
+        stale.map((violation) => `  ${keyOf(violation)}`).join('\n') +
+        `\n\nRun \`npm run deps:baseline\` and commit the smaller file.`
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `Baseline holds at ${baseline.length} suppressed violation${baseline.length === 1 ? '' : 's'}, all still reproducing.`
+  );
+});


### PR DESCRIPTION
## Description

The dependency-cruiser suppression list had drifted to 51 entries with nobody pruning it, so the number stopped being useful for judging anything. Three passes, in the order #1590 laid out.

**1. Re-baselined.** Dropped 20 stale entries, 51 -> 31. Nearly all of them were `not-to-dev-dep` against `src/stories/**/*.stories.tsx`, which the rule's own `from.pathNot` at `.dependency-cruiser.cjs:214` already excludes. They'd been sitting there suppressing violations that stopped firing a while ago.

**2. Scoped the two rules that were reporting tooling blind spots as debt.** 31 -> 17.

- All 7 `no-orphans` hits are Jest manual mocks under `__mocks__/`, reached through bare `jest.mock('path')` calls. Those aren't import statements, so dependency-cruiser can't see the edge and reads every mock as stranded. Added `(^|/)__mocks__/` to the rule's `from.pathNot`.
- All 7 `types-no-implementation-imports` hits are `typeof import()` positions in `src/types/global.d.ts:16-22`. They erase at compile time and pull in no implementation. Added `dependencyTypesNot: ['type-only', 'type-import']` to the rule's `to` clause. Both values, because dependency-cruiser tags these particular edges `type-import` rather than `type-only`, which is what the config's other rules use.

**3. Added `deps:check`, the other half of the ratchet.** `deps:validate` already blocks new violations landing. Nothing was stopping fixed ones from lingering as dead suppressions, which is exactly how the list got to 51. `scripts/check-deps-baseline.mjs` fails when a baseline entry no longer reproduces, so fixing a violation forces a re-baseline. Same idea as `check-circular-count.mjs` and `.skott-baseline.json`, one level more precise since it compares individual entries rather than a count. Wired into the Lint Check job right after `deps:validate`.

What's left is actual debt worth burning down: 8 `no-circular`, 7 `components-no-direct-lib-imports`, 2 test-only dev-dep imports.

## Related Issue

Closes #1590

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

N/A. This is CI tooling config with no product code touched, so there's no unit test to write first. Verification is by running the tooling itself, documented under Testing Instructions.

- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [ ] Test coverage maintained or improved

## User Stories Addressed

N/A. Tooling and CI only, no user-facing behavior.

## Flow Diagrams

N/A.

## Component Development

N/A. No components touched.

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes

Both rule changes got a negative test before I trusted them, since a scoping change that quietly turns a rule off is worse than the noise it removes. Dropped a probe file into `src/types/` that does a real value import, and a stranded module under `src/lib/`, then ran the cruise:

```
warn no-orphans: src/lib/__tmpprobe/orphan.ts
error types-no-implementation-imports: src/types/__tmp_probe.ts -> src/state/worldStore.ts
```

Both still fire. The probes were removed.

The ratchet got the same treatment. Added a fake entry pointing at a file that doesn't exist and ran `deps:check`:

```
1 baseline entry no longer reproduces:
  dependency|x|src/nonexistent/ghost.ts -> src/lib/ai/presets.ts

Run `npm run deps:baseline` and commit the smaller file.
```

Exit code 1 on a stale entry, 0 on a clean baseline.

`public_docs/architecture/dependency-analysis.md` had stale counts throughout (51 violations, "630 lines", a "Type Violations (23 errors)" section that no longer describes anything). Updated the counts, rewrote the violation categories to match what's actually left, and documented both rule exemptions and the new command. `CLAUDE.md` gained the `deps:check` half of the gate and its failure mode.

## Screenshots

N/A. No UI changes.

## Code Review Summary (if applicable)

N/A.

## Chrome DevTools MCP Verification Summary (if applicable)

N/A.

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

`npm run lint` exits 0 (144 pre-existing warnings, 0 errors). `npm run type-check` exits 0. `npm run knip` exits 0. Security audit not run, since no dependencies changed.

## Testing Instructions

```bash
npm run deps:validate:strict
```

Reports 17 violations: 8 `no-circular`, 7 `components-no-direct-lib-imports`, 2 `not-to-dev-dep`. Before this branch it reported 31.

```bash
npm run deps:validate
```

Passes with "17 known violations ignored".

```bash
npm run deps:check
```

Prints "Baseline holds at 17 suppressed violations, all still reproducing" and exits 0. To see it fail, hand-add an entry to `.dependency-cruiser-known-violations.json` pointing at a path that doesn't exist and run it again.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed

Accessibility is N/A. Nothing here renders.
