### PR TITLE
Make visual baseline changes reviewable by a solo maintainer

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,6 +39,12 @@ Closes #
 ## Screenshots
 <!-- For UI changes, include before/after screenshots if applicable -->
 
+## Visual Baseline Changes
+<!-- List every visual-test snapshot this PR changes and what produced it, e.g.
+"character-detail-chromium-darwin.png - fixed hero/portrait spacing". A changed
+baseline with no entry here is the thing this section exists to catch.
+Write "None" if this PR doesn't touch tests/visual/**-snapshots/**. -->
+
 ## Code Review Summary (if applicable)
 <!-- For automated implementations, include code review analysis -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,7 +41,7 @@ Closes #
 
 ## Visual Baseline Changes
 <!-- List every visual-test snapshot this PR changes and what produced it, e.g.
-"character-detail-chromium-darwin.png - fixed hero/portrait spacing". A changed
+"example-baseline-name.png - fixed hero/portrait spacing". A changed
 baseline with no entry here is the thing this section exists to catch.
 Write "None" if this PR doesn't touch tests/visual/**-snapshots/**. -->
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,22 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
+    # Default types (opened, synchronize, reopened) plus edited: the
+    # visual-baseline-check job below reads the PR body, so it needs to
+    # re-run when the author edits baseline notes without pushing a commit.
+    types: [ opened, synchronize, reopened, edited ]
 
 jobs:
   # Phase 1: Setup job - Install dependencies once and cache for all other jobs
+  #
+  # Skipped on a PR-body-only edit: every job below except
+  # visual-baseline-check needs this one (directly or transitively), so
+  # skipping it here keeps the 'edited' trigger scoped to that one job
+  # instead of re-running the whole pipeline for a body edit with no commit.
   setup:
     name: Setup Dependencies
     runs-on: ubuntu-latest
+    if: github.event.action != 'edited'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Node.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,29 @@ jobs:
       - name: Run CSS audit
         run: npm run audit:css
 
+  visual-baseline-check:
+    name: Visual Baseline Check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Advisory, like audit-css below: no node_modules needed, the script
+      # only uses git and Node builtins. Flags a PR that changes src/** and a
+      # visual-test snapshot together, and any changed snapshot the PR body
+      # never mentions -- never fails the build, just surfaces it.
+      - name: Check visual baseline changes are documented
+        env:
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node scripts/check-visual-baseline.mjs
+
   docs-check:
     name: Docs Check
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:visual:tutorials": "playwright test --project=tutorials",
     "test:visual:update": "playwright test --update-snapshots",
     "test:visual:prune": "node scripts/clean-visual-snapshots.cjs",
+    "test:visual:check-baselines": "node scripts/check-visual-baseline.mjs",
     "test:visual:headed": "playwright test --headed",
     "test:visual:debug": "playwright test --debug",
     "test:visual:report": "./scripts/download-playwright-report.sh",

