### PR TITLE
docs: plain-language pass on player copy and dev-facing filler

### DIFF
--- a/public_docs/README.md
+++ b/public_docs/README.md
@@ -73,7 +73,7 @@ Guides for developers working on Narraitor:
 
 ### Testing
 
-- [Testing Guide](./development/testing-guide.md) - Comprehensive testing strategy
+- [Testing Guide](./development/testing-guide.md) - Testing strategy
 - [Visual Regression Testing](./development/visual-regression-testing.md) - Playwright visual tests
 - [Visual Testing Best Practices](./development/visual-testing-best-practices.md)
 - [Visual Test Examples](./development/visual-test-examples.md)

--- a/public_docs/architecture/ADR-009-guided-onboarding-system.md
+++ b/public_docs/architecture/ADR-009-guided-onboarding-system.md
@@ -88,7 +88,7 @@ Built a guided onboarding system for new users:
 - Need to maintain the onboarding flow as core features evolve (this is the big ongoing cost)
 
 ### Mitigation Strategies
-- Comprehensive test coverage (26 tests) because onboarding is critical and can't be broken
+- Test coverage (26 tests) because onboarding is critical and can't be broken
 - Graceful fallback systems so AI service failures don't kill the experience
 - Three-stage verification process (Storybook, then the test harness, then full system integration) for quality assurance
 - Documentation and Storybook coverage so future developers can understand what's happening

