### PR TITLE
Honor prefers-reduced-motion across the app (#1678)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,6 +38,38 @@ a[href="#main-content"]:focus {
   outline-offset: 2px;
 }
 
+/* Honor OS-level "reduce motion" (#1678). A blanket reset covers the vast
+   majority of the app's 65 transitions and 14 animations in one place instead
+   of needing every future keyframe to remember to check the media query.
+   `!important` is deliberate here — this has to win over every animation's own
+   specificity, including ones written after this rule. Near-zero duration
+   (rather than `none`) keeps animation/transitionend listeners firing. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  /* Walk back the handful of cases where the blanket reset reads as broken
+     rather than calm. Rotation and positional movement (the die tick, the
+     drawer slide-in) are exactly what triggers vestibular symptoms, so those
+     stay fully stopped. But an in-progress indicator that freezes solid reads
+     as a stalled screen, not "still working" -- these are opacity-only, so
+     they don't carry the same risk. Give them back a slow, steady loop. */
+  :root .manuscript-streaming-dot,
+  .component-loading-pulse-avatar-circle,
+  .component-loading-pulse-line,
+  .component-loading-skeleton-line,
+  .component-loading-dot {
+    animation-duration: 2s !important;
+    animation-iteration-count: infinite !important;
+  }
+}
+
 /* react-joyride appends its portal as the last child of <body>, where it picks
    up position: relative in normal flow and lands below all page content. That
    pushed the tour overlay + spotlight roughly a viewport down, so the dim

--- a/src/components/TutorialProvider/TutorialProvider.tsx
+++ b/src/components/TutorialProvider/TutorialProvider.tsx
@@ -8,6 +8,7 @@ import { TutorialPhase } from '@/types/tutorial.types';
 import { TutorialProgressWidget } from '@/components/TutorialProgress/TutorialProgressWidget';
 import Logger from '@/lib/utils/logger';
 import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 import { useTutorialAutoScroll } from './useTutorialAutoScroll';
 import { useTourTargetRetry } from './useTourTargetRetry';
 import { useTutorialTooltipReposition } from './useTutorialTooltipReposition';
@@ -89,6 +90,9 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
   const [joyrideRuntime, setJoyrideRuntime] = useState<JoyrideModule | null>(null);
 
   useTutorialAutoScroll(run, steps, stepIndex);
+  // Native Joyride scrolling isn't reached by the CSS prefers-reduced-motion
+  // media query (#1678) -- collapse its scroll animation to instant instead.
+  const prefersReducedMotion = useReducedMotion();
 
   const activeTarget = steps[stepIndex]?.target;
   const remeasureStep = useCallback(() => {
@@ -482,6 +486,7 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
             showProgress={tourOptions.showProgress}
             showSkipButton={tourOptions.showSkipButton}
             disableScrolling={tourOptions.disableScrolling}
+            scrollDuration={prefersReducedMotion ? 0 : undefined}
             floaterProps={{ ...tourOptions.floaterProps, getPopper: capturePopper }}
             styles={joyrideStyles}
             callback={handleJoyrideCallback}

--- a/src/components/TutorialProvider/useTutorialAutoScroll.ts
+++ b/src/components/TutorialProvider/useTutorialAutoScroll.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import type { Step } from 'react-joyride';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 
 export function useTutorialAutoScroll(
   run: boolean,
@@ -8,6 +9,10 @@ export function useTutorialAutoScroll(
 ) {
   const prevStepIndexRef = useRef<number | null>(null);
   const lastStepIndexRef = useRef<number | null>(null);
+  // Programmatic scrollIntoView isn't reachable by the CSS
+  // prefers-reduced-motion media query (#1678) -- jump instead of animating.
+  const prefersReducedMotion = useReducedMotion();
+  const scrollBehavior = prefersReducedMotion ? 'auto' : 'smooth';
 
   // Track previous step index
   useEffect(() => {
@@ -58,19 +63,19 @@ export function useTutorialAutoScroll(
 
     if (stepData.autoScroll === 'down') {
       if (!isForward) return;
-      element.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      element.scrollIntoView({ block: 'center', behavior: scrollBehavior });
       return;
     }
 
     if (stepData.autoScroll === 'up') {
       if (!isBackward) return;
-      element.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      element.scrollIntoView({ block: 'center', behavior: scrollBehavior });
       return;
     }
 
     if (isForward && !isBelow) return;
     if (isBackward && !isAbove) return;
-    
-    element.scrollIntoView({ block: 'center', behavior: 'smooth' });
-  }, [run, steps, stepIndex]);
+
+    element.scrollIntoView({ block: 'center', behavior: scrollBehavior });
+  }, [run, steps, stepIndex, scrollBehavior]);
 }

--- a/src/hooks/__tests__/useReducedMotion.test.ts
+++ b/src/hooks/__tests__/useReducedMotion.test.ts
@@ -1,0 +1,57 @@
+import { renderHook, act } from '@testing-library/react';
+import { useReducedMotion } from '../useReducedMotion';
+
+describe('useReducedMotion', () => {
+  let matchMediaListeners: Array<(e: { matches: boolean }) => void>;
+
+  const mockMatchMedia = (initialMatches: boolean) => {
+    matchMediaListeners = [];
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: jest.fn().mockImplementation((query: string) => ({
+        matches: initialMatches,
+        media: query,
+        addEventListener: (_event: string, handler: (e: { matches: boolean }) => void) => {
+          matchMediaListeners.push(handler);
+        },
+        removeEventListener: jest.fn(),
+      })),
+    });
+  };
+
+  it('reflects the OS preference on mount', () => {
+    mockMatchMedia(true);
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(true);
+  });
+
+  it('defaults to false when the OS has no preference', () => {
+    mockMatchMedia(false);
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(false);
+  });
+
+  it('updates when the OS preference changes mid-session', () => {
+    mockMatchMedia(false);
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      matchMediaListeners.forEach((handler) => handler({ matches: true }));
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('does not crash in environments without matchMedia (jsdom, older browsers)', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: undefined,
+    });
+
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+const QUERY = '(prefers-reduced-motion: reduce)';
+
+// jsdom (the test environment) doesn't implement matchMedia, so every caller
+// needs this guard rather than assuming browser support.
+const supportsMatchMedia = () =>
+  typeof window !== 'undefined' && typeof window.matchMedia === 'function';
+
+/**
+ * Tracks the OS-level "reduce motion" preference (#1678). CSS handles the
+ * animation/transition side via the global media query in globals.css; this
+ * hook exists only for the JS-driven motion that query can't reach --
+ * react-joyride's scroll animation and the manual auto-scroll in
+ * useTutorialAutoScroll.ts.
+ */
+export function useReducedMotion(): boolean {
+  const [prefersReduced, setPrefersReduced] = useState(() =>
+    supportsMatchMedia() ? window.matchMedia(QUERY).matches : false
+  );
+
+  useEffect(() => {
+    if (!supportsMatchMedia()) return;
+
+    const mediaQueryList = window.matchMedia(QUERY);
+    const handleChange = (event: MediaQueryListEvent | MediaQueryList) =>
+      setPrefersReduced(event.matches);
+
+    handleChange(mediaQueryList);
+    mediaQueryList.addEventListener('change', handleChange);
+    return () => mediaQueryList.removeEventListener('change', handleChange);
+  }, []);
+
+  return prefersReduced;
+}

