### PR TITLE
Wire up keyboard shortcuts for the game session (#276)

### DIFF
--- a/src/components/GameSession/ActiveGameSession.tsx
+++ b/src/components/GameSession/ActiveGameSession.tsx
@@ -36,6 +36,8 @@ import {
 } from './ManuscriptDrawerPanels';
 import { CharacterSnapshot } from './CharacterSnapshot';
 import { SceneStatus } from './SceneStatus';
+import { KeyboardShortcutsDialog } from './KeyboardShortcutsDialog';
+import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { isFeatureEnabled } from '@/lib/featureFlags';
 
 type DrawerType = 'character' | 'inventory' | 'story-summary' | 'choice-history' | 'journal';
@@ -84,6 +86,7 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
   const [isEvaluatingAction, setIsEvaluatingAction] = React.useState(false);
   const [isCharacterSummaryExpanded, setIsCharacterSummaryExpanded] = React.useState(false);
   const [activeDrawer, setActiveDrawer] = React.useState<DrawerType | null>(null);
+  const [isShortcutsHelpOpen, setIsShortcutsHelpOpen] = React.useState(false);
 
   const characterButtonRef = React.useRef<HTMLButtonElement>(null);
   const drawerTriggerRef = React.useRef<HTMLElement | null>(null);
@@ -223,6 +226,49 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
 
     return () => clearTimeout(timer);
   }, [isGameReady, shouldShowTour, isTourActive, startTour]);
+
+  // Journal opens as a drawer under progressive disclosure, otherwise it's a
+  // route (matches the two "Open Journal" entry points already in the HUD /
+  // ActiveGameSessionControls).
+  const handleOpenJournalShortcut = React.useCallback(() => {
+    if (isProgressiveDisclosureEnabled) {
+      setActiveDrawer('journal');
+    } else {
+      router.push(`/worlds/${worldId}/play/journal`);
+    }
+  }, [isProgressiveDisclosureEnabled, router, worldId]);
+
+  const handleToggleCharacterShortcut = React.useCallback(() => {
+    setIsCharacterSummaryExpanded((prev) => !prev);
+  }, []);
+
+  // Game-session keyboard shortcuts (#276): number keys for choices live in
+  // ChoiceSelector itself since that's where the option list is. These cover
+  // the remaining common actions the issue calls out - journal, character
+  // sheet, and a discoverable reference for all of it. Only active once the
+  // session has rendered its real HUD (isGameReady), same gate the Escape
+  // handling above effectively relies on.
+  const gameSessionShortcuts = React.useMemo(
+    () => [
+      {
+        key: '?',
+        description: 'Show keyboard shortcuts',
+        action: () => setIsShortcutsHelpOpen(true),
+      },
+      {
+        key: 'j',
+        description: 'Open journal',
+        action: handleOpenJournalShortcut,
+      },
+      {
+        key: 'c',
+        description: 'Toggle character sheet',
+        action: handleToggleCharacterShortcut,
+      },
+    ],
+    [handleOpenJournalShortcut, handleToggleCharacterShortcut]
+  );
+  useKeyboardShortcuts(gameSessionShortcuts, isGameReady);
 
   const { createDecisionJournalEntry, createJournalEntryFromSegment } = useActiveGameSessionJournal({
     sessionId,
@@ -387,6 +433,7 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
           onStartNew={handleHudStartNew}
           onBack={handleHudBack}
           onEndStory={handleEndStoryClick}
+          onShowShortcuts={() => setIsShortcutsHelpOpen(true)}
           saveIndicator={
             <SaveIndicator
               status={autoSave.status}
@@ -523,6 +570,11 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
           )}
         </ManuscriptDrawer>
       )}
+
+      <KeyboardShortcutsDialog
+        open={isShortcutsHelpOpen}
+        onOpenChange={setIsShortcutsHelpOpen}
+      />
     </ManuscriptSessionShell>
   );
 };

--- a/src/components/GameSession/ActiveGameSession.tsx
+++ b/src/components/GameSession/ActiveGameSession.tsx
@@ -242,34 +242,6 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
     setIsCharacterSummaryExpanded((prev) => !prev);
   }, []);
 
-  // Game-session keyboard shortcuts (#276): number keys for choices live in
-  // ChoiceSelector itself since that's where the option list is. These cover
-  // the remaining common actions the issue calls out - journal, character
-  // sheet, and a discoverable reference for all of it. Only active once the
-  // session has rendered its real HUD (isGameReady), same gate the Escape
-  // handling above effectively relies on.
-  const gameSessionShortcuts = React.useMemo(
-    () => [
-      {
-        key: '?',
-        description: 'Show keyboard shortcuts',
-        action: () => setIsShortcutsHelpOpen(true),
-      },
-      {
-        key: 'j',
-        description: 'Open journal',
-        action: handleOpenJournalShortcut,
-      },
-      {
-        key: 'c',
-        description: 'Toggle character sheet',
-        action: handleToggleCharacterShortcut,
-      },
-    ],
-    [handleOpenJournalShortcut, handleToggleCharacterShortcut]
-  );
-  useKeyboardShortcuts(gameSessionShortcuts, isGameReady);
-
   const { createDecisionJournalEntry, createJournalEntryFromSegment } = useActiveGameSessionJournal({
     sessionId,
     worldId,
@@ -294,6 +266,44 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
     character,
     generateEnding,
   });
+
+  // True while any modal/dialog is up over the session (shortcuts help, a
+  // progressive-disclosure drawer, or the End Story confirmation). Global
+  // hotkeys - both the j/c/? bindings below and ChoiceSelector's number keys
+  // - must not fire while one of these is open: the underlying content stays
+  // mounted behind the overlay, so without this gate a player reading the
+  // shortcuts dialog could press "1" and silently advance the turn behind it
+  // (#276 review follow-up). The character summary panel is deliberately
+  // excluded - it's non-modal and doesn't trap focus.
+  const isModalOpen = isShortcutsHelpOpen || activeDrawer !== null || showEndConfirmation;
+
+  // Game-session keyboard shortcuts (#276): number keys for choices live in
+  // ChoiceSelector itself since that's where the option list is. These cover
+  // the remaining common actions the issue calls out - journal, character
+  // sheet, and a discoverable reference for all of it. Only active once the
+  // session has rendered its real HUD (isGameReady) and no modal is already
+  // covering it.
+  const gameSessionShortcuts = React.useMemo(
+    () => [
+      {
+        key: '?',
+        description: 'Show keyboard shortcuts',
+        action: () => setIsShortcutsHelpOpen(true),
+      },
+      {
+        key: 'j',
+        description: 'Open journal',
+        action: handleOpenJournalShortcut,
+      },
+      {
+        key: 'c',
+        description: 'Toggle character sheet',
+        action: handleToggleCharacterShortcut,
+      },
+    ],
+    [handleOpenJournalShortcut, handleToggleCharacterShortcut]
+  );
+  useKeyboardShortcuts(gameSessionShortcuts, isGameReady && !isModalOpen);
 
   const { scheduleChoiceFallback } = useActiveGameSessionEffects({
     sessionId,
@@ -475,6 +485,7 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
               endingSuggestion={endingSuggestion}
               generationError={generationError}
               onRetryGeneration={handleRetryGeneration}
+              shortcutsSuspended={isModalOpen}
             />
           </div>
         </ManuscriptActionRail>

--- a/src/components/GameSession/ActiveGameSessionChoicesColumn.tsx
+++ b/src/components/GameSession/ActiveGameSessionChoicesColumn.tsx
@@ -38,6 +38,8 @@ interface ActiveGameSessionChoicesColumnProps {
   generationError?: NarrativeError | null;
   /** Retry the failed turn (only meaningful for transient/retryable errors). */
   onRetryGeneration?: () => void;
+  /** Suppress ChoiceSelector's number-key shortcuts while a modal/dialog is open over the session (#276). */
+  shortcutsSuspended?: boolean;
 }
 
 const ActiveGameSessionChoicesColumn: React.FC<
@@ -66,6 +68,7 @@ const ActiveGameSessionChoicesColumn: React.FC<
   endingSuggestion,
   generationError = null,
   onRetryGeneration,
+  shortcutsSuspended = false,
 }) => {
   const [showSuggestedActions, setShowSuggestedActions] = React.useState(false);
 
@@ -188,6 +191,7 @@ const ActiveGameSessionChoicesColumn: React.FC<
                 inventoryItems={inventoryItems}
                 endingSuggestion={endingSuggestion}
                 inputActions={resolvedInputActions}
+                shortcutsSuspended={shortcutsSuspended}
               />
             </div>
           )

