### PR TITLE
Escalate the story after a stretch of uneventful turns

### DIFF
--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -22,6 +22,7 @@ import {
   evaluateDecisionSkillChecks,
   isFatalCriticalDecision,
 } from '@/lib/narrative/evaluateDecisionSkillChecks';
+import { computeTurnsSinceComplication } from '@/lib/narrative/turnsSinceComplication';
 import { logger } from '@/lib/utils/logger';
 import { AI_GENERATION_TIMEOUT_MS } from '@/lib/constants/timeouts';
 import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
@@ -585,6 +586,9 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
     try {
       // Use recent segments for context (last 3 segments for efficiency)
       const recentSegments = segments.slice(-3);
+      // Streak tracked over the whole session, not just the trimmed context
+      // window above — a quiet stretch spans more than 3 segments.
+      const turnsSinceComplication = computeTurnsSinceComplication(segments);
 
       // Get the actual choice text from the narrative store
       const decisions = useNarrativeStore
@@ -698,6 +702,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
               currentTags,
               sessionId,
               recentSegments,
+              turnsSinceComplication,
               currentSituation: `Player chose: "${choiceText}"${skillCheckContext}`,
             },
             generationParameters: {

--- a/src/lib/narrative/__tests__/turnsSinceComplication.test.ts
+++ b/src/lib/narrative/__tests__/turnsSinceComplication.test.ts
@@ -1,0 +1,67 @@
+import { computeTurnsSinceComplication } from '../turnsSinceComplication';
+import type { NarrativeSegment } from '@/types/narrative.types';
+
+function makeSegment(overrides: Partial<NarrativeSegment['metadata']> = {}): NarrativeSegment {
+  return {
+    id: 'segment-id',
+    content: 'content',
+    type: 'scene',
+    metadata: { tags: [], ...overrides },
+    timestamp: new Date(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+describe('computeTurnsSinceComplication', () => {
+  it('returns 0 for an empty session', () => {
+    expect(computeTurnsSinceComplication([])).toBe(0);
+  });
+
+  it('counts every segment when no complication ever occurred (the cautious-play chain)', () => {
+    const segments = [makeSegment(), makeSegment(), makeSegment()];
+    expect(computeTurnsSinceComplication(segments)).toBe(3);
+  });
+
+  it('resets to 0 right after a failed skill check', () => {
+    const segments = [
+      makeSegment(),
+      makeSegment({ decisionOutcome: 'failure' }),
+    ];
+    expect(computeTurnsSinceComplication(segments)).toBe(0);
+  });
+
+  it('only counts segments after the most recent complication', () => {
+    const segments = [
+      makeSegment({ decisionOutcome: 'failure' }),
+      makeSegment(),
+      makeSegment(),
+    ];
+    expect(computeTurnsSinceComplication(segments)).toBe(2);
+  });
+
+  it('treats a critical-failure and a mixed outcome as complications too', () => {
+    expect(
+      computeTurnsSinceComplication([makeSegment({ decisionOutcome: 'critical-failure' }), makeSegment()])
+    ).toBe(1);
+    expect(
+      computeTurnsSinceComplication([makeSegment({ decisionOutcome: 'mixed' }), makeSegment()])
+    ).toBe(1);
+  });
+
+  it('does not reset on a pure success or critical success', () => {
+    const segments = [
+      makeSegment({ decisionOutcome: 'success' }),
+      makeSegment({ decisionOutcome: 'critical-success' }),
+    ];
+    expect(computeTurnsSinceComplication(segments)).toBe(2);
+  });
+
+  it('resets on a segment with a majorEvent even without a skill check', () => {
+    const segments = [
+      makeSegment({ majorEvent: 'Discovered they are wanted by the authorities' }),
+      makeSegment(),
+    ];
+    expect(computeTurnsSinceComplication(segments)).toBe(1);
+  });
+});

--- a/src/lib/narrative/turnsSinceComplication.ts
+++ b/src/lib/narrative/turnsSinceComplication.ts
@@ -1,0 +1,35 @@
+import type { NarrativeSegment } from '@/types/narrative.types';
+
+/**
+ * Outcomes that count as a real complication for pacing purposes. A pure
+ * success (or no skill check at all, e.g. a cautious no-requirement choice)
+ * doesn't reset the streak — only a segment where something actually went
+ * wrong does.
+ */
+const COMPLICATION_OUTCOMES = new Set(['failure', 'critical-failure', 'mixed']);
+
+/**
+ * Counts how many segments in a row have passed since the last complication
+ * (a failed or mixed skill-check outcome), walking backward from the most
+ * recent segment. A cautious playstyle that never triggers a skill check, or
+ * always succeeds, never resets this count — it just keeps climbing, giving
+ * the narrative prompt a signal to escalate when a session has gone quiet
+ * for too long.
+ *
+ * A segment's own majorEvent also resets the streak: a story-changing beat
+ * (arrival, revelation, injury) is a complication in its own right even
+ * without a dice roll behind it.
+ */
+export function computeTurnsSinceComplication(segments: NarrativeSegment[]): number {
+  let count = 0;
+  for (let i = segments.length - 1; i >= 0; i--) {
+    const metadata = segments[i]?.metadata;
+    const outcome = metadata?.decisionOutcome;
+    const hadComplication = (outcome && COMPLICATION_OUTCOMES.has(outcome)) || Boolean(metadata?.majorEvent);
+    if (hadComplication) {
+      break;
+    }
+    count++;
+  }
+  return count;
+}

--- a/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts
+++ b/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts
@@ -32,6 +32,12 @@ describe('sceneTemplate pacing guidance', () => {
     expect(prompt).toContain('3 turns in a row');
   });
 
+  it('tells the model to record the forced complication as a majorEvent so the streak actually resets', () => {
+    const prompt = sceneTemplate(makeContext(3));
+    expect(prompt).toContain('counts as a major event');
+    expect(prompt).toContain('metadata.majorEvent');
+  });
+
   it('keeps escalating the guidance for longer streaks', () => {
     const prompt = sceneTemplate(makeContext(9));
     expect(prompt).toContain('9 turns in a row');

--- a/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts
+++ b/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts
@@ -1,0 +1,39 @@
+import { sceneTemplate } from '../sceneTemplate';
+import type { NarrativeTemplateContext } from '../context';
+
+function makeContext(turnsSinceComplication?: number): NarrativeTemplateContext {
+  return {
+    worldName: 'Butler County Outskirts',
+    genre: 'zombie survival',
+    tone: 'tense',
+    playerCharacterName: 'Alex',
+    narrativeContext: {
+      recentSegments: [{ content: 'You crouch by the fence, watching the road.' }],
+      currentSituation: 'Player chose: "Follow the trail cautiously"',
+      currentTags: [],
+      turnsSinceComplication,
+    },
+  };
+}
+
+describe('sceneTemplate pacing guidance', () => {
+  it('omits pacing guidance when the streak is below the threshold', () => {
+    expect(sceneTemplate(makeContext(2))).not.toContain('PACING GUIDANCE');
+  });
+
+  it('omits pacing guidance when no streak is tracked at all', () => {
+    expect(sceneTemplate(makeContext(undefined))).not.toContain('PACING GUIDANCE');
+  });
+
+  it('tells the model to introduce a complication once the streak crosses the threshold', () => {
+    const prompt = sceneTemplate(makeContext(3));
+    expect(prompt).toContain('PACING GUIDANCE');
+    expect(prompt).toContain('MUST introduce a complication');
+    expect(prompt).toContain('3 turns in a row');
+  });
+
+  it('keeps escalating the guidance for longer streaks', () => {
+    const prompt = sceneTemplate(makeContext(9));
+    expect(prompt).toContain('9 turns in a row');
+  });
+});

--- a/src/lib/promptTemplates/templates/narrative/context.ts
+++ b/src/lib/promptTemplates/templates/narrative/context.ts
@@ -17,6 +17,8 @@ interface NarrativeTemplateNarrativeContext {
   currentLocation?: string;
   currentSituation?: string;
   currentTags?: string[];
+  /** Consecutive segments since the last complication — see computeTurnsSinceComplication */
+  turnsSinceComplication?: number;
   importantEntities?: Array<{
     id?: string;
     type?: string;

--- a/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
+++ b/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
@@ -3,6 +3,13 @@ import { majorEventGuidelines } from './majorEventGuidelines';
 import { describeNarrativeLength } from './narrativeLength';
 import type { NarrativeTemplateContext } from './context';
 
+/**
+ * Number of consecutive uneventful segments before the prompt starts pushing
+ * the model to break the calm. Below this, a quiet stretch just reads as
+ * normal pacing; at or above it, cautious play stops being a free pass.
+ */
+const STALE_PACING_THRESHOLD = 3;
+
 export const sceneTemplate = (context: NarrativeTemplateContext) => {
   const {
     worldName,
@@ -39,6 +46,8 @@ export const sceneTemplate = (context: NarrativeTemplateContext) => {
       : hasSuccess
         ? 'success'
         : null;
+  const turnsSinceComplication = narrativeContext?.turnsSinceComplication ?? 0;
+  const isStale = turnsSinceComplication >= STALE_PACING_THRESHOLD;
 
   const formattedRoster = Array.isArray(npcRoster) && npcRoster.length > 0
     ? `
@@ -65,6 +74,14 @@ ${skillResult === 'critical-failure' ? '- CRITICAL FAILURE: consequences may be 
 - DO NOT explicitly mention skill names, skill levels, or game mechanics
 - Show the outcome through what actually happens in the story
 - Success = things work out, failure = things go wrong or backfire
+` : ''}
+
+${isStale ? `
+PACING GUIDANCE — RISING TENSION:
+- It has been ${turnsSinceComplication} turns in a row with no real complication for the player.
+- This segment MUST introduce a complication: an interruption, a new threat, an unexpected cost, or a setback tied to the current situation.
+- The complication does not need a skill check behind it — it can simply happen (an NPC arrives, a resource runs out, the trail leads somewhere worse than expected, time runs short).
+- Do not extend the current chain with another same-shape discovery (another clue, another trace) with nothing else changing.
 ` : ''}
 
 ${generationParameters?.decisionWeight === 'critical' && narrativeContext?.currentTags?.some((tag: string) => tag.startsWith('skill-failure:') || tag.startsWith('skill-critical-failure:')) ? `

--- a/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
+++ b/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
@@ -82,6 +82,7 @@ PACING GUIDANCE — RISING TENSION:
 - This segment MUST introduce a complication: an interruption, a new threat, an unexpected cost, or a setback tied to the current situation.
 - The complication does not need a skill check behind it — it can simply happen (an NPC arrives, a resource runs out, the trail leads somewhere worse than expected, time runs short).
 - Do not extend the current chain with another same-shape discovery (another clue, another trace) with nothing else changing.
+- Whatever complication you introduce here counts as a major event: record it in metadata.majorEvent (see the rules below) so this guidance doesn't fire again next turn for a problem you already resolved.
 ` : ''}
 
 ${generationParameters?.decisionWeight === 'critical' && narrativeContext?.currentTags?.some((tag: string) => tag.startsWith('skill-failure:') || tag.startsWith('skill-critical-failure:')) ? `

--- a/src/types/narrative.types.ts
+++ b/src/types/narrative.types.ts
@@ -307,6 +307,8 @@ export interface NarrativeContext {
   sessionId: EntityID;
   /** Most recent segments (typically last 3-5) for immediate context. Subset of previousSegments */
   recentSegments?: NarrativeSegment[];
+  /** Consecutive segments since the last complication — see computeTurnsSinceComplication */
+  turnsSinceComplication?: number;
   currentLocation?: string;
   currentSituation?: string;
   importantEntities?: Array<{


### PR DESCRIPTION
## Description
Cautious play could chain clue-following turns indefinitely — nothing tracked how long a session had gone without a real setback, so nothing pushed back on a player who always picked the safe option. This adds a "turns since complication" counter, computed from the session's segment history, and feeds it into the scene prompt. Once a session has gone 3+ turns without a failed/mixed skill check or major story beat, the prompt now tells the model to introduce a complication regardless of what the player chose.

## Related Issue
Closes #1680

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — bug fix, no new user-facing story.

## Flow Diagrams
N/A

## Component Development
N/A — no UI/component change; this is prompt-generation and narrative-state logic only.

## Implementation Notes
- `computeTurnsSinceComplication` (`src/lib/narrative/turnsSinceComplication.ts`) walks a session's segments backward and counts how many have passed since the last failed/mixed skill-check outcome or `metadata.majorEvent`. A pure success, a critical success, or a no-skill-check "safe" choice never resets it.
- `NarrativeController` computes this over the full session (not just the trimmed 3-segment context window) and passes it through as `narrativeContext.turnsSinceComplication`.
- `sceneTemplate.ts` injects a "PACING GUIDANCE" block once the streak crosses a threshold of 3, instructing the model to introduce a complication — an interruption, a cost, a setback — without requiring a skill check behind it.
- Deliberately scoped to instrumentation + prompt guidance rather than new consequence mechanics or a forced skill-check injection, per the issue's own note that the roll math isn't the culprit — the gap was that nothing tracked pacing at all.

## Screenshots
N/A — no visual change.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A — no browser-observable change; this only alters the AI prompt text sent for narrative generation, not verifiable without a live Gemini call.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm test -- src/lib/narrative/__tests__/turnsSinceComplication.test.ts src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts`
2. `npm run test:ci` — full suite (2539 tests) green.
3. `npm run type-check` / `npm run lint` — clean.
4. `npm run deps:validate` — no new violations.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