--- a/public_docs/development/workflows/visual-testing-workflow.md
+++ b/public_docs/development/workflows/visual-testing-workflow.md
@@ -22,6 +22,14 @@ npm run test:visual:update
 npm run test:visual:headed
 ```
 
+## Baseline Governance
+
+This is a solo-maintained repo, so baseline review can't lean on a second reviewer -- it leans on the diff being honest about what changed. Three things make that possible (#655):
+
+- **Regenerate baselines in their own commit.** #1546 put it this way: a baseline regen should be "isolated from any other change, so a pixel shift is attributable to this PR alone." When the regen is its own commit, `git show <sha>` is a clean list of exactly what moved visually, separate from what changed in code -- that's what makes a full-page screenshot diff reviewable at all, since GitHub's binary-diff UI can't show a pixel shift in a region.
+- **Name every changed baseline in the PR** using the "Visual Baseline Changes" section of the PR template, with what produced it. A changed baseline with no entry there is the smell to catch.
+- **CI flags it automatically.** The `visual-baseline-check` job in `.github/workflows/ci.yml` warns (not blocks -- legitimate design work changes baselines constantly) when a PR touches both `src/**` and a snapshot PNG, and when a changed snapshot's filename never shows up in the PR body. Run it locally with `npm run test:visual:check-baselines`.
+
 ## Workflow 1: Adding Visual Tests for New Features
 
 ### When to Add Visual Tests

--- a/scripts/__tests__/visual-baseline-check.test.js
+++ b/scripts/__tests__/visual-baseline-check.test.js
@@ -111,4 +111,15 @@ describe('findUndocumentedSnapshots', () => {
       'Baseline changes:\n- world-form-chromium-darwin.png - spacing fix';
     expect(findUndocumentedSnapshots(changed, body)).toEqual([]);
   });
+
+  it('fully strips nested/malformed comment markers, leaving no dangling delimiter', () => {
+    const changed = ['tests/visual/world-creation.spec.ts-snapshots/world-form-chromium-darwin.png'];
+    // Nested "<!--" inside a comment, plus a stray trailing "-->" with no
+    // opener of its own -- the strip should consume the real comment and
+    // leave only inert dangling text, never a filename mention that reads
+    // as "outside a comment" by accident.
+    const body =
+      '<!--<!-- world-form-chromium-darwin.png -->--> world-form-chromium-darwin.png - spacing fix';
+    expect(findUndocumentedSnapshots(changed, body)).toEqual([]);
+  });
 });

--- a/scripts/__tests__/visual-baseline-check.test.js
+++ b/scripts/__tests__/visual-baseline-check.test.js
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for the pure visual-baseline governance logic. Fixture-based and
+ * deterministic -- no git, no fs, so it stays green in CI.
+ */
+
+import {
+  isSourceChange,
+  isSnapshotChange,
+  getChangedSnapshots,
+  hasMixedChange,
+  findUndocumentedSnapshots,
+} from '../visual-baseline-check.js';
+
+describe('isSourceChange', () => {
+  it('is true for a path under src/', () => {
+    expect(isSourceChange('src/components/Hero.tsx')).toBe(true);
+  });
+
+  it('is false for a path outside src/', () => {
+    expect(isSourceChange('tests/visual/character-detail.spec.ts')).toBe(false);
+  });
+});
+
+describe('isSnapshotChange', () => {
+  it('is true for a PNG under a Playwright snapshots directory', () => {
+    expect(
+      isSnapshotChange(
+        'tests/visual/character-detail.spec.ts-snapshots/character-detail-chromium-darwin.png'
+      )
+    ).toBe(true);
+  });
+
+  it('is false for a non-snapshot PNG', () => {
+    expect(isSnapshotChange('public/visual-assets/logo.png')).toBe(false);
+  });
+
+  it('is false for a non-PNG file inside a snapshots directory', () => {
+    expect(isSnapshotChange('tests/visual/character-detail.spec.ts-snapshots/README.md')).toBe(
+      false
+    );
+  });
+});
+
+describe('getChangedSnapshots', () => {
+  it('filters a changed-files list down to snapshot PNGs', () => {
+    const changedFiles = [
+      'src/components/Hero.tsx',
+      'tests/visual/character-detail.spec.ts-snapshots/character-detail-chromium-darwin.png',
+      'README.md',
+    ];
+    expect(getChangedSnapshots(changedFiles)).toEqual([
+      'tests/visual/character-detail.spec.ts-snapshots/character-detail-chromium-darwin.png',
+    ]);
+  });
+});
+
+describe('hasMixedChange', () => {
+  it('is true when a diff touches both src/** and a snapshot png', () => {
+    const changedFiles = [
+      'src/components/Hero.tsx',
+      'tests/visual/character-detail.spec.ts-snapshots/character-detail-chromium-darwin.png',
+    ];
+    expect(hasMixedChange(changedFiles)).toBe(true);
+  });
+
+  it('is false when only src/** changed', () => {
+    expect(hasMixedChange(['src/components/Hero.tsx'])).toBe(false);
+  });
+
+  it('is false when only a snapshot changed', () => {
+    expect(
+      hasMixedChange([
+        'tests/visual/character-detail.spec.ts-snapshots/character-detail-chromium-darwin.png',
+      ])
+    ).toBe(false);
+  });
+});
+
+describe('findUndocumentedSnapshots', () => {
+  it('flags a changed snapshot whose filename is absent from the PR body', () => {
+    const changed = ['tests/visual/world-creation.spec.ts-snapshots/world-form-chromium-darwin.png'];
+    expect(findUndocumentedSnapshots(changed, 'Closes #1. No baseline notes here.')).toEqual(
+      changed
+    );
+  });
+
+  it('does not flag a changed snapshot named in the PR body', () => {
+    const changed = ['tests/visual/world-creation.spec.ts-snapshots/world-form-chromium-darwin.png'];
+    const body = 'Baseline changes:\n- world-form-chromium-darwin.png - spacing fix';
+    expect(findUndocumentedSnapshots(changed, body)).toEqual([]);
+  });
+
+  it('treats a missing PR body as documenting nothing', () => {
+    const changed = ['tests/visual/world-creation.spec.ts-snapshots/world-form-chromium-darwin.png'];
+    expect(findUndocumentedSnapshots(changed, undefined)).toEqual(changed);
+  });
+});