--- a/tests/visual/reduced-motion.spec.ts
+++ b/tests/visual/reduced-motion.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Probes read computed style off elements injected directly into the DOM
+// (rather than a live app screen) so the assertion is about the CSS contract
+// in globals.css, not about which page happens to render these classes.
+const probeAnimation = (page: Page, className: string) =>
+  page.evaluate((cls) => {
+    const el = document.createElement('div');
+    el.className = cls;
+    document.body.appendChild(el);
+    const style = getComputedStyle(el);
+    const raw = style.animationDuration.split(',')[0].trim();
+    const durationMs = raw.endsWith('ms') ? parseFloat(raw) : parseFloat(raw) * 1000;
+    const iterationCount = style.animationIterationCount.split(',')[0].trim();
+    el.remove();
+    return { durationMs, iterationCount };
+  }, className);
+
+test.describe('prefers-reduced-motion (#1678)', () => {
+  test.describe('with reduce-motion enabled', () => {
+    test.use({ contextOptions: { reducedMotion: 'reduce' } });
+
+    test('stops the rotating and sliding animations', async ({ page }) => {
+      await page.goto('/');
+
+      const dieTick = await probeAnimation(page, 'manuscript-evaluating-die');
+      const drawerSlide = await probeAnimation(page, 'manuscript-drawer-panel');
+
+      expect(dieTick.durationMs).toBeLessThan(1);
+      expect(drawerSlide.durationMs).toBeLessThan(1);
+    });
+
+    test('keeps opacity-only "still working" indicators looping instead of freezing', async ({ page }) => {
+      await page.goto('/');
+
+      const streamingDot = await probeAnimation(page, 'manuscript-streaming-dot');
+      const loadingDot = await probeAnimation(page, 'component-loading-dot');
+
+      expect(streamingDot.iterationCount).toBe('infinite');
+      expect(streamingDot.durationMs).toBeGreaterThan(1);
+      expect(loadingDot.iterationCount).toBe('infinite');
+      expect(loadingDot.durationMs).toBeGreaterThan(1);
+    });
+  });
+
+  test('runs at full speed when the OS has no motion preference set', async ({ page }) => {
+    await page.goto('/');
+
+    const dieTick = await probeAnimation(page, 'manuscript-evaluating-die');
+
+    expect(dieTick.iterationCount).toBe('infinite');
+    expect(dieTick.durationMs).toBeGreaterThan(1000);
+  });
+});


