### PR TITLE
Assert .component-landing directly in the landing visual spec

### DIFF
--- a/tests/visual/landing-page.spec.ts
+++ b/tests/visual/landing-page.spec.ts
@@ -39,6 +39,10 @@ test.describe('Landing page rendering', () => {
   test('landing renders consistently at the root route', async ({ page }) => {
     await gotoLanding(page);
     await expect(page.locator('html')).toHaveAttribute('data-theme', 'ds3');
+    // #main-content holds the screenshot (see file banner for why), but
+    // .component-landing is the locator #1383 asked this spec to exercise —
+    // assert it directly too, rather than only through its ancestor.
+    await expect(page.locator('.component-landing')).toBeVisible();
     await expect(page.locator('#main-content')).toHaveScreenshot(
       'landing-ds3.png'
     );


### PR DESCRIPTION
## Description
Adds a direct assertion on `.component-landing` to the existing landing-page visual spec. The spec already screenshots the page via `#main-content` (documented in the file: `.component-landing`'s bounding box clips the hero/selector/closing bands, which bleed past it with a negative inline margin), but never exercised `.component-landing` itself. This adds that.

## Related Issue
Related to #1383 (already closed — the spec, baselines, and CI coverage this issue asked for were shipped in #1565/#1702/#1704 before this issue was revisited; `/welcome` itself has been a redirect to `/` since #1528. This PR just closes the remaining gap between the issue's literal wording and the spec.)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — test-only change.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

## Implementation Notes
One line added to the existing `landing renders consistently at the root route` test: `await expect(page.locator('.component-landing')).toBeVisible();`. No new screenshot, no baseline change — this is an assertion alongside the existing `#main-content` screenshot, not a replacement for it.

## Screenshots
N/A — no visual change.

## Visual Baseline Changes
None.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm run dev` (or point at this worktree's own port)
2. `npx playwright test tests/visual/landing-page.spec.ts --project=chromium`
3. All 4 tests pass, including the new `.component-landing` visibility assertion — no snapshot regen needed.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
