### PR TITLE
Pin the visual suite's timezone so dated pages render deterministically

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -106,7 +106,29 @@ export default defineConfig({
     
     // Cross-platform snapshot configuration
     testIdAttribute: 'data-testid',
-    
+
+    // Pin the browser's clock zone and locale so rendered dates are identical
+    // everywhere. Several baselined pages print a formatted date (character
+    // detail's "Created:", WorldCard's "Created:", world detail's
+    // Created/Updated fields) via formatDate(), which ends in
+    // toLocaleDateString(undefined, ...) — both the zone and the locale are
+    // ambient, so an unpinned run renders whatever the host machine has.
+    //
+    // The seeded fixture dates sit near midnight UTC (char-cyberpunk-hacker is
+    // 2024-01-01T01:00:00.000Z), so a negative-offset host rolls them back a
+    // day: "Jan 1, 2024" becomes "Dec 31, 2023". That longer string wraps
+    // .character-detail-header-meta's flex row at the 375px mobile viewport and
+    // pushes the rest of the page down 34px, failing mobile-character-detail on
+    // a size mismatch. Re-baselining can't fix that — it just moves the
+    // mismatch to whoever runs in the other zone.
+    //
+    // UTC/en-US is what the GitHub macos-latest runners already use, and the
+    // committed baselines are adopted from that job's artifacts, so pinning
+    // these keeps every existing baseline valid while making local runs
+    // reproduce CI instead of the developer's own zone.
+    timezoneId: 'UTC',
+    locale: 'en-US',
+
     // Force consistent font rendering on Darwin platform
     extraHTTPHeaders: {
       'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'

--- a/tests/visual/world-details-npcs.spec.ts
+++ b/tests/visual/world-details-npcs.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from '@playwright/test';
-import { getTimestamp } from '@/lib/utils';
 
 /**
  * World detail NPCs section — single-theme (default DS1).
@@ -9,7 +8,21 @@ import { getTimestamp } from '@/lib/utils';
  * surface is covered across DS1/DS2/DS3 by tests/visual/world-detail-themes.spec.ts.
  */
 
-const GET_TIMESTAMP_SOURCE = getTimestamp.toString();
+/**
+ * Frozen seed timestamp. This used to be getTimestamp() (i.e. "now"), which the
+ * page prints back through WorldInfoSection's Created/Updated fields — so the
+ * baseline baked in whatever day it was captured and drifted from every later
+ * run. The DataFields are fixed-width, so the diff never reflowed the page and
+ * stayed under maxDiffPixels; it was burning diff budget silently rather than
+ * failing loudly.
+ *
+ * The value is the capture date of the committed baseline (last adopted in
+ * #1660, from a CI run on 2026-08-04 UTC), so the frozen render still prints
+ * "Aug 4, 2026" and matches it — no re-baseline needed. Noon UTC keeps the
+ * formatted date a full 12 hours from a day boundary, so it can't roll over
+ * even if a run somehow escapes the UTC pin in playwright.config.ts.
+ */
+const SEEDED_AT = '2026-08-04T12:00:00.000Z';
 const WORLD_ID = 'world-npcs-playwright';
 const NPC_WITH_PORTRAIT = 'npc-elara';
 const NPC_NO_PORTRAIT = 'npc-thorgrim';
@@ -45,11 +58,7 @@ test.describe('World details NPC portraits', () => {
     baseURL,
   }) => {
     await page.addInitScript(
-      async ({ getTimestampSource, seed }) => {
-        const instantiateGetTimestamp = (source: string) =>
-          new Function(`return (${source});`)() as () => string;
-        const getTs = instantiateGetTimestamp(getTimestampSource);
-        const now = getTs();
+      async ({ now, seed }) => {
         const dbName = 'narraitor-state';
         const storeName = 'narraitor-store';
 
@@ -160,7 +169,7 @@ test.describe('World details NPC portraits', () => {
           put('narraitor-npc-store', npcPersist),
         ]);
       },
-      { getTimestampSource: GET_TIMESTAMP_SOURCE, seed: SEED_PAYLOAD }
+      { now: SEEDED_AT, seed: SEED_PAYLOAD }
     );
 
     await page.goto(`${baseURL}/worlds/${WORLD_ID}`, {


### PR DESCRIPTION
## Description

`mobile-character-detail` has been failing on `develop` for anyone whose machine isn't on UTC. Re-baselining can't fix it — it just moves the failure to whoever runs in the other zone.

`CharacterHeader` prints `Created: {formatDate(character.createdAt)}`, and `formatDate` ends in `toLocaleDateString(undefined, ...)`, so the zone is **ambient**. The seeded fixture date is already pinned (`char-cyberpunk-hacker` is `2024-01-01T01:00:00.000Z`) — but it sits an hour past midnight UTC, so a negative-offset host rolls it back a day and renders `Dec 31, 2023` instead of `Jan 1, 2024`. The longer string wraps `.character-detail-header-meta`'s flex row at the 375px viewport, and the extra line plus its `--space-4` row gap pushes the whole page down **34px**.

Measured at the 375px viewport, same page, only the zone varying:

| Zone | Rendered | meta height | page height |
|---|---|---|---|
| `America/New_York` | `Created: Dec 31, 2023` | 52px (2 lines) | **2561px** |
| `UTC` | `Created: Jan 1, 2024` | 18px (1 line) | **2527px** |

That is exactly the reported failure — *expected 375×2527, received 375×2561*.

The fix pins `timezoneId` and `locale` in the config's `use` block. UTC/en-US is what the `macos-latest` runners already use, and the baselines are adopted from that job's artifacts, so this keeps **every existing baseline valid** while making local runs reproduce CI instead of the developer's own zone.

It also covers the other dated surfaces that were quietly zone-sensitive: `main-pages`' character-detail and `mobile-worlds-list` (WorldCard prints a Created date too), where the text differed but the fixed layout kept the diff under `maxDiffPixels`.

## Related Issue

No tracking issue — reported directly as a pre-existing `develop` failure, confirmed unrelated to any feature branch.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation — the failing behaviour was reproduced and measured before any fix was written
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

This is test-infrastructure work, so the "test" is the reproduction itself: a DOM probe that measured the rendered date string, the meta block's height, and the full page height before and after. No product code changed.

## User Stories Addressed

None directly — this restores a trustworthy visual gate for everyone working in the repo.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated — N/A, no component changed
- [ ] Components developed in isolation first — N/A
- [x] Visual consistency verified — the pinned render is byte-consistent across zones and matches the committed baseline's dimensions

## Implementation Notes

**Audited the other seeded fixtures for the same class of bug.** The shared fixtures (`characters.fixture.ts`, `worlds.fixture.ts`) all use fixed ISO dates and are fine once the zone is pinned.

`world-details-npcs` was the one real offender. It seeded `getTimestamp()` — literally *now* — into a world whose Created/Updated fields the page prints back, so its baseline baked in its own capture date and drifted from every later run. Because the `DataField`s are fixed-width the page never reflowed, so it stayed under `maxDiffPixels` and burned diff budget **silently** rather than failing. The committed baseline shows `Aug 4, 2026`; today it renders `Aug 7, 2026`.

That seed is now frozen to the baseline's own capture date (`2026-08-04T12:00:00.000Z`), chosen so the render still prints `Aug 4, 2026` and matches the existing baseline — **no re-baseline needed**. Noon UTC keeps it a full 12 hours from a day boundary. Freezing it also lets the `new Function(getTimestamp.toString())` plumbing go, which only existed to carry a clock reading into the page context.

The remaining `getTimestamp()` seeds are fine: `characters-roster` takes a screenshot but `CharacterCard` renders no date, and `verify-fresh-session` / `manuscript-regression-assertions` take no screenshots at all. `tests/visual/global.setup.ts` also seeds `now`, but it isn't wired in (`globalSetup: undefined`, and it's not a `.spec.ts`), so it affects no baseline.

## Screenshots

N/A — no rendered output changes under CI's zone. The whole point is that the pinned render is identical to what the committed baselines already contain.

## Visual Baseline Changes

**None.** No file under `tests/visual/**-snapshots/**` is touched. Both changes were chosen specifically to keep existing baselines valid — the config pins to the zone/locale CI already runs in, and `SEEDED_AT` is set to the date the `world-details-npcs` baseline already has baked in.

## Code Review Summary

N/A

## Chrome DevTools MCP Verification Summary

N/A

## Quality Checks

- [x] Linting passed — 0 errors; no findings in either changed file
- [x] Type checking passed — `tsc --noEmit` clean
- [x] Security audit passed — no dependency or product-code changes; removes a `new Function(...)` source-injection
- [x] No console.log statements in production code
- [x] No unhandled promises

Also ran `npm run deps:validate` (clean) and the Jest suite: **381 suites / 2540 tests passing**. No CSS changed, so `lint:css` isn't applicable.

## Testing Instructions

The Playwright snapshot comparison is macOS-only, so **the darwin snapshot assertion itself was not run** — verification was done by measuring the DOM directly on a Linux runner, plus static review of the baselines. On a Mac:

1. **It passes without `--update-snapshots`:**
   ```bash
   npx playwright test --project=chromium mobile-layouts -g 'character sheet folds'
   ```

2. **It's independent of the host zone** — all three should pass identically, where before only a UTC machine passed:
   ```bash
   TZ=America/New_York npx playwright test --project=chromium mobile-layouts
   TZ=Asia/Tokyo       npx playwright test --project=chromium mobile-layouts
   TZ=UTC              npx playwright test --project=chromium mobile-layouts
   ```

3. **It's independent of the clock** — shift the system clock forward (or trust that `createdAt` and `SEEDED_AT` are now constant literals with no `Date` call on the path) and re-run. `world-details-npcs` is the one to watch here:
   ```bash
   npx playwright test --project=chromium world-details-npcs
   ```

What was verified here against the develop tip (`db61e48`), using a probe that reads the config pin rather than setting its own zone: identical rendered text, meta height, and page height under `UTC`, `America/New_York`, and `Pacific/Kiritimati`; unchanged with the page clock shifted to 2030; and the pinned page height is **2527px — matching the committed baseline exactly**. `world-details-npcs` re-renders `Aug 4, 2026` under a shifted zone three days after its capture date.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic — both changes carry a comment explaining the failure mode, since the reason a constant matters isn't visible from the constant
- [x] Documentation updated (if required) — the reasoning lives next to the code it governs
- [x] No new warnings generated
- [x] Accessibility considerations addressed — no user-facing change

---
_Generated by [Claude Code](https://claude.ai/code/session_019TuCYzH8ojzHJVSL5eUhGH)_