### PR TITLE
Keep the 11 MB Gemini tokenizer vocabulary out of the client bundle

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -7,7 +7,10 @@
   "entry": [
     "src/app/**/{page,layout,template,error,loading,not-found,route,default,global-error}.{ts,tsx}!",
     ".storybook/{main,preview}.{cjs,ts,tsx}",
-    "scripts/**/*.{js,cjs,mjs}"
+    "scripts/**/*.{js,cjs,mjs}",
+    // Reached only through the client-side webpack alias in next.config.ts, which
+    // knip resolves as a string path rather than an import.
+    "src/lib/promptContext/geminiTokenizerBrowserStub.ts!"
   ],
   "project": ["src/**/*.{ts,tsx,js,jsx}!", "scripts/**/*.{js,cjs,mjs}"],
   "ignoreExportsUsedInFile": true,

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { NextConfig } from "next";
 
 // Content Security Policy (enforced). 'unsafe-inline' is kept for script/style
@@ -110,9 +111,27 @@ const nextConfig: NextConfig = {
   },
 
   // Webpack configuration
-  webpack: (config) => {
+  webpack: (config, { isServer }) => {
     // Add path resolver fallback for client-side builds
     config.resolve.fallback = { fs: false, path: false };
+
+    // The Gemini tokenizer's BPE vocabulary is 11 MB. The browser reaches it
+    // because NarrativeController assembles prompts client-side before posting
+    // them to /api/narrative/*, so the lazy GameSession chunk pulled the whole
+    // merge table down at the start of every session. Swap in a character-count
+    // approximation for the client and keep the vocabulary in the server
+    // bundle, where serverExternalPackages already makes it a native require
+    // and the API routes count against the real thing.
+    if (!isServer) {
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        '@lenml/tokenizer-gemini': path.resolve(
+          process.cwd(),
+          'src/lib/promptContext/geminiTokenizerBrowserStub.ts'
+        ),
+      };
+    }
+
     return config;
   },
 };

--- a/src/lib/promptContext/__tests__/geminiTokenizerBrowserStub.test.ts
+++ b/src/lib/promptContext/__tests__/geminiTokenizerBrowserStub.test.ts
@@ -1,0 +1,32 @@
+import { fromPreTrained as fromPreTrainedBrowser } from '../geminiTokenizerBrowserStub';
+import { fromPreTrained } from '@lenml/tokenizer-gemini';
+
+/**
+ * The stub only ever runs behind the client-side webpack alias, so nothing else
+ * exercises it. What matters is that it stays a safe stand-in: same call shape
+ * as the real package, and an estimate that runs high, since `applyBudget`
+ * truncates against whatever number it gets.
+ */
+const countBrowser = (text: string) =>
+  fromPreTrainedBrowser().encode(text, { add_special_tokens: false }).length;
+
+const countExact = (text: string) =>
+  fromPreTrained().encode(text, { add_special_tokens: false }).length;
+
+const NARRATIVE_SAMPLES = [
+  'The bandit captain blocks the road and asks for a toll.',
+  'You are traveling through a dark forest when a group of armed bandits steps out from behind the trees, weapons drawn.',
+  'Location: Forest Path\nSituation: A group of bandits blocks your path\n',
+];
+
+describe('geminiTokenizerBrowserStub', () => {
+  it('returns 0 for empty text', () => {
+    expect(countBrowser('')).toBe(0);
+  });
+
+  it('never undercounts narrative prose against the real tokenizer', () => {
+    NARRATIVE_SAMPLES.forEach((sample) => {
+      expect(countBrowser(sample)).toBeGreaterThanOrEqual(countExact(sample));
+    });
+  });
+});

--- a/src/lib/promptContext/geminiTokenizerBrowserStub.ts
+++ b/src/lib/promptContext/geminiTokenizerBrowserStub.ts
@@ -1,0 +1,30 @@
+/**
+ * Browser stand-in for `@lenml/tokenizer-gemini`, swapped in by the client-side
+ * webpack alias in next.config.ts.
+ *
+ * The real package carries an 11 MB BPE merge table. Webpack emitted the whole
+ * thing into the client build, and the `next/dynamic` GameSession import pulled
+ * it down at the start of every real session, so players were paying 11 MB to
+ * count tokens for a prompt they immediately hand to the server.
+ *
+ * The exact vocabulary now stays server-side. What the browser gets instead is
+ * a deliberately low characters-per-token divisor: the only consumer that acts
+ * on the number is `applyBudget`, and an estimate that runs high makes it
+ * truncate a shade early rather than let an oversized section through. English
+ * narrative prose sits nearer four characters per token, so this leaves roughly
+ * 15% headroom. Dense scripts and emoji still count for more tokens than any
+ * character ratio predicts — exact enforcement belongs on the server, where
+ * routes assemble prompts against the real tokenizer.
+ *
+ * Callers only read `.length` off the result.
+ */
+const CONSERVATIVE_CHARS_PER_TOKEN = 3.5;
+
+export function fromPreTrained() {
+  return {
+    encode(text: string, _options?: { add_special_tokens?: boolean }): number[] {
+      if (!text) return [];
+      return new Array(Math.ceil(text.length / CONSERVATIVE_CHARS_PER_TOKEN));
+    },
+  };
+}


### PR DESCRIPTION
## Description

