### PR TITLE
Add a named DS3 type scale and migrate the highest-traffic sizes

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -164,14 +164,19 @@ Use the utility classes when consuming in components:
 
 ### Sizes
 
-There is no named typographic scale yet (no `headline-lg`, `body-md`). Sizes are inline. The values in active use:
+A named type scale exists as `--font-size-*` custom properties in [_shared-tokens.css](src/lib/theme/themes/_shared-tokens.css) (#1622). Steps are calibrated to real anchors already in use rather than forced onto one strict ratio, so adjacent steps span roughly a Major Second to Major Third (1.11-1.25):
 
-- `1.5rem` and up — page titles
-- `1.125rem` — section headings
-- `1rem` — body and narrative default
-- `0.875rem` — interface text, labels
-- `0.75rem` — small metadata
-- Below `0.75rem` is reserved for badges and dense data tables only
+- `--font-size-3xl` (`2.125rem`) — the largest heading in the app (page-layout hero title)
+- `--font-size-2xl` (`1.875rem`)
+- `--font-size-xl` (`1.5rem`) and up — page titles
+- `--font-size-lg` (`1.25rem`)
+- `--font-size-md` (`1.125rem`) — section headings
+- `--font-size-base` (`1rem`) — body and narrative default
+- `--font-size-sm` (`0.875rem`) — interface text, labels
+- `--font-size-xs` (`0.75rem`) — small metadata
+- `--font-size-2xs` (`0.625rem`) — badges and dense data tables only
+
+The highest-traffic hardcoded sizes across the app have been migrated onto these tokens; a handful of one-off in-between values (e.g. `1.0625rem`, `1.75rem`) haven't been touched yet — that's tracked as incremental follow-up, not a gap in the scale itself.
 
 ### Usage rules
 

--- a/src/app/about.css
+++ b/src/app/about.css
@@ -44,7 +44,7 @@
 .component-about-lead {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   line-height: 1.6;
   color: var(--color-text-secondary);
 }
@@ -75,7 +75,7 @@
 .component-about-section-title {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1.25rem;
+  font-size: var(--font-size-lg);
   font-weight: 600;
   letter-spacing: 0.01em;
   color: var(--color-text-primary);
@@ -90,7 +90,7 @@
 .component-about-prose p {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   line-height: 1.65;
   color: var(--color-text-secondary);
 }
@@ -146,7 +146,7 @@
   width: 2rem;
   height: 2rem;
   font-family: var(--font-system);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 600;
 
   /* accent-strong, not accent: plain accent on accent-soft only hits 3.9:1,
@@ -190,7 +190,7 @@
   align-items: center;
   padding: var(--space-3) var(--space-5);
   font-family: var(--font-interface);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   font-weight: 600;
   color: var(--color-on-accent);
   background: var(--color-accent);
@@ -339,7 +339,7 @@
 
 :root .component-about-step-description {
   font-family: var(--font-system);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
 }
 
 :root .component-about-cta {

--- a/src/app/app-shell.css
+++ b/src/app/app-shell.css
@@ -143,7 +143,7 @@
   }
 
   .home-hero-tagline {
-    font-size: 1.125rem;
+    font-size: var(--font-size-md);
   }
 }
 
@@ -190,7 +190,7 @@
 :root .home-hero-tagline {
   font-family: var(--font-narrative);
   font-style: italic;
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   line-height: 1.6;
   letter-spacing: 0.005em;
   color: var(--color-text-secondary);
@@ -233,13 +233,13 @@
 
 .app-surface-app h2 {
   font-family: var(--font-interface);
-  font-size: 1.5rem;
+  font-size: var(--font-size-xl);
   line-height: 1.25;
 }
 
 .app-surface-app h3 {
   font-family: var(--font-interface);
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   line-height: 1.35;
 }
 
@@ -343,7 +343,7 @@
 
 .header-nav-links a[data-navigation] {
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   color: var(--color-text-secondary);
   text-decoration: none;
@@ -470,7 +470,7 @@
   align-items: center;
   gap: var(--space-1);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
 }
 
 .header-dropdown-menu {
@@ -490,7 +490,7 @@
 .header-dropdown-header {
   padding: var(--space-2) var(--space-3);
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -505,7 +505,7 @@
   padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-sm);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-primary);
   text-decoration: none;
   transition: background-color 120ms ease;
@@ -588,7 +588,7 @@
 
 .breadcrumbs-separator {
   color: var(--color-text-muted);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
 }
 
 /* Responsive breadcrumb gating: truncated on mobile, full on desktop */
@@ -660,7 +660,7 @@
 
 .mobile-nav-section-title {
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -724,7 +724,7 @@
   background: hsl(var(--success-background));
   color: hsl(var(--success-text));
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -888,7 +888,7 @@
 
 .component-world-card footer time {
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
@@ -936,7 +936,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   color: var(--color-text-secondary);
 }
@@ -1058,7 +1058,7 @@
 
 .world-list-empty-title {
   font-family: var(--font-narrative);
-  font-size: 1.5rem;
+  font-size: var(--font-size-xl);
   font-weight: 600;
   color: var(--color-text-primary);
   margin: 0;
@@ -1066,7 +1066,7 @@
 
 .world-list-empty-lede {
   font-family: var(--font-interface);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   color: var(--color-text-secondary);
   margin: 0;
   max-width: 36rem;
@@ -1134,7 +1134,7 @@
 .world-list-empty-tip p {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
 }
 
@@ -1176,7 +1176,7 @@
 .world-detail-section h2 {
   margin: 0 0 var(--space-4);
   font-family: var(--font-interface);
-  font-size: 1.25rem;
+  font-size: var(--font-size-lg);
   font-weight: 600;
   color: var(--color-text-primary);
 }
@@ -1264,7 +1264,7 @@
 .component-collapsible-section [data-testid="collapsible-section-title"] {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   font-weight: 600;
   color: var(--color-text-primary);
 }
@@ -1348,7 +1348,7 @@
 
 .component-character-card h3 {
   font-family: var(--font-interface);
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   font-weight: 600;
   color: var(--color-text-primary);
   cursor: pointer;
@@ -1369,7 +1369,7 @@
 
 .component-character-card > div > div:first-child > p {
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
   line-height: 1.5;
   margin: var(--space-2) 0;
@@ -1407,7 +1407,7 @@
 .page-layout-description {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   color: var(--color-text-secondary);
 
   /* Prose keeps its measure while the tables and grids beside it use the full
@@ -1421,7 +1421,7 @@
 
 :root .page-layout-title {
   font-family: var(--font-narrative);
-  font-size: 2.125rem;
+  font-size: var(--font-size-3xl);
   font-weight: 500;
 }
 
@@ -1520,7 +1520,7 @@
 .characters-empty h2 {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1.25rem;
+  font-size: var(--font-size-lg);
   font-weight: 600;
   color: var(--color-text-primary);
 }
@@ -1674,7 +1674,7 @@
   gap: var(--space-4);
   margin-top: var(--space-1);
   color: var(--color-text-muted);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
 }
 
 .character-detail-header-meta p {
@@ -1697,7 +1697,7 @@
 .character-detail-section h2 {
   margin: 0 0 var(--space-4);
   font-family: var(--font-interface);
-  font-size: 1.25rem;
+  font-size: var(--font-size-lg);
   font-weight: 600;
   color: var(--color-text-primary);
 }
@@ -1919,7 +1919,7 @@
 .settings-section h2 {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1.25rem;
+  font-size: var(--font-size-lg);
   font-weight: 600;
   color: var(--color-text-primary);
 }
@@ -1940,7 +1940,7 @@
 
 .settings-appearance-label {
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   color: var(--color-text-secondary);
 }
@@ -1967,7 +1967,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
 }
 
@@ -2084,7 +2084,7 @@
 
 .journal-list-header h2 {
   font-family: var(--font-interface);
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   font-weight: 600;
   color: var(--color-text-primary);
   margin: 0;
@@ -2120,7 +2120,7 @@
 
 .journal-detail-empty h3 {
   font-family: var(--font-interface);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   font-weight: 600;
   color: var(--color-text-secondary);
   margin: 0 0 var(--space-1);
@@ -2128,7 +2128,7 @@
 
 .journal-detail-empty p {
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-muted);
   margin: 0;
 }
@@ -2185,7 +2185,7 @@
   align-items: center;
   gap: var(--space-1);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   color: var(--color-text-primary);
   margin: 0 0 var(--space-1);
@@ -2213,7 +2213,7 @@
 
 .journal-entry-list [data-slot="card"] > div:last-child > span {
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
@@ -2228,7 +2228,7 @@
   align-items: center;
   gap: var(--space-2);
   font-family: var(--font-interface);
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   font-weight: 600;
   color: var(--color-text-primary);
   margin: 0;
@@ -2242,7 +2242,7 @@
 
 .journal-entry-detail h4 {
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -2259,7 +2259,7 @@
 
 .journal-entry-detail > div:nth-child(2) > span {
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
@@ -2332,7 +2332,7 @@
   padding: var(--space-3) 0 var(--space-4);
   font-family: var(--font-interface);
   color: var(--color-text-secondary);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
 }
 
 /* DS3 — Mechanical Manuscript: dotted radial-gradient divider above the nav,
@@ -2458,7 +2458,7 @@
 .component-hero-subtitle {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   color: var(--color-text-secondary);
 }
 
@@ -2529,7 +2529,7 @@
 .component-section-wrapper-title {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   font-weight: 600;
   color: var(--color-text-primary);
 }
@@ -2653,7 +2653,7 @@
 .component-ending-screen-hero-meta {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   color: var(--color-text-secondary);
 }
 
@@ -2839,7 +2839,7 @@
 
 .world-detail-npc-avatar-fallback {
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   color: var(--color-text-secondary);
 }
@@ -2894,14 +2894,14 @@
 .world-detail-stat-name {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   font-weight: 600;
   color: var(--color-text-primary);
 }
 
 .world-detail-stat-range {
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   letter-spacing: 0.05em;
   color: var(--color-text-muted);
 }
@@ -2909,7 +2909,7 @@
 .world-detail-stat-description {
   margin: 0 0 var(--space-2);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
   line-height: 1.5;
 }
@@ -2917,7 +2917,7 @@
 .world-detail-stat-default {
   margin: 0;
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
@@ -2926,7 +2926,7 @@
   flex-wrap: wrap;
   gap: var(--space-3);
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
@@ -3084,14 +3084,14 @@ section[aria-labelledby="image-details-heading"] .component-data-field-stacked >
 .character-detail-derived-stat-name {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   font-weight: 600;
   color: var(--color-text-primary);
 }
 
 .character-detail-derived-stat-values {
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   letter-spacing: 0.05em;
   color: var(--color-text-muted);
 }
@@ -3124,7 +3124,7 @@ section[aria-labelledby="image-details-heading"] .component-data-field-stacked >
 .character-detail-derived-stat-warning {
   margin: var(--space-2) 0 0;
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-danger);
 }
 
@@ -3464,7 +3464,7 @@ section[aria-labelledby="image-details-heading"] .component-data-field-stacked >
   padding: 0;
   font-family: var(--font-narrative);
   font-style: italic;
-  font-size: 1rem;
+  font-size: var(--font-size-base);
 }
 
 :root .component-character-card .character-card-meta {

--- a/src/app/badge.css
+++ b/src/app/badge.css
@@ -22,7 +22,7 @@
 
 .badge-sm {
   padding: var(--space-0_5) var(--space-1_5);
-  font-size: 0.625rem;
+  font-size: var(--font-size-2xs);
 }
 
 .badge-md {
@@ -32,7 +32,7 @@
 
 .badge-lg {
   padding: var(--space-1) var(--space-3);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
 }
 
 /* ─── Variants ───

--- a/src/app/character-display.css
+++ b/src/app/character-display.css
@@ -34,7 +34,7 @@
 .character-attribute-category-heading,
 .character-skill-category-heading {
   margin: 0 0 var(--space-3) 0;
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   font-weight: 600;
   color: var(--color-text-primary);
   text-transform: capitalize;
@@ -70,7 +70,7 @@
 .character-attribute-name,
 .character-skill-name {
   margin: 0 0 var(--space-1) 0;
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   color: var(--color-text-muted);
 }
@@ -78,7 +78,7 @@
 .character-attribute-value,
 .character-skill-value {
   margin: 0;
-  font-size: 1.5rem;
+  font-size: var(--font-size-xl);
   font-weight: 700;
   color: var(--color-text-primary);
 }
@@ -86,14 +86,14 @@
 .character-attribute-base,
 .character-skill-level-label {
   margin: 0 0 var(--space-2) 0;
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
 .character-attribute-description,
 .character-skill-description {
   margin: 0;
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
@@ -126,7 +126,7 @@
 .skills-form-header h2 {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   font-weight: 600;
 }
 
@@ -156,13 +156,13 @@
 
 .attributes-form-meta,
 .skills-form-meta {
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
 .attributes-form-description,
 .skills-form-description {
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
 }
 
@@ -193,7 +193,7 @@
   color: var(--color-text-secondary);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-full);
-  font-size: 0.625rem;
+  font-size: var(--font-size-2xs);
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;

--- a/src/app/dashboard.css
+++ b/src/app/dashboard.css
@@ -50,7 +50,7 @@
 .component-dashboard-getting-started h2 {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   font-weight: 600;
   letter-spacing: 0.01em;
   color: var(--color-text-primary);
@@ -178,7 +178,7 @@
 .dashboard-continue-card-meta {
   margin: 0;
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
@@ -253,7 +253,7 @@
 
 .dashboard-recent-item h3 {
   font-family: var(--font-interface);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   font-weight: 600;
   color: var(--color-text-primary);
   margin: 0;
@@ -343,7 +343,7 @@
   background: transparent;
   color: var(--color-text-muted);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   text-align: left;
   transition: border-color 120ms ease, background-color 120ms ease, color 120ms ease;
@@ -449,7 +449,7 @@
 .dashboard-getting-started-complete-body p {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
   line-height: 1.5;
 }
@@ -566,7 +566,7 @@
   align-items: center;
   gap: var(--space-2);
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-weight: 500;
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -612,7 +612,7 @@
 
 :root .dashboard-recent-item h3 {
   font-family: var(--font-system);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   letter-spacing: 0;
 }
@@ -668,7 +668,7 @@
 
 :root .dashboard-getting-started-step-label {
   font-family: var(--font-system);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   line-height: 1.4;
 }
 
@@ -750,7 +750,7 @@
 
 :root .world-list-empty-lede {
   font-family: var(--font-narrative);
-  font-size: 1.25rem;
+  font-size: var(--font-size-lg);
   color: var(--color-text-primary);
 }
 
@@ -762,7 +762,7 @@
 
 :root .world-list-empty-guide-heading {
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-weight: 500;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -771,7 +771,7 @@
 
 :root .world-list-empty-guide-steps {
   font-family: var(--font-system);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
 }
 
 :root .world-list-empty-tip {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,7 +32,7 @@ a[href="#main-content"]:focus {
   border-radius: var(--radius-md);
   color: var(--color-text-primary);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   z-index: 9999;
   outline: 2px solid var(--color-text-primary);
   outline-offset: 2px;
@@ -97,7 +97,7 @@ a[href="#main-content"]:focus {
 /* Narrative Content Styling for Readable Storytelling */
 .text-narrative {
   font-family: var(--font-narrative);
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   line-height: 1.75;
   color: var(--color-text-primary);
 }
@@ -162,7 +162,7 @@ body > * {
 /* Typography role classes */
 .text-technical {
   font-family: var(--font-system);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   line-height: 1.4;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -171,7 +171,7 @@ body > * {
 
 .text-ui {
   font-family: var(--font-interface);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   line-height: 1.5;
   color: var(--color-text-primary);
 }
@@ -188,7 +188,7 @@ body > * {
   gap: var(--space-2);
   border-radius: var(--radius-md);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   line-height: 1;
   cursor: pointer;
@@ -352,7 +352,7 @@ body > * {
 /* Size: sm */
 .button-size-sm {
   padding: var(--space-1) var(--space-3);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   min-height: var(--control-height-touch);
   min-width: var(--control-height-touch);
 }
@@ -360,7 +360,7 @@ body > * {
 /* Size: lg */
 .button-size-lg {
   padding: var(--space-3) var(--space-6);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   min-height: var(--control-height-touch);
 }
 
@@ -421,7 +421,7 @@ body > * {
   background: transparent;
   color: var(--color-text-muted);
   font-family: var(--font-system);
-  font-size: 0.625rem;
+  font-size: var(--font-size-2xs);
   font-weight: 600;
   letter-spacing: 0.05em;
   cursor: pointer;
@@ -509,7 +509,7 @@ body > * {
    before a skill can be selected during character creation. */
 
 .component-skill-prerequisites-editor .skill-prerequisites-hint {
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
   margin-bottom: var(--space-2);
 }
@@ -545,7 +545,7 @@ body > * {
 
 .app-global-error-title {
   font-family: var(--font-narrative);
-  font-size: 1.5rem;
+  font-size: var(--font-size-xl);
   font-weight: 600;
   margin: 0;
 }
@@ -569,7 +569,7 @@ body > * {
 
 .app-global-error-action {
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   padding: var(--space-2) var(--space-5);
   margin-top: var(--space-2);
   border: 1px solid var(--color-accent);

--- a/src/app/landing.css
+++ b/src/app/landing.css
@@ -76,7 +76,7 @@
 .component-landing-lead {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1.25rem;
+  font-size: var(--font-size-lg);
   line-height: 1.6;
   color: var(--color-text-secondary);
 }
@@ -192,7 +192,7 @@
 .component-landing-step-title {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   font-weight: 600;
   color: var(--color-text-primary);
 }
@@ -366,5 +366,5 @@
 :root .component-landing-step-description,
 :root .component-landing-note-description {
   font-family: var(--font-system);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
 }

--- a/src/app/legal.css
+++ b/src/app/legal.css
@@ -38,7 +38,7 @@
 .component-legal-eyebrow {
   margin: 0;
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -95,7 +95,7 @@
 .component-legal-prose p {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   line-height: 1.65;
   color: var(--color-text-secondary);
 }
@@ -177,7 +177,7 @@
 
 :root .component-legal-lead {
   font-family: var(--font-narrative);
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   line-height: 1.55;
 }
 

--- a/src/app/wizard.css
+++ b/src/app/wizard.css
@@ -21,7 +21,7 @@
 
 .wizard-title {
   font-family: var(--font-interface);
-  font-size: 1.5rem;
+  font-size: var(--font-size-xl);
   font-weight: 600;
   line-height: 1.2;
   color: var(--color-text-primary);
@@ -44,7 +44,7 @@
 
 .wizard-step-title {
   font-family: var(--font-interface);
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   font-weight: 600;
   color: var(--color-text-primary);
   margin: 0 0 var(--space-1);
@@ -52,7 +52,7 @@
 
 .wizard-step-description {
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
   line-height: 1.5;
   margin: 0;
@@ -74,7 +74,7 @@
 
 .form-label {
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   color: var(--color-text-primary);
 }
@@ -87,7 +87,7 @@
   background: var(--color-surface);
   color: var(--color-text-primary);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   transition: border-color 120ms ease, box-shadow 120ms ease;
   box-sizing: border-box;
@@ -121,7 +121,7 @@
   background: var(--color-surface);
   color: var(--color-text-primary);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   resize: vertical;
   transition: border-color 120ms ease, box-shadow 120ms ease;
@@ -146,7 +146,7 @@
   background: var(--color-surface);
   color: var(--color-text-primary);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   cursor: pointer;
   transition: border-color 120ms ease, box-shadow 120ms ease;
@@ -161,14 +161,14 @@
 
 .form-error {
   font-family: var(--font-interface);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-danger);
   margin: 0;
 }
 
 .form-help-text {
   font-family: var(--font-interface);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
   margin: 0;
 }
@@ -193,7 +193,7 @@
   display: block;
   margin-bottom: var(--space-1);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   color: var(--color-text-primary);
 }
@@ -207,7 +207,7 @@
   background: var(--color-surface);
   color: var(--color-text-primary);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   box-sizing: border-box;
 }
@@ -240,7 +240,7 @@
   background: var(--color-surface-hover);
   color: var(--color-text-muted);
   font-family: var(--font-display);
-  font-size: 1.5rem;
+  font-size: var(--font-size-xl);
   font-weight: 600;
 }
 
@@ -259,7 +259,7 @@
   background: var(--color-surface-hover);
   color: var(--color-text-muted);
   font-family: var(--font-interface);
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   font-weight: 600;
 }
 
@@ -300,7 +300,7 @@
   background: var(--color-accent);
   color: var(--color-on-accent);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   cursor: pointer;
   transition: background-color 120ms ease;
@@ -345,7 +345,7 @@
   background: var(--color-accent);
   color: var(--color-on-accent);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   cursor: pointer;
   transition: background-color 120ms ease;
@@ -379,7 +379,7 @@
   background: var(--color-surface);
   color: var(--color-text-secondary);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   cursor: pointer;
   transition: all 120ms ease;
@@ -411,7 +411,7 @@
   background: transparent;
   color: var(--color-text-muted);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   cursor: pointer;
   transition: color 120ms ease;
 }
@@ -467,7 +467,7 @@
   height: 2rem;
   border-radius: var(--radius-full);
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   transition: all 120ms ease;
 }
@@ -492,7 +492,7 @@
 
 .wizard-progress-label {
   font-family: var(--font-interface);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-secondary);
   text-align: center;
 }
@@ -553,7 +553,7 @@
   padding: var(--space-0_5) var(--space-2);
   border-radius: var(--radius-full);
   font-family: var(--font-system);
-  font-size: 0.625rem;
+  font-size: var(--font-size-2xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -596,7 +596,7 @@
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   font-family: var(--font-interface);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-weight: 500;
   cursor: pointer;
   transition: all 120ms ease;
@@ -656,7 +656,7 @@
 
 .wizard-subheading {
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -671,7 +671,7 @@
   background: color-mix(in srgb, var(--color-danger) 8%, transparent);
   color: var(--color-danger);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
 }
 
 .wizard-error-container p {
@@ -706,7 +706,7 @@
 
 .wizard-page-title {
   font-family: var(--font-interface);
-  font-size: 1.875rem;
+  font-size: var(--font-size-2xl);
   font-weight: 700;
   line-height: 1.2;
   color: var(--color-text-primary);
@@ -715,7 +715,7 @@
 
 .wizard-page-subtitle {
   font-family: var(--font-interface);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   color: var(--color-text-secondary);
   margin: 0;
 }
@@ -841,7 +841,7 @@
 
 .wizard-info-banner p {
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-primary);
   margin: 0;
   line-height: 1.5;
@@ -860,7 +860,7 @@
   border-radius: var(--radius-md);
   background: var(--color-surface);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
   text-align: center;
 }
@@ -959,7 +959,7 @@
 .range-slider-scale-label {
   top: 0;
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   line-height: 1;
   color: var(--color-text-muted);
 }
@@ -1194,7 +1194,7 @@
 
 :root .wizard-page .wizard-card-title {
   font-family: var(--font-system);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   letter-spacing: 0.05em;
 }
@@ -1261,7 +1261,7 @@
 :root .wizard-page .wizard-toggle {
   border-radius: 4px;
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
 }
 
 :root .wizard-page .wizard-info-banner {
@@ -1567,13 +1567,13 @@
   flex-direction: column;
   gap: var(--space-3);
   min-width: 0;
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
 }
 
 .wizard-review-card-range {
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
@@ -1645,7 +1645,7 @@
 .wizard-custom-editor h2 {
   margin: 0 0 var(--space-3);
   font-family: var(--font-interface);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   font-weight: 600;
   color: var(--color-text-primary);
 }
@@ -1698,7 +1698,7 @@
 }
 
 .wizard-slot-summary-note {
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
@@ -1747,7 +1747,7 @@
 
 .wizard-dialog-panel p {
   margin: 0;
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
 }
 
@@ -1872,7 +1872,7 @@
 
 .wizard-skill-card-linked {
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
@@ -1882,7 +1882,7 @@
 
 .wizard-skill-card-requirement {
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-danger);
   margin-top: var(--space-1);
 }
@@ -1900,7 +1900,7 @@
   justify-content: space-between;
   gap: var(--space-2);
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-secondary);
 }
 
@@ -1953,7 +1953,7 @@
 
 :root .wizard-page .wizard-custom-editor h2 {
   font-family: var(--font-system);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   letter-spacing: 0.05em;
 }
 
@@ -2089,7 +2089,7 @@
 
 .component-guided-first-time-step-num {
   font-family: var(--font-system);
-  font-size: 1.5rem;
+  font-size: var(--font-size-xl);
   font-weight: 700;
   line-height: 1;
   color: var(--color-accent);
@@ -2098,7 +2098,7 @@
 .component-guided-first-time-step-heading {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   font-weight: 600;
   color: var(--color-text-primary);
 }
@@ -2106,7 +2106,7 @@
 .component-guided-first-time-step-copy {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   color: var(--color-text-secondary);
 }
@@ -2122,7 +2122,7 @@
 .component-guided-first-time-step-title {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1.25rem;
+  font-size: var(--font-size-lg);
   font-weight: 600;
   color: var(--color-text-primary);
 }
@@ -2158,7 +2158,7 @@
   display: flex;
   justify-content: center;
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
 }
 
@@ -2356,7 +2356,7 @@
 .component-world-creation-wizard .wizard-suggestion-preview-heading {
   margin: 0 0 var(--space-2);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   color: var(--color-text-primary);
 }

--- a/src/components/GenerateCharacterDialog/GenerateCharacterDialog.css
+++ b/src/components/GenerateCharacterDialog/GenerateCharacterDialog.css
@@ -42,7 +42,7 @@
 
 .generate-character-option-description {
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
 }
 
@@ -51,6 +51,6 @@
   align-items: center;
   gap: var(--space-2);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
 }

--- a/src/components/ai/provider-config.css
+++ b/src/components/ai/provider-config.css
@@ -54,7 +54,7 @@
 }
 
 .provider-card-meta {
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-muted);
 }
 
@@ -65,7 +65,7 @@
 }
 
 .provider-badge {
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   padding: var(--space-1) var(--space-2);
   border-radius: var(--radius-full);
   border: 1px solid var(--color-border);
@@ -134,7 +134,7 @@
 }
 
 .provider-preset-note {
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
@@ -156,7 +156,7 @@
   cursor: pointer;
   color: var(--color-accent);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
 }
 
 /* Mobile wizard fit (#1539): at phone widths the auto-fill preset grid
@@ -193,7 +193,7 @@
   padding: var(--space-3);
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
 }
 

--- a/src/components/devtools/DecisionFlowSection/DecisionFlowSection.css
+++ b/src/components/devtools/DecisionFlowSection/DecisionFlowSection.css
@@ -132,7 +132,7 @@
   background: var(--color-surface);
   white-space: pre-wrap;
   overflow-wrap: anywhere;
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
 }
 
 .devtools-decision-flow-empty {

--- a/src/components/devtools/TokenBudgetPanel/TokenBudgetPanel.css
+++ b/src/components/devtools/TokenBudgetPanel/TokenBudgetPanel.css
@@ -86,7 +86,7 @@
 .token-budget-panel-suggestion {
   margin: 0;
   color: var(--color-danger);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
 }
 
 .token-budget-panel-calibration {
@@ -113,5 +113,5 @@
 .token-budget-panel-empty {
   margin: 0;
   color: var(--color-text-muted);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
 }

--- a/src/components/devtools/shared/DevToolsSection.css
+++ b/src/components/devtools/shared/DevToolsSection.css
@@ -16,7 +16,7 @@
 
 .devtools-section-title {
   margin: 0;
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;

--- a/src/components/shared/NotFoundState.css
+++ b/src/components/shared/NotFoundState.css
@@ -31,7 +31,7 @@
 .not-found-state-content p {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   line-height: 1.5;
   color: var(--color-text-secondary);
 }

--- a/src/components/shared/WorldTypeSelector/WorldTypeSelector.css
+++ b/src/components/shared/WorldTypeSelector/WorldTypeSelector.css
@@ -27,6 +27,6 @@
 
 .world-type-option-description {
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
 }

--- a/src/components/ui/EmptyState/EmptyState.css
+++ b/src/components/ui/EmptyState/EmptyState.css
@@ -40,7 +40,7 @@
 .component-empty-state-content h3 {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   font-weight: 600;
   color: var(--color-text-primary);
 }

--- a/src/components/ui/alert.css
+++ b/src/components/ui/alert.css
@@ -25,7 +25,7 @@
 }
 
 .alert-description {
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
 }
 

--- a/src/components/ui/card.css
+++ b/src/components/ui/card.css
@@ -25,7 +25,7 @@
 .card-title {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   font-weight: 600;
   color: var(--color-text-primary);
 }
@@ -37,7 +37,7 @@
 .card-description {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   color: var(--color-text-secondary);
 }

--- a/src/components/ui/checkbox.css
+++ b/src/components/ui/checkbox.css
@@ -18,6 +18,6 @@
   display: inline-flex;
   align-items: center;
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-primary);
 }

--- a/src/components/ui/radio-group.css
+++ b/src/components/ui/radio-group.css
@@ -37,6 +37,6 @@
   display: inline-flex;
   align-items: center;
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-primary);
 }

--- a/src/components/ui/table.css
+++ b/src/components/ui/table.css
@@ -20,13 +20,13 @@
   width: 100%;
   border-collapse: collapse;
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
 }
 
 .table-wrapper thead th {
   padding: var(--space-2) var(--space-3);
   text-align: left;
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;

--- a/src/components/ui/tabs.css
+++ b/src/components/ui/tabs.css
@@ -25,7 +25,7 @@
   border-bottom: 2px solid transparent;
   background: transparent;
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   color: var(--color-text-muted);
   cursor: pointer;
@@ -43,6 +43,6 @@
 
 .tabs-content {
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
 }

--- a/src/components/ui/toast/toast.css
+++ b/src/components/ui/toast/toast.css
@@ -49,7 +49,7 @@
 }
 
 .toast-description {
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   line-height: 1.4;
   color: var(--color-text-secondary);
 }

--- a/src/lib/theme/themes/__tests__/typeScale.test.ts
+++ b/src/lib/theme/themes/__tests__/typeScale.test.ts
@@ -1,0 +1,57 @@
+import fs from 'fs';
+import path from 'path';
+
+const sharedTokensCss = fs.readFileSync(
+  path.join(__dirname, '../_shared-tokens.css'),
+  'utf-8'
+);
+
+// Named steps, in ascending order, anchored to real DS3 usage:
+// --font-size-xs/sm/base/md/lg/xl already match DESIGN.md's documented
+// "values in active use" (badges/metadata, interface text, body, section
+// headings, page titles); --font-size-3xl matches the page-layout hero
+// title (app-shell.css .page-layout-title, ex-workshop.css:1810 per #1622).
+const EXPECTED_SCALE: Array<[token: string, rem: number]> = [
+  ['--font-size-2xs', 0.625],
+  ['--font-size-xs', 0.75],
+  ['--font-size-sm', 0.875],
+  ['--font-size-base', 1],
+  ['--font-size-md', 1.125],
+  ['--font-size-lg', 1.25],
+  ['--font-size-xl', 1.5],
+  ['--font-size-2xl', 1.875],
+  ['--font-size-3xl', 2.125],
+];
+
+function readTokenValue(css: string, token: string): string | null {
+  const match = css.match(
+    new RegExp(`${token.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}:\\s*([^;]+);`)
+  );
+  return match ? match[1].trim() : null;
+}
+
+describe('DS3 type scale tokens (_shared-tokens.css)', () => {
+  it.each(EXPECTED_SCALE)('defines %s as %srem', (token, rem) => {
+    const value = readTokenValue(sharedTokensCss, token);
+    expect(value).toBe(`${rem}rem`);
+  });
+
+  it('orders the named steps ascending by value', () => {
+    const values = EXPECTED_SCALE.map(([token]) => {
+      const raw = readTokenValue(sharedTokensCss, token);
+      expect(raw).not.toBeNull();
+      return parseFloat(raw as string);
+    });
+    const sorted = [...values].sort((a, b) => a - b);
+    expect(values).toEqual(sorted);
+  });
+
+  it('keeps every step a genuine increase over the last (no duplicate sizes)', () => {
+    const values = EXPECTED_SCALE.map(([token]) =>
+      parseFloat(readTokenValue(sharedTokensCss, token) as string)
+    );
+    for (let i = 1; i < values.length; i++) {
+      expect(values[i]).toBeGreaterThan(values[i - 1]);
+    }
+  });
+});

--- a/src/lib/theme/themes/__tests__/typeScaleMigration.test.ts
+++ b/src/lib/theme/themes/__tests__/typeScaleMigration.test.ts
@@ -1,0 +1,57 @@
+import fs from 'fs';
+import path from 'path';
+import { globSync } from 'glob';
+
+const rootDir = path.join(__dirname, '../../../../..');
+
+// The exact rem values that now have a named --font-size-* token
+// (see typeScale.test.ts). Once a value has a token, production CSS should
+// reference the token instead of repeating the literal.
+const MIGRATED_VALUES = [
+  '0.625rem',
+  '0.75rem',
+  '0.875rem',
+  '1rem',
+  '1.125rem',
+  '1.25rem',
+  '1.5rem',
+  '1.875rem',
+  '2.125rem',
+];
+
+// The token definition file is the one place the literals are allowed to
+// live; everything else under src/ should consume them via var(...).
+const EXCLUDED_FILES = [
+  path.join(rootDir, 'src/lib/theme/themes/_shared-tokens.css'),
+];
+
+function findProductionCssFiles(): string[] {
+  return globSync('src/**/*.css', { cwd: rootDir, absolute: true }).filter(
+    (file) => !EXCLUDED_FILES.includes(file)
+  );
+}
+
+describe('DS3 type scale migration: no re-introduced literals', () => {
+  const cssFiles = findProductionCssFiles();
+
+  it('found production CSS files to check (sanity check on the glob)', () => {
+    expect(cssFiles.length).toBeGreaterThan(10);
+  });
+
+  it.each(MIGRATED_VALUES)(
+    'no font-size declaration hardcodes %s where a token now exists',
+    (value) => {
+      const offenders: string[] = [];
+      const pattern = new RegExp(`font-size:\\s*${value.replace('.', '\\.')}\\b`);
+
+      for (const file of cssFiles) {
+        const contents = fs.readFileSync(file, 'utf-8');
+        if (pattern.test(contents)) {
+          offenders.push(path.relative(rootDir, file));
+        }
+      }
+
+      expect(offenders).toEqual([]);
+    }
+  );
+});

--- a/src/lib/theme/themes/_shared-tokens.css
+++ b/src/lib/theme/themes/_shared-tokens.css
@@ -17,6 +17,28 @@
   --space-6:   1.5rem;
   --space-8:   2rem;
 
+  /* Type scale (#1622). Named steps rather than a single fixed ratio: each
+   * value is calibrated to a real anchor already in use rather than forced
+   * onto one strict progression, so adjacent steps land in a 1.11-1.25
+   * range (a Major Second to Major Third spread) instead of drifting off
+   * into sizes nothing in the app actually needs.
+   *   xs/sm/base/md/lg/xl match DESIGN.md's documented in-use values
+   *     (badges & metadata, interface text, body, section headings, page
+   *     titles).
+   *   3xl matches the page-layout hero title (app-shell.css
+   *     .page-layout-title), the largest real anchor in the app.
+   * 2xs and 2xl fill the floor (dense data, below the badge threshold) and
+   * a step between page titles and the hero size. */
+  --font-size-2xs:  0.625rem;
+  --font-size-xs:   0.75rem;
+  --font-size-sm:   0.875rem;
+  --font-size-base: 1rem;
+  --font-size-md:   1.125rem;
+  --font-size-lg:   1.25rem;
+  --font-size-xl:   1.5rem;
+  --font-size-2xl:  1.875rem;
+  --font-size-3xl:  2.125rem;
+
   /* Universal radius token */
   --radius-full: 9999px;
 

--- a/src/stories/00-foundation/DesignSystemShowcase.css
+++ b/src/stories/00-foundation/DesignSystemShowcase.css
@@ -26,7 +26,7 @@
 
 .ds-showcase-description {
   max-width: 60ch;
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
 }
 
@@ -38,27 +38,27 @@
 }
 
 .ds-showcase-text-large {
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   color: var(--color-text-primary);
 }
 
 .ds-showcase-text-body {
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   color: var(--color-text-primary);
 }
 
 .ds-showcase-text-small {
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-primary);
 }
 
 .ds-showcase-text-xs {
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-primary);
 }
 
 .ds-showcase-text-muted {
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-muted);
 }
 
@@ -160,7 +160,7 @@
 
 .ds-showcase-demo-box {
   padding: var(--space-4);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
   text-align: center;
   background: var(--color-surface-hover);
@@ -193,6 +193,6 @@
 
 .ds-showcase-spacing-token {
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }

--- a/src/styles/character-suggestions.css
+++ b/src/styles/character-suggestions.css
@@ -55,7 +55,7 @@
 .character-suggestion-card-title {
   margin: 0;
   color: var(--color-text-primary);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   font-weight: 600;
 }
 

--- a/src/styles/error-block.css
+++ b/src/styles/error-block.css
@@ -12,7 +12,7 @@
 
 .error-block-message {
   margin-top: var(--space-1);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-danger);
 }
 

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -199,7 +199,7 @@ body.manuscript-overlay-open {
 
 .play-page-shell > div > div > header h1 {
   font-family: var(--font-interface);
-  font-size: 1.5rem;
+  font-size: var(--font-size-xl);
   font-weight: 700;
   line-height: 1.25;
   color: var(--color-text-primary);
@@ -224,7 +224,7 @@ body.manuscript-overlay-open {
 
 .play-page-active > div > div > header h1 {
   font-family: var(--font-narrative);
-  font-size: 1.5rem;
+  font-size: var(--font-size-xl);
   font-weight: 600;
   line-height: 1.25;
   color: var(--color-text-primary);
@@ -366,7 +366,7 @@ body.manuscript-overlay-open {
   background: var(--color-surface);
   color: var(--color-text-primary);
   font-family: var(--font-interface);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-weight: 500;
   cursor: pointer;
   transition: all 120ms ease;
@@ -618,7 +618,7 @@ body.manuscript-overlay-open {
   background: var(--color-surface);
   color: var(--color-text-primary);
   font-family: var(--font-interface), system-ui, sans-serif;
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   line-height: 1rem;
   font-weight: 500;
   cursor: pointer;
@@ -701,7 +701,7 @@ body.manuscript-overlay-open {
   border-radius: var(--radius-sm);
   background: var(--color-surface-hover);
   border: 1px solid var(--color-border);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-secondary);
   font-family: var(--font-interface), system-ui, sans-serif;
 }
@@ -745,7 +745,7 @@ body.manuscript-overlay-open {
   border: 1px solid var(--color-warning-border);
   color: var(--color-warning);
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   cursor: pointer;
   transition: all 120ms ease;
@@ -781,7 +781,7 @@ body.manuscript-overlay-open {
 
 .manuscript-context-summary {
   color: var(--color-text-secondary);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   line-height: 1.4;
   font-weight: 500;
   margin-bottom: var(--space-1_5);
@@ -792,7 +792,7 @@ body.manuscript-overlay-open {
 .manuscript-choice-prompt {
   margin: 0;
   font-family: var(--font-interface), system-ui, sans-serif;
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   font-weight: 600;
   color: var(--color-text-primary);
   max-width: 48rem;
@@ -809,7 +809,7 @@ body.manuscript-overlay-open {
   background: var(--color-surface);
   color: var(--color-text-primary);
   font-family: var(--font-interface), system-ui, sans-serif;
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   transition: all 120ms ease;
 }
 
@@ -823,7 +823,7 @@ body.manuscript-overlay-open {
 }
 
 .manuscript-input-count {
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-secondary);
 }
 
@@ -837,7 +837,7 @@ body.manuscript-overlay-open {
   background: var(--color-accent);
   color: var(--color-on-accent);
   font-family: var(--font-interface), system-ui, sans-serif;
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   cursor: pointer;
   transition: all 120ms ease;
@@ -926,7 +926,7 @@ body.manuscript-overlay-open {
 .manuscript-journal-snapshot-title {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   color: var(--color-text-primary);
   line-height: 1.2;
@@ -940,7 +940,7 @@ body.manuscript-overlay-open {
 
 .manuscript-journal-snapshot-badge {
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -973,14 +973,14 @@ body.manuscript-overlay-open {
   display: flex;
   justify-content: space-between;
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
 .manuscript-journal-snapshot-empty {
   font-family: var(--font-narrative);
   font-style: italic;
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-muted);
   text-align: center;
   padding: var(--space-8) var(--space-4);
@@ -1001,7 +1001,7 @@ body.manuscript-overlay-open {
 
 .manuscript-story-summary-paragraph {
   font-family: var(--font-narrative);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   line-height: 1.75;
   color: var(--color-text-primary);
   margin: 0;
@@ -1009,7 +1009,7 @@ body.manuscript-overlay-open {
 
 .manuscript-story-summary-empty {
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -1017,7 +1017,7 @@ body.manuscript-overlay-open {
 
 .manuscript-story-summary-error {
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-danger);
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -1070,7 +1070,7 @@ body.manuscript-overlay-open {
 .manuscript-end-story-title {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   font-weight: 600;
   color: var(--color-text-primary);
 }
@@ -1082,7 +1082,7 @@ body.manuscript-overlay-open {
 .manuscript-end-story-message {
   margin: 0;
   font-family: var(--font-narrative);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   line-height: 1.6;
   color: var(--color-text-secondary);
 }
@@ -1102,7 +1102,7 @@ body.manuscript-overlay-open {
   background: var(--color-surface);
   color: var(--color-text-secondary);
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -1122,7 +1122,7 @@ body.manuscript-overlay-open {
   background: var(--color-danger);
   color: var(--color-text-inverse);
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -1170,7 +1170,7 @@ body.manuscript-overlay-open {
 
   display: block;
 
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
 
   font-family: var(--font-interface), system-ui, sans-serif;
 
@@ -1197,7 +1197,7 @@ body.manuscript-overlay-open {
   align-items: center;
   border-radius: var(--radius-full);
   padding: var(--space-0_5) var(--space-1_5);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-family: var(--font-system);
   font-weight: 600;
   letter-spacing: 0.03em;
@@ -1226,7 +1226,7 @@ body.manuscript-overlay-open {
 
   padding: var(--space-0_5) var(--space-1_5);
 
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
 
   font-family: var(--font-system);
 
@@ -1319,7 +1319,7 @@ body.manuscript-overlay-open {
   align-items: center;
   gap: var(--space-1);
   font-family: var(--font-interface), system-ui, sans-serif;
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
 }
 
 .manuscript-drawer-backdrop {
@@ -1381,14 +1381,14 @@ body.manuscript-overlay-open {
 .manuscript-drawer-title {
   margin: 0;
   font-family: var(--font-interface), system-ui, sans-serif;
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   font-weight: 600;
   color: var(--color-text-primary);
 }
 
 .manuscript-drawer-subtitle {
   margin: 0;
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
   white-space: nowrap;
   overflow: hidden;
@@ -1402,7 +1402,7 @@ body.manuscript-overlay-open {
   background: var(--color-surface-hover);
   color: var(--color-text-secondary);
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -1509,7 +1509,7 @@ body.manuscript-overlay-open {
 
 .manuscript-character-summary-name {
   margin: 0;
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   font-family: var(--font-interface), system-ui, sans-serif;
   font-weight: 600;
 }
@@ -1525,7 +1525,7 @@ body.manuscript-overlay-open {
 
 .manuscript-character-summary-level {
   margin: var(--space-0_5) 0 0;
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-secondary);
 }
 
@@ -1536,7 +1536,7 @@ body.manuscript-overlay-open {
   background: var(--color-surface);
   color: var(--color-text-secondary);
   cursor: pointer;
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   transition: all 120ms ease;
 }
 
@@ -1552,7 +1552,7 @@ body.manuscript-overlay-open {
 .manuscript-character-summary-history {
   margin: 0 0 var(--space-3);
   color: var(--color-text-secondary);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   line-height: 1.45;
 }
 
@@ -1594,19 +1594,19 @@ body.manuscript-overlay-open {
 }
 
 .manuscript-character-summary-item-label {
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-primary);
 }
 
 .manuscript-character-summary-item-value {
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-family: var(--font-system), ui-monospace, monospace;
   font-weight: 500;
   color: var(--color-text-secondary);
 }
 
 .manuscript-character-summary-links {
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
@@ -1628,7 +1628,7 @@ body.manuscript-overlay-open {
 
 .manuscript-inventory-category-title {
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.1em;
@@ -1689,7 +1689,7 @@ body.manuscript-overlay-open {
   background: var(--color-surface-hover);
   border: 1px solid var(--color-border);
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--color-text-muted);
@@ -1715,7 +1715,7 @@ body.manuscript-overlay-open {
   margin-bottom: var(--space-2);
   padding: var(--space-0_5) var(--space-2);
   font-family: var(--font-system);
-  font-size: 0.625rem;
+  font-size: var(--font-size-2xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -1746,7 +1746,7 @@ body.manuscript-overlay-open {
 
 .manuscript-inventory-item-quantity {
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
@@ -1777,7 +1777,7 @@ body.manuscript-overlay-open {
 
 .manuscript-inventory-action-button {
   font-family: var(--font-system);
-  font-size: 0.625rem;
+  font-size: var(--font-size-2xs);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   height: 1.75rem;
@@ -1816,7 +1816,7 @@ body.manuscript-overlay-open {
 
 .manuscript-choice-history-meta-item {
   font-family: var(--font-system);
-  font-size: 0.625rem;
+  font-size: var(--font-size-2xs);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--color-text-muted);
@@ -1837,7 +1837,7 @@ body.manuscript-overlay-open {
 
 .manuscript-choice-history-details {
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   line-height: 1.4;
   color: var(--color-text-muted);
   background: var(--color-surface-hover);
@@ -1849,7 +1849,7 @@ body.manuscript-overlay-open {
 
 .manuscript-choice-history-empty {
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--color-text-muted);
@@ -1863,7 +1863,7 @@ body.manuscript-overlay-open {
 
 .manuscript-choice-history-details-button {
   font-family: var(--font-system);
-  font-size: 0.625rem;
+  font-size: var(--font-size-2xs);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   height: 1.25rem;
@@ -1876,7 +1876,7 @@ body.manuscript-overlay-open {
 
 .manuscript-ending-prose {
   font-family: var(--font-narrative);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   line-height: 1.75;
   color: var(--color-text-primary);
 }
@@ -1956,7 +1956,7 @@ body.manuscript-overlay-open {
 }
 
 .save-indicator-text {
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   color: var(--color-text-primary);
   line-height: 1.1;
 }
@@ -1971,7 +1971,7 @@ body.manuscript-overlay-open {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   padding: var(--space-1) var(--space-2);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-family: var(--font-interface), system-ui, sans-serif;
   background: var(--color-surface);
   color: var(--color-text-primary);
@@ -2000,7 +2000,7 @@ body.manuscript-overlay-open {
   .manuscript-warning-action-button {
     padding: var(--space-2) var(--space-3);
     height: 2rem;
-    font-size: 0.75rem;
+    font-size: var(--font-size-xs);
   }
 
   .manuscript-input-row {
@@ -2022,7 +2022,7 @@ body.manuscript-overlay-open {
   .manuscript-warning-action-button {
     padding: var(--space-2) var(--space-3);
     height: 2rem;
-    font-size: 0.75rem;
+    font-size: var(--font-size-xs);
   }
 }
 
@@ -2224,7 +2224,7 @@ body.manuscript-overlay-open {
 
 .manuscript-character-snapshot-name {
   font-family: var(--font-interface), system-ui, sans-serif;
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 400;
   color: var(--color-text-primary);
 }
@@ -2251,7 +2251,7 @@ body.manuscript-overlay-open {
 .manuscript-character-snapshot-subheading {
   margin: 0;
   font-family: var(--font-system), ui-monospace, monospace;
-  font-size: 0.625rem;
+  font-size: var(--font-size-2xs);
   font-weight: 600;
   letter-spacing: 0.05em;
   color: var(--color-text-muted);
@@ -2325,7 +2325,7 @@ body.manuscript-overlay-open {
 
 .choice-outcome-label {
   font-family: var(--font-system), ui-monospace, monospace;
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   margin-bottom: var(--space-1);
   color: var(--color-accent);
   text-transform: uppercase;
@@ -2336,7 +2336,7 @@ body.manuscript-overlay-open {
 .choice-outcome-text {
   font-family: var(--font-narrative);
   font-style: italic;
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   color: var(--color-text-secondary);
   margin: 0;
@@ -2537,7 +2537,7 @@ body.manuscript-overlay-open {
 
 .manuscript-generation-error-message {
   color: var(--color-text);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
 }
 
 .manuscript-generation-error-suggestion {
@@ -2557,7 +2557,7 @@ body.manuscript-overlay-open {
   background: var(--color-accent);
   color: var(--color-on-accent);
   font-family: var(--font-interface), system-ui, sans-serif;
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   cursor: pointer;
   transition: all 120ms ease;
@@ -2596,7 +2596,7 @@ body.manuscript-overlay-open {
 
 /* Base error dismiss button (replaces Tailwind utilities) */
 .error-display-dismiss {
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-weight: 500;
   text-decoration: underline;
   text-underline-offset: 2px;
@@ -2613,14 +2613,14 @@ body.manuscript-overlay-open {
 }
 
 .error-display-title {
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   font-weight: 600;
   color: var(--color-danger);
   margin: 0 0 var(--space-1_5);
 }
 
 .error-display-message {
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   color: var(--color-danger);
   margin: 0 0 var(--space-2_5);
@@ -2633,7 +2633,7 @@ body.manuscript-overlay-open {
 
 .error-display-actions .error-display-retry {
   padding: var(--space-1_5) var(--space-3);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   background: var(--color-danger);
   color: var(--color-on-danger);
@@ -2649,7 +2649,7 @@ body.manuscript-overlay-open {
 
 .error-display-actions .error-display-dismiss {
   padding: var(--space-1_5) var(--space-3);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   background: var(--color-surface);
   color: var(--color-danger);
@@ -2682,7 +2682,7 @@ body.manuscript-overlay-open {
 
 .error-display-actions .error-display-fallback-action {
   padding: var(--space-1_5) var(--space-3);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   background: var(--color-surface);
   color: var(--color-danger);
@@ -2713,7 +2713,7 @@ body.manuscript-overlay-open {
 
 /* Inline errors previously had no colour; give them a severity accent. */
 .error-display-inline {
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   line-height: 1.4;
   margin: var(--space-1) 0 0;
 }
@@ -3086,7 +3086,7 @@ body.manuscript-overlay-open {
 
 :root .choice-outcome-label {
   font-family: var(--font-system);
-  font-size: 0.625rem;
+  font-size: var(--font-size-2xs);
   font-weight: 600;
   letter-spacing: 0.1em;
   padding: 2px 8px;
@@ -3352,7 +3352,7 @@ body.manuscript-overlay-open {
 
 /* DS3 narrative text — 18px with generous line-height */
 :root .text-narrative {
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   line-height: 1.75;
 }
 
@@ -3440,7 +3440,7 @@ body.manuscript-overlay-open {
 }
 
 :root .manuscript-drawer-title {
-  font-size: 1rem;
+  font-size: var(--font-size-base);
 }
 
 :root .manuscript-drawer-content {
@@ -3455,7 +3455,7 @@ body.manuscript-overlay-open {
 /* DS3 character snapshot stat values — larger, bolder, system font (Pass 8, fix 1) */
 :root .manuscript-character-snapshot-item-value {
   font-family: var(--font-system);
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   font-weight: 600;
 }
 
@@ -3488,7 +3488,7 @@ body.manuscript-overlay-open {
 
 :root .manuscript-journal-snapshot-content {
   font-family: var(--font-interface);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   line-height: 1.55;
   opacity: 0.85;
   color: var(--color-text-primary);
@@ -3497,7 +3497,7 @@ body.manuscript-overlay-open {
 }
 
 :root .manuscript-journal-snapshot-meta {
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -3528,7 +3528,7 @@ body.manuscript-overlay-open {
 }
 
 :root .manuscript-inventory-item-name {
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 500;
 }
 
@@ -3624,7 +3624,7 @@ body.manuscript-overlay-open {
 .manuscript-marginalia-category {
   display: inline-block;
   font-family: var(--font-system);
-  font-size: 0.625rem;
+  font-size: var(--font-size-2xs);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -3760,7 +3760,7 @@ body.manuscript-overlay-open {
    relationship state exists for that NPC. */
 .scene-status-disposition {
   font-family: var(--font-system), ui-monospace, monospace;
-  font-size: 0.625rem;
+  font-size: var(--font-size-2xs);
   text-transform: uppercase;
   letter-spacing: 0.06em;
   padding: 0 var(--space-1);
@@ -3859,12 +3859,12 @@ body.manuscript-overlay-open {
   border: 1px solid var(--color-border);
   background: var(--color-surface-hover);
   font-family: var(--font-system);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   font-weight: 500;
   color: var(--color-text-secondary);
 }
 
 :root .keyboard-shortcuts-description {
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   color: var(--color-text-primary);
 }

--- a/src/styles/session-recovery.css
+++ b/src/styles/session-recovery.css
@@ -60,7 +60,7 @@
 .game-session-recovery-prompt-title {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 1.125rem;
+  font-size: var(--font-size-md);
   font-weight: 600;
   letter-spacing: 0.01em;
   color: var(--color-text-primary);


### PR DESCRIPTION
## Description
Adds a real, named DS3 type scale and migrates the highest-traffic hardcoded font sizes onto it. Font sizes were previously dozens of ad hoc rem values (0.5625rem to 2.125rem, mostly in ~1px increments) scattered across CSS with no naming or system behind them.

`_shared-tokens.css` now has nine `--font-size-*` tokens (`2xs` through `3xl`). Rather than forcing one rigid mathematical ratio across the board, each step is calibrated against a real anchor already in use in the app — DESIGN.md's documented "values in active use" and the `.page-layout-title` hero heading (the largest real anchor, `2.125rem`) — so adjacent steps land in roughly a 1.11-1.25 range instead of drifting toward sizes nothing actually needs.

I then migrated every exact-match hardcoded `font-size` across the app (249 declarations, 29 files) onto the matching token. A handful of odd in-between values (`1.0625rem`, `1.75rem`, etc.) are untouched for now — per the issue's own suggested approach, this is incremental, not a single big-bang pass across every literal.

DESIGN.md's Typography > Sizes section is updated to describe the real scale instead of "there is no named typographic scale yet."

**This PR is part of a parallel batch of DS3 follow-up work (issues #1543/#1544) and should merge LAST of that batch.** It touches a lot of shared CSS, so I'd rather it land after the others to minimize conflicts. Visual regression baselines will need regeneration after this merges — see below.

## Related Issue
Closes #1622

Note: this PR targets `develop`, not the repo's default branch, so GitHub won't auto-close the issue on merge — closing it out is a manual step for whoever merges this.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — this is a design-system infrastructure change (part of the bolder-DS3 redesign, #1543), not a user-facing feature.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

No new components or stories — this migrates existing CSS onto tokens with identical values (exact-match replacement only), so no component behavior changed. `DesignSystemShowcase.css` (the Storybook foundation story's own stylesheet) is one of the migrated files.

## Implementation Notes
- New tokens live in `src/lib/theme/themes/_shared-tokens.css`, next to the existing `--space-*` scale, with a comment explaining the calibration approach and anchors.
- Migration was mechanical: only exact-value `font-size:` declarations matching one of the nine token values were touched (scripted, then verified file-by-file in the diff). No visual value changed as a result of the migration itself.
- Two new tests: one asserts the token values and their ascending order, the other scans all production CSS and fails if any of the now-tokenized values get hardcoded again (regression guard against literals creeping back in).

## Screenshots
N/A — no visual values changed (token substitution only, same rem values).

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit left unchecked — not run as part of this change (no dependency or auth surface touched).

## Testing Instructions
1. `npm test` — full suite green, including the two new files under `src/lib/theme/themes/__tests__/`.
2. `npm run type-check` and `npm run lint` — clean (lint warnings present are pre-existing and untouched by this diff).
3. `npm run lint:css` — clean.
4. `npm run deps:validate` — no new violations.
5. Visually: since every migration is an exact-value substitution (e.g. `font-size: 0.875rem` to `font-size: var(--font-size-sm)`, which is also `0.875rem`), there should be zero rendered difference from this PR. **Visual regression baselines are expected to need regeneration anyway** once this PR and the rest of the parallel DS3 batch have merged — the plan is to regenerate once against the combined final state rather than per-PR, so I did not touch `test:visual` baselines here.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

No accessibility impact — font-size values are unchanged, only how they're expressed in CSS.