### PR DESCRIPTION
## Description
Nothing in the app checked `prefers-reduced-motion`, so players with motion sickness or vestibular issues had no way to stop the play surface's two infinite loops (streaming pulse, evaluating-die rotation) or the drawer's slide-in.

Added a blanket `@media (prefers-reduced-motion: reduce)` reset in `globals.css` that zeroes animation/transition duration app-wide, then walked back the couple of cases where "frozen" reads as "broken" rather than "calm": the streaming dot and loading pulse/dots are opacity-only busy indicators, so they keep a slow loop instead of going fully static. Rotation and positional movement (the die tick, the drawer slide) stay fully stopped since those are exactly what triggers vestibular symptoms.

CSS can't reach react-joyride's own scroll animation or the manual auto-scroll in `useTutorialAutoScroll.ts`, so I added a small `useReducedMotion` hook and wired it into both: the tour's `scrollDuration` collapses to 0 and the auto-scroll's `behavior` switches from `'smooth'` to `'auto'`.

## Related Issue
Closes #1678

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
As a player who sets reduce-motion at the OS level, I don't want the app running two infinite animations at me during the most-repeated moment in the app (story generation), and I don't want the tour scrolling the page with a smooth animation I didn't ask for.

## Flow Diagrams
N/A

## Component Development
N/A — CSS-level and hook-level change, no new components.

## Implementation Notes
- The reset uses `!important` deliberately (flagged in a code comment) — it has to win over every animation's own specificity, including ones written after this rule, and that's the standard pattern for this exact media query.
- Used near-zero duration (`0.01ms`) rather than `animation: none` so `animationend`/`transitionend` listeners still fire (grepped the codebase — nothing currently depends on them, but no reason to foreclose it).
- `react-joyride` 3.0.0-7 (pinned per #1251) exposes `scrollDuration` as a plain number prop, no `scrollIntoViewOptions` needed.
- Did not add a per-app "reduce motion" setting — the issue called that out of scope unless nearly free, and it isn't; OS-level preference is enough for v1.

## Screenshots
N/A — no visual change when the OS preference is off; the difference only shows up in a motion capture, which doesn't screenshot well. Verified live via browser devtools (computed `animation-duration`/`animation-iteration-count`) instead — see Testing Instructions.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks
- [x] Linting passed (`npm run lint`, `npm run lint:css`)
- [x] Type checking passed (`npm run type-check`)
- [x] Security audit passed (`npm run deps:validate`, `npm run knip`)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm run dev`, open the app in a browser with reduce-motion emulated (Chrome DevTools → Rendering → "Emulate CSS media feature prefers-reduced-motion: reduce").
2. Start any tour (e.g. world creation) — the tooltip should jump to each target instantly instead of smooth-scrolling.
3. During story generation, the streaming/evaluating indicators should keep a slow opacity pulse instead of freezing solid or spinning.
4. Automated coverage: `npx playwright test tests/visual/reduced-motion.spec.ts --project=chromium` (invariant assertions on computed animation duration/iteration-count, not a pixel baseline) and `npx jest src/hooks/__tests__/useReducedMotion.test.ts`.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) — N/A, no doc references this behavior
- [x] No new warnings generated
- [x] Accessibility considerations addressed (this PR is the accessibility fix — WCAG 2.3.3)