--- a/public_docs/development/visual-testing-best-practices.md
+++ b/public_docs/development/visual-testing-best-practices.md
@@ -204,7 +204,7 @@ test('button component states', async ({ page }) => {
 });
 ```
 
-**Page-level testing** (comprehensive, slower):
+**Page-level testing** (full page, slower):
 ```typescript
 test('complete checkout flow', async ({ page }) => {
   await page.goto('/checkout');

--- a/public_docs/features/custom-player-input.md
+++ b/public_docs/features/custom-player-input.md
@@ -105,7 +105,7 @@ const handleCustomSubmit = (customText: string) => {
 
 ## Testing
 
-Comprehensive test coverage includes:
+Test coverage includes:
 - Unit tests for input validation and character limits
 - Integration tests for narrative flow
 - Manual scenarios: creative actions, combat, social interactions

--- a/public_docs/technical-guides/type-guards-usage-guide.md
+++ b/public_docs/technical-guides/type-guards-usage-guide.md
@@ -189,7 +189,7 @@ if (!formResult.valid) {
 ## Available Type Guards
 
 ### Core Objects
-- `validateWorld` - Comprehensive world validation with detailed errors
+- `validateWorld` - World validation with detailed errors
 
 ### World Components
 - `validateWorldAttribute`
@@ -212,7 +212,7 @@ function isValidWorld(obj: any): boolean {
          typeof obj.name === 'string';
 }
 
-// After - comprehensive validation
+// After - full validation
 import { validateWorld } from '@/lib/utils/typeGuards';
 
 const result = validateWorld(data);

--- a/src/app/README.md
+++ b/src/app/README.md
@@ -25,7 +25,7 @@ Storybook (`npm run storybook`) — see [ADR-012](../../public_docs/architecture
 
 ## World Creation Wizard
 
-The wizard has been fully implemented and it's pretty comprehensive:
+The wizard is fully implemented:
 
 - **5 steps**: Basic Info, Description, Attributes, Skills, Finalize
 - **6 default attributes**: Strength, Intelligence, Agility, Charisma, Dexterity, Constitution

--- a/src/app/api/generate-ending-image/README.md
+++ b/src/app/api/generate-ending-image/README.md
@@ -51,7 +51,7 @@ This API endpoint generates AI-powered image prompts for story ending visualizat
 
 ## Testing
 
-Comprehensive testing through:
+Testing through:
 
 1. **Dev Test Harness:**
    - `/dev/ending-system` - Full ending generation with image prompts (UI-only variants live in `EndingScreen.stories.tsx`)

--- a/src/app/api/narrative/ending/README.md
+++ b/src/app/api/narrative/ending/README.md
@@ -58,4 +58,4 @@ The API endpoints are thoroughly tested through:
    - Error conditions verified (missing fields, invalid types, AI failures)
    - Success paths confirmed with real AI responses
 
-The development harnesses provide comprehensive coverage of the API functionality including error conditions, validation, and AI integration, which is more practical than complex Jest setup for Next.js API routes.
+The development harnesses cover the API functionality — error conditions, validation, and AI integration — which is more practical than complex Jest setup for Next.js API routes.

--- a/src/app/dev/lore-viewer/page.tsx
+++ b/src/app/dev/lore-viewer/page.tsx
@@ -325,7 +325,7 @@ export default function LoreViewerTestPage() {
             <li>• Detects aliases and alternative names for entities</li>
             <li>• Captures events with significance and relationships</li>
             <li>• Recognizes rules and world mechanics</li>
-            <li>• Much more comprehensive than regex patterns</li>
+            <li>• Covers more cases than regex patterns</li>
           </ul>
         </div>
 

--- a/src/components/CharacterPortrait/README.md
+++ b/src/components/CharacterPortrait/README.md
@@ -100,6 +100,6 @@ You'll see this component throughout the app:
 
 ## Storybook Stories
 
-The component includes comprehensive Storybook stories showing all size variations, loading and error states, different character name lengths, interactive variants, and AI-generated vs placeholder states.
+The component includes Storybook stories showing all size variations, loading and error states, different character name lengths, interactive variants, and AI-generated vs placeholder states.
 
 Run `npm run storybook` and navigate to "Components/CharacterPortrait" to see all the examples in action.

--- a/src/components/GameSession/README.md
+++ b/src/components/GameSession/README.md
@@ -60,7 +60,7 @@ This hook encapsulates:
 
 ## Testing
 
-Each component has comprehensive testing:
+Each component is tested:
 - Unit tests in `.test.tsx` files
 - Storybook stories in `.stories.tsx` files
 - Integration tests in `__tests__/integration.test.tsx`

--- a/src/components/GameSession/StorySummarySection.tsx
+++ b/src/components/GameSession/StorySummarySection.tsx
@@ -59,7 +59,7 @@ export const StorySummarySection: React.FC<StorySummarySectionProps> = ({
         </div>
       ) : showFailedState ? (
         <p className="manuscript-story-summary-error">
-          {error ?? 'Story summary failed to generate.'}
+          {error ?? "Couldn't put together a story summary yet."}
         </p>
       ) : (
         <p className="manuscript-story-summary-empty">

--- a/src/components/GuidedFirstTimeExperience/README.md
+++ b/src/components/GuidedFirstTimeExperience/README.md
@@ -72,7 +72,7 @@ Each step includes appropriate validation:
 
 ## Testing
 
-The component includes comprehensive tests covering:
+The component includes tests covering:
 - Step navigation and progression
 - Form validation and error handling
 - Mobile responsiveness

--- a/src/components/WorldCard/WorldCard.tsx
+++ b/src/components/WorldCard/WorldCard.tsx
@@ -43,7 +43,7 @@ interface WorldCardProps {
  * - Character count with navigation to characters list
  * - Smart play button that handles session resume
  * - Make active button for non-active worlds
- * - Comprehensive action buttons
+ * - Action buttons
  *
  * @param props - World card configuration and event handlers
  * @returns A formatted world card with image, details, and action buttons

--- a/src/components/WorldCreationWizard/README.md
+++ b/src/components/WorldCreationWizard/README.md
@@ -78,7 +78,7 @@ The wizard handles errors gracefully:
 
 ## Testing
 
-The wizard includes comprehensive test coverage:
+The wizard includes test coverage:
 - Unit tests for each step component
 - Integration tests for the full wizard flow
 - Storybook stories for visual testing

--- a/src/components/WorldListScreen/WorldListScreen.tsx
+++ b/src/components/WorldListScreen/WorldListScreen.tsx
@@ -85,7 +85,7 @@ const WorldListScreen: React.FC<WorldListScreenProps> = ({
           ? getUserFriendlyError(err)
           : ({
               title: 'Failed to Load Worlds',
-              message: 'An unexpected error occurred while loading worlds.',
+              message: 'Try refreshing the page.',
               retryable: false,
               type: ErrorType.UNKNOWN,
               severity: 'error',

--- a/src/components/devtools/ConsistencyValidationSection/ConsistencyValidationSection.tsx
+++ b/src/components/devtools/ConsistencyValidationSection/ConsistencyValidationSection.tsx
@@ -26,7 +26,7 @@ const CONTINUITY_BADGE_VARIANTS: Record<
 /**
  * Consistency Validation Debug Section
  * 
- * A comprehensive debugging interface for the AI consistency validation system.
+ * A debugging interface for the AI consistency validation system.
  * This DevTools-only component provides real-time analysis of how lore facts
  * are processed and converted into consistency instructions for narrative generation.
  * 

--- a/src/components/devtools/TestDataGeneratorSection/TestDataGeneratorSection.tsx
+++ b/src/components/devtools/TestDataGeneratorSection/TestDataGeneratorSection.tsx
@@ -620,7 +620,7 @@ export const TestDataGeneratorSection: React.FC = () => {
           
           size="sm"
           variant="info"
-          title="Creates 5 diverse AI worlds with mix of original, 'set in', and 'based on' types for comprehensive testing"
+          title="Creates 5 diverse AI worlds with a mix of original, 'set in', and 'based on' types"
         >
           Generate 5 Diverse AI Worlds
         </Button>

--- a/src/components/inventory/InventoryList.tsx
+++ b/src/components/inventory/InventoryList.tsx
@@ -179,7 +179,7 @@ export const InventoryList: React.FC<InventoryListProps> = ({
         setErrorFeedback(result.error?.message || 'Failed to use item');
       }
     } catch {
-      setErrorFeedback('An unexpected error occurred');
+      setErrorFeedback("Couldn't use that item. Try again.");
     } finally {
       setUsingItemId(null);
     }

--- a/src/components/shared/NavigationLoadingProvider.tsx
+++ b/src/components/shared/NavigationLoadingProvider.tsx
@@ -61,7 +61,7 @@ export const NavigationLoadingProvider: React.FC<NavigationLoadingProviderProps>
       case 'data':
         return 'Loading data...';
       case 'error':
-        return 'Something went wrong. Please wait...';
+        return 'Something went wrong loading this page.';
       default:
         return 'Loading...';
     }

--- a/src/components/shared/RecoveryNotification.tsx
+++ b/src/components/shared/RecoveryNotification.tsx
@@ -3,7 +3,7 @@
  *
  * A modal dialog that presents recovery options when saved character creation data is detected.
  * Provides clear user choice between recovering previous progress or starting fresh with
- * comprehensive data preview and conflict detection.
+ * data preview and conflict detection.
  *
  * Key Features:
  * - Data preview with character name, progress step, and completion status
@@ -66,7 +66,7 @@ interface RecoveryNotificationProps {
  * RecoveryNotification Component
  *
  * Renders a modal dialog allowing users to choose between recovering saved character data
- * or starting fresh. Includes comprehensive data preview and conflict warnings.
+ * or starting fresh. Includes data preview and conflict warnings.
  *
  * @param props - Component props
  * @returns JSX element or null if not visible

--- a/src/components/shared/WorldTypeSelector/README.md
+++ b/src/components/shared/WorldTypeSelector/README.md
@@ -203,7 +203,7 @@ const { reference, relationship } = convertToGenerationParams(worldTypeData);
 
 ## Testing
 
-The component includes comprehensive Storybook stories demonstrating:
+The component includes Storybook stories demonstrating:
 
 - All size variants (small, medium, large)
 - Layout options (vertical, horizontal)

--- a/src/components/shared/wizard/hooks/useWizardFlow.ts
+++ b/src/components/shared/wizard/hooks/useWizardFlow.ts
@@ -236,7 +236,7 @@ export function useWizardFlow<T>(config: WizardFlowConfig<T>) {
       setState(prev => ({
         ...prev,
         isProcessing: false,
-        errors: { ...prev.errors, submit: error instanceof Error ? error.message : 'An error occurred' },
+        errors: { ...prev.errors, submit: error instanceof Error ? error.message : 'Something went wrong submitting this. Try again.' },
       }));
     }
   }, [state.data, steps.length, validateStep, onComplete, persistKey]);

--- a/src/components/ui/toast/index.ts
+++ b/src/components/ui/toast/index.ts
@@ -1,7 +1,7 @@
 /**
  * Toast Notification System
  * 
- * A comprehensive toast notification system for Narraitor with support for multiple variants,
+ * A toast notification system for Narraitor with support for multiple variants,
  * auto-dismissal, manual dismissal, and accessibility features.
  * 
  * @example

--- a/src/components/world/SkillEditor/README.md
+++ b/src/components/world/SkillEditor/README.md
@@ -84,7 +84,7 @@ The validation rules are pretty straightforward, but there are a few gotchas:
 
 ## Testing
 
-The component includes comprehensive tests covering:
+The component includes tests covering:
 - Create and edit modes
 - Multi-attribute selection
 - Validation scenarios

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -53,7 +53,7 @@ import { useToast } from '@/components/ui/toast';
 /**
  * Hook for managing auto-save functionality with toast notifications
  * 
- * Provides comprehensive auto-save capabilities with user feedback through toast notifications.
+ * Provides auto-save capabilities with user feedback through toast notifications.
  * Handles both automatic and manual saves, with different notification strategies for each.
  * 
  * @returns Object containing auto-save state and control methods

--- a/src/lib/ai/README.md
+++ b/src/lib/ai/README.md
@@ -24,7 +24,7 @@ The system has a few key components:
 
 **`ResponseFormatter`** - Takes the raw AI response and formats it with dialogue formatting, italics, etc.
 
-Plus configuration utilities and comprehensive error handling with retry logic.
+Plus configuration utilities and error handling with retry logic.
 
 ## Basic Usage
 
@@ -132,7 +132,7 @@ Lower temperature gives more consistent responses, higher temperature gives more
 
 ## Testing
 
-The module has comprehensive test coverage with mocked SDK interactions:
+The module has test coverage with mocked SDK interactions:
 
 ```bash
 npm test src/lib/ai/__tests__/geminiClient.test.ts

--- a/src/lib/promptTemplates/examples/README.md
+++ b/src/lib/promptTemplates/examples/README.md
@@ -114,7 +114,7 @@ The `shouldIncludeExamples()` helper determines if examples should be included:
 - **< 50 tokens available**: No examples (budget too limited)
 - **50-150 tokens**: Include only high/critical priority examples
 - **150+ tokens**: Include more examples based on priority
-- **5000+ chars context**: Skip examples (context is already comprehensive)
+- **5000+ chars context**: Skip examples (there's already enough context)
 
 ## Example Types in the Library
 
@@ -203,7 +203,7 @@ Tests cover:
 3. **Quality Control**: Examples guide consistent AI output
 4. **Flexibility**: Easy to add, update, or remove examples
 5. **Type Safety**: Full TypeScript support with interfaces
-6. **Testing**: Comprehensive test coverage ensures reliability
+6. **Testing**: Test coverage ensures reliability
 
 ## Future Enhancements
 

--- a/src/lib/promptTemplates/templates/narrative/choiceTypeTemplates.ts
+++ b/src/lib/promptTemplates/templates/narrative/choiceTypeTemplates.ts
@@ -33,7 +33,7 @@ export const alignedChoiceTemplate = (context: PlayerChoiceTemplateContext): str
   // Extract current location for context
   const location = narrativeContext?.currentLocation || '';
   
-  // Create a more comprehensive context by including more of the narrative
+  // Include more of the narrative for context
   // but still managing token usage intelligently
   let shortContext = '';
   if (recentContent.length <= 1000) {

--- a/src/lib/promptTemplates/templates/narrative/playerChoiceTemplate.ts
+++ b/src/lib/promptTemplates/templates/narrative/playerChoiceTemplate.ts
@@ -39,7 +39,7 @@ export const playerChoiceTemplate = (context: PlayerChoiceTemplateContext): stri
   // Extract current location for context
   const location = narrativeContext?.currentLocation || '';
   
-  // Create a more comprehensive context by including more of the narrative
+  // Include more of the narrative for context
   // but still managing token usage intelligently
   let shortContext = '';
   if (recentContent.length <= 1000) {

--- a/src/lib/tutorial/worldGenerationTour.ts
+++ b/src/lib/tutorial/worldGenerationTour.ts
@@ -3,7 +3,7 @@ import { Step } from 'react-joyride';
 export const worldGenerationTour: Step[] = [
   {
     target: '[aria-describedby="generate-world-desc"]',
-    content: 'This tool lets you instantly generate a complete world setup. Perfect for quick starts!',
+    content: 'This generates a complete world setup for you — a fast way to get started.',
     placement: 'center',
   },
   {
@@ -13,12 +13,12 @@ export const worldGenerationTour: Step[] = [
   },
   {
     target: '[role="radiogroup"]', // Targets the WorldTypeSelector
-    content: 'You can choose "Original" for a unique setting, or use "Inspired By" / "Set Within" to leverage existing fiction or history.',
+    content: 'You can choose "Original" for a unique setting, or use "Inspired By" / "Set Within" to draw on existing fiction or history.',
     placement: 'auto',
   },
   {
     target: '[data-tutorial="generate-world-button"]',
-    content: 'When ready, click here to create your world! The system will generate attributes, skills, and a cover image automatically.',
+    content: "When you're ready, this creates your world — attributes, skills, and a cover image, generated automatically.",
     placement: 'auto',
   },
 ];

--- a/src/lib/utils/README.md
+++ b/src/lib/utils/README.md
@@ -229,7 +229,7 @@ import {
 
 ## Testing
 
-All utility functions have comprehensive test coverage. Run tests with:
+All utility functions have test coverage. Run tests with:
 
 ```bash
 npm test src/lib/utils/__tests__

--- a/src/lib/utils/__tests__/errorUtils.test.ts
+++ b/src/lib/utils/__tests__/errorUtils.test.ts
@@ -156,7 +156,7 @@ describe('errorUtils', () => {
       const result = getUserFriendlyError(error);
 
       expect(result.title).toBe('Something Went Wrong');
-      expect(result.message).toBe('An unexpected error occurred. Please try again.');
+      expect(result.message).toBe("That didn't work.");
       expect(result.type).toBe(ErrorType.UNKNOWN);
       expect(result.actionLabel).toBe('Try Again');
     });

--- a/src/lib/utils/errorUtils.ts
+++ b/src/lib/utils/errorUtils.ts
@@ -133,7 +133,7 @@ export function getUserFriendlyError(error: Error): UserFriendlyError {
   // Default for unknown errors
   return {
     title: 'Something Went Wrong',
-    message: 'An unexpected error occurred. Please try again.',
+    message: "That didn't work.",
     suggestion: 'If this keeps happening, try reloading the page.',
     actionLabel: 'Try Again',
     retryable: isRetryableError(error),

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -15,7 +15,7 @@ export { cssClasses } from './classNames';
 // === FORMATTING UTILITIES ===
 
 /**
- * Comprehensive formatting utilities for dates, strings, and numbers
+ * Formatting utilities for dates, strings, and numbers
  * @see README.md for detailed usage examples
  */
 export {

--- a/src/lib/utils/typeGuards/worldGuards.ts
+++ b/src/lib/utils/typeGuards/worldGuards.ts
@@ -3,7 +3,7 @@
 import type { ValidationResult } from '@/lib/utils';
 
 /**
- * Comprehensive World validation with detailed error messages.
+ * World validation with detailed error messages.
  * 
  * Validates that an unknown object conforms to the World interface structure.
  * Returns a ValidationResult object containing validation status and detailed error descriptions.
@@ -133,7 +133,7 @@ export function validateWorld(obj: unknown, partial: boolean = false): Validatio
 }
 
 /**
- * Comprehensive Character validation with detailed error messages.
+ * Character validation with detailed error messages.
  * 
  * Validates that an unknown object conforms to the Character interface structure.
  * Returns a ValidationResult object containing validation status and detailed error descriptions.

--- a/src/types/personalization.types.ts
+++ b/src/types/personalization.types.ts
@@ -146,7 +146,7 @@ export interface PlayerPreferences {
 }
 
 /**
- * Comprehensive personalized context for narrative generation
+ * Personalized context for narrative generation
  */
 export interface PersonalizedNarrativeContext {
   /** Character personality information */

--- a/src/types/runtime-error.types.ts
+++ b/src/types/runtime-error.types.ts
@@ -2,7 +2,7 @@
  * Runtime Error Types
  * 
  * Type definitions for runtime error capture and display in DevTools.
- * These types support comprehensive error reporting with context information.
+ * These types support error reporting with context information.
  */
 
 /**

--- a/src/types/tone-settings.types.ts
+++ b/src/types/tone-settings.types.ts
@@ -23,7 +23,7 @@ export type NarrativeStyle =
 export type LanguageComplexity = 'simple' | 'moderate' | 'advanced' | 'literary';
 
 /**
- * Comprehensive tone settings for narrative generation
+ * Tone settings for narrative generation
  */
 export interface ToneSettings {
   /** Content rating that determines mature content filtering */


### PR DESCRIPTION
## Description
Fixes the high-severity findings from the weekly plain-language sweep in #1705: three tutorial tooltips (one told players to "click here," one overclaimed "instantly," one used "leverage" — a word the repo's own writing template already bans), and six error messages that either gave no next step or, in one case, told the player to "please wait" on a message that reports an error. Also cuts "comprehensive" wherever it was pure filler across docs and comments (37 sites) — left the one instance in the writing template itself alone, since it's citing the word as the example to avoid, not using it.

Leaving the "gracefully" rewrites (30 sites, each needs a look at the actual failure behavior to write something real), the low-severity restating-comments, and the two AI-tell doc openers for a follow-up — didn't want to blow up this diff past what's easy to review in one pass.

## Related Issue
Related to #1705 (does not close it — the remaining findings in that issue are still open)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

N/A in the usual sense — this is copy-only, no new logic. Ran the full suite for every file touched (12 suites, 63 tests, all passing) to confirm nothing snapshot-tested the old strings.

## User Stories Addressed
N/A — text-quality fix, not a feature.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A — no component structure or styling changed, only string literals and comments.

## Implementation Notes
All 38 changed files are string-literal or comment edits — no logic, props, or types touched. The nine UI-copy changes (tutorial tooltips + error messages) were drafted and reviewed with Jack before applying, since wording is a judgment call the automated sweep flags but doesn't auto-fix.

`npm run type-check` fails on this branch, but it fails identically on `develop` at the same commit (`005b5ded`) — a pre-existing `Cannot find module 'pngjs'` error in `tests/visual/landing-contrast.spec.ts`, unrelated to this change. Confirmed via `git stash` before committing.

## Screenshots
N/A — copy-only changes, no visual layout affected.

## Visual Baseline Changes
None.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [ ] Type checking passed (pre-existing failure on `develop`, unrelated to this change — see Implementation Notes)
- [ ] Security audit passed (not run)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm run lint` — should pass clean.
2. `npx jest src/lib/tutorial src/lib/utils/errorUtils src/lib/utils/typeGuards/worldGuards src/components/shared/wizard src/components/inventory/InventoryList src/components/WorldListScreen src/components/GameSession/StorySummarySection src/components/shared/NavigationLoadingProvider src/components/shared/RecoveryNotification src/hooks/useAutoSave src/lib/promptTemplates` — 12 suites, 63 tests, all passing.
3. Spot-check the world-generation tutorial in the app (`/dev/world-generation` or the real onboarding flow) to see the three tooltip rewrites in context.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic (N/A — no logic added)
- [x] Documentation updated (if required)
- [ ] No new warnings generated (pre-existing type-check failure noted above, not introduced by this PR)
- [x] Accessibility considerations addressed (dropped "click here" from a tooltip — meaningless out of visual context for screen readers)
