### PR TITLE
Collapse the HUD toolbar and fix drawer focus return (#276)

### DIFF
--- a/src/components/GameSession/ActiveGameSession.tsx
+++ b/src/components/GameSession/ActiveGameSession.tsx
@@ -193,28 +193,23 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
   const { startTour, isTourActive } = useTutorial();
   const shouldShowTour = useSessionStore(state => state.shouldShowTutorialPhase('firstPlay'));
 
+  // Escape for the drawer belongs to Radix, which closes it through
+  // onOpenChange and restores focus via the drawer's restoreFocusRef. The
+  // character panel is a plain popover with no dialog behaviour of its own,
+  // so it still needs its own Escape and focus return.
   React.useEffect(() => {
-    if (!isCharacterSummaryExpanded && activeDrawer === null) return;
+    if (!isCharacterSummaryExpanded) return;
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        if (activeDrawer !== null) {
-          setActiveDrawer(null);
-          drawerTriggerRef.current?.focus();
-          drawerTriggerRef.current = null;
-          return;
-        }
-        if (isCharacterSummaryExpanded) {
-          setIsCharacterSummaryExpanded(false);
-          characterButtonRef.current?.focus();
-          return;
-        }
+        setIsCharacterSummaryExpanded(false);
+        characterButtonRef.current?.focus();
       }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isCharacterSummaryExpanded, activeDrawer]);