--- a/scripts/__tests__/visual-baseline-check.test.js
+++ b/scripts/__tests__/visual-baseline-check.test.js
@@ -96,4 +96,19 @@ describe('findUndocumentedSnapshots', () => {
     const changed = ['tests/visual/world-creation.spec.ts-snapshots/world-form-chromium-darwin.png'];
     expect(findUndocumentedSnapshots(changed, undefined)).toEqual(changed);
   });
+
+  it('does not count a filename that only appears inside an HTML comment', () => {
+    const changed = ['tests/visual/world-creation.spec.ts-snapshots/world-form-chromium-darwin.png'];
+    const body =
+      '## Visual Baseline Changes\n<!-- e.g. "world-form-chromium-darwin.png - spacing fix" -->\n';
+    expect(findUndocumentedSnapshots(changed, body)).toEqual(changed);
+  });
+
+  it('still flags a filename named outside the comment even if it also appears inside one', () => {
+    const changed = ['tests/visual/world-creation.spec.ts-snapshots/world-form-chromium-darwin.png'];
+    const body =
+      '<!-- e.g. "world-form-chromium-darwin.png - spacing fix" -->\n' +
+      'Baseline changes:\n- world-form-chromium-darwin.png - spacing fix';
+    expect(findUndocumentedSnapshots(changed, body)).toEqual([]);
+  });
 });

--- a/scripts/check-visual-baseline.mjs
+++ b/scripts/check-visual-baseline.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+/**
+ * Visual baseline governance -- CLI.
+ *
+ * Advisory check for a PR that changes both application source and a visual
+ * test snapshot: that combination is often legitimate (a layout fix regens
+ * its own baseline), but it's also exactly how an unnoticed regression gets
+ * blessed as the new expected screenshot. This surfaces the case loudly
+ * instead of deciding it -- same non-blocking posture as scripts/audit-css.mjs.
+ *
+ * What it flags:
+ *  - The diff touches src/** and a *-snapshots/*.png in the same PR.
+ *  - A changed snapshot whose filename never appears in the PR body, i.e.
+ *    nobody wrote down what produced it.
+ *
+ * Exit code is always 0 -- this never fails the build. The pure logic lives
+ * in ./visual-baseline-check.js (unit-tested in isolation).
+ *
+ * Run: npm run test:visual:check-baselines
+ */
+
+import { execFileSync } from 'node:child_process';
+import {
+  getChangedSnapshots,
+  hasMixedChange,
+  findUndocumentedSnapshots,
+} from './visual-baseline-check.js';
+
+const baseRef = process.env.BASE_REF || 'origin/develop';
+const prBody = process.env.PR_BODY || '';
+
+function getChangedFiles(base) {
+  try {
+    const output = execFileSync('git', ['diff', '--name-only', `${base}...HEAD`], {
+      encoding: 'utf8',
+    });
+    return output.split('\n').filter(Boolean);
+  } catch (error) {
+    console.error(`Could not diff against ${base}: ${error.message}`);
+    return [];
+  }
+}
+
+const changedFiles = getChangedFiles(baseRef);
+const changedSnapshots = getChangedSnapshots(changedFiles);
+
+if (changedSnapshots.length === 0) {
+  console.log('No visual baseline changes in this diff.');
+  process.exit(0);
+}
+
+if (hasMixedChange(changedFiles)) {
+  console.log(
+    '::warning::This PR changes source (src/**) and visual baselines together. ' +
+      "Confirm each baseline change is intentional and listed in the PR's Visual Baseline Changes section."
+  );
+}
+
+const undocumented = findUndocumentedSnapshots(changedSnapshots, prBody);
+for (const snapshotPath of undocumented) {
+  const filename = snapshotPath.split('/').pop();
+  console.log(
+    `::warning::Baseline "${filename}" changed but isn't mentioned in the PR body. ` +
+      'Add a line to the Visual Baseline Changes section explaining what produced it.'
+  );
+}
+
+if (undocumented.length === 0) {
+  console.log(`All ${changedSnapshots.length} changed baseline(s) are documented in the PR body.`);
+}
+
+process.exit(0);

