### PR TITLE
test(storybook): add WithoutRail story for ManuscriptSessionShell

### DIFF
--- a/src/stories/03-organisms/game-session/ManuscriptSessionShell.stories.tsx
+++ b/src/stories/03-organisms/game-session/ManuscriptSessionShell.stories.tsx
@@ -126,9 +126,18 @@ function DemoSnapshot() {
 
 /**
  * Renders the shell with the real composed session. `mode` toggles the
- * representative state the action rail / narrative reflect.
+ * representative state the action rail / narrative reflect. `withRail`
+ * mirrors ActiveGameSession's own `hasSceneStatus` gate — the app omits
+ * `marginContent` entirely (not just an empty SceneStatus) whenever the
+ * latest segment has no participants or location to report.
  */
-function SessionShellHarness({ mode = 'active' }: { mode?: 'active' | 'streaming' | 'loading' }) {
+function SessionShellHarness({
+  mode = 'active',
+  withRail = true,
+}: {
+  mode?: 'active' | 'streaming' | 'loading';
+  withRail?: boolean;
+}) {
   const [isCharacterOpen, setIsCharacterOpen] = useState(false);
 
   // Seed demo NPCs so the real SceneStatus resolves participant names.
@@ -153,7 +162,7 @@ function SessionShellHarness({ mode = 'active' }: { mode?: 'active' | 'streaming
           characterSummaryPanel={<DemoSnapshot />}
         />
       }
-      marginContent={<SceneStatus segment={SEGMENTS[SEGMENTS.length - 1]} />}
+      marginContent={withRail ? <SceneStatus segment={SEGMENTS[SEGMENTS.length - 1]} /> : null}
       actionRail={
         <ManuscriptActionRail isStreaming={isStreaming}>
           <div className="manuscript-action-rail-stack">
@@ -198,4 +207,8 @@ export const Streaming: Story = {
 
 export const LoadingNarrative: Story = {
   render: () => <SessionShellHarness mode="loading" />,
+};
+
+export const WithoutRail: Story = {
+  render: () => <SessionShellHarness mode="active" withRail={false} />,
 };


### PR DESCRIPTION
## Description
Issue #1064 asked for Storybook coverage on the Manuscript* layout components. Most of it turned out to already exist from earlier PRs - `ManuscriptActionRail`, `ManuscriptFloatingHud`, and `ManuscriptDrawer` all have stories covering their real states, and `ManuscriptCharactersRail` was folded into `SceneStatus` (which has its own stories) when the cross-theme Scene Status work landed. The issue's "tools panel open" HUD state no longer applies either - the DS3 collapse (#1526) deleted the Tools-menu wiring outright once it lost its only trigger.

The one real gap: `ManuscriptSessionShell` had no story for its rail-less layout. `ActiveGameSession` only passes `marginContent` when `hasSceneStatus` is true, so the shell genuinely renders without the characters rail whenever the latest segment has no participants or location - a distinct, real code path (`manuscript-no-rail`) with no story covering it. This PR adds a `WithoutRail` story for that state.

## Related Issue
Note: base branch is `develop`, not this repo's default branch, so the `Closes` keyword below won't auto-close the issue on merge - closing it will need a manual follow-up.

Closes #1064

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A - Storybook coverage task, not a user-facing story.

## Flow Diagrams
N/A

## Component Development
- [x] Storybook stories created/updated
- [x] Components developed in isolation first
- [x] Visual consistency verified

## Implementation Notes
Investigated the issue's full component list before writing anything new:
- `ManuscriptActionRail.stories.tsx` already covers default + streaming (matches the issue's AC).
- `ManuscriptFloatingHud.stories.tsx` already covers the base state + character panel open. The AC also asked for a "tools panel open" state, but that UI doesn't exist anymore - PR #1526 (DS3 collapse) deliberately removed the Tools-menu wiring, so there's nothing real to add a story for.
- `ManuscriptDrawer.stories.tsx` already covers open state with mock content (character sheet, inventory, and a long-content variant).
- `ManuscriptCharactersRail` doesn't exist as a component anymore - it was replaced by `SceneStatus`, which already has its own story file covering participants/location/dispositions.

Only new story: `WithoutRail` on `ManuscriptSessionShell.stories.tsx`, added by parameterizing the existing harness with a `withRail` flag that omits `marginContent` the same way `ActiveGameSession` does when `hasSceneStatus` is false.

## Screenshots
N/A - Storybook-only change, no visual/behavioral change to the app itself.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm test` - full suite passes (376 suites / 2488 tests).
2. `npm run type-check` - clean.
3. `npm run lint` - 0 errors (pre-existing warnings only, unrelated to this change).
4. `npm run build-storybook` - builds clean.
5. `npm run storybook`, navigate to `03-Organisms/Game Session/ManuscriptSessionShell` and check the new `WithoutRail` story.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