+  }, [isCharacterSummaryExpanded]);
 
   React.useEffect(() => {
     if (!isGameReady) return;
@@ -526,11 +521,10 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
       {isProgressiveDisclosureEnabled && (
         <ManuscriptDrawer
           open={activeDrawer !== null}
+          restoreFocusRef={drawerTriggerRef}
           onOpenChange={(open) => {
             if (!open) {
               setActiveDrawer(null);
-              drawerTriggerRef.current?.focus();
-              drawerTriggerRef.current = null;
             }
           }}
           title={

--- a/src/components/GameSession/ActiveGameSession.tsx
+++ b/src/components/GameSession/ActiveGameSession.tsx
@@ -222,16 +222,25 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
     return () => clearTimeout(timer);
   }, [isGameReady, shouldShowTour, isTourActive, startTour]);
 
+  // Every path into a drawer records what had focus, so closing it returns the
+  // player where they were. Routing the keyboard shortcut through here too
+  // keeps a stale HUD icon from stealing focus back after a `j` open.
+  const openDrawer = React.useCallback((drawerType: DrawerType) => {
+    drawerTriggerRef.current = document.activeElement as HTMLElement | null;
+    setActiveDrawer(drawerType);
+    setIsCharacterSummaryExpanded(false);
+  }, []);
+
   // Journal opens as a drawer under progressive disclosure, otherwise it's a
   // route (matches the two "Open Journal" entry points already in the HUD /
   // ActiveGameSessionControls).
   const handleOpenJournalShortcut = React.useCallback(() => {
     if (isProgressiveDisclosureEnabled) {
-      setActiveDrawer('journal');
+      openDrawer('journal');
     } else {
       router.push(`/worlds/${worldId}/play/journal`);
     }
-  }, [isProgressiveDisclosureEnabled, router, worldId]);
+  }, [isProgressiveDisclosureEnabled, openDrawer, router, worldId]);
 
   const handleToggleCharacterShortcut = React.useCallback(() => {
     setIsCharacterSummaryExpanded((prev) => !prev);
@@ -430,11 +439,7 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
           drawerTriggers={isProgressiveDisclosureEnabled}
           characterName={character?.name}
           characterPortrait={character?.portrait}
-          onOpenDrawer={(drawerType) => {
-            drawerTriggerRef.current = document.activeElement as HTMLElement;
-            setActiveDrawer(drawerType as DrawerType);
-            setIsCharacterSummaryExpanded(false);
-          }}
+          onOpenDrawer={(drawerType) => openDrawer(drawerType as DrawerType)}
           onStartNew={handleHudStartNew}
           onBack={handleHudBack}
           onEndStory={handleEndStoryClick}

--- a/src/components/GameSession/ManuscriptDrawer.tsx
+++ b/src/components/GameSession/ManuscriptDrawer.tsx
@@ -14,6 +14,13 @@ interface ManuscriptDrawerProps {
   subtitle?: string;
   children: React.ReactNode;
   side?: 'left' | 'right';
+  /**
+   * Control to focus once the drawer closes, normally whatever opened it.
+   * Radix's own restore runs while the outside content is still hidden from
+   * assistive tech, so the focus call lands on nothing and the player is
+   * dropped at <body> — the top of the tab order — after every Escape.
+   */
+  restoreFocusRef?: React.RefObject<HTMLElement | null>;
 }
 
 export const ManuscriptDrawer: React.FC<ManuscriptDrawerProps> = ({
@@ -23,6 +30,7 @@ export const ManuscriptDrawer: React.FC<ManuscriptDrawerProps> = ({
   subtitle,
   children,
   side = 'right',
+  restoreFocusRef,
 }) => {
   // Add manuscript-overlay-open class to body when drawer is open
   React.useEffect(() => {
@@ -46,6 +54,14 @@ export const ManuscriptDrawer: React.FC<ManuscriptDrawerProps> = ({
         <DialogPrimitive.Content
           className="manuscript-drawer-layer"
           aria-describedby={undefined}
+          onCloseAutoFocus={(event) => {
+            const trigger = restoreFocusRef?.current;
+            if (!trigger?.isConnected) return;
+            event.preventDefault();
+            // A frame after the layer unwinds, so the trigger is visible to
+            // focus() again rather than still hidden behind the modal.
+            requestAnimationFrame(() => trigger.focus());
+          }}
         >
           <aside
             className={clsx(

--- a/src/components/GameSession/ManuscriptFloatingHud.tsx
+++ b/src/components/GameSession/ManuscriptFloatingHud.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { BookOpen, Backpack, FileText, RotateCcw, LogOut, History, Keyboard } from 'lucide-react';
 import { HudCloseButton } from './HudCloseButton';
 import { CharacterPortrait } from '@/components/CharacterPortrait';
+import { useRovingToolbar } from '@/hooks/useRovingToolbar';
 import type { GeneratedImage } from '@/types/common.types';
 
 interface ManuscriptFloatingHudProps {
@@ -43,6 +44,8 @@ export const ManuscriptFloatingHud: React.FC<ManuscriptFloatingHudProps> = ({
     node?.focus();
   }, []);
 
+  const { toolbarRef, onKeyDown, onFocus } = useRovingToolbar<HTMLDivElement>();
+
   return (
     <>
       <div className="manuscript-overlay-header-left">
@@ -76,7 +79,14 @@ export const ManuscriptFloatingHud: React.FC<ManuscriptFloatingHudProps> = ({
       </div>
 
       <div className="manuscript-overlay-header-right">
-        <div className="manuscript-ds3-controls">
+        <div
+          ref={toolbarRef}
+          onKeyDown={onKeyDown}
+          onFocus={onFocus}
+          role="toolbar"
+          aria-label="Session tools"
+          className="manuscript-ds3-controls"
+        >
           {saveIndicator}
           {drawerTriggers && (
             <>

--- a/src/components/GameSession/ManuscriptSessionShell.tsx
+++ b/src/components/GameSession/ManuscriptSessionShell.tsx
@@ -47,8 +47,10 @@ export const ManuscriptSessionShell: React.FC<ManuscriptSessionShellProps> = ({
             {hud}
           </header>
 
-          {/* Main Narrative Stage */}
-          <main className="manuscript-overlay-main">
+          {/* Main Narrative Stage. A section, not a <main>: AppSurfaceShell
+              already wraps the play route in the page's one main landmark, and
+              nesting a second one breaks landmark navigation. */}
+          <section aria-label="Story" className="manuscript-overlay-main">
             <div className={clsx("manuscript-main-stage manuscript-main-stage-mobile-stack", !marginContent && "manuscript-no-rail")}>
                 {marginContent && (
                   <aside
@@ -68,7 +70,7 @@ export const ManuscriptSessionShell: React.FC<ManuscriptSessionShellProps> = ({
 
                 <div className="manuscript-rail-spacer" aria-hidden="true" />
               </div>
-          </main>
+          </section>
 
           {/* Docked Action Rail */}
           <div ref={actionRailRef}>

--- a/src/components/GameSession/__tests__/ActiveGameSession.manuscriptLayout.test.tsx
+++ b/src/components/GameSession/__tests__/ActiveGameSession.manuscriptLayout.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import ActiveGameSession from '../ActiveGameSession';
 import { useNarrativeStore } from '@/state/narrativeStore';
 import { useSessionStore } from '@/state/sessionStore';
@@ -371,6 +371,45 @@ describe('ActiveGameSession Manuscript Layout', () => {
 
       const drawer = await screen.findByTestId('manuscript-drawer');
       expect(drawer).toBeInTheDocument();
+    });
+
+    // The restore target is captured per open. Without that, opening from a
+    // HUD icon once leaves the ref pinned to that icon, and a later "j" open
+    // yanks focus to the icon instead of back where the player was.
+    it('returns focus where the player was when the drawer opened via "j"', async () => {
+      (isFeatureEnabled as jest.Mock).mockImplementation((flag) => flag === 'PROGRESSIVE_DISCLOSURE');
+
+      render(
+        <ActiveGameSession
+          worldId={mockWorldId}
+          sessionId={mockSessionId}
+          onChoiceSelected={jest.fn()}
+        />
+      );
+
+      await screen.findByTestId('manuscript-session-shell');
+
+      const hudTools = within(
+        screen.getByRole('toolbar', { name: 'Session tools' })
+      );
+
+      // Open and close once from the HUD icon so the ref is populated.
+      const journalIcon = hudTools.getByRole('button', { name: 'Journal' });
+      fireEvent.click(journalIcon);
+      await screen.findByTestId('manuscript-drawer');
+      fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+      await waitFor(() =>
+        expect(screen.queryByTestId('manuscript-drawer')).not.toBeInTheDocument()
+      );
+
+      // Now open from somewhere else entirely via the shortcut.
+      const elsewhere = hudTools.getByRole('button', { name: 'End Story' });
+      elsewhere.focus();
+      fireEvent.keyDown(document, { key: 'j' });
+      await screen.findByTestId('manuscript-drawer');
+
+      fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+      await waitFor(() => expect(elsewhere).toHaveFocus());
     });
 
     it('routes to the journal page when "j" is pressed without progressive disclosure', async () => {

--- a/src/components/GameSession/__tests__/ManuscriptDrawer.test.tsx
+++ b/src/components/GameSession/__tests__/ManuscriptDrawer.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ManuscriptDrawer } from '../ManuscriptDrawer';
 
 describe('ManuscriptDrawer', () => {
@@ -88,5 +88,40 @@ describe('ManuscriptDrawer', () => {
 
     unmount();
     expect(document.body).not.toHaveClass('manuscript-overlay-open');
+  });
+
+  // Closing a drawer used to leave focus on <body>, which drops a keyboard
+  // player back at the very top of the tab order after every peek at the
+  // journal or inventory.
+  it('returns focus to the control that opened it', async () => {
+    const trigger = document.createElement('button');
+    trigger.textContent = 'Journal';
+    document.body.appendChild(trigger);
+    const triggerRef = { current: trigger };
+
+    const { rerender } = render(
+      <ManuscriptDrawer
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        title="Test Drawer"
+        restoreFocusRef={triggerRef}
+      >
+        <div>Content</div>
+      </ManuscriptDrawer>
+    );
+
+    rerender(
+      <ManuscriptDrawer
+        open={false}
+        onOpenChange={mockOnOpenChange}
+        title="Test Drawer"
+        restoreFocusRef={triggerRef}
+      >
+        <div>Content</div>
+      </ManuscriptDrawer>
+    );
+
+    await waitFor(() => expect(trigger).toHaveFocus());
+    trigger.remove();
   });
 });

--- a/src/components/GameSession/__tests__/ManuscriptFloatingHud.a11y.test.tsx
+++ b/src/components/GameSession/__tests__/ManuscriptFloatingHud.a11y.test.tsx
@@ -144,6 +144,29 @@ describe('ManuscriptFloatingHud accessibility', () => {
       expect(last).toHaveFocus();
     });
 
+    // The shortcuts trigger is display:none on phones. Arrowing onto a box
+    // that isn't laid out silently drops focus, so it can't be in the set.
+    it('skips tools hidden by CSS', () => {
+      render(<ManuscriptFloatingHud {...baseProps} onShowShortcuts={jest.fn()} />);
+
+      const toolbar = screen.getByRole('toolbar', { name: 'Session tools' });
+      const shortcuts = screen.getByRole('button', {
+        name: /keyboard shortcuts/i,
+      });
+      const choiceHistory = screen.getByRole('button', {
+        name: /choice history/i,
+      });
+      const resetSession = screen.getByRole('button', {
+        name: /reset session/i,
+      });
+      shortcuts.style.display = 'none';
+
+      choiceHistory.focus();
+      fireEvent.keyDown(toolbar, { key: 'ArrowRight' });
+
+      expect(resetSession).toHaveFocus();
+    });
+
     it('leaves the last used tool as the tab stop', () => {
       render(<ManuscriptFloatingHud {...baseProps} onShowShortcuts={jest.fn()} />);
 

--- a/src/components/GameSession/__tests__/ManuscriptFloatingHud.a11y.test.tsx
+++ b/src/components/GameSession/__tests__/ManuscriptFloatingHud.a11y.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { ManuscriptFloatingHud } from '../ManuscriptFloatingHud';
 
 describe('ManuscriptFloatingHud accessibility', () => {
@@ -94,5 +94,64 @@ describe('ManuscriptFloatingHud accessibility', () => {
 
     const button = screen.getByRole('button', { name: /keyboard shortcuts/i });
     expect(button).toHaveClass('manuscript-hud-shortcuts-button');
+  });
+
+  // The icon row is a toolbar, not eight separate destinations. Left as
+  // eight tab stops it sits between the top of the page and the choices, so
+  // reaching an action costs eight extra presses on every single turn.
+  describe('session tools toolbar', () => {
+    const getTools = () =>
+      Array.from(
+        document.querySelectorAll<HTMLButtonElement>('.manuscript-hud-icon-button')
+      );
+
+    it('exposes the icon row as one named toolbar', () => {
+      render(<ManuscriptFloatingHud {...baseProps} onShowShortcuts={jest.fn()} />);
+
+      expect(
+        screen.getByRole('toolbar', { name: 'Session tools' })
+      ).toHaveClass('manuscript-ds3-controls');
+    });
+
+    it('keeps exactly one tool in the tab cycle', () => {
+      render(<ManuscriptFloatingHud {...baseProps} onShowShortcuts={jest.fn()} />);
+
+      const tools = getTools();
+      expect(tools.length).toBeGreaterThan(1);
+      expect(tools.filter((tool) => tool.tabIndex === 0)).toHaveLength(1);
+      expect(tools[0].tabIndex).toBe(0);
+    });
+
+    it('moves between tools with arrow keys, wrapping at both ends', () => {
+      render(<ManuscriptFloatingHud {...baseProps} onShowShortcuts={jest.fn()} />);
+
+      const toolbar = screen.getByRole('toolbar', { name: 'Session tools' });
+      const tools = getTools();
+      const last = tools[tools.length - 1];
+
+      tools[0].focus();
+      fireEvent.keyDown(toolbar, { key: 'ArrowRight' });
+      expect(tools[1]).toHaveFocus();
+
+      fireEvent.keyDown(toolbar, { key: 'ArrowLeft' });
+      fireEvent.keyDown(toolbar, { key: 'ArrowLeft' });
+      expect(last).toHaveFocus();
+
+      fireEvent.keyDown(toolbar, { key: 'Home' });
+      expect(tools[0]).toHaveFocus();
+
+      fireEvent.keyDown(toolbar, { key: 'End' });
+      expect(last).toHaveFocus();
+    });
+
+    it('leaves the last used tool as the tab stop', () => {
+      render(<ManuscriptFloatingHud {...baseProps} onShowShortcuts={jest.fn()} />);
+
+      const tools = getTools();
+      fireEvent.focus(tools[2], { target: tools[2] });
+
+      expect(tools[2].tabIndex).toBe(0);
+      expect(tools[0].tabIndex).toBe(-1);
+    });
   });
 });

--- a/src/components/GameSession/__tests__/ManuscriptSessionShell.test.tsx
+++ b/src/components/GameSession/__tests__/ManuscriptSessionShell.test.tsx
@@ -77,4 +77,22 @@ describe('ManuscriptSessionShell', () => {
     expect(mainStage).toHaveClass('manuscript-main-stage-mobile-stack');
     expect(characterRail).toHaveClass('manuscript-characters-rail-mobile-stack');
   });
+
+  // AppSurfaceShell already wraps the play route in the page's one main
+  // landmark. A second <main> here nests landmarks, which is invalid and
+  // leaves screen-reader landmark navigation with two "main" destinations.
+  it('labels the narrative stage as a region rather than a second main landmark', () => {
+    render(
+      <ManuscriptSessionShell>
+        <div>Main Content</div>
+      </ManuscriptSessionShell>
+    );
+
+    const shell = screen.getByTestId('manuscript-session-shell');
+    expect(shell.querySelector('main')).toBeNull();
+
+    const stage = shell.querySelector('.manuscript-overlay-main');
+    expect(stage?.tagName).toBe('SECTION');
+    expect(stage).toHaveAttribute('aria-label', 'Story');
+  });
 });

--- a/src/hooks/useRovingToolbar.ts
+++ b/src/hooks/useRovingToolbar.ts
@@ -1,0 +1,98 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Roving-tabindex behaviour for a group of buttons that acts as one control
+ * cluster (the WAI-ARIA toolbar pattern).
+ *
+ * Without it every button in the cluster is its own tab stop, so a keyboard
+ * player crossing an 8-button HUD pays eight presses before reaching the story.
+ * With it the cluster is a single stop and arrow keys move inside it.
+ *
+ * Tabindex is written straight onto the DOM nodes rather than threaded through
+ * each button's props, so callers only wrap the container.
+ */
+export function useRovingToolbar<T extends HTMLElement>(): {
+  toolbarRef: React.RefObject<T | null>;
+  onKeyDown: (event: React.KeyboardEvent<T>) => void;
+  onFocus: (event: React.FocusEvent<T>) => void;
+} {
+  const toolbarRef = useRef<T>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const getButtons = useCallback(
+    () =>
+      Array.from(
+        toolbarRef.current?.querySelectorAll<HTMLButtonElement>(
+          'button:not([disabled])'
+        ) ?? []
+      ),
+    []
+  );
+
+  // No dependency array on purpose: buttons mount and unmount with the session
+  // (drawer triggers, save indicator), and each render has to leave exactly one
+  // of whatever is currently there in the tab cycle.
+  useEffect(() => {
+    const buttons = getButtons();
+    if (buttons.length === 0) return;
+    const target = Math.min(activeIndex, buttons.length - 1);
+    buttons.forEach((button, index) => {
+      button.tabIndex = index === target ? 0 : -1;
+    });
+  });
+
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent<T>) => {
+      const buttons = getButtons();
+      if (buttons.length === 0) return;
+
+      const current = buttons.indexOf(
+        document.activeElement as HTMLButtonElement
+      );
+      if (current === -1) return;
+
+      let next: number;
+      switch (event.key) {
+        case 'ArrowRight':
+        case 'ArrowDown':
+          next = (current + 1) % buttons.length;
+          break;
+        case 'ArrowLeft':
+        case 'ArrowUp':
+          next = (current - 1 + buttons.length) % buttons.length;
+          break;
+        case 'Home':
+          next = 0;
+          break;
+        case 'End':
+          next = buttons.length - 1;
+          break;
+        default:
+          return;
+      }
+
+      event.preventDefault();
+      setActiveIndex(next);
+      buttons[next].focus();
+    },
+    [getButtons]
+  );
+
+  // Clicking or shift-tabbing into a button makes it the cluster's tab stop, so
+  // leaving and returning lands on the control last used rather than the first.
+  const onFocus = useCallback(
+    (event: React.FocusEvent<T>) => {
+      const index = getButtons().indexOf(
+        event.target as unknown as HTMLButtonElement
+      );
+      if (index !== -1) {
+        setActiveIndex(index);
+      }
+    },
+    [getButtons]
+  );
+
+  return { toolbarRef, onKeyDown, onFocus };
+}

--- a/src/hooks/useRovingToolbar.ts
+++ b/src/hooks/useRovingToolbar.ts
@@ -21,13 +21,21 @@ export function useRovingToolbar<T extends HTMLElement>(): {
   const toolbarRef = useRef<T>(null);
   const [activeIndex, setActiveIndex] = useState(0);
 
+  // Rendered-but-hidden buttons have to stay out of the set: the HUD drops its
+  // shortcuts trigger to display:none on phones, and arrowing onto one would
+  // silently lose focus, since focus() is a no-op on a box that isn't laid out.
+  // Computed style rather than getClientRects, which reports nothing at all
+  // under jsdom and would make the whole hook inert in tests.
   const getButtons = useCallback(
     () =>
       Array.from(
         toolbarRef.current?.querySelectorAll<HTMLButtonElement>(
           'button:not([disabled])'
         ) ?? []
-      ),
+      ).filter((button) => {
+        const style = window.getComputedStyle(button);
+        return style.display !== 'none' && style.visibility !== 'hidden';
+      }),
     []
   );
 


### PR DESCRIPTION
## Description
Two acceptance criteria were still open after the shortcuts work in #1685: full keyboard navigability, and a tab order that follows a logical flow. Tabbing the play surface with a seeded session turned up three real problems.

**The HUD toolbar ate the tab order.** Its eight icon buttons sit between the top of the page and the choices, and each was its own tab stop — reaching the first suggested action cost thirteen Tab presses, on every single turn. They're one control cluster, so they now follow the ARIA toolbar pattern: one tab stop, arrow keys to move inside it, Home/End to jump the ends, and the tool you used last stays the stop you come back to. Measured on the live surface, first choice is now six presses instead of thirteen, and all eight tools are still reachable.

**Closing a drawer dropped focus on `<body>`.** Open the journal, press Escape, and a keyboard player was thrown back to the top of the tab order — every time. Root cause: Radix restores focus while the outside content is still hidden from assistive tech, so its `focus()` call lands on nothing. The drawer now takes a `restoreFocusRef` and restores a frame after the layer unwinds. The window-level Escape handler that duplicated Radix's own close goes with it; the character panel is a plain popover with no dialog behaviour of its own, so it keeps its handler.

**Nested `<main>` landmarks.** `AppSurfaceShell` already wraps the play route in the page's one main landmark, and `ManuscriptSessionShell` put a second inside it — invalid, and it gives screen-reader landmark navigation two "main" destinations. The narrative stage is a labelled `<section>` now.

Verified live against a seeded session on this worktree's dev server, not just in jsdom. The focus-on-body bug reproduces on `develop` with the toolbar change stashed, so it's pre-existing rather than something this PR introduced.

## Related Issue
Closes #276

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
As a player with a keyboard, I want full keyboard navigation so I can play without a mouse.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

No new component, and nothing here changes pixels — `game-session` and `manuscript-layout` visual specs pass unchanged.

## Implementation Notes
`useRovingToolbar` writes tabindex onto the DOM nodes rather than threading an index prop through all eight buttons, so callers only wrap the container. Its effect deliberately has no dependency array: the drawer triggers and save indicator mount and unmount during a session, and every render has to leave exactly one of whatever is currently there in the tab cycle. It's eight nodes.

The audit also flagged things that turned out to be fine and were left alone: no positive tabindex anywhere, no clickable non-focusable elements on the play surface, the drawer's focus trap works, and the `CharacterSummary` header's div-level click is a mouse convenience layered over a real `aria-expanded` button rather than a keyboard gap.

## Screenshots
N/A — no visual change.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
Verified with a Playwright probe against the worktree dev server: enumerated the real tab order before and after, walked the toolbar with arrow keys to confirm all eight tools stay reachable and wrap at both ends, and confirmed focus returns to the trigger after both Escape and the Close control. Probe was scratch tooling and is not part of the diff.

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
```bash
npx jest src/components/GameSession src/hooks
```

By hand: start a session, press Tab from the top. You should reach the first choice in six presses. Tab once into the tools cluster, then arrow through all eight. Press Enter on Journal, then Escape — focus should be back on the Journal button, not at the top of the page.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
