### PR TITLE
Stop the errorReport test fixture from matching Google's key-scan pattern

### DIFF
--- a/src/lib/telemetry/__tests__/errorReport.test.ts
+++ b/src/lib/telemetry/__tests__/errorReport.test.ts
@@ -12,7 +12,10 @@ import {
  */
 describe('errorReport privacy contract (#1641)', () => {
   it('keeps the message out of the payload, key-shaped strings and story text included', () => {
-    const secret = 'AIzaSyD-1234567890abcdefghijklmnopqrstu';
+    // Deliberately too short to match GitHub's Google-API-key secret scan
+    // (AIza + 35 chars) — still key-shaped enough to prove the message field
+    // gets dropped wholesale rather than selectively redacted.
+    const secret = 'AIzaSy-FAKE-TEST-KEY-DO-NOT-USE';
     const error = new Error(
       `Request failed with key ${secret} while generating for Thornwick the Bold in the Ashen Reach`
     );


### PR DESCRIPTION
## Description
GitHub secret scanning flagged `AIzaSyD-1234567890abcdefghijklmnopqrstu` in `errorReport.test.ts` as a leaked Google API key. It's a fake fixture proving the error-report payload drops the message field wholesale (issue #1641's privacy contract) — never a real key — but it was long enough to match GitHub's `AIza` + 35-char detector pattern. Shortened it so it still reads as key-shaped but falls under the length the scanner checks for.

## Related Issue
Closes #
N/A — filed directly from a GitHub secret-scanning alert, not a tracked issue.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — false-positive secret-scan remediation, not a product change.

## Flow Diagrams
N/A

## Component Development
N/A — no UI change.

## Implementation Notes
The fixture's redaction assertions were never about matching a real Google key pattern — the test proves `buildErrorReport` omits `error.message` entirely rather than selectively scrubbing it. Shortening the fake secret below the 35-char threshold after `AIza` keeps that intent intact while no longer tripping the scanner.

## Screenshots
N/A

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A — not browser-observable.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npx jest src/lib/telemetry/__tests__/errorReport.test.ts` — 6/6 pass
2. `npm run type-check` — clean
3. `npx eslint src/lib/telemetry/__tests__/errorReport.test.ts` — clean

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed
