### PR TITLE
Scale narrative beat length to decision weight (#1585)

### DIFF
--- a/src/app/api/narrative/generate/route.ts
+++ b/src/app/api/narrative/generate/route.ts
@@ -11,7 +11,10 @@ export const maxDuration = 60;
 
 export async function POST(request: NextRequest) {
   return processGeminiTextRequest(request, {
-    maxTokens: 1024,
+    // Matches lib/ai/config's default. A weighty beat asks for 3-4 paragraphs
+    // plus its JSON metadata, which crowds a 1024 ceiling and gets truncated
+    // mid-object — and a truncated response is unparseable, not just short.
+    maxTokens: 2048,
     temperature: 0.7,
     errorContext: 'Narrative generation'
   });

--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -702,7 +702,8 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
             },
             generationParameters: {
               includedTopics: [choiceText],
-              desiredLength: 'short',
+              // No desiredLength: the template scales the beat off decisionWeight
+              // so weighty moments get more room than routine ones.
               decisionWeight,
               // Critical decisions with critical failures should have tragic tone
               desiredTone:

--- a/src/lib/ai/clientGeminiClient.ts
+++ b/src/lib/ai/clientGeminiClient.ts
@@ -78,7 +78,7 @@ export class ClientGeminiClient implements AIClient {
   async generateContent(prompt: string, options?: AIGenerateOptions): Promise<AIResponse> {
     const data = await this.postJson<{ content: string; finishReason?: string; promptTokens?: number; completionTokens?: number }>(
       '/api/narrative/generate',
-      { prompt, config: { temperature: 0.7, maxTokens: 1024 } },
+      { prompt, config: { temperature: 0.7, maxTokens: 2048 } },
       'generation',
       // The route makes a single 30s Gemini attempt (makeGeminiRequest), so
       // the wait ceiling is that budget + headroom, not the retry worst case.

--- a/src/lib/promptTemplates/templates/__tests__/narrativeLength.test.ts
+++ b/src/lib/promptTemplates/templates/__tests__/narrativeLength.test.ts
@@ -1,0 +1,55 @@
+// Guards the beat-length wiring: sceneTemplate is the template the main story
+// loop actually runs, so a length knob that only baseNarrativeTemplate honors is
+// a dead knob. These pin the template TEXT rather than generated prose — asserting
+// on a model's output is how a prompt test gets rigged.
+
+import {
+  describeNarrativeLength,
+  resolveNarrativeLength,
+} from '../narrative/narrativeLength';
+import { sceneTemplate } from '../narrative/sceneTemplate';
+
+describe('resolveNarrativeLength', () => {
+  it('honors an explicit desiredLength over the decision weight', () => {
+    expect(
+      resolveNarrativeLength({ desiredLength: 'short', decisionWeight: 'critical' })
+    ).toBe('short');
+  });
+
+  it('scales length with decision weight when no length is requested', () => {
+    expect(resolveNarrativeLength({ decisionWeight: 'minor' })).toBe('short');
+    expect(resolveNarrativeLength({ decisionWeight: 'major' })).toBe('medium');
+    expect(resolveNarrativeLength({ decisionWeight: 'critical' })).toBe('long');
+  });
+
+  it('falls back to short for unweighted or unknown signals', () => {
+    expect(resolveNarrativeLength()).toBe('short');
+    expect(resolveNarrativeLength({ decisionWeight: 'nonsense' })).toBe('short');
+  });
+});
+
+describe('sceneTemplate length instruction', () => {
+  const buildScene = (
+    generationParameters?: Record<string, unknown>
+  ) =>
+    sceneTemplate({
+      worldName: 'Testworld',
+      genre: 'fantasy',
+      tone: 'grim',
+      narrativeContext: { recentSegments: [{ content: 'Something happened.' }] },
+      generationParameters,
+    } as Parameters<typeof sceneTemplate>[0]);
+
+  it('no longer hardcodes a 3-5 sentence cap', () => {
+    const longScene = buildScene({ desiredLength: 'long' });
+    expect(longScene).toContain(describeNarrativeLength({ desiredLength: 'long' }));
+    expect(longScene).not.toContain('3-5 sentences');
+  });
+
+  it('gives a critical decision more room than a minor one', () => {
+    expect(buildScene({ decisionWeight: 'critical' })).toContain('3-4 paragraphs');
+    expect(buildScene({ decisionWeight: 'minor' })).toContain(
+      '3-5 sentences (1 focused paragraph)'
+    );
+  });
+});

--- a/src/lib/promptTemplates/templates/narrative/baseNarrativeTemplate.ts
+++ b/src/lib/promptTemplates/templates/narrative/baseNarrativeTemplate.ts
@@ -1,5 +1,6 @@
 import { getExamplesForPrompt, shouldIncludeExamples } from '../../examples';
 import { majorEventGuidelines } from './majorEventGuidelines';
+import { describeNarrativeLength } from './narrativeLength';
 import { estimateTokenCount } from '@/lib/promptContext/tokenUtils';
 import type { NarrativeTemplateContext } from './context';
 
@@ -19,13 +20,7 @@ export const baseNarrativeTemplate = (context: NarrativeTemplateContext) => {
   // Tone settings are handled by the AI system prompt enhancement
   void toneSettings;
 
-  const length = generationParameters?.desiredLength || 'short';
-  const lengthGuide: Record<string, string> = {
-    short: '3-5 sentences (1 focused paragraph)',
-    medium: '1-2 paragraphs',
-    long: '3-4 paragraphs'
-  };
-  const lengthDescription = lengthGuide[length] || lengthGuide.medium;
+  const lengthDescription = describeNarrativeLength(generationParameters);
 
   const formattedRoster = Array.isArray(npcRoster) && npcRoster.length > 0
     ? `

--- a/src/lib/promptTemplates/templates/narrative/narrativeLength.ts
+++ b/src/lib/promptTemplates/templates/narrative/narrativeLength.ts
@@ -1,0 +1,51 @@
+export type NarrativeLength = 'short' | 'medium' | 'long';
+
+const LENGTH_GUIDE: Record<NarrativeLength, string> = {
+  short: '3-5 sentences (1 focused paragraph)',
+  medium: '1-2 paragraphs',
+  long: '3-4 paragraphs',
+};
+
+/**
+ * Weightier beats earn more room on the page. Without this every segment comes
+ * back the same size, which is a large part of why long sessions read flat.
+ * decisionWeight is the only length signal available before generation —
+ * metadata.majorEvent is computed from the response, too late to shape it.
+ */
+const LENGTH_BY_DECISION_WEIGHT: Record<string, NarrativeLength> = {
+  minor: 'short',
+  major: 'medium',
+  critical: 'long',
+};
+
+export interface NarrativeLengthSignals {
+  desiredLength?: NarrativeLength;
+  decisionWeight?: string;
+}
+
+/**
+ * An explicit desiredLength always wins — callers that need a deliberately
+ * small beat (item use, acknowledgments) say so. Otherwise the decision's
+ * weight drives it, falling back to short for unweighted beats.
+ */
+export function resolveNarrativeLength(
+  signals?: NarrativeLengthSignals
+): NarrativeLength {
+  if (signals?.desiredLength && LENGTH_GUIDE[signals.desiredLength]) {
+    return signals.desiredLength;
+  }
+
+  const weight = signals?.decisionWeight;
+  if (weight && LENGTH_BY_DECISION_WEIGHT[weight]) {
+    return LENGTH_BY_DECISION_WEIGHT[weight];
+  }
+
+  return 'short';
+}
+
+/** The prose fragment a prompt template drops into its length instruction. */
+export function describeNarrativeLength(
+  signals?: NarrativeLengthSignals
+): string {
+  return LENGTH_GUIDE[resolveNarrativeLength(signals)];
+}

--- a/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
+++ b/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
@@ -1,5 +1,6 @@
 import { getExamplesForPrompt, shouldIncludeExamples } from '../../examples';
 import { majorEventGuidelines } from './majorEventGuidelines';
+import { describeNarrativeLength } from './narrativeLength';
 import type { NarrativeTemplateContext } from './context';
 
 export const sceneTemplate = (context: NarrativeTemplateContext) => {
@@ -16,6 +17,7 @@ export const sceneTemplate = (context: NarrativeTemplateContext) => {
   } = context;
 
   const segmentType = generationParameters?.segmentType || 'scene';
+  const lengthDescription = describeNarrativeLength(generationParameters);
   const recentSegments = narrativeContext?.recentSegments || [];
   const recentContent = recentSegments.map((seg, i: number) =>
     `[Scene ${recentSegments.length - i}]: ${seg.content}`
@@ -104,7 +106,7 @@ Generate a ${segmentType} that:
 3. Does NOT repeat or revisit events that already happened
 4. Advances the story forward in time (never backward)
 5. Maintains the ${tone} tone
-6. Is approximately 3-5 sentences long (1 focused paragraph)
+6. Is approximately ${lengthDescription} in length
 
 ${(worldName && (worldName.toLowerCase().includes('1990') || worldName.toLowerCase().includes('1980') || worldName.toLowerCase().includes('1970'))) || (genre && (genre.toLowerCase().includes('modern') || genre.toLowerCase().includes('contemporary') || genre.toLowerCase().includes('realistic'))) ? `
 


### PR DESCRIPTION
## Description
`desiredLength` was threaded from `NarrativeController` and `itemUsageService` into generation and then dropped on the floor. Only `baseNarrativeTemplate` read it, and the main story loop never requests that template — it always asks for `narrative/scene`, whose length was hardcoded at "3-5 sentences". So every beat came back the same size, which is a big part of why long sessions read flat.

This pulls the length guide into a shared `narrativeLength` helper both templates use, and makes it adaptive:

- an explicit `desiredLength` still wins, so callers that want a deliberately small beat (item use) keep getting one
- otherwise the decision's weight drives it: `minor` -> 3-5 sentences, `major` -> 1-2 paragraphs, `critical` -> 3-4 paragraphs
- `NarrativeController` stops pinning `desiredLength: 'short'`, which is what let the adaptive path apply at all

`decisionWeight` is the only length signal available before generation — `metadata.majorEvent` is computed from the response, too late to shape it. It's a real varied signal, parsed per-decision from the choice generator rather than a constant.

Also raises the narrative generate route to 2048 max tokens, matching `lib/ai/config`'s own default. A 3-4 paragraph beat plus its JSON metadata crowds a 1024 ceiling, and a truncated response is unparseable rather than merely short.

Left the sibling templates alone on purpose. `transition`, `action`, and `skillAcknowledgment` are deliberately terse beats, and `initialScene` is a one-off opening — the dead-parameter defect the issue describes is specific to the template that actually runs every turn.

## Related Issue
Closes #1585

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — enhancement issue, not a user story.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A — prompt and wiring change, no UI surface.

## Implementation Notes
The tests pin the template *text*, not generated prose. Asserting that a model returned three paragraphs is how a prompt test gets rigged; asserting that the prompt asks for three paragraphs is checkable and stays honest.

Per the AI-quality skill, a length change wants an evaluation pass across several worlds before anyone calls the pacing "better". This PR fixes the dead parameter and gives length something real to vary on — whether the new mapping is the right mapping is a tuning question that needs live play across worlds, not a few good-looking generations.

## Screenshots
N/A

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
```bash
npx jest src/lib/promptTemplates src/lib/ai/narrativeGenerator src/components/Narrative
```

Live check: play a session and take a choice the generator marked `critical` (the weight badge shows in the choice history) — that beat should run visibly longer than a routine one.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