--- a/src/components/GameSession/KeyboardShortcutsDialog.tsx
+++ b/src/components/GameSession/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import React from 'react';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+
+interface ShortcutEntry {
+  keys: string[];
+  description: string;
+}
+
+// Only the shortcuts actually wired up in the game session (#276). Keep this
+// list in sync with ChoiceSelector's number-key handling and the 'j'/'c'/'?'
+// bindings in ActiveGameSession.
+const SHORTCUTS: ShortcutEntry[] = [
+  { keys: ['1', '-', '9'], description: 'Select a suggested action' },
+  { keys: ['Enter'], description: 'Submit a custom action while typing' },
+  { keys: ['J'], description: 'Open journal' },
+  { keys: ['C'], description: 'Toggle character sheet' },
+  { keys: ['Esc'], description: 'Close a dialog or panel' },
+  { keys: ['?'], description: 'Show this shortcuts guide' },
+];
+
+interface KeyboardShortcutsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function KeyboardShortcutsDialog({ open, onOpenChange }: KeyboardShortcutsDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="keyboard-shortcuts-dialog"
+        aria-describedby={undefined}
+      >
+        <DialogTitle>Keyboard Shortcuts</DialogTitle>
+        <ul className="keyboard-shortcuts-list">
+          {SHORTCUTS.map((shortcut) => (
+            <li key={shortcut.description} className="keyboard-shortcuts-item">
+              <span className="keyboard-shortcuts-keys">
+                {shortcut.keys.map((key) => (
+                  <kbd key={key} className="keyboard-shortcuts-key">
+                    {key}
+                  </kbd>
+                ))}
+              </span>
+              <span className="keyboard-shortcuts-description">{shortcut.description}</span>
+            </li>
+          ))}
+        </ul>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/GameSession/ManuscriptFloatingHud.tsx
+++ b/src/components/GameSession/ManuscriptFloatingHud.tsx
@@ -123,7 +123,7 @@ export const ManuscriptFloatingHud: React.FC<ManuscriptFloatingHudProps> = ({
             onClick={onShowShortcuts}
             title="Keyboard Shortcuts"
             aria-label="Keyboard Shortcuts"
-            className="manuscript-hud-icon-button"
+            className="manuscript-hud-icon-button manuscript-hud-shortcuts-button"
           >
             <Keyboard size={16} aria-hidden="true" />
           </button>

--- a/src/components/GameSession/ManuscriptFloatingHud.tsx
+++ b/src/components/GameSession/ManuscriptFloatingHud.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { BookOpen, Backpack, FileText, RotateCcw, LogOut, History } from 'lucide-react';
+import { BookOpen, Backpack, FileText, RotateCcw, LogOut, History, Keyboard } from 'lucide-react';
 import { HudCloseButton } from './HudCloseButton';
 import { CharacterPortrait } from '@/components/CharacterPortrait';
 import type { GeneratedImage } from '@/types/common.types';
@@ -18,6 +18,7 @@ interface ManuscriptFloatingHudProps {
   onStartNew?: () => void;
   onBack?: () => void;
   onEndStory?: () => void;
+  onShowShortcuts?: () => void;
   saveIndicator?: React.ReactNode;
   characterButtonRef?: React.RefObject<HTMLButtonElement | null>;
 }
@@ -34,6 +35,7 @@ export const ManuscriptFloatingHud: React.FC<ManuscriptFloatingHudProps> = ({
   onStartNew,
   onBack,
   onEndStory,
+  onShowShortcuts,
   saveIndicator,
   characterButtonRef,
 }) => {
@@ -116,6 +118,15 @@ export const ManuscriptFloatingHud: React.FC<ManuscriptFloatingHudProps> = ({
               </button>
             </>
           )}
+          <button
+            type="button"
+            onClick={onShowShortcuts}
+            title="Keyboard Shortcuts"
+            aria-label="Keyboard Shortcuts"
+            className="manuscript-hud-icon-button"
+          >
+            <Keyboard size={16} aria-hidden="true" />
+          </button>
           <button
             type="button"
             onClick={onStartNew}

--- a/src/components/GameSession/__tests__/ActiveGameSession.manuscriptLayout.test.tsx
+++ b/src/components/GameSession/__tests__/ActiveGameSession.manuscriptLayout.test.tsx
@@ -43,12 +43,12 @@ jest.mock('../ActiveGameSessionNarrativeColumn', () => ({
 
 jest.mock('../ActiveGameSessionChoicesColumn', () => ({
   __esModule: true,
-  default: ({ inputActions, endStoryAction }: { inputActions?: React.ReactNode; endStoryAction?: React.ReactNode }) => (
+  default: jest.fn(({ inputActions, endStoryAction }: { inputActions?: React.ReactNode; endStoryAction?: React.ReactNode }) => (
     <div data-testid="choices-column">
       {inputActions}
       {endStoryAction}
     </div>
-  ),
+  )),
 }));
 
 jest.mock('../ActiveGameSessionControls', () => ({
@@ -302,6 +302,38 @@ describe('ActiveGameSession Manuscript Layout', () => {
       fireEvent.keyDown(document, { key: '?' });
 
       expect(await screen.findByRole('dialog', { name: /keyboard shortcuts/i })).toBeInTheDocument();
+    });
+
+    it('suspends ChoiceSelector\'s number-key hotkeys while the shortcuts dialog is open (review follow-up)', async () => {
+      const ActiveGameSessionChoicesColumn = require('../ActiveGameSessionChoicesColumn').default;
+      // Progressive disclosure ON so "j" would open the journal drawer if it
+      // weren't suspended - proves the gate actually blocks something,
+      // rather than "j" being a no-op for an unrelated reason.
+      (isFeatureEnabled as jest.Mock).mockImplementation((flag) => flag === 'PROGRESSIVE_DISCLOSURE');
+
+      render(
+        <ActiveGameSession
+          worldId={mockWorldId}
+          sessionId={mockSessionId}
+          onChoiceSelected={jest.fn()}
+        />
+      );
+
+      await screen.findByTestId('manuscript-session-shell');
+
+      const propsBeforeOpen = (ActiveGameSessionChoicesColumn as jest.Mock).mock.calls.slice(-1)[0][0];
+      expect(propsBeforeOpen.shortcutsSuspended).toBe(false);
+
+      fireEvent.keyDown(document, { key: '?' });
+      await screen.findByRole('dialog', { name: /keyboard shortcuts/i });
+
+      const propsWhileOpen = (ActiveGameSessionChoicesColumn as jest.Mock).mock.calls.slice(-1)[0][0];
+      expect(propsWhileOpen.shortcutsSuspended).toBe(true);
+
+      // "j" is also suspended once a modal is up, so it must not stack a
+      // second overlay (the journal drawer) behind the shortcuts dialog.
+      fireEvent.keyDown(document, { key: 'j' });
+      expect(screen.queryByTestId('manuscript-drawer')).not.toBeInTheDocument();
     });
 
     it('toggles the character summary when "c" is pressed', async () => {

--- a/src/components/GameSession/__tests__/ActiveGameSession.manuscriptLayout.test.tsx
+++ b/src/components/GameSession/__tests__/ActiveGameSession.manuscriptLayout.test.tsx
@@ -273,6 +273,94 @@ describe('ActiveGameSession Manuscript Layout', () => {
     expect(hudToggle).toHaveAttribute('aria-expanded', 'false');
   });
 
+  describe('keyboard shortcuts (#276)', () => {
+    it('opens the shortcuts dialog via the HUD button', async () => {
+      render(
+        <ActiveGameSession
+          worldId={mockWorldId}
+          sessionId={mockSessionId}
+          onChoiceSelected={jest.fn()}
+        />
+      );
+
+      const trigger = await screen.findByRole('button', { name: /keyboard shortcuts/i });
+      fireEvent.click(trigger);
+
+      expect(await screen.findByRole('dialog', { name: /keyboard shortcuts/i })).toBeInTheDocument();
+    });
+
+    it('opens the shortcuts dialog when "?" is pressed', async () => {
+      render(
+        <ActiveGameSession
+          worldId={mockWorldId}
+          sessionId={mockSessionId}
+          onChoiceSelected={jest.fn()}
+        />
+      );
+
+      await screen.findByTestId('manuscript-session-shell');
+      fireEvent.keyDown(document, { key: '?' });
+
+      expect(await screen.findByRole('dialog', { name: /keyboard shortcuts/i })).toBeInTheDocument();
+    });
+
+    it('toggles the character summary when "c" is pressed', async () => {
+      (isFeatureEnabled as jest.Mock).mockReturnValue(false);
+
+      render(
+        <ActiveGameSession
+          worldId={mockWorldId}
+          sessionId={mockSessionId}
+          onChoiceSelected={jest.fn()}
+        />
+      );
+
+      const hudToggle = await screen.findByRole('button', { name: /hero/i });
+      expect(hudToggle).toHaveAttribute('aria-expanded', 'false');
+
+      fireEvent.keyDown(document, { key: 'c' });
+
+      expect(hudToggle).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('opens the journal drawer when "j" is pressed under progressive disclosure', async () => {
+      (isFeatureEnabled as jest.Mock).mockImplementation((flag) => flag === 'PROGRESSIVE_DISCLOSURE');
+
+      render(
+        <ActiveGameSession
+          worldId={mockWorldId}
+          sessionId={mockSessionId}
+          onChoiceSelected={jest.fn()}
+        />
+      );
+
+      await screen.findByTestId('manuscript-session-shell');
+      fireEvent.keyDown(document, { key: 'j' });
+
+      const drawer = await screen.findByTestId('manuscript-drawer');
+      expect(drawer).toBeInTheDocument();
+    });
+
+    it('routes to the journal page when "j" is pressed without progressive disclosure', async () => {
+      const pushMock = jest.fn();
+      (useRouter as jest.Mock).mockReturnValue({ push: pushMock });
+      (isFeatureEnabled as jest.Mock).mockReturnValue(false);
+
+      render(
+        <ActiveGameSession
+          worldId={mockWorldId}
+          sessionId={mockSessionId}
+          onChoiceSelected={jest.fn()}
+        />
+      );
+
+      await screen.findByTestId('manuscript-session-shell');
+      fireEvent.keyDown(document, { key: 'j' });
+
+      expect(pushMock).toHaveBeenCalledWith(`/worlds/${mockWorldId}/play/journal`);
+    });
+  });
+
   it('passes isStreaming to ManuscriptActionRail when generating', async () => {
     const ManuscriptActionRail = require('../ManuscriptActionRail').ManuscriptActionRail;
 

--- a/src/components/GameSession/__tests__/ActiveGameSessionChoicesColumn.test.tsx
+++ b/src/components/GameSession/__tests__/ActiveGameSessionChoicesColumn.test.tsx
@@ -51,6 +51,16 @@ describe('ActiveGameSessionChoicesColumn', () => {
     expect(selectorProps.isDisabled).toBe(false);
   });
 
+  it('forwards shortcutsSuspended to ChoiceSelector so its number-key hotkeys stay off behind a modal (#276)', () => {
+    render(<ActiveGameSessionChoicesColumn {...baseProps} shortcutsSuspended />);
+
+    const selectorProps = (ChoiceSelector as jest.Mock).mock.calls[0][0] as {
+      shortcutsSuspended?: boolean;
+    };
+
+    expect(selectorProps.shortcutsSuspended).toBe(true);
+  });
+
   it('does not render ChoiceSelector when no decision is available', () => {
     render(
       <ActiveGameSessionChoicesColumn

--- a/src/components/GameSession/__tests__/KeyboardShortcutsDialog.test.tsx
+++ b/src/components/GameSession/__tests__/KeyboardShortcutsDialog.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { KeyboardShortcutsDialog } from '../KeyboardShortcutsDialog';
+
+describe('KeyboardShortcutsDialog', () => {
+  it('is not in the document when closed', () => {
+    render(<KeyboardShortcutsDialog open={false} onOpenChange={jest.fn()} />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('lists the game-session keyboard shortcuts when open', () => {
+    render(<KeyboardShortcutsDialog open onOpenChange={jest.fn()} />);
+
+    const dialog = screen.getByRole('dialog', { name: /keyboard shortcuts/i });
+    expect(dialog).toBeInTheDocument();
+
+    expect(screen.getByText(/select a suggested action/i)).toBeInTheDocument();
+    expect(screen.getByText(/open journal/i)).toBeInTheDocument();
+    expect(screen.getByText(/toggle character sheet/i)).toBeInTheDocument();
+    expect(screen.getByText(/close a dialog or panel/i)).toBeInTheDocument();
+    expect(screen.getByText(/show this shortcuts guide/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/GameSession/__tests__/ManuscriptFloatingHud.a11y.test.tsx
+++ b/src/components/GameSession/__tests__/ManuscriptFloatingHud.a11y.test.tsx
@@ -82,4 +82,17 @@ describe('ManuscriptFloatingHud accessibility', () => {
     const avatar = document.querySelector('.manuscript-hud-character-pill-avatar');
     expect(avatar?.querySelector('img')).toBeNull();
   });
+
+  // At 8 icons wide, the HUD's auto-sized icon row overlaps the character
+  // pill's clickable area on mobile viewports and steals its clicks (#276
+  // review follow-up - a real layout bug, not a modal-gating one). The fix is
+  // a mobile-only `display: none` keyed off this class; jsdom can't compute
+  // real layout to catch the overlap itself, so this locks in the CSS hook
+  // the fix depends on.
+  it('marks the keyboard shortcuts trigger so it can be hidden on mobile (#276)', () => {
+    render(<ManuscriptFloatingHud {...baseProps} onShowShortcuts={jest.fn()} />);
+
+    const button = screen.getByRole('button', { name: /keyboard shortcuts/i });
+    expect(button).toHaveClass('manuscript-hud-shortcuts-button');
+  });
 });

--- a/src/components/shared/ChoiceSelector/ChoiceSelector.tsx
+++ b/src/components/shared/ChoiceSelector/ChoiceSelector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { Decision } from '@/types/narrative.types';
 import { WorldSkill } from '@/types/world.types';
 import { InventoryItem } from '@/types/inventory.types';
@@ -10,6 +10,7 @@ import { EndingSuggestionBanner } from '@/components/GameSession/EndingSuggestio
 import { ArrowUp } from 'lucide-react';
 import { clsx } from 'clsx';
 import { safeTrim } from '@/lib/utils';
+import { useKeyboardShortcuts, KeyboardShortcut } from '@/hooks/useKeyboardShortcuts';
 import { normalizeDecisionOptions } from './optionNormalizer';
 import type { NormalizedOption } from './optionNormalizer';
 import {
@@ -131,6 +132,22 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
     },
     [onSelect]
   );
+
+  // Number-key shortcuts (1-9) mirror the kbd hints rendered on each option
+  // (#276) so choices are selectable without a mouse. Disabled whenever the
+  // selector itself is disabled (turn in progress, session ended, etc.); the
+  // shared hook already ignores keystrokes while typing in an input.
+  const choiceShortcuts: KeyboardShortcut[] = useMemo(
+    () =>
+      allOptions.slice(0, 9).map((option, index) => ({
+        key: String(index + 1),
+        description: `Select "${option.text}"`,
+        action: () =>
+          handleOptionSelect(option.id, option.isDisabledByRequirements ?? false),
+      })),
+    [allOptions, handleOptionSelect]
+  );
+  useKeyboardShortcuts(choiceShortcuts, !isDisabled);
 
   // Handle custom input submission
   const handleCustomSubmit = useCallback(() => {

--- a/src/components/shared/ChoiceSelector/ChoiceSelector.tsx
+++ b/src/components/shared/ChoiceSelector/ChoiceSelector.tsx
@@ -61,6 +61,12 @@ interface ChoiceSelectorProps {
     onAccept: () => void;
     onDismiss: () => void;
   };
+
+  // True while a modal/dialog (shortcuts help, a drawer, End Story
+  // confirmation, ...) is open over the session. Suppresses the number-key
+  // shortcuts below so a player interacting with that overlay can't also
+  // silently select a choice behind it (#276 review follow-up).
+  shortcutsSuspended?: boolean;
 }
 
 /**
@@ -83,6 +89,7 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
   characterSkills = [],
   inventoryItems = [],
   endingSuggestion,
+  shortcutsSuspended = false,
 }) => {
   // Custom input state
   const [customInputText, setCustomInputText] = useState('');
@@ -147,7 +154,7 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
       })),
     [allOptions, handleOptionSelect]
   );
-  useKeyboardShortcuts(choiceShortcuts, !isDisabled);
+  useKeyboardShortcuts(choiceShortcuts, !isDisabled && !shortcutsSuspended);
 
   // Handle custom input submission
   const handleCustomSubmit = useCallback(() => {

--- a/src/components/shared/ChoiceSelector/__tests__/ChoiceSelector.test.tsx
+++ b/src/components/shared/ChoiceSelector/__tests__/ChoiceSelector.test.tsx
@@ -141,6 +141,54 @@ describe('ChoiceSelector', () => {
     });
   });
 
+  describe('Keyboard shortcuts (#276)', () => {
+    it('selects a choice when its number key is pressed', () => {
+      renderChoiceSelector({ decision, onSelect: mockOnSelect });
+
+      fireEvent.keyDown(document, { key: '2' });
+
+      expect(mockOnSelect).toHaveBeenCalledWith('opt-2');
+    });
+
+    it('does not select a disabled-by-requirements choice via its number key', () => {
+      // combinedRequirementDecision's first option (key "1") is item-gated
+      // and no lockpick is supplied here, so it renders disabled.
+      renderChoiceSelector({
+        decision: combinedRequirementDecision,
+        onSelect: mockOnSelect,
+        worldSkills: mockWorldSkills,
+        characterSkills: [],
+        inventoryItems: [],
+      });
+
+      fireEvent.keyDown(document, { key: '1' });
+
+      expect(mockOnSelect).not.toHaveBeenCalled();
+    });
+
+    it('ignores number keys while typing in the custom input', () => {
+      renderChoiceSelector({
+        decision,
+        onSelect: mockOnSelect,
+        enableCustomInput: true,
+        onCustomSubmit: mockOnCustomSubmit,
+      });
+
+      const input = screen.getByPlaceholderText('Describe your action...');
+      fireEvent.keyDown(input, { key: '1' });
+
+      expect(mockOnSelect).not.toHaveBeenCalled();
+    });
+
+    it('does not respond to number keys once the selector is disabled', () => {
+      renderChoiceSelector({ decision, onSelect: mockOnSelect, isDisabled: true });
+
+      fireEvent.keyDown(document, { key: '1' });
+
+      expect(mockOnSelect).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Custom Input', () => {
     it('shows custom input field when enabled', () => {
       renderChoiceSelector({decision: decision, onSelect: mockOnSelect, enableCustomInput: true, onCustomSubmit: mockOnCustomSubmit});

--- a/src/components/shared/ChoiceSelector/__tests__/ChoiceSelector.test.tsx
+++ b/src/components/shared/ChoiceSelector/__tests__/ChoiceSelector.test.tsx
@@ -187,6 +187,14 @@ describe('ChoiceSelector', () => {
 
       expect(mockOnSelect).not.toHaveBeenCalled();
     });
+
+    it('does not respond to number keys while shortcutsSuspended (a modal is open)', () => {
+      renderChoiceSelector({ decision, onSelect: mockOnSelect, shortcutsSuspended: true });
+
+      fireEvent.keyDown(document, { key: '1' });
+
+      expect(mockOnSelect).not.toHaveBeenCalled();
+    });
   });
 
   describe('Custom Input', () => {

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -2038,6 +2038,22 @@ body.manuscript-overlay-open {
   .manuscript-header-controls {
     gap: var(--space-1);
   }
+
+  /* The HUD icon row's auto-sized grid track overlaps the character pill's
+     clickable area on narrow viewports once it grows past ~7 icons (#276
+     review follow-up - confirmed by measuring the two boxes overlapping at
+     375px). Dropping the shortcuts trigger here is also the right call on
+     its own merits: it opens a reference for keyboard-only bindings, which
+     aren't actionable on a touch-only device anyway. The "?" binding itself
+     still works if an external keyboard is attached.
+     Specificity note: needs to beat the unconditional `:root
+     .manuscript-hud-icon-button { display: inline-flex }` base rule below,
+     which shares this element's other class - a plain `.manuscript-hud-
+     shortcuts-button` selector loses that cascade fight regardless of media
+     query, so this chains both classes under :root to outrank it. */
+  :root .manuscript-hud-icon-button.manuscript-hud-shortcuts-button {
+    display: none;
+  }
 }
 
 @media (width >= 1024px) {

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -3803,3 +3803,49 @@ body.manuscript-overlay-open {
   padding: var(--space-0_5) var(--space-2);
   font-size: 0.6875rem;
 }
+
+/* Keyboard shortcuts help dialog (#276) — reference list of every binding
+   wired up in the game session. Uses the shared .dialog-content shell. */
+:root .keyboard-shortcuts-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+:root .keyboard-shortcuts-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+:root .keyboard-shortcuts-keys {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex-shrink: 0;
+  min-width: 5rem;
+}
+
+:root .keyboard-shortcuts-key {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  padding: 0 var(--space-1_5);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-hover);
+  font-family: var(--font-system);
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+}
+
+:root .keyboard-shortcuts-description {
+  font-size: 0.875rem;
+  color: var(--color-text-primary);
+}


### PR DESCRIPTION
## Description
The game session had no keyboard shortcuts at all - you couldn't select a choice, submit a custom action shortcut, open the journal, or check your character sheet without a mouse. `ChoiceSelector` was already rendering numbered kbd hints (1, 2, 3) next to each suggested action, but nothing was listening for the actual keypresses.

This wires up the shortcuts the issue calls out as missing, plus a discoverable reference for them:
- **1-9** selects a suggested action (skips options disabled by unmet item requirements, same as a click)
- **j** opens the journal (drawer under progressive disclosure, the journal route otherwise)
- **c** toggles the character sheet
- **?** or the new keyboard icon in the HUD opens a "Keyboard Shortcuts" dialog listing all of the above, plus Enter (submit custom action) and Esc (close a dialog/panel)

Tab order and Escape handling for drawers, the character panel, and the End Story confirmation were already solid from prior work (#1536, #1424) - verified manually in the browser rather than touched, since nothing was actually broken there.

## Related Issue
Closes #276

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
"As a player with a keyboard, I want full keyboard navigation so I can play without a mouse" (#276) - the game-session portion of it. Number-key choice selection, journal/character-sheet shortcuts, and a discoverable shortcuts reference.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [x] Components developed in isolation first
- [x] Visual consistency verified

`KeyboardShortcutsDialog` is small and single-purpose enough that a dedicated story didn't seem worth it - it's exercised via the existing `ActiveGameSession` manuscript-layout stories/tests instead. Verified visually via the dev server (`/dev/game-session`), both the number-key selection flow and the shortcuts dialog open/close.

## Implementation Notes
- Number-key shortcuts live in `ChoiceSelector` itself (where the option list already is) via the existing `useKeyboardShortcuts` hook, which already ignores keystrokes while typing in an input - so digits typed into the custom-action field don't trigger a selection.
- `j`/`c`/`?` are wired in `ActiveGameSession`, gated on `isGameReady` so they don't fire against the skeleton state.
- `KeyboardShortcutsDialog` reuses the shared `Dialog` primitive (Radix) for focus trap + Escape-to-close, same pattern as `GameSessionRecoveryPrompt`.
- Scope call: the issue also asks for "keyboard shortcuts... for common actions" broadly. I limited this to the ones explicitly named in the maintainer's own scoping comment on the issue (choices, journal, character sheet) rather than guessing at others, to keep the change reviewable.

## Screenshots
N/A (no accessible screenshot host configured for this session) - verified live via the dev server; see Implementation Notes.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit (`npm audit`) wasn't run as part of this change - no new dependencies were added.

## Testing Instructions
1. `npm run dev`, open `/dev/game-session` (or any active session)
2. Click into empty space (not the custom-action input) so keyboard shortcuts are live
3. Press `1`, `2`, or `3` - the matching suggested action fires, same as clicking it
4. Type in the custom-action input - digits type normally, no shortcut fires
5. Press `j` - journal opens (drawer or route depending on the progressive-disclosure flag)
6. Press `c` - character sheet toggles
7. Press `?`, or click the keyboard icon in the top-right HUD row - shortcuts dialog opens; `Esc` or the Close button dismiss it

## Checklist
- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

`ActiveGameSession.tsx` was already over 300 lines before this change (531 -> 582); splitting it further is out of scope for this issue. No user-facing docs reference game-session shortcuts today, so there's nothing to update - the in-app dialog is the reference.
