### PR TITLE
Flag recently overused words in narrative prompts

### DIFF
--- a/.claude/skills/narraitor-prompt-template-governance/eval-logs/1681-phrase-variety.md
+++ b/.claude/skills/narraitor-prompt-template-governance/eval-logs/1681-phrase-variety.md
@@ -1,0 +1,34 @@
+# Prompt/template eval log — #1681 repeated-phrasing guardrail
+
+- Change: added `enhancePromptWithPhraseVariety` (`src/lib/ai/narrativeGenerator.phraseVariety.ts`), wired into `NarrativeGenerator.generateSegment`'s enhance chain. Pulls words that repeat (count >= 2) across `narrativeContext.recentSegments` and appends a short "already used, find another angle" list to the prompt. No-ops when nothing repeats (fresh session, or genuinely varied prose).
+- Diff: PR for issue #1681, branch `issue-1681-vary-recent-phrasing`
+- Date / evaluator: 2026-08-05, automated implementation session (no live provider key available in this environment)
+
+## Coverage matrix
+
+Not run. This environment has no configured Gemini provider key (`.env.local` absent — BYO-key architecture, see `project_byo_key_architecture` memory), so a live multi-turn generation matrix (2+ worlds x 2+ characters x 3+ runs per narraitor-ai-quality-discipline section 5) could not be executed here.
+
+What **was** verified deterministically (unit + integration, `src/lib/ai/__tests__/narrativeGenerator.phraseVariety.test.ts`):
+- `extractRepeatedPhrases` returns words that reappear across segments, excludes words that occur once, excludes common short words, caps output at 8 words, and returns `[]` for no/undefined segments.
+- `enhancePromptWithPhraseVariety` appends the flagged-words section only when there's something to flag; returns the prompt unchanged otherwise.
+- Integration: `NarrativeGenerator.generateSegment()` includes `RECENTLY OVERUSED WORDS` with the actual repeated words in the real prompt sent to the AI client when `recentSegments` shows reuse, and omits the section entirely on a fresh session.
+
+This proves the mechanism assembles correctly. It does **not** prove the model actually varies its phrasing in response — that requires the live matrix below.
+
+## Arc check (>= 3 consecutive turns, one cell)
+Not run (no live key). Recommend as manual QA follow-up: play 3+ turns in a world prone to repetition (per the issue, a survival/action genre reads worst) and confirm flagged words stop recurring verbatim, and separately that regular vocabulary (character names, established locations) isn't accidentally suppressed.
+
+## Failure drill
+- Malformed/empty response path: unaffected — this change only alters the outbound prompt, not response parsing (`narrativeGenerator.response*.ts` untouched).
+- Slow-response/timeout behavior: unaffected — no new AI calls added (extraction is local/synchronous, no extra round trip).
+- Missing/invalid key: unaffected — `extractRepeatedPhrases` and `enhancePromptWithPhraseVariety` run before the `geminiClient.generateContent` call and never touch the client.
+
+## Regression vs prior good outputs
+No prior eval log exists for this prompt surface to regress against. `sceneTemplate.ts`'s existing generic "vary your sensory language" line (line ~130) is unchanged — this change adds a second, more concrete signal alongside it rather than replacing it, per the issue's stated preference for a concrete list over a vague instruction.
+
+## Cost/latency
+- Added at most ~8 short words plus a fixed instruction sentence (~40-60 tokens) per turn, gated behind a new `phrase-variety` budget component (`target: 100, max: 200` tokens — smallest tier alongside `item-instructions`/`examples`) in `DEFAULT_ALLOCATIONS` (`src/lib/promptContext/tokenBudgetManager.ts`). No extra AI round trip. Negligible relative to the ~80k total request budget.
+
+## Verdict
+- Mechanism verified via deterministic tests; behavioral "reads better" claim is NOT made — no live matrix was run. Per narraitor-ai-quality-discipline, this stays a "single-sample impression" pending a manual QA pass with a real provider key.
+- Ship decision: shipping the mechanism (small, reversible, fail-open — no-ops when there's nothing to flag) with the live-quality check flagged as a follow-up manual QA item, not a blocking gate for this small-complexity issue. Recorded at: PR for issue #1681.

--- a/.claude/skills/narraitor-prompt-template-governance/eval-logs/1681-phrase-variety.md
+++ b/.claude/skills/narraitor-prompt-template-governance/eval-logs/1681-phrase-variety.md
@@ -29,6 +29,9 @@ No prior eval log exists for this prompt surface to regress against. `sceneTempl
 ## Cost/latency
 - Added at most ~8 short words plus a fixed instruction sentence (~40-60 tokens) per turn, gated behind a new `phrase-variety` budget component (`target: 100, max: 200` tokens — smallest tier alongside `item-instructions`/`examples`) in `DEFAULT_ALLOCATIONS` (`src/lib/promptContext/tokenBudgetManager.ts`). No extra AI round trip. Negligible relative to the ~80k total request budget.
 
+## Review follow-up (Codex, PR #1684)
+Codex flagged that the original version counted NPC/location names like any other repeated word, so a name mentioned twice (e.g. "Mara") could land in the `RECENTLY OVERUSED WORDS` list and conflict with the scene prompt's instruction to use NPC names naturally (`sceneTemplate.ts` NPC METADATA RULES). Fixed by excluding known entity names (world name, player character, NPC roster, other important entities - all already available on the `buildNarrativeContext` output used earlier in the same request) before counting repeats. Added `buildKnownNameTokens` plus unit/integration coverage asserting an NPC name mentioned twice is never flagged while unrelated repeated words still are.
+
 ## Verdict
 - Mechanism verified via deterministic tests; behavioral "reads better" claim is NOT made — no live matrix was run. Per narraitor-ai-quality-discipline, this stays a "single-sample impression" pending a manual QA pass with a real provider key.
 - Ship decision: shipping the mechanism (small, reversible, fail-open — no-ops when there's nothing to flag) with the live-quality check flagged as a follow-up manual QA item, not a blocking gate for this small-complexity issue. Recorded at: PR for issue #1681.

--- a/src/lib/ai/__tests__/narrativeGenerator.phraseVariety.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.phraseVariety.test.ts
@@ -1,0 +1,151 @@
+import {
+  extractRepeatedPhrases,
+  enhancePromptWithPhraseVariety,
+} from '../narrativeGenerator.phraseVariety';
+import { NarrativeGenerator } from '../narrativeGenerator';
+import { useWorldStore } from '@/state/worldStore';
+import { MockAIClient } from '../../__mocks__/mockAiClient';
+import type { NarrativeSegment } from '@/types/narrative.types';
+
+const segment = (content: string): NarrativeSegment => ({
+  id: 'seg',
+  content,
+  type: 'scene',
+  metadata: { tags: [] },
+  timestamp: new Date(),
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+});
+
+describe('extractRepeatedPhrases', () => {
+  it('returns words that reappear across recent segments', () => {
+    const segments = [
+      segment('The rifle felt cold metal against your palm.'),
+      segment('You push through the dense woods, rifle ready.'),
+      segment('The cold metal grip is a reassuring weight now.'),
+    ];
+
+    const result = extractRepeatedPhrases(segments);
+
+    expect(result).toContain('rifle');
+    expect(result).toContain('cold');
+    expect(result).toContain('metal');
+  });
+
+  it('ignores words that only appear once', () => {
+    const segments = [
+      segment('The rifle felt cold metal against your palm.'),
+      segment('You push through the dense woods.'),
+    ];
+
+    const result = extractRepeatedPhrases(segments);
+
+    expect(result).not.toContain('woods');
+    expect(result).not.toContain('palm');
+  });
+
+  it('returns an empty list when there are no segments', () => {
+    expect(extractRepeatedPhrases([])).toEqual([]);
+    expect(extractRepeatedPhrases(undefined)).toEqual([]);
+  });
+
+  it('caps the result to a small number of words', () => {
+    const filler = Array.from({ length: 12 }, (_, i) => `distinctive${i}`).join(' ');
+    const segments = [segment(filler), segment(filler)];
+
+    const result = extractRepeatedPhrases(segments);
+
+    expect(result.length).toBeLessThanOrEqual(8);
+  });
+});
+
+describe('enhancePromptWithPhraseVariety', () => {
+  it('appends a "find another angle" list when words repeat', () => {
+    const segments = [
+      segment('The rifle felt cold metal against your palm.'),
+      segment('The cold metal grip is a reassuring weight now.'),
+    ];
+
+    const result = enhancePromptWithPhraseVariety('BASE PROMPT', segments);
+
+    expect(result).toContain('BASE PROMPT');
+    expect(result).toContain('cold');
+    expect(result).toContain('metal');
+  });
+
+  it('returns the prompt unchanged when there is nothing to flag', () => {
+    const result = enhancePromptWithPhraseVariety('BASE PROMPT', []);
+    expect(result).toBe('BASE PROMPT');
+  });
+
+  it('returns the prompt unchanged when recentSegments is undefined', () => {
+    const result = enhancePromptWithPhraseVariety('BASE PROMPT', undefined);
+    expect(result).toBe('BASE PROMPT');
+  });
+});
+
+describe('NarrativeGenerator phrase-variety integration', () => {
+  let generator: NarrativeGenerator;
+  let mockAiClient: MockAIClient;
+  let worldId: string;
+
+  beforeEach(() => {
+    useWorldStore.getState().reset();
+    mockAiClient = new MockAIClient();
+    generator = new NarrativeGenerator(mockAiClient);
+
+    worldId = useWorldStore.getState().createWorld({
+      name: 'Test World',
+      description: 'A test world',
+      genre: 'horror',
+      attributes: [],
+      skills: [],
+      settings: {
+        maxAttributes: 10,
+        maxSkills: 10,
+        attributePointPool: 100,
+        skillPointPool: 100,
+      },
+    });
+  });
+
+  it('flags words reused across recent segments in the generation prompt', async () => {
+    mockAiClient.setMockResponse({ content: 'Generated narrative content' });
+
+    await generator.generateSegment({
+      worldId,
+      sessionId: 'test-session',
+      characterIds: ['test-character'],
+      narrativeContext: {
+        worldId,
+        currentSceneId: 'scene-1',
+        characterIds: ['test-character'],
+        sessionId: 'test-session',
+        previousSegments: [],
+        currentTags: [],
+        recentSegments: [
+          segment('The rifle felt cold metal against your palm.'),
+          segment('The cold metal grip is a reassuring weight now.'),
+        ],
+      },
+    });
+
+    const prompt = mockAiClient.getPrompts()[0];
+    expect(prompt).toContain('RECENTLY OVERUSED WORDS');
+    expect(prompt).toContain('cold');
+    expect(prompt).toContain('metal');
+  });
+
+  it('does not add the overused-words section on a fresh session', async () => {
+    mockAiClient.setMockResponse({ content: 'Generated narrative content' });
+
+    await generator.generateSegment({
+      worldId,
+      sessionId: 'test-session',
+      characterIds: ['test-character'],
+    });
+
+    const prompt = mockAiClient.getPrompts()[0];
+    expect(prompt).not.toContain('RECENTLY OVERUSED WORDS');
+  });
+});

--- a/src/lib/ai/__tests__/narrativeGenerator.phraseVariety.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.phraseVariety.test.ts
@@ -1,9 +1,11 @@
 import {
   extractRepeatedPhrases,
   enhancePromptWithPhraseVariety,
+  buildKnownNameTokens,
 } from '../narrativeGenerator.phraseVariety';
 import { NarrativeGenerator } from '../narrativeGenerator';
 import { useWorldStore } from '@/state/worldStore';
+import { useNPCStore } from '@/state/npcStore';
 import { MockAIClient } from '../../__mocks__/mockAiClient';
 import type { NarrativeSegment } from '@/types/narrative.types';
 
@@ -57,6 +59,32 @@ describe('extractRepeatedPhrases', () => {
 
     expect(result.length).toBeLessThanOrEqual(8);
   });
+
+  it('never flags a repeated word that belongs to a known entity name', () => {
+    const segments = [
+      segment('Mara Chen pushes through the dense woods, rifle ready.'),
+      segment('Mara Chen finds cold metal debris near the dense woods.'),
+    ];
+    const knownNameTokens = buildKnownNameTokens(['Mara Chen']);
+
+    const result = extractRepeatedPhrases(segments, knownNameTokens);
+
+    expect(result).not.toContain('mara');
+    expect(result).not.toContain('chen');
+    // Non-name repeats are still flagged.
+    expect(result).toContain('woods');
+  });
+});
+
+describe('buildKnownNameTokens', () => {
+  it('lowercases and splits multi-word names into individual tokens', () => {
+    const tokens = buildKnownNameTokens(['Mara Chen', 'Rustwater Camp', null, undefined]);
+
+    expect(tokens.has('mara')).toBe(true);
+    expect(tokens.has('chen')).toBe(true);
+    expect(tokens.has('rustwater')).toBe(true);
+    expect(tokens.has('camp')).toBe(true);
+  });
 });
 
 describe('enhancePromptWithPhraseVariety', () => {
@@ -81,6 +109,20 @@ describe('enhancePromptWithPhraseVariety', () => {
   it('returns the prompt unchanged when recentSegments is undefined', () => {
     const result = enhancePromptWithPhraseVariety('BASE PROMPT', undefined);
     expect(result).toBe('BASE PROMPT');
+  });
+
+  it('excludes known entity names from the flagged list', () => {
+    const segments = [
+      segment('Mara Chen pushes through the dense woods, rifle ready.'),
+      segment('Mara Chen finds cold metal debris near the dense woods.'),
+    ];
+    const knownNameTokens = buildKnownNameTokens(['Mara Chen']);
+
+    const result = enhancePromptWithPhraseVariety('BASE PROMPT', segments, knownNameTokens);
+
+    expect(result).not.toContain('mara');
+    expect(result).not.toContain('chen');
+    expect(result).toContain('woods');
   });
 });
 
@@ -147,5 +189,40 @@ describe('NarrativeGenerator phrase-variety integration', () => {
 
     const prompt = mockAiClient.getPrompts()[0];
     expect(prompt).not.toContain('RECENTLY OVERUSED WORDS');
+  });
+
+  it('does not flag an NPC name mentioned twice in recent segments', async () => {
+    useNPCStore.getState().createNPC({
+      worldId,
+      name: 'Mara',
+      description: 'A fellow survivor',
+    });
+    mockAiClient.setMockResponse({ content: 'Generated narrative content' });
+
+    await generator.generateSegment({
+      worldId,
+      sessionId: 'test-session',
+      characterIds: ['test-character'],
+      narrativeContext: {
+        worldId,
+        currentSceneId: 'scene-1',
+        characterIds: ['test-character'],
+        sessionId: 'test-session',
+        previousSegments: [],
+        currentTags: [],
+        recentSegments: [
+          segment('Mara leads you through the dense woods, rifle ready.'),
+          segment('Mara finds cold metal debris near the dense woods.'),
+        ],
+      },
+    });
+
+    const prompt = mockAiClient.getPrompts()[0];
+    // Other repeated words still get flagged — only the NPC's name is excluded.
+    expect(prompt).toContain('RECENTLY OVERUSED WORDS');
+    const [, flaggedWordsLine] =
+      prompt.match(/RECENTLY OVERUSED WORDS[^\n]*\n([^\n]*)/i) ?? [];
+    expect(flaggedWordsLine).toBeDefined();
+    expect(flaggedWordsLine?.toLowerCase()).not.toContain('mara');
   });
 });

--- a/src/lib/ai/narrativeGenerator.phraseVariety.ts
+++ b/src/lib/ai/narrativeGenerator.phraseVariety.ts
@@ -1,0 +1,95 @@
+/**
+ * Repeated-phrasing guardrail for narrative generation (#1681).
+ *
+ * Long sessions drift toward the same handful of nouns and adjectives
+ * ("cold metal", "dense woods") because each turn's prompt only shows the
+ * model the recent story, never flags which words it has already leaned on.
+ * This pulls distinctive words that reappear across the last few segments
+ * and tells the model to find another way to say them — a short, concrete
+ * list rather than a vague "vary your word choice" instruction, which tends
+ * to get ignored once the context fills up.
+ */
+
+import type { NarrativeSegment } from '@/types/narrative.types';
+import type { RequestBudget } from '@/lib/promptContext/tokenBudgetManager';
+import { applyBudget } from './narrativeGenerator.budget';
+
+/** How many of the most-repeated words to surface — enough to be useful, small enough to stay cheap. */
+const MAX_FLAGGED_WORDS = 8;
+
+/** A word must reappear at least this many times across recent segments to count as "reused". */
+const MIN_REPEAT_COUNT = 2;
+
+/** Below this length, common short words (verbs, prepositions) swamp the signal. */
+const MIN_WORD_LENGTH = 4;
+
+/**
+ * Common words long enough to clear MIN_WORD_LENGTH but not distinctive —
+ * excluded so the flagged list stays focused on the setting/sensory words
+ * that actually make repetition noticeable (nouns, adjectives), not glue
+ * words that legitimately recur in every scene.
+ */
+const COMMON_WORDS = new Set([
+  'that', 'this', 'with', 'from', 'have', 'were', 'they', 'them', 'then',
+  'than', 'into', 'onto', 'upon', 'when', 'what', 'where', 'which', 'while',
+  'before', 'after', 'around', 'still', 'just', 'like', 'here', 'there',
+  'toward', 'towards', 'through', 'against', 'began', 'begin', 'could',
+  'would', 'should', 'might', 'about', 'again', 'back', 'down', 'over',
+  'under', 'each', 'even', 'much', 'more', 'most', 'some', 'every', 'other',
+  'same', 'such', 'only', 'very', 'also', 'your', 'yours', 'their', 'these',
+  'those', 'been', 'being', 'does', 'doing', 'know', 'knew', 'feel', 'felt',
+  'seem', 'seems', 'seemed', 'look', 'looks', 'looked', 'make', 'makes',
+  'made', 'take', 'takes', 'took',
+]);
+
+const tokenize = (content: string): string[] =>
+  (content.match(/[a-zA-Z']+/g) || []).map((word) => word.toLowerCase());
+
+/**
+ * Pure extraction: counts word frequency across the given segments and
+ * returns the words that reappear (not just the ones that occur once),
+ * sorted by frequency then alphabetically for a deterministic list.
+ */
+export const extractRepeatedPhrases = (
+  segments: NarrativeSegment[] | undefined
+): string[] => {
+  if (!segments || segments.length === 0) {
+    return [];
+  }
+
+  const counts = new Map<string, number>();
+  for (const seg of segments) {
+    if (!seg?.content) continue;
+    for (const word of tokenize(seg.content)) {
+      if (word.length < MIN_WORD_LENGTH || COMMON_WORDS.has(word)) continue;
+      counts.set(word, (counts.get(word) || 0) + 1);
+    }
+  }
+
+  return Array.from(counts.entries())
+    .filter(([, count]) => count >= MIN_REPEAT_COUNT)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, MAX_FLAGGED_WORDS)
+    .map(([word]) => word);
+};
+
+/**
+ * Prevention layer: appends a short "already used, find another angle" list
+ * to the prompt when recent segments show word reuse. No-ops (returns the
+ * prompt unchanged) when there's nothing to flag, so it never pads the
+ * prompt on a fresh session or a session with genuinely varied prose.
+ */
+export const enhancePromptWithPhraseVariety = (
+  prompt: string,
+  recentSegments: NarrativeSegment[] | undefined,
+  budget?: RequestBudget
+): string => {
+  const repeated = extractRepeatedPhrases(recentSegments);
+  if (repeated.length === 0) {
+    return prompt;
+  }
+
+  const guidance = `\n\nRECENTLY OVERUSED WORDS (used more than once in the last few segments — find a different way to describe these instead of repeating them):\n${repeated.join(', ')}`;
+
+  return prompt + applyBudget(guidance, 'phrase-variety', budget);
+};

--- a/src/lib/ai/narrativeGenerator.phraseVariety.ts
+++ b/src/lib/ai/narrativeGenerator.phraseVariety.ts
@@ -46,12 +46,37 @@ const tokenize = (content: string): string[] =>
   (content.match(/[a-zA-Z']+/g) || []).map((word) => word.toLowerCase());
 
 /**
+ * Builds a lowercase token set from known entity names (world name, player
+ * character, NPCs, other important entities) so those names — and their
+ * individual name parts, e.g. "Chen" from "Mara Chen" — never get flagged
+ * as overused prose. The scene prompt separately instructs the model to use
+ * NPC names naturally (sceneTemplate.ts); flagging a name here would work
+ * against that and risk the model paraphrasing or dropping it for
+ * "variety", breaking continuity instead of improving prose (#1681 review).
+ */
+export const buildKnownNameTokens = (
+  names: Array<string | null | undefined>
+): Set<string> => {
+  const tokens = new Set<string>();
+  for (const name of names) {
+    if (!name) continue;
+    for (const word of tokenize(name)) {
+      tokens.add(word);
+    }
+  }
+  return tokens;
+};
+
+/**
  * Pure extraction: counts word frequency across the given segments and
  * returns the words that reappear (not just the ones that occur once),
- * sorted by frequency then alphabetically for a deterministic list.
+ * sorted by frequency then alphabetically for a deterministic list. Words
+ * belonging to a known entity name are always excluded, regardless of how
+ * often they repeat.
  */
 export const extractRepeatedPhrases = (
-  segments: NarrativeSegment[] | undefined
+  segments: NarrativeSegment[] | undefined,
+  knownNameTokens?: Set<string>
 ): string[] => {
   if (!segments || segments.length === 0) {
     return [];
@@ -62,6 +87,7 @@ export const extractRepeatedPhrases = (
     if (!seg?.content) continue;
     for (const word of tokenize(seg.content)) {
       if (word.length < MIN_WORD_LENGTH || COMMON_WORDS.has(word)) continue;
+      if (knownNameTokens?.has(word)) continue;
       counts.set(word, (counts.get(word) || 0) + 1);
     }
   }
@@ -82,9 +108,10 @@ export const extractRepeatedPhrases = (
 export const enhancePromptWithPhraseVariety = (
   prompt: string,
   recentSegments: NarrativeSegment[] | undefined,
+  knownNameTokens?: Set<string>,
   budget?: RequestBudget
 ): string => {
-  const repeated = extractRepeatedPhrases(recentSegments);
+  const repeated = extractRepeatedPhrases(recentSegments, knownNameTokens);
   if (repeated.length === 0) {
     return prompt;
   }

--- a/src/lib/ai/narrativeGenerator.ts
+++ b/src/lib/ai/narrativeGenerator.ts
@@ -53,6 +53,7 @@ import {
   buildContinuityContractFromStores,
   enhancePromptWithContinuityExpectations,
 } from './narrativeGenerator.continuity';
+import { enhancePromptWithPhraseVariety } from './narrativeGenerator.phraseVariety';
 
 /**
  * Stop an abandoned generation before its side effects run. Callers that race
@@ -147,9 +148,15 @@ export class NarrativeGenerator {
         characterInventory
       );
 
+      const phraseVarietyPrompt = enhancePromptWithPhraseVariety(
+        fullyEnhancedPrompt,
+        requestForTemplate.narrativeContext?.recentSegments,
+        budget
+      );
+
       const continuityContract = buildContinuityContractFromStores(request);
       const finalPrompt = enhancePromptWithContinuityExpectations(
-        fullyEnhancedPrompt,
+        phraseVarietyPrompt,
         continuityContract
       );
 

--- a/src/lib/ai/narrativeGenerator.ts
+++ b/src/lib/ai/narrativeGenerator.ts
@@ -53,7 +53,10 @@ import {
   buildContinuityContractFromStores,
   enhancePromptWithContinuityExpectations,
 } from './narrativeGenerator.continuity';
-import { enhancePromptWithPhraseVariety } from './narrativeGenerator.phraseVariety';
+import {
+  buildKnownNameTokens,
+  enhancePromptWithPhraseVariety,
+} from './narrativeGenerator.phraseVariety';
 
 /**
  * Stop an abandoned generation before its side effects run. Callers that race
@@ -148,9 +151,18 @@ export class NarrativeGenerator {
         characterInventory
       );
 
+      // Never flag names the model is instructed to use naturally (sceneTemplate.ts) —
+      // the world/player/NPC/important-entity names already in context.
+      const knownNameTokens = buildKnownNameTokens([
+        context.worldName,
+        context.playerCharacterName,
+        ...context.npcRoster.map((npc) => npc.name),
+        ...(context.narrativeContext?.importantEntities?.map((entity) => entity.name) ?? []),
+      ]);
       const phraseVarietyPrompt = enhancePromptWithPhraseVariety(
         fullyEnhancedPrompt,
         requestForTemplate.narrativeContext?.recentSegments,
+        knownNameTokens,
         budget
       );
 

--- a/src/lib/promptContext/tokenBudgetManager.ts
+++ b/src/lib/promptContext/tokenBudgetManager.ts
@@ -289,6 +289,7 @@ export const DEFAULT_ALLOCATIONS: BudgetAllocation[] = [
   { componentId: 'personalization', priority: ComponentPriority.MEDIUM, min: 200, target: 800, max: 1500 },
   { componentId: 'item-instructions', priority: ComponentPriority.LOW, min: 0, target: 200, max: 400 },
   { componentId: 'examples', priority: ComponentPriority.LOW, min: 0, target: 200, max: 400 },
+  { componentId: 'phrase-variety', priority: ComponentPriority.LOW, min: 0, target: 100, max: 200 },
 ];
 
 /**


### PR DESCRIPTION
## Description
Narrative generation prompts didn't tell the model anything about which words it had already reached for, so long sessions drifted into repeating the same nouns and adjectives turn after turn (a rifle going "cold metal" three times running, a forest cycling through "dense woods," "dense canopy," "dense undergrowth"). This adds `enhancePromptWithPhraseVariety`, which pulls words that reappear across the last few segments (`narrativeContext.recentSegments`) and appends a short, concrete "already used, find another angle" list to the generation prompt - instead of a vague "vary your word choice" line, which the issue calls out as easy for the model to ignore once the context fills up.

It's wired into `NarrativeGenerator.generateSegment()`'s existing enhance-function chain (same pattern as tone/lore/inventory/continuity), no-ops when there's nothing to flag (fresh session, or genuinely varied prose already), and adds no extra AI round trip - it's a local word-frequency count over segments already present in the request. Budgeted at a small, low-priority token allocation (100-200 tokens) alongside the other lightweight prompt add-ons.

## Related Issue
Closes #1681

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
As a player in a long session, I want the generated prose to keep reaching for fresh phrasing instead of noticeably repeating the same words, so the world doesn't start to feel like it only has five nouns in it.

## Flow Diagrams
N/A

## Component Development
N/A - no UI/component changes, this is a prompt-assembly change in `src/lib/ai/`.

## Implementation Notes
- New file `src/lib/ai/narrativeGenerator.phraseVariety.ts`, following the existing `narrativeGenerator.<concern>.ts` split (alongside `.continuity.ts`, `.budget.ts`, `.npc.ts`, `.languageComplexity.ts`).
- `extractRepeatedPhrases` is a pure function: tokenizes segment content, filters short/common words, counts frequency, and returns words that appear 2+ times, capped at 8, sorted by frequency then alphabetically for determinism.
- `enhancePromptWithPhraseVariety` formats that list into a short instruction block and appends it via the same `applyBudget` helper the other enhance functions use, under a new `phrase-variety` budget component in `DEFAULT_ALLOCATIONS` (`src/lib/promptContext/tokenBudgetManager.ts`).
- Wired only into `generateSegment` (the per-turn scene continuation), matching where the existing continuity guardrail was scoped - `generateInitialScene` has no prior segments to repeat, and `generateTransition`/`generateSkillAcknowledgment` sit outside this enhance chain entirely.
- Per the `narraitor-prompt-template-governance` and `narraitor-ai-quality-discipline` skills, this is a prompt-context addition (not a registry template rewrite) using the codebase's established enhance-function pattern, and the eval log at `.claude/skills/narraitor-prompt-template-governance/eval-logs/1681-phrase-variety.md` records what was and wasn't verified: the mechanism is proven deterministically via unit/integration tests, but a live multi-turn quality matrix needs a real Gemini provider key, which this automated environment doesn't have. That's flagged there as a manual QA follow-up rather than claimed as done.
- Scope note: kept strictly to the prompt-assembly mechanism described in the issue. Didn't touch the existing generic "vary your sensory language" line already in `sceneTemplate.ts` (it's complementary, not redundant) or extend this to `generateTransition`/`generateSkillAcknowledgment`, since neither is in scope for #1681.

## Screenshots
N/A

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed (not run - no dependency changes)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm test -- --testPathPattern="narrativeGenerator.phraseVariety"` - 9 new tests covering the extraction heuristic and prompt assembly, including a `NarrativeGenerator.generateSegment()` integration check that the flagged-words section shows up in the real outbound prompt when recent segments repeat words, and is absent on a fresh session.
2. `npm test` - full suite (374 suites / 2456 tests) passes.
3. `npm run type-check` and `npm run lint` - both clean (lint has pre-existing warnings unrelated to this change, no new ones, no errors).

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required) - eval log added per prompt-template-governance skill
- [x] No new warnings generated
- [ ] Accessibility considerations addressed - N/A, no UI change