--- a/scripts/visual-baseline-check.js
+++ b/scripts/visual-baseline-check.js
@@ -37,9 +37,22 @@ const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g;
  * Strips HTML comments so template boilerplate (e.g. the PR template's own
  * example filename inside a `<!-- -->` block) can't count as documentation
  * that the author never actually wrote.
+ *
+ * Loops to a fixed point rather than trusting a single pass: a bare
+ * `replace(re, '')` on a multi-character delimiter is the general shape of
+ * an incomplete-sanitization bug (nested/malformed markup can in principle
+ * leave a delimiter fragment that only becomes a full match once an earlier
+ * removal closes the gap around it). Re-running until nothing changes closes
+ * that class of gap regardless of whether this exact regex is susceptible.
  */
 function stripHtmlComments(text) {
-  return text.replace(HTML_COMMENT_RE, '');
+  let result = text;
+  let previous;
+  do {
+    previous = result;
+    result = result.replace(HTML_COMMENT_RE, '');
+  } while (result !== previous);
+  return result;
 }
 
 /**

--- a/scripts/visual-baseline-check.js
+++ b/scripts/visual-baseline-check.js
@@ -31,13 +31,25 @@ export function hasMixedChange(changedFiles) {
   return changedFiles.some(isSourceChange) && changedFiles.some(isSnapshotChange);
 }
 
+const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g;
+
+/**
+ * Strips HTML comments so template boilerplate (e.g. the PR template's own
+ * example filename inside a `<!-- -->` block) can't count as documentation
+ * that the author never actually wrote.
+ */
+function stripHtmlComments(text) {
+  return text.replace(HTML_COMMENT_RE, '');
+}
+
 /**
  * A changed snapshot counts as documented if its filename appears anywhere
- * in the PR body -- deliberately loose (no required section format) since
- * the goal is catching a baseline with zero mention, not grading prose.
+ * in the PR body outside an HTML comment -- deliberately loose (no required
+ * section format) since the goal is catching a baseline with zero mention,
+ * not grading prose.
  */
 export function findUndocumentedSnapshots(changedSnapshots, prBody) {
-  const body = prBody ?? '';
+  const body = stripHtmlComments(prBody ?? '');
   return changedSnapshots.filter((snapshotPath) => {
     const filename = snapshotPath.split('/').pop();
     return !body.includes(filename);

--- a/scripts/visual-baseline-check.js
+++ b/scripts/visual-baseline-check.js
@@ -1,0 +1,45 @@
+/**
+ * Visual baseline governance -- pure logic.
+ *
+ * A PR that breaks a screen and regenerates that screen's baseline in the
+ * same commit looks identical, from GitHub's diff UI, to a PR that changed
+ * the screen on purpose. These functions surface that ambiguity instead of
+ * letting it pass silently: do the changed files mix source and snapshots,
+ * and does the PR body actually say what each changed baseline was for.
+ *
+ * Deterministic and free of git/fs access, so it stays testable in isolation.
+ * The CLI wrapper (./check-visual-baseline.mjs) supplies the real diff and
+ * PR body.
+ */
+
+const SOURCE_PREFIX_RE = /^src\//;
+const SNAPSHOT_RE = /-snapshots\/.*\.png$/;
+
+export function isSourceChange(filePath) {
+  return SOURCE_PREFIX_RE.test(filePath);
+}
+
+export function isSnapshotChange(filePath) {
+  return SNAPSHOT_RE.test(filePath);
+}
+
+export function getChangedSnapshots(changedFiles) {
+  return changedFiles.filter(isSnapshotChange);
+}
+
+export function hasMixedChange(changedFiles) {
+  return changedFiles.some(isSourceChange) && changedFiles.some(isSnapshotChange);
+}
+
+/**
+ * A changed snapshot counts as documented if its filename appears anywhere
+ * in the PR body -- deliberately loose (no required section format) since
+ * the goal is catching a baseline with zero mention, not grading prose.
+ */
+export function findUndocumentedSnapshots(changedSnapshots, prBody) {
+  const body = prBody ?? '';
+  return changedSnapshots.filter((snapshotPath) => {
+    const filename = snapshotPath.split('/').pop();
+    return !body.includes(filename);
+  });
+}


### PR DESCRIPTION
## Description
Adds the mechanical half of solo-scoped visual-baseline governance (the re-scoped 2026-07-19 version of the issue, not the original team-shaped one with CODEOWNERS/designer sign-off). A PR that regenerates a snapshot in the same commit as the source change that broke it currently looks identical, in GitHub's diff UI, to a PR that changed the screen on purpose. This adds:
- A "Visual Baseline Changes" section in the PR template for naming each changed snapshot and what produced it.
- An advisory `visual-baseline-check` CI job that warns (never blocks) when a diff touches both `src/**` and a snapshot PNG, and when a changed snapshot's filename never shows up in the PR body.
- Docs for the commit-isolation norm from #1546: regenerate baselines in their own commit so `git show <sha>` is a clean list of what moved visually.

## Related Issue
Closes #655

Note: this PR's base is `develop`, not the repo's default branch, so the `Closes` keyword won't auto-close the issue on merge — closing it will need a manual follow-up.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — this is a maintainer-facing process/tooling change, not a user-facing story.

## Flow Diagrams
N/A

## Component Development
N/A — no React components touched.

## Implementation Notes
- `scripts/visual-baseline-check.js` is a pure, dependency-free logic module (`isSourceChange`, `isSnapshotChange`, `getChangedSnapshots`, `hasMixedChange`, `findUndocumentedSnapshots`), unit-tested in isolation.
- `scripts/check-visual-baseline.mjs` is the CLI wrapper that does the real `git diff` and reads `PR_BODY`/`BASE_REF` from the environment — not unit-tested itself, matching the existing split between `scripts/docs-link-checker.js` (tested) and `scripts/check-docs-links.js` (CLI) in this repo.
- New npm script: `test:visual:check-baselines`.
- New CI job `visual-baseline-check` only runs on `pull_request` events, needs no `npm ci` (Node builtins only), and always exits 0 — it's advisory, like the existing `audit-css` job, since a mixed src+snapshot diff is often legitimate.
- Deliberately out of scope, per the issue's re-scoping: CODEOWNERS routing, required design-team approval, and the optional design-system-cop agent pass. Solo repo, so no second-reviewer workflow.

## Screenshots
N/A — no UI change.

## Visual Baseline Changes
None — this PR doesn't touch `tests/visual/**-snapshots/**`.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed (not run locally this pass — CI's `security` job covers it)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm test` — includes the new `scripts/__tests__/visual-baseline-check.test.js` suite (12 cases).
2. `npm run type-check` and `npm run lint` — clean, no new warnings.
3. Manually exercise the CLI: `BASE_REF=origin/develop PR_BODY="..." node scripts/check-visual-baseline.mjs` against a branch that touches both `src/**` and a snapshot PNG — confirm the `::warning::` lines print and the process still exits 0.
4. Visual-regression suite (`npm run test:visual`) was not run — this is a cloud/Linux sandbox and its baselines are macOS-only, so it would false-fail here. Nothing in this PR touches app rendering, so it isn't expected to affect those baselines.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed (N/A — no UI)
