### PR TITLE
Close the character panel on an outside click (#265)

### DIFF
--- a/src/components/GameSession/ManuscriptFloatingHud.tsx
+++ b/src/components/GameSession/ManuscriptFloatingHud.tsx
@@ -46,9 +46,27 @@ export const ManuscriptFloatingHud: React.FC<ManuscriptFloatingHudProps> = ({
 
   const { toolbarRef, onKeyDown, onFocus } = useRovingToolbar<HTMLDivElement>();
 
+  // Close the character panel on an outside click, matching the click-outside
+  // pattern the header's other popovers already use (ThemeMenu,
+  // RecentPagesDropdown). Escape and the toggle button itself stay the
+  // caller's job (ActiveGameSession owns isCharacterSummaryExpanded).
+  const headerLeftRef = React.useRef<HTMLDivElement>(null);
+  React.useEffect(() => {
+    if (!isCharacterSummaryExpanded) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!headerLeftRef.current?.contains(event.target as Node)) {
+        onToggleCharacterSummary();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isCharacterSummaryExpanded, onToggleCharacterSummary]);
+
   return (
     <>
-      <div className="manuscript-overlay-header-left">
+      <div className="manuscript-overlay-header-left" ref={headerLeftRef}>
         <div className="manuscript-header-controls">
           <button
             ref={characterButtonRef}

--- a/src/components/GameSession/__tests__/ManuscriptFloatingHud.a11y.test.tsx
+++ b/src/components/GameSession/__tests__/ManuscriptFloatingHud.a11y.test.tsx
@@ -49,6 +49,44 @@ describe('ManuscriptFloatingHud accessibility', () => {
     expect(panel).toHaveFocus();
   });
 
+  // Issue #265: a click anywhere outside the pill/panel closes it, so an open
+  // panel doesn't sit over the narrative until the player finds the tiny
+  // trigger again or reaches for Escape.
+  it('closes the character panel on an outside click', () => {
+    const onToggleCharacterSummary = jest.fn();
+    render(
+      <div>
+        <div data-testid="outside">Narrative text</div>
+        <ManuscriptFloatingHud
+          {...baseProps}
+          onToggleCharacterSummary={onToggleCharacterSummary}
+          isCharacterSummaryExpanded={true}
+          characterSummaryPanel={<div>Character info</div>}
+        />
+      </div>
+    );
+
+    fireEvent.mouseDown(screen.getByTestId('outside'));
+
+    expect(onToggleCharacterSummary).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the character panel open on a click inside it', () => {
+    const onToggleCharacterSummary = jest.fn();
+    render(
+      <ManuscriptFloatingHud
+        {...baseProps}
+        onToggleCharacterSummary={onToggleCharacterSummary}
+        isCharacterSummaryExpanded={true}
+        characterSummaryPanel={<div>Character info</div>}
+      />
+    );
+
+    fireEvent.mouseDown(screen.getByText('Character info'));
+
+    expect(onToggleCharacterSummary).not.toHaveBeenCalled();
+  });
+
   it('character button has aria-expanded reflecting panel state', () => {
     const { rerender } = render(
       <ManuscriptFloatingHud {...baseProps} isCharacterSummaryExpanded={false} />


### PR DESCRIPTION
## Description
Issue #265 asked for a way to collapse/expand the character info panel in the game session. Turns out that control already exists — the manuscript HUD's floating character pill toggles a `CharacterSnapshot` overlay, with a keyboard shortcut (`c`), `aria-expanded`, and Escape-to-close, all already tested. The narrative column is full-width by default (DS3's manuscript single-column layout replaced the old sidebar this issue originally described), so there's no layout to resize on collapse either.

What was actually missing, confirmed by driving a live seeded session: the panel didn't close on an outside click. Open it, then click anywhere on the narrative behind it, and it just sits there covering the story until you find the tiny pill again or reach for Escape. That's the one real gap against the issue's "intuitive and accessible" requirement, so this PR wires up the same click-outside pattern the header's other popovers already use (`ThemeMenu`, `RecentPagesDropdown`, `HeaderNavigation`): a wrapping ref around the pill + panel, a `mousedown` listener, close on a click outside it.

## Related Issue
Closes #265

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The gap surfaced through live browser verification, not a red test — tests were added after to lock the fix in. Full disclosure since that's not the front-loaded TDD order the checkbox above implies.

## User Stories Addressed
As a player, I want to collapse or expand the character panel so I can focus on the narrative when desired — including by clicking away from it, not just re-finding the toggle or pressing Escape.

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

No new component or visual surface — this is a behavior-only change to an existing component (`ManuscriptFloatingHud`), verified live in the browser rather than through new stories.

## Implementation Notes
- `ManuscriptFloatingHud` owns the fix: a `headerLeftRef` wraps the pill + panel, and a `mousedown` listener (active only while the panel is expanded) calls the existing `onToggleCharacterSummary` when the click lands outside that ref.
- State ownership didn't move — `ActiveGameSession` still owns `isCharacterSummaryExpanded`; `ManuscriptFloatingHud` stays a controlled component.
- Confirmed live against a seeded `/dev/game-session` session: open panel -> click narrative text -> panel closes; `aria-expanded` flips `true` -> `false`.

## Screenshots
No visual change — the panel looks identical, this only changes when it closes. Verified via `aria-expanded` on the character pill against a live seeded session (see Testing Instructions).

## Visual Baseline Changes
None — `tests/visual/**` untouched, no snapshots changed.

## Testing Instructions
1. `npm run dev`, open `/dev/game-session` (seeds a real session with a test character).
2. Click the character pill (top-left) to open the panel.
3. Click anywhere on the narrative text — panel should close.
4. Re-open, press Escape — still closes (unchanged behavior).
5. Re-open, click the pill again — still closes (unchanged behavior).
6. `npx jest src/components/GameSession/__tests__/ManuscriptFloatingHud.a11y.test.tsx` — new outside-click tests pass.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required) — no doc referenced this behavior; nothing was stale
- [x] No new warnings generated
- [x] Accessibility considerations addressed — outside-click close is additive to the existing Escape/aria-expanded/focus-management behavior, no regression