The production build shipped 14 MB of `.next/static`, and 11 MB of that was one chunk: the `@lenml/tokenizer-gemini` BPE merge table.

The sweep in #1653 called this dead dev-route weight, but that came from the First Load column, which doesn't count lazily-imported chunks. Checking `react-loadable-manifest.json` on a pre-change build:

```
dynamic import: app/play/page.tsx             -> @/components/GameSession/GameSession
dynamic import: app/worlds/[id]/play/page.tsx -> @/components/GameSession/GameSession
entry chunk of: /dev/game-session, /dev/journal-access, /dev/choice-alignment
```

So real players were downloading an 11 MB vocabulary the moment a session started. `ActiveGameSession` mounts `NarrativeController` -> `useNarrativeGenerator` -> `NarrativeGenerator`, which calls `applyBudget` -> `estimateTokenCount` while assembling the prompt, then hands it to `/api/narrative/*` through `ClientGeminiClient`. The `next/dynamic` boundary on the play page kept all of that out of First Load, which is why `/worlds/[id]/play` read 177 kB while the dev pages read ~5 MB.

That also rules out the other option the issue floated: excluding `/dev` from the production build would have left the vocabulary sitting in the gameplay chunk. Making the tokenizer server-only is the fix that actually works.

The client build now aliases `@lenml/tokenizer-gemini` to a character-count approximation. The vocabulary stays in the server bundle, where `serverExternalPackages` already makes it a native require and the API routes count against the real thing. Aliasing the package rather than a module is the durable version: any future client import gets the stub, not 11 MB.

Measured with a real `next build` (`NEXT_PUBLIC_SITE_URL=http://localhost:3000 npm run build:app`):

| | before | after |
|---|---|---|
| `.next/static` | 14 MB | 3.4 MB |
| largest client chunk | 11,217,848 B | 201,713 B |
| play route, lazy GameSession JS | ~11.6 MB | 421 kB |
| `/dev/choice-alignment` First Load | 4.88 MB | 206 kB |
| `/dev/game-session` First Load | 4.98 MB | 308 kB |
| `/dev/journal-access` First Load | 4.98 MB | 305 kB |
| `/worlds/[id]/play` First Load | 177 kB | 177 kB |

## Related Issue

Part of #1653, the first finding only ("79% of the static build output is a tokenizer vocabulary that exists only for three dev routes"), with the correction above. The other seven findings in that sweep are untouched.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The measurement here is a build, not a unit test, so the loop ran build-first: baseline `next build`, change, rebuild, diff the numbers, then a third build with the alias reverted to trace the chunk back to its consumers. The new spec covers what a unit test can reach: that the stub matches the call shape `tokenizer.ts` uses, and that it never undercounts narrative prose against the real tokenizer.

## User Stories Addressed

As a player, starting a session shouldn't download 11 MB of tokenizer vocabulary before the first scene renders.

## Flow Diagrams

N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A, no components changed.

## Implementation Notes

- `src/lib/promptContext/geminiTokenizerBrowserStub.ts` is the browser stand-in. The divisor is 3.5 characters per token rather than the usual 4, on purpose: `applyBudget` truncates against whatever number it gets, so an estimate that runs high truncates a shade early instead of letting an oversized section through. English narrative prose sits nearer 4, which leaves roughly 15% headroom.
- `next.config.ts` guards the alias with `!isServer`, so the server build is untouched.
- `knip.json` needs the stub declared as an entry, since it's reached through a string path in the webpack config rather than an import. That check is blocking in CI.

The trade-off worth naming: client-side prompt budgeting is now approximate. With `NEXT_PUBLIC_ENABLE_TOKEN_BUDGET_MANAGER` off, `applyBudget` only records the estimate for observability and never truncates, so all that changes is the precision of a debug number. With it on, browser-side truncation runs against the conservative estimate. Dense scripts and emoji exceed any character ratio, so exact enforcement stays server-side. Making the browser exact again means moving prompt assembly to the server, which belongs in its own issue.

## Screenshots

N/A

## Code Review Summary (if applicable)

Codex flagged (P2) that gameplay, not just `/dev`, would hit the stub. That's right, and the build evidence above confirms it. The description and code comments were corrected, and the divisor was made conservative so an undercount can't loosen the budget guard.

## Chrome DevTools MCP Verification Summary (if applicable)

All three affected pages loaded clean against this worktree's dev server on port 3678: `/dev/choice-alignment`, `/dev/journal-access`, `/dev/game-session`, no console errors on any of them. `/dev/game-session` hydrated into a live session from persisted state, so the generator path still resolves.

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Local: `npm test` 371 suites / 2439 tests green, `npm run type-check` clean, `npm run lint` 0 errors, plus `lint:css`, `lint:layout-usage`, `lint:ds-canon`, `deps:validate`, `skott:check`, and `knip` all exit 0.

## Testing Instructions

1. `NEXT_PUBLIC_SITE_URL=http://localhost:3000 npm run build:app`, then `du -sh .next/static`. Expect ~3.4 MB, no chunk over ~200 kB.
2. `grep -rl "@lenml" .next/static/chunks/`. Expect no matches.
3. `npm run dev`, then load `/dev/choice-alignment`, `/dev/game-session`, and `/dev/journal-access`. All three render with no console errors.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
