### PR TITLE
Stream narrative prose progressively instead of popping in after generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ NEXT_PUBLIC_ENABLE_TOKEN_BUDGET_MANAGER=false
 # Feature flags. Their defaults live in src/lib/featureFlags.ts - leave these
 # unset to get them. Each line below is the override, not the default, so
 # uncommenting one flips that flag away from what the code ships with.
-# NEXT_PUBLIC_FEATURE_BUFFERED_STREAMING=false
+# NEXT_PUBLIC_FEATURE_BUFFERED_STREAMING=true
 # NEXT_PUBLIC_FEATURE_PROGRESSIVE_DISCLOSURE=false
 
 # Public site origin, used for metadataBase, robots.txt, and the sitemap.

--- a/.storybook/msw/handlers.ts
+++ b/.storybook/msw/handlers.ts
@@ -23,6 +23,22 @@ const textResponse = (content: string) =>
     completionTokens: 0,
   });
 
+// /api/narrative/generate alone streams newline-delimited JSON (issue #1476)
+// instead of the single-JSON shape above — see processGeminiStreamingTextRequest
+// and ClientGeminiClient.generateContent's ndjson reader. One line is a valid
+// stream: just the terminal `done` event, carrying the same fields.
+const streamingTextResponse = (content: string) =>
+  new HttpResponse(
+    `${JSON.stringify({
+      done: true,
+      content,
+      finishReason: 'STOP',
+      promptTokens: 0,
+      completionTokens: 0,
+    })}\n`,
+    { headers: { 'Content-Type': 'application/x-ndjson; charset=utf-8' } }
+  );
+
 const CANNED_NARRATIVE =
   'The corridor opens into a vaulted hall. Dust hangs in the lantern light, ' +
   'and somewhere ahead water drips in a slow, deliberate rhythm. You sense ' +
@@ -44,7 +60,7 @@ const placeholderImage = (seed: string) =>
 
 export const handlers = [
   // --- Narrative text routes ---
-  http.post('/api/narrative/generate', () => textResponse(CANNED_NARRATIVE)),
+  http.post('/api/narrative/generate', () => streamingTextResponse(CANNED_NARRATIVE)),
   http.post('/api/narrative/choices', () => textResponse(CANNED_CHOICES)),
   http.post('/api/narrative/ending', () => textResponse(CANNED_NARRATIVE)),
   http.post('/api/narrative/summarize', () => textResponse('A brief recap of events so far.')),

--- a/scripts/generate-homepage-showcase.mjs
+++ b/scripts/generate-homepage-showcase.mjs
@@ -123,6 +123,31 @@ async function bundleProductionModules() {
   return { modules: await import(out), buildDir };
 }
 
+/**
+ * /api/narrative/generate streams newline-delimited JSON (issue #1476) — one
+ * or more `{delta}` progress lines, then a terminal `{done: true, content,
+ * finishReason, promptTokens, completionTokens}` line carrying the same
+ * fields the old single-JSON response had. The other routes this script
+ * calls still return plain JSON. Rather than branching per-route, parse the
+ * body as JSON first and only fall back to scanning it as ndjson when that
+ * fails, so every caller of post() keeps working unchanged either way.
+ */
+function parseRouteResponse(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    // Fall through to ndjson parsing below.
+  }
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const event = JSON.parse(trimmed);
+    if ('error' in event) throw new Error(event.error);
+    if ('done' in event) return event;
+  }
+  throw new Error('Streamed response ended without a completion event.');
+}
+
 async function post(port, route, body, apiKey) {
   let lastError;
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
@@ -134,7 +159,7 @@ async function post(port, route, body, apiKey) {
       });
       const text = await response.text();
       if (!response.ok) throw new Error(`${route} returned ${response.status}: ${text.slice(0, 300)}`);
-      return JSON.parse(text);
+      return parseRouteResponse(text);
     } catch (error) {
       lastError = error;
       if (attempt < MAX_ATTEMPTS) {

--- a/src/app/api/narrative/generate/route.ts
+++ b/src/app/api/narrative/generate/route.ts
@@ -1,7 +1,7 @@
 // src/app/api/narrative/generate/route.ts
 
 import { NextRequest } from 'next/server';
-import { processGeminiTextRequest } from '../../../../utils/apiHelpers';
+import { processGeminiStreamingTextRequest } from '../../../../utils/apiHelpers';
 
 // Vercel function budget. Must be a static literal (Next.js segment config);
 // sized as the single 30s Gemini attempt (GEMINI_ATTEMPT_TIMEOUT_MS in
@@ -9,8 +9,12 @@ import { processGeminiTextRequest } from '../../../../utils/apiHelpers';
 // a plan default shorter than the attempt itself.
 export const maxDuration = 60;
 
+// Streaming (issue #1476): the narrative panel is the most-repeated moment
+// in the app, so this is the one Gemini text route worth the extra
+// complexity of forwarding progressive content instead of the simpler
+// single-JSON-response path the other narrative routes use.
 export async function POST(request: NextRequest) {
-  return processGeminiTextRequest(request, {
+  return processGeminiStreamingTextRequest(request, {
     // Matches lib/ai/config's default. A weighty beat asks for 3-4 paragraphs
     // plus its JSON metadata, which crowds a 1024 ceiling and gets truncated
     // mid-object — and a truncated response is unparseable, not just short.

--- a/src/components/GameSession/ActiveGameSession.tsx
+++ b/src/components/GameSession/ActiveGameSession.tsx
@@ -74,6 +74,16 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
   selectedChoiceId,
 }) => {
   const [isGenerating, setIsGenerating] = React.useState(true);
+  // Live preview of the segment currently generating (issue #1476), fed by
+  // the hidden NarrativeController via onStreamingPreviewChange. Cleared
+  // whenever a turn stops generating, for whatever reason (completion,
+  // error, retry) — isGenerating already tracks all of those.
+  const [streamingPreview, setStreamingPreview] = React.useState('');
+  React.useEffect(() => {
+    if (!isGenerating) {
+      setStreamingPreview('');
+    }
+  }, [isGenerating]);
   const [initialized, setInitialized] = React.useState(false);
   const [currentDecision, setCurrentDecision] = React.useState<Decision | null>(null);
   const [localSelectedChoiceId, setLocalSelectedChoiceId] = React.useState<string | undefined>();
@@ -507,6 +517,9 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
         onEndingSuggested={handleEndingSuggested}
         segmentCount={segmentCount}
         retryToken={retryToken}
+        isGenerating={isGenerating}
+        streamingContent={streamingPreview}
+        onStreamingPreviewChange={setStreamingPreview}
       />
 
       <div className="manuscript-secondary-controls">

--- a/src/components/GameSession/ActiveGameSessionNarrativeColumn.tsx
+++ b/src/components/GameSession/ActiveGameSessionNarrativeColumn.tsx
@@ -22,6 +22,10 @@ interface ActiveGameSessionNarrativeColumnProps {
   onEndingSuggested: (reason: string, endingType: EndingType) => void;
   segmentCount: number;
   retryToken?: number;
+  /** See NarrativeHistoryManager's isGenerating/streamingContent (issue #1476). */
+  isGenerating?: boolean;
+  streamingContent?: string;
+  onStreamingPreviewChange?: (preview: string) => void;
 }
 
 const ActiveGameSessionNarrativeColumn: React.FC<
@@ -42,6 +46,9 @@ const ActiveGameSessionNarrativeColumn: React.FC<
   onEndingSuggested,
   segmentCount,
   retryToken,
+  isGenerating,
+  streamingContent,
+  onStreamingPreviewChange,
 }) => {
   return (
     <div
@@ -56,6 +63,8 @@ const ActiveGameSessionNarrativeColumn: React.FC<
         key={`display-${controllerKey}`}
         sessionId={sessionId}
         disableInitialAutoScroll={false}
+        isGenerating={isGenerating}
+        streamingContent={streamingContent}
       />
 
       {/* Hidden controller just to generate content - always include it but hide from view */}
@@ -76,6 +85,7 @@ const ActiveGameSessionNarrativeColumn: React.FC<
           generateChoices={true}
           hideHistory={true}
           retryToken={retryToken}
+          onStreamingPreviewChange={onStreamingPreviewChange}
         />
       </div>
     </div>

--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -56,6 +56,15 @@ interface NarrativeControllerProps {
    * controller's internal retry handler. Ignored at its initial value.
    */
   retryToken?: number;
+  /**
+   * Fires with the growing narrative preview as the active generation
+   * streams in, and with '' once a turn finishes (issue #1476). A composer
+   * that renders its own visible history from the store instead of this
+   * controller's own (often hidden, see hideHistory) NarrativeHistory — the
+   * live play surface does this via NarrativeHistoryManager — uses this to
+   * feed that display instead.
+   */
+  onStreamingPreviewChange?: (preview: string) => void;
 }
 
 export const NarrativeController: React.FC<NarrativeControllerProps> = ({
@@ -72,11 +81,33 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
   generateChoices = true,
   hideHistory = false,
   retryToken = 0,
+  onStreamingPreviewChange,
 }) => {
   const [segments, setSegments] = useState<NarrativeSegment[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const toast = useToast();
+
+  // Live-updating preview of the segment currently generating (issue #1476:
+  // real API streaming). streamingPreviewRef is the source of truth so
+  // handleStreamChunk stays a stable callback and the post-await read in
+  // generate*() below never sees a stale closure; streamingPreview mirrors it
+  // into state purely to trigger the re-render NarrativeHistory needs to show
+  // each new delta.
+  const [streamingPreview, setStreamingPreview] = useState('');
+  const streamingPreviewRef = useRef('');
+
+  const handleStreamChunk = useCallback((delta: string) => {
+    streamingPreviewRef.current += delta;
+    setStreamingPreview(streamingPreviewRef.current);
+    onStreamingPreviewChange?.(streamingPreviewRef.current);
+  }, [onStreamingPreviewChange]);
+
+  const resetStreamingPreview = useCallback(() => {
+    streamingPreviewRef.current = '';
+    setStreamingPreview('');
+    onStreamingPreviewChange?.('');
+  }, [onStreamingPreviewChange]);
 
   // Access store methods in a way that works with testing
   const addSegment = useNarrativeStore((state) => state.addSegment);
@@ -426,6 +457,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
 
       setIsLoading(true);
       setError(null);
+      resetStreamingPreview();
 
       // Race AI generation with a timeout so we can fallback gracefully.
       // Losing the race must also ABORT the generation: without the signal,
@@ -445,7 +477,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
           worldId,
           characterId ? [characterId] : [],
           sessionId,
-          { signal: generationAbort.signal }
+          { signal: generationAbort.signal, onChunk: handleStreamChunk }
         ),
         timeoutPromise,
       ]);
@@ -562,6 +594,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
     } finally {
       clearTimeout(generationTimeoutId);
       initialGenerationLocksRef.current.delete(lockKey);
+      resetStreamingPreview();
       if (mountedRef.current) {
         setIsLoading(false);
       }
@@ -581,6 +614,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
     setIsLoading(true);
     setError(null);
     clearGenerationError();
+    resetStreamingPreview();
 
     let segmentTimeoutId: ReturnType<typeof setTimeout> | undefined;
     try {
@@ -718,7 +752,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
                   : undefined,
             },
           },
-          { signal: segmentAbort.signal }
+          { signal: segmentAbort.signal, onChunk: handleStreamChunk }
         ),
         segmentTimeoutPromise,
       ]);
@@ -817,6 +851,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
       setGenerationError(getNarrativeError(err as Error));
     } finally {
       clearTimeout(segmentTimeoutId);
+      resetStreamingPreview();
       if (mountedRef.current) {
         setIsLoading(false);
       }
@@ -864,6 +899,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
           isLoading={isLoading || isGeneratingChoices}
           error={error || undefined}
           onRetry={handleRetry}
+          streamingContent={streamingPreview}
         />
       )}
       {!hideHistory && process.env.NODE_ENV !== 'production' && npcRoster.length > 0 && (

--- a/src/components/Narrative/NarrativeHistory.tsx
+++ b/src/components/Narrative/NarrativeHistory.tsx
@@ -18,6 +18,14 @@ interface NarrativeHistoryProps {
    * generated one once it does arrive.
    */
   isHydrating?: boolean;
+  /**
+   * The active generation's narrative prose so far, growing as tokens
+   * stream in from /api/narrative/generate (issue #1476). While isLoading is
+   * true, this takes the place of the bare "Continuing your story..."
+   * spinner as soon as the first token arrives — the spinner remains the
+   * fallback for the gap before that.
+   */
+  streamingContent?: string;
 }
 
 export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
@@ -27,7 +35,8 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
   className = '',
   onRetry,
   disableInitialAutoScroll = false,
-  isHydrating = false
+  isHydrating = false,
+  streamingContent
 }) => {
   const scrollAreaRef = useRef<HTMLDivElement>(null);
   const scrollViewportRef = useRef<HTMLElement>(null);
@@ -193,11 +202,34 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
         break;
     }
   }, []);
+  // A synthetic segment carrying the in-progress generation's prose so far,
+  // rendered through the normal NarrativeDisplay presentation instead of the
+  // bare spinner once the first token arrives (issue #1476).
+  const streamingPreviewSegment: NarrativeSegment | null =
+    isLoading && streamingContent
+      ? {
+          id: '__streaming-preview__',
+          content: streamingContent,
+          type: 'scene',
+          metadata: { tags: [] },
+          timestamp: new Date(),
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        }
+      : null;
+
   // Only render once to prevent flashing
   const renderContent = () => {
-    // If we're loading with no segments, just show the loading indicator
+    // If we're loading with no segments, show the live preview once tokens
+    // have started arriving, otherwise the spinner for the gap before that.
     if (isLoading && renderedSegments.length === 0) {
-      return (
+      return streamingPreviewSegment ? (
+        <NarrativeDisplay
+          segment={streamingPreviewSegment}
+          isLoading={false}
+          error={undefined}
+        />
+      ) : (
         <NarrativeDisplay
           segment={null}
           isLoading={true}
@@ -235,13 +267,19 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
             </React.Fragment>
           ))}
 
-          {/* Loading indicator for additional segments */}
+          {/* Loading indicator (or, once tokens arrive, the live preview)
+              for the segment currently generating */}
           {isLoading && (
-            <NarrativeDisplay
-              segment={null}
-              isLoading={true}
-              error={undefined}
-            />
+            <>
+              {streamingPreviewSegment && (
+                <hr className="manuscript-narrative-divider" />
+              )}
+              <NarrativeDisplay
+                segment={streamingPreviewSegment}
+                isLoading={!streamingPreviewSegment}
+                error={undefined}
+              />
+            </>
           )}
         </>
       );

--- a/src/components/Narrative/NarrativeHistoryManager.tsx
+++ b/src/components/Narrative/NarrativeHistoryManager.tsx
@@ -12,13 +12,26 @@ interface NarrativeHistoryManagerProps {
   className?: string;
   onStabilized?: () => void;
   disableInitialAutoScroll?: boolean;
+  /**
+   * True while a NarrativeController elsewhere in the tree is actively
+   * generating the next turn (issue #1476). This component only displays
+   * persisted segments, so it has no generation state of its own — a
+   * composer that hides its own NarrativeController's history (the live play
+   * surface does, via ActiveGameSessionNarrativeColumn) passes its
+   * isGenerating/streamingContent through here instead.
+   */
+  isGenerating?: boolean;
+  /** The active generation's narrative prose so far — see isGenerating. */
+  streamingContent?: string;
 }
 
 export const NarrativeHistoryManager: React.FC<NarrativeHistoryManagerProps> = ({
   sessionId,
   className,
   onStabilized,
-  disableInitialAutoScroll = false
+  disableInitialAutoScroll = false,
+  isGenerating = false,
+  streamingContent
 }) => {
   const [segments, setSegments] = useState<NarrativeSegment[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -150,8 +163,10 @@ export const NarrativeHistoryManager: React.FC<NarrativeHistoryManagerProps> = (
       <NarrativeHistory
         // Only show segments when they've stabilized
         segments={stabilized ? segments : []}
-        // Always show loading animation until stabilized, regardless of whether we have segments
-        isLoading={isLoading || !stabilized}
+        // Always show loading animation until stabilized, regardless of whether we have segments —
+        // also true while a sibling NarrativeController generates the next turn (issue #1476).
+        isLoading={isLoading || !stabilized || isGenerating}
+        streamingContent={streamingContent}
         // Segments withheld pre-stabilization are historical, not newly generated —
         // tell the buffered-reveal hook so it doesn't replay the reveal animation on
         // a stored segment once stabilization finally supplies it. Deliberately just

--- a/src/components/Narrative/__tests__/NarrativeHistory.streaming.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeHistory.streaming.test.tsx
@@ -153,6 +153,63 @@ describe('NarrativeHistory (Streaming & Anchoring)', () => {
     expect(mockScrollTo).not.toHaveBeenCalled();
   });
 
+  describe('streamingContent (issue #1476: real API streaming)', () => {
+    it('shows the live preview instead of the spinner once tokens arrive, with no segments yet', () => {
+      mockIsFeatureEnabled.mockReturnValue(false);
+      render(
+        <NarrativeHistory
+          segments={[]}
+          isLoading={true}
+          streamingContent="The door creaks"
+        />
+      );
+
+      expect(screen.getByText(/The door creaks/)).toBeInTheDocument();
+      expect(screen.queryByText('Writing your story...')).not.toBeInTheDocument();
+    });
+
+    it('falls back to the spinner before the first token arrives', () => {
+      mockIsFeatureEnabled.mockReturnValue(false);
+      render(
+        <NarrativeHistory segments={[]} isLoading={true} streamingContent="" />
+      );
+
+      expect(screen.getByText('Writing your story...')).toBeInTheDocument();
+    });
+
+    it('appends the live preview after existing segments while generating the next one', () => {
+      mockIsFeatureEnabled.mockReturnValue(false);
+      render(
+        <NarrativeHistory
+          segments={segments}
+          isLoading={true}
+          streamingContent="A new beat unfolds"
+        />
+      );
+
+      expect(screen.getByText('First segment.')).toBeInTheDocument();
+      expect(screen.getByText(/A new beat unfolds/)).toBeInTheDocument();
+    });
+
+    it('does not show a stale preview once loading finishes', () => {
+      mockIsFeatureEnabled.mockReturnValue(false);
+      const { rerender } = render(
+        <NarrativeHistory
+          segments={segments}
+          isLoading={true}
+          streamingContent="A new beat unfolds"
+        />
+      );
+      expect(screen.getByText(/A new beat unfolds/)).toBeInTheDocument();
+
+      rerender(
+        <NarrativeHistory segments={segments} isLoading={false} streamingContent="" />
+      );
+
+      expect(screen.queryByText(/A new beat unfolds/)).not.toBeInTheDocument();
+    });
+  });
+
   it('applies layout classes for height stability', () => {
     mockIsFeatureEnabled.mockReturnValue(true);
     const { container } = render(

--- a/src/lib/__tests__/featureFlags.test.ts
+++ b/src/lib/__tests__/featureFlags.test.ts
@@ -16,32 +16,41 @@ describe('featureFlags', () => {
     return require('@/lib/featureFlags') as typeof import('@/lib/featureFlags');
   };
 
-  it('defaults BUFFERED_STREAMING and PROGRESSIVE_DISCLOSURE to true when env vars are missing', () => {
+  it('defaults PROGRESSIVE_DISCLOSURE to true and BUFFERED_STREAMING to false when env vars are missing', () => {
     const { isFeatureEnabled } = load({
       NEXT_PUBLIC_FEATURE_BUFFERED_STREAMING: undefined,
       NEXT_PUBLIC_FEATURE_PROGRESSIVE_DISCLOSURE: undefined,
     });
 
-    expect(isFeatureEnabled('BUFFERED_STREAMING')).toBe(true);
+    // BUFFERED_STREAMING defaults off: real API streaming (issue #1476)
+    // covers the live play surface's progressive-reveal now, and this
+    // fake-typewriter pass is only an opt-in fallback for when it can't.
+    expect(isFeatureEnabled('BUFFERED_STREAMING')).toBe(false);
     expect(isFeatureEnabled('PROGRESSIVE_DISCLOSURE')).toBe(true);
   });
 
-  it('disables BUFFERED_STREAMING only when env var is exactly "false"', () => {
+  it('enables BUFFERED_STREAMING only when env var is exactly "true"', () => {
     const { isFeatureEnabled } = load({
-      NEXT_PUBLIC_FEATURE_BUFFERED_STREAMING: 'false',
+      NEXT_PUBLIC_FEATURE_BUFFERED_STREAMING: 'true',
+    });
+
+    expect(isFeatureEnabled('BUFFERED_STREAMING')).toBe(true);
+  });
+
+  it('treats non-true values as disabled for a default-off flag', () => {
+    const { isFeatureEnabled } = load({
+      NEXT_PUBLIC_FEATURE_BUFFERED_STREAMING: 'TRUE',
     });
 
     expect(isFeatureEnabled('BUFFERED_STREAMING')).toBe(false);
   });
 
-  it('treats non-false values as enabled for default-on flags', () => {
+  it('treats non-false values as enabled for a default-on flag', () => {
     const { isFeatureEnabled } = load({
       NEXT_PUBLIC_FEATURE_PROGRESSIVE_DISCLOSURE: 'TRUE',
-      NEXT_PUBLIC_FEATURE_BUFFERED_STREAMING: '1',
     });
 
     expect(isFeatureEnabled('PROGRESSIVE_DISCLOSURE')).toBe(true);
-    expect(isFeatureEnabled('BUFFERED_STREAMING')).toBe(true);
   });
 
   it('supports downstream gating decisions for BUFFERED_STREAMING', () => {

--- a/src/lib/ai/__tests__/clientGeminiClient.test.ts
+++ b/src/lib/ai/__tests__/clientGeminiClient.test.ts
@@ -1,0 +1,97 @@
+import { ClientGeminiClient } from '../clientGeminiClient';
+import { aiFetch } from '../aiFetch';
+
+jest.mock('../aiFetch');
+
+const mockedAiFetch = aiFetch as jest.MockedFunction<typeof aiFetch>;
+const encoder = new TextEncoder();
+
+/** A fake response.body whose reader yields the given ndjson lines as
+ * separate chunks — matches the ReadableStreamDefaultReader shape without
+ * needing a real web ReadableStream (unavailable in this jsdom test env). */
+function fakeStreamingResponse(lines: string[]) {
+  const chunks = lines.map((line) => encoder.encode(`${line}\n`));
+  let index = 0;
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      getReader: () => ({
+        read: jest.fn(async () => {
+          if (index >= chunks.length) return { done: true, value: undefined };
+          return { done: false, value: chunks[index++] };
+        }),
+      }),
+    },
+  };
+}
+
+describe('ClientGeminiClient.generateContent', () => {
+  beforeEach(() => {
+    mockedAiFetch.mockReset();
+  });
+
+  it('forwards each delta to onChunk as it streams and resolves with the done event', async () => {
+    mockedAiFetch.mockResolvedValue(
+      fakeStreamingResponse([
+        JSON.stringify({ delta: 'The door ' }),
+        JSON.stringify({ delta: 'creaks open.' }),
+        JSON.stringify({
+          done: true,
+          content: '{"content": "The door creaks open."}',
+          finishReason: 'STOP',
+          promptTokens: 12,
+          completionTokens: 8,
+        }),
+      ]) as unknown as Response
+    );
+
+    const client = new ClientGeminiClient();
+    const onChunk = jest.fn();
+
+    const result = await client.generateContent('a prompt', { onChunk });
+
+    expect(onChunk.mock.calls).toEqual([['The door '], ['creaks open.']]);
+    expect(result).toEqual({
+      content: '{"content": "The door creaks open."}',
+      finishReason: 'STOP',
+      promptTokens: 12,
+      completionTokens: 8,
+    });
+  });
+
+  it('resolves without a subscriber when onChunk is omitted', async () => {
+    mockedAiFetch.mockResolvedValue(
+      fakeStreamingResponse([
+        JSON.stringify({ delta: 'Hello' }),
+        JSON.stringify({ done: true, content: 'Hello', finishReason: 'STOP' }),
+      ]) as unknown as Response
+    );
+
+    const client = new ClientGeminiClient();
+    const result = await client.generateContent('a prompt');
+
+    expect(result.content).toBe('Hello');
+  });
+
+  it('rejects with a friendly message when the stream carries an error event', async () => {
+    mockedAiFetch.mockResolvedValue(
+      fakeStreamingResponse([JSON.stringify({ error: 'connection reset' })]) as unknown as Response
+    );
+
+    const client = new ClientGeminiClient();
+    await expect(client.generateContent('a prompt')).rejects.toThrow();
+  });
+
+  it('rejects when the HTTP response itself is not ok', async () => {
+    mockedAiFetch.mockResolvedValue({
+      ok: false,
+      status: 429,
+      statusText: 'Too Many Requests',
+      json: async () => ({ error: 'Rate limit exceeded. Please try again later.' }),
+    } as unknown as Response);
+
+    const client = new ClientGeminiClient();
+    await expect(client.generateContent('a prompt')).rejects.toThrow(/rate limit/i);
+  });
+});

--- a/src/lib/ai/__tests__/narrativeStreamPreview.test.ts
+++ b/src/lib/ai/__tests__/narrativeStreamPreview.test.ts
@@ -49,6 +49,15 @@ describe('extractStreamingContentPreview', () => {
     expect(extractStreamingContentPreview('```json')).toBe('');
   });
 
+  it('withholds output for an in-progress fence word, not just an exact-length prefix', () => {
+    // Regression: a naive "backticks, then the whole word or nothing" check
+    // let a partially-typed fence word ("```j", "```js", "```jso") leak
+    // through as prose for a chunk or two before the fence resolved.
+    expect(extractStreamingContentPreview('```j')).toBe('');
+    expect(extractStreamingContentPreview('```js')).toBe('');
+    expect(extractStreamingContentPreview('```jso')).toBe('');
+  });
+
   it('returns the full value once the JSON object is complete', () => {
     const buffer = JSON.stringify({
       content: 'A complete beat.',

--- a/src/lib/ai/__tests__/narrativeStreamPreview.test.ts
+++ b/src/lib/ai/__tests__/narrativeStreamPreview.test.ts
@@ -1,0 +1,60 @@
+import { extractStreamingContentPreview } from '../narrativeStreamPreview';
+
+describe('extractStreamingContentPreview', () => {
+  it('returns nothing before the "content" field key has arrived', () => {
+    expect(extractStreamingContentPreview('')).toBe('');
+    expect(extractStreamingContentPreview('{')).toBe('');
+    expect(extractStreamingContentPreview('{\n  "con')).toBe('');
+  });
+
+  it('grows the visible prefix as the content value streams in', () => {
+    expect(
+      extractStreamingContentPreview('{"content": "Once upon a ti')
+    ).toBe('Once upon a ti');
+    expect(
+      extractStreamingContentPreview('{"content": "Once upon a time, the')
+    ).toBe('Once upon a time, the');
+  });
+
+  it('stops at the closing quote and ignores trailing fields', () => {
+    const buffer =
+      '{"content": "The door creaks open.", "type": "scene", "metadata": {"mood": "tense"';
+    expect(extractStreamingContentPreview(buffer)).toBe(
+      'The door creaks open.'
+    );
+  });
+
+  it('unescapes quotes and newlines within the streamed value', () => {
+    const buffer = '{"content": "She said \\"run\\"\\nand did not look back';
+    expect(extractStreamingContentPreview(buffer)).toBe(
+      'She said "run"\nand did not look back'
+    );
+  });
+
+  it('does not emit a mangled trailing char when a chunk cuts mid-escape', () => {
+    // Buffer ends right after a bare backslash — the escape target hasn't
+    // arrived yet, so the partial escape must not appear in the output.
+    const buffer = '{"content": "The rope snapped\\';
+    expect(extractStreamingContentPreview(buffer)).toBe('The rope snapped');
+  });
+
+  it('strips a markdown JSON fence before scanning for the field', () => {
+    const buffer = '```json\n{"content": "Grounded in the ruins';
+    expect(extractStreamingContentPreview(buffer)).toBe('Grounded in the ruins');
+  });
+
+  it('withholds output for a fence-only buffer', () => {
+    expect(extractStreamingContentPreview('`')).toBe('');
+    expect(extractStreamingContentPreview('``')).toBe('');
+    expect(extractStreamingContentPreview('```json')).toBe('');
+  });
+
+  it('returns the full value once the JSON object is complete', () => {
+    const buffer = JSON.stringify({
+      content: 'A complete beat.',
+      type: 'scene',
+      metadata: { itemsLost: [] },
+    });
+    expect(extractStreamingContentPreview(buffer)).toBe('A complete beat.');
+  });
+});

--- a/src/lib/ai/clientGeminiClient.ts
+++ b/src/lib/ai/clientGeminiClient.ts
@@ -1,6 +1,6 @@
 // src/lib/ai/clientGeminiClient.ts
 
-import { AIClient, AIGenerateOptions, AIResponse, AIImageResponse } from './types';
+import { AIClient, AIGenerateOptions, AIResponse, AIImageResponse, NarrativeStreamEvent, NarrativeStreamDone } from './types';
 import { userFriendlyError } from './userFriendlyErrors';
 import { aiFetch } from './aiFetch';
 import { SINGLE_ATTEMPT_TEXT_TIMEOUT_MS } from '@/lib/constants/aiTimeouts';
@@ -71,20 +71,107 @@ export class ClientGeminiClient implements AIClient {
   }
 
   /**
+   * POSTs to an API route that streams newline-delimited JSON
+   * (NarrativeStreamEvent — see /api/narrative/generate) and consumes it
+   * progressively: each `delta` line is forwarded to the caller's onChunk as
+   * it arrives, and the trailing `done` line becomes the resolved AIResponse.
+   * Error handling mirrors postJson so callers see the same friendly
+   * messages regardless of which path served the request.
+   */
+  private async postNdjsonStream(
+    endpoint: string,
+    body: unknown,
+    logContext: string,
+    options: AIGenerateOptions & { timeoutMs?: number } = {}
+  ): Promise<AIResponse> {
+    try {
+      const response = await aiFetch(
+        `${this.baseUrl}${endpoint}`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(body),
+          signal: options.signal,
+        },
+        { timeoutMs: options.timeoutMs }
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        if (response.status === 429) {
+          throw new Error(errorData.error || 'Rate limit exceeded. Please try again later.');
+        }
+        throw new Error(errorData.error || `HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      if (!response.body) {
+        throw new Error('Streaming response had no body');
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let finalEvent: NarrativeStreamDone | null = null;
+
+      const consumeLine = (line: string) => {
+        const trimmed = line.trim();
+        if (!trimmed) return;
+        const event = JSON.parse(trimmed) as NarrativeStreamEvent;
+        if ('error' in event) {
+          throw new Error(event.error);
+        } else if ('done' in event) {
+          finalEvent = event;
+        } else {
+          options.onChunk?.(event.delta);
+        }
+      };
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+        for (const line of lines) {
+          consumeLine(line);
+        }
+      }
+      // The final line may not carry a trailing newline.
+      consumeLine(buffer);
+
+      if (!finalEvent) {
+        throw new Error('Stream ended without a completion event');
+      }
+
+      return this.toAIResponse(finalEvent);
+    } catch (error) {
+      logger.error(`ClientGeminiClient ${logContext} error:`, error);
+      const friendlyMessage = userFriendlyError(error instanceof Error ? error : new Error('Unknown error'));
+      throw new Error(friendlyMessage);
+    }
+  }
+
+  /**
    * Generate narrative content via the server-side API route. Choice
    * generation goes through generateChoices() — callers pick the endpoint
    * explicitly instead of this method inferring it from prompt content.
+   *
+   * Consumes the route's progressive stream (issue #1476): pass onChunk in
+   * options to receive narrative prose as it's generated instead of only on
+   * completion.
    */
   async generateContent(prompt: string, options?: AIGenerateOptions): Promise<AIResponse> {
-    const data = await this.postJson<{ content: string; finishReason?: string; promptTokens?: number; completionTokens?: number }>(
+    return this.postNdjsonStream(
       '/api/narrative/generate',
       { prompt, config: { temperature: 0.7, maxTokens: 2048 } },
       'generation',
       // The route makes a single 30s Gemini attempt (makeGeminiRequest), so
       // the wait ceiling is that budget + headroom, not the retry worst case.
-      { signal: options?.signal, timeoutMs: SINGLE_ATTEMPT_TEXT_TIMEOUT_MS }
+      { signal: options?.signal, timeoutMs: SINGLE_ATTEMPT_TEXT_TIMEOUT_MS, onChunk: options?.onChunk }
     );
-    return this.toAIResponse(data);
   }
 
   /**

--- a/src/lib/ai/narrativeGenerator.ts
+++ b/src/lib/ai/narrativeGenerator.ts
@@ -79,7 +79,7 @@ export class NarrativeGenerator {
 
   async generateSegment(
     request: NarrativeGenerationRequest,
-    options?: { signal?: AbortSignal }
+    options?: { signal?: AbortSignal; onChunk?: (delta: string) => void }
   ): Promise<NarrativeGenerationResult> {
     try {
       const world = this.getWorld(request.worldId);
@@ -174,6 +174,7 @@ export class NarrativeGenerator {
 
       const response = await this.geminiClient.generateContent(finalPrompt, {
         signal: options?.signal,
+        onChunk: options?.onChunk,
       });
       throwIfAborted(options?.signal);
       recordRequestCalibration(budget, finalPrompt, response);
@@ -339,7 +340,11 @@ export class NarrativeGenerator {
     worldId: string,
     characterIds: string[],
     sessionId?: string,
-    options?: { generationParameters?: GenerationParameters; signal?: AbortSignal }
+    options?: {
+      generationParameters?: GenerationParameters;
+      signal?: AbortSignal;
+      onChunk?: (delta: string) => void;
+    }
   ): Promise<NarrativeGenerationResult> {
     try {
       const world = this.getWorld(worldId);
@@ -418,6 +423,7 @@ export class NarrativeGenerator {
 
       const response = await this.geminiClient.generateContent(fullyEnhancedPrompt, {
         signal: options?.signal,
+        onChunk: options?.onChunk,
       });
       throwIfAborted(options?.signal);
       recordRequestCalibration(budget, fullyEnhancedPrompt, response);

--- a/src/lib/ai/narrativeGenerator.ts
+++ b/src/lib/ai/narrativeGenerator.ts
@@ -77,6 +77,17 @@ export class NarrativeGenerator {
 
   constructor(private geminiClient: AIClient) {}
 
+  /**
+   * options.onChunk streams the RAW model draft as it's generated, before
+   * enforceLanguageComplexity/applyContinuityGuardrail below get a chance to
+   * rewrite it. On the rare turn where one of those fires a real correction,
+   * a caller subscribed to onChunk briefly shows the uncorrected line before
+   * the final NarrativeGenerationResult replaces it. Buffering the stream
+   * until guardrails clear would remove that gap, but at the cost of the
+   * extra guardrail round-trip's latency on every turn that has one — the
+   * exact wait this streaming path exists to cut. Accepted trade-off for
+   * now; revisit if guardrail corrections turn out more common than rare.
+   */
   async generateSegment(
     request: NarrativeGenerationRequest,
     options?: { signal?: AbortSignal; onChunk?: (delta: string) => void }

--- a/src/lib/ai/narrativeStreamPreview.ts
+++ b/src/lib/ai/narrativeStreamPreview.ts
@@ -1,0 +1,66 @@
+// src/lib/ai/narrativeStreamPreview.ts
+
+import { stripMarkdownFences } from './parseJSON';
+
+const PARTIAL_FENCE_ONLY = /^`{1,3}(json)?$/;
+
+/**
+ * Extracts the currently-decodable prefix of the "content" field from a
+ * growing, possibly-incomplete JSON buffer streamed from the model.
+ *
+ * The narrative response format wraps prose in
+ * `{"content": "...", "type": ..., "metadata": {...}}` (see
+ * narrativeGenerator.prompt.ts and the narrative templates). Mid-stream, the
+ * buffer is a truncated JSON document — this recovers whatever of the
+ * "content" string value has arrived so far, unescaped, without waiting for
+ * the closing brace.
+ *
+ * Recomputes from scratch on every call rather than tracking incremental
+ * state: a chunk boundary that lands mid-escape-sequence just yields the
+ * previous safe prefix until the next chunk resolves it, so a caller can
+ * call this after every network chunk without ever emitting a mangled
+ * character.
+ */
+export function extractStreamingContentPreview(rawBuffer: string): string {
+  const stripped = stripMarkdownFences(rawBuffer);
+
+  if (PARTIAL_FENCE_ONLY.test(stripped)) {
+    return '';
+  }
+
+  const contentFieldStart = stripped.indexOf('"content"');
+  if (contentFieldStart === -1) {
+    // No "content" field visible yet. If the model hasn't started emitting
+    // JSON structure at all, show the raw buffer as-is so early chunks of a
+    // plain-prose response (unexpected, but not our contract to enforce)
+    // aren't held back.
+    return stripped.trimStart().startsWith('{') ? '' : stripped;
+  }
+
+  const colonIndex = stripped.indexOf(':', contentFieldStart);
+  if (colonIndex === -1) return '';
+
+  const valueStart = stripped.indexOf('"', colonIndex + 1);
+  if (valueStart === -1) return '';
+
+  let result = '';
+  for (let i = valueStart + 1; i < stripped.length; i++) {
+    const char = stripped[i];
+
+    if (char === '\\') {
+      const next = stripped[i + 1];
+      if (next === undefined) break; // escape sequence cut off mid-chunk
+      if (next === 'n') result += '\n';
+      else if (next === 't') result += '\t';
+      else result += next; // \" \\ \/ and anything else: literal char
+      i++;
+      continue;
+    }
+
+    if (char === '"') break; // unescaped quote closes the string
+
+    result += char;
+  }
+
+  return result;
+}

--- a/src/lib/ai/narrativeStreamPreview.ts
+++ b/src/lib/ai/narrativeStreamPreview.ts
@@ -2,7 +2,19 @@
 
 import { stripMarkdownFences } from './parseJSON';
 
-const PARTIAL_FENCE_ONLY = /^`{1,3}(json)?$/;
+const FENCE_MARKER = '```json';
+
+/**
+ * True while `text` could still turn into the opening fence marker as more
+ * characters arrive — not just an exact-length match ("`", "``", "```json")
+ * but any in-progress prefix ("```j", "```jso", ...). A prefix-length regex
+ * only catching the exact backtick run or the fully-typed word missed those
+ * partial-word states, which let fence characters leak into the preview as
+ * prose for a chunk or two.
+ */
+function isPartialFencePrefix(text: string): boolean {
+  return FENCE_MARKER.startsWith(text) && text.length < FENCE_MARKER.length;
+}
 
 /**
  * Extracts the currently-decodable prefix of the "content" field from a
@@ -22,11 +34,17 @@ const PARTIAL_FENCE_ONLY = /^`{1,3}(json)?$/;
  * character.
  */
 export function extractStreamingContentPreview(rawBuffer: string): string {
-  const stripped = stripMarkdownFences(rawBuffer);
-
-  if (PARTIAL_FENCE_ONLY.test(stripped)) {
+  // Check the RAW (pre-strip) buffer for a partial fence: stripMarkdownFences
+  // already consumes a complete "```" run, so by the time it's run, a
+  // partial one ("```j") has had its backticks removed and no longer looks
+  // like a fence prefix — checking after stripping missed exactly the
+  // in-progress case this guard exists for.
+  const trimmedRaw = rawBuffer.trimStart();
+  if (isPartialFencePrefix(trimmedRaw)) {
     return '';
   }
+
+  const stripped = stripMarkdownFences(trimmedRaw).trimStart();
 
   const contentFieldStart = stripped.indexOf('"content"');
   if (contentFieldStart === -1) {
@@ -34,7 +52,7 @@ export function extractStreamingContentPreview(rawBuffer: string): string {
     // JSON structure at all, show the raw buffer as-is so early chunks of a
     // plain-prose response (unexpected, but not our contract to enforce)
     // aren't held back.
-    return stripped.trimStart().startsWith('{') ? '' : stripped;
+    return stripped.startsWith('{') ? '' : stripped;
   }
 
   const colonIndex = stripped.indexOf(':', contentFieldStart);

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -77,11 +77,42 @@ export interface AIImageResponse {
 /**
  * Per-call options for AI clients. `signal` lets a caller cancel the
  * underlying request (e.g. when a UI-level timeout races the generation);
- * implementations that can't cancel may ignore it.
+ * implementations that can't cancel may ignore it. `onChunk` is an optional
+ * progressive-reveal hook: implementations that stream (currently
+ * ClientGeminiClient.generateContent) invoke it with each newly-visible
+ * slice of narrative prose as it arrives, ahead of the final resolved
+ * AIResponse. Implementations that don't stream simply never call it.
  */
 export interface AIGenerateOptions {
   signal?: AbortSignal;
+  onChunk?: (delta: string) => void;
 }
+
+/**
+ * Streaming protocol for /api/narrative/generate: the response body is
+ * newline-delimited JSON, zero or more progress events followed by exactly
+ * one terminal event. The terminal `done` event carries the same fields as
+ * the non-streaming GeminiTextResponse, so everything downstream of the
+ * network call (parseNarrativeResponse, the continuity guardrail, lore/item
+ * extraction) reads identical data regardless of which path produced it.
+ */
+export interface NarrativeStreamDelta {
+  delta: string;
+}
+export interface NarrativeStreamDone {
+  done: true;
+  content: string;
+  finishReason?: string;
+  promptTokens?: number;
+  completionTokens?: number;
+}
+export interface NarrativeStreamError {
+  error: string;
+}
+export type NarrativeStreamEvent =
+  | NarrativeStreamDelta
+  | NarrativeStreamDone
+  | NarrativeStreamError;
 
 /**
  * Interface for AI clients (both real and mock)

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -9,7 +9,13 @@
  * in the browser.
  */
 const FEATURE_FLAG_DEFAULTS = {
-  BUFFERED_STREAMING: true,
+  // Client-side typewriter reveal over an already-complete response (#1695).
+  // Real token streaming from /api/narrative/generate (issue #1476) now
+  // covers the same "text should arrive progressively" goal for the live
+  // play surface, so this defaults off — playing both back to back would
+  // double the reveal instead of speeding it up. Kept as an opt-in fallback
+  // for embeds/environments where the real stream's onChunk never fires.
+  BUFFERED_STREAMING: false,
   PROGRESSIVE_DISCLOSURE: true,
 } as const;
 

--- a/src/utils/__tests__/apiHelpers.test.ts
+++ b/src/utils/__tests__/apiHelpers.test.ts
@@ -15,9 +15,17 @@ jest.mock('../rateLimiter', () => ({
   }
 }));
 
-import { getSafetySettingsFromPrompt, makeGeminiRequest } from '../apiHelpers';
+import {
+  getSafetySettingsFromPrompt,
+  makeGeminiRequest,
+  consumeGeminiStreamEvents,
+  processGeminiStreamingTextRequest,
+} from '../apiHelpers';
 import { getAIConfig } from '../../lib/ai/config';
 import { GEMINI_ATTEMPT_TIMEOUT_MS } from '../../lib/constants/aiTimeouts';
+import { PROVIDER_API_KEY_HEADER } from '../../lib/ai/providerKeyHeader';
+import { globalRateLimiter } from '../rateLimiter';
+import { NextResponse, type NextRequest } from 'next/server';
 
 describe('getSafetySettingsFromPrompt', () => {
   it('returns BLOCK_MEDIUM_AND_ABOVE for G-rated content', () => {
@@ -181,5 +189,149 @@ describe('makeGeminiRequest', () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+});
+
+describe('consumeGeminiStreamEvents', () => {
+  const encoder = new TextEncoder();
+
+  /** A fake reader that yields the given SSE `data:` payloads one chunk per
+   * read(), then signals done — matches the ByteStreamReader shape without
+   * needing a real web ReadableStream (unavailable in this jsdom test env). */
+  function fakeReader(payloads: unknown[]) {
+    const frames = payloads.map((payload) => encoder.encode(`data: ${JSON.stringify(payload)}\n\n`));
+    let index = 0;
+    return {
+      read: jest.fn(async () => {
+        if (index >= frames.length) return { done: true };
+        return { done: false, value: frames[index++] };
+      }),
+    };
+  }
+
+  it('yields growing content deltas as candidate text streams in, then a done event', async () => {
+    const reader = fakeReader([
+      { candidates: [{ content: { parts: [{ text: '{"content": "Once upon a ' }] } }] },
+      { candidates: [{ content: { parts: [{ text: 'time, a hero' }] } }] },
+      {
+        candidates: [
+          { content: { parts: [{ text: ' arose.", "type": "scene"}' }] }, finishReason: 'STOP' },
+        ],
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 },
+      },
+    ]);
+
+    const events = [];
+    for await (const event of consumeGeminiStreamEvents(reader, 'Test')) {
+      events.push(event);
+    }
+
+    const deltas = events.filter((e): e is { delta: string } => 'delta' in e);
+    expect(deltas.map((d) => d.delta).join('')).toBe('Once upon a time, a hero arose.');
+
+    const last = events[events.length - 1];
+    expect(last).toEqual({
+      done: true,
+      content: '{"content": "Once upon a time, a hero arose.", "type": "scene"}',
+      finishReason: 'STOP',
+      promptTokens: 10,
+      completionTokens: 5,
+    });
+  });
+
+  it('skips an unparsable SSE frame instead of aborting the turn', async () => {
+    const badFrame = encoder.encode('data: {not json\n\n');
+    const goodFrame = encoder.encode(`data: ${JSON.stringify({
+      candidates: [{ content: { parts: [{ text: '{"content": "Still works"}' }] }, finishReason: 'STOP' }],
+    })}\n\n`);
+    let index = 0;
+    const reader = {
+      read: jest.fn(async () => {
+        const frames = [badFrame, goodFrame];
+        if (index >= frames.length) return { done: true };
+        return { done: false, value: frames[index++] };
+      }),
+    };
+
+    const events = [];
+    for await (const event of consumeGeminiStreamEvents(reader, 'Test')) {
+      events.push(event);
+    }
+
+    const last = events[events.length - 1];
+    expect(last).toMatchObject({ done: true, content: '{"content": "Still works"}' });
+  });
+
+  it('yields an error event when the reader itself fails mid-stream', async () => {
+    const reader = {
+      read: jest.fn().mockRejectedValue(new Error('connection reset')),
+    };
+
+    const events = [];
+    for await (const event of consumeGeminiStreamEvents(reader, 'Test')) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([{ error: 'connection reset' }]);
+  });
+});
+
+describe('processGeminiStreamingTextRequest', () => {
+  function fakeRequest(body: unknown, headerKey?: string): NextRequest {
+    return {
+      headers: { get: (name: string) => (name === PROVIDER_API_KEY_HEADER ? headerKey ?? null : null) },
+      json: async () => body,
+    } as unknown as NextRequest;
+  }
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+    // makeGeminiRequest's describe block above calls jest.resetAllMocks() in
+    // its own afterEach, which wipes the module-level rateLimiter mock's
+    // implementation for every test that runs after it in this file.
+    (globalRateLimiter.checkLimit as jest.Mock).mockReturnValue({
+      allowed: true,
+      remaining: 50,
+      resetTime: Date.now() + 3600000,
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('rejects a request with no prompt before ever calling Gemini', async () => {
+    await processGeminiStreamingTextRequest(fakeRequest({}), { errorContext: 'Test' });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('errors without calling Gemini when no API key resolves', async () => {
+    // No header key, and jest.setup.ts pins GEMINI_API_KEY to the MOCK_API_KEY
+    // sentinel, which resolveApiKey treats as unset.
+    await processGeminiStreamingTextRequest(fakeRequest({ prompt: 'hello' }), { errorContext: 'Test' });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an upstream non-ok response as an error instead of streaming', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 429,
+      statusText: 'Too Many Requests',
+      text: async () => 'rate limited upstream',
+    });
+
+    await processGeminiStreamingTextRequest(
+      fakeRequest({ prompt: 'hello' }, 'player-supplied-key'),
+      { errorContext: 'Test' }
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining(':streamGenerateContent?alt=sse'),
+      expect.any(Object)
+    );
+    expect(NextResponse.json).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ status: 429 })
+    );
   });
 });

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -399,7 +399,16 @@ export async function* consumeGeminiStreamEvents(
         if (typeof text === 'string') {
           rawContent += text;
           const nextPreview = extractStreamingContentPreview(rawContent);
-          if (nextPreview.length > visiblePreview.length) {
+          // Only ever emit a delta when the new preview grows the previous
+          // one by appending characters. extractStreamingContentPreview is
+          // recomputed from scratch each call and is meant to be monotonic,
+          // but this guard keeps a future edge case there from slicing a
+          // false prefix off content that never actually preceded it, which
+          // would otherwise corrupt the reveal (see #1717 review).
+          if (
+            nextPreview.length > visiblePreview.length &&
+            nextPreview.startsWith(visiblePreview)
+          ) {
             yield { delta: nextPreview.slice(visiblePreview.length) };
             visiblePreview = nextPreview;
           }

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -6,6 +6,8 @@ import { getAIConfig } from '../lib/ai/config';
 import { resolveApiKey } from '../lib/ai/resolveApiKey';
 import { createAPIErrorResponse } from '../lib/utils/createAPIErrorResponse';
 import { GEMINI_ATTEMPT_TIMEOUT_MS } from '../lib/constants/aiTimeouts';
+import { extractStreamingContentPreview } from '../lib/ai/narrativeStreamPreview';
+import type { NarrativeStreamEvent } from '../lib/ai/types';
 
 import Logger from '@/lib/utils/logger';
 const logger = new Logger('ApiHelpers');
@@ -320,4 +322,225 @@ export async function processGeminiTextRequest(
       error instanceof Error ? error.message : 'Unknown error'
     );
   }
+}
+
+/** Minimal shape needed to drive the SSE parser — matches a real
+ * ReadableStreamDefaultReader<Uint8Array>, but kept structural so tests can
+ * hand it a plain object instead of constructing a real web ReadableStream. */
+interface ByteStreamReader {
+  read(): Promise<{ done: boolean; value?: Uint8Array }>;
+}
+
+/**
+ * Consumes a Gemini `:streamGenerateContent?alt=sse` response body and
+ * yields our own narrative streaming protocol events (see
+ * NarrativeStreamEvent). Each `data:` SSE frame's text delta is accumulated
+ * into the raw buffer; extractStreamingContentPreview recovers whatever of
+ * the "content" JSON field is decodable so far, and only the newly-revealed
+ * suffix is yielded as a delta — recomputing from scratch each time means a
+ * chunk that lands mid-escape-sequence just withholds output until the next
+ * chunk resolves it, instead of ever yielding a mangled character.
+ *
+ * Kept independent of the real ReadableStream/Response constructors (which
+ * jsdom's jest environment doesn't provide) so it's unit-testable with a
+ * hand-rolled reader.
+ */
+export async function* consumeGeminiStreamEvents(
+  reader: ByteStreamReader,
+  errorContext: string
+): AsyncGenerator<NarrativeStreamEvent> {
+  const decoder = new TextDecoder();
+  let sseBuffer = '';
+  let rawContent = '';
+  let visiblePreview = '';
+  let finishReason = 'STOP';
+  let promptTokens: number | undefined;
+  let completionTokens: number | undefined;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      sseBuffer += decoder.decode(value, { stream: true });
+      const lines = sseBuffer.split('\n');
+      // The last element may be a partial line still being written — hold it
+      // back in the buffer until more bytes complete it.
+      sseBuffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith('data:')) continue;
+
+        const payload = trimmed.slice('data:'.length).trim();
+        if (!payload || payload === '[DONE]') continue;
+
+        let parsed: {
+          candidates?: Array<{
+            content?: { parts?: Array<{ text?: string }> };
+            finishReason?: string;
+          }>;
+          usageMetadata?: {
+            promptTokenCount?: number;
+            candidatesTokenCount?: number;
+          };
+        };
+        try {
+          parsed = JSON.parse(payload);
+        } catch {
+          // An unparsable SSE frame is skipped rather than aborting the
+          // whole turn — the next frame (or the final done event, built
+          // from whatever text did arrive) carries the turn forward.
+          continue;
+        }
+
+        const candidate = parsed.candidates?.[0];
+        const text = candidate?.content?.parts?.[0]?.text;
+        if (typeof text === 'string') {
+          rawContent += text;
+          const nextPreview = extractStreamingContentPreview(rawContent);
+          if (nextPreview.length > visiblePreview.length) {
+            yield { delta: nextPreview.slice(visiblePreview.length) };
+            visiblePreview = nextPreview;
+          }
+        }
+        if (candidate?.finishReason) {
+          finishReason = candidate.finishReason;
+        }
+        if (parsed.usageMetadata) {
+          promptTokens = parsed.usageMetadata.promptTokenCount ?? promptTokens;
+          completionTokens = parsed.usageMetadata.candidatesTokenCount ?? completionTokens;
+        }
+      }
+    }
+
+    yield {
+      done: true,
+      content: rawContent,
+      finishReason,
+      promptTokens,
+      completionTokens,
+    };
+  } catch (error) {
+    logger.error(`${errorContext} stream error:`, error);
+    yield {
+      error: error instanceof Error ? error.message : 'Stream interrupted',
+    };
+  }
+}
+
+/**
+ * Streaming counterpart to processGeminiTextRequest: same rate limiting,
+ * validation, and key resolution, but calls Gemini's SSE streaming endpoint
+ * and forwards narrative content to the client as it's generated instead of
+ * waiting for the full response. See NarrativeStreamEvent for the wire
+ * protocol. Used only by /api/narrative/generate — the other Gemini text
+ * routes (choices, ending, summarize) have no progressive-reveal UI and stay
+ * on the simpler processGeminiTextRequest.
+ */
+export async function processGeminiStreamingTextRequest(
+  request: NextRequest,
+  options: GeminiTextOptions = {}
+): Promise<Response> {
+  const {
+    maxTokens = 1024,
+    temperature = 0.7,
+    errorContext = 'Generation'
+  } = options;
+
+  const { response: rateLimitResponse, result: rateLimitResult } = handleRateLimiting(request);
+  if (rateLimitResponse) {
+    return rateLimitResponse;
+  }
+
+  const requestData = await validateAIRequest(request);
+  if (!requestData) {
+    return createAPIErrorResponse(
+      new Error('400 bad request: prompt is required'),
+      400
+    );
+  }
+
+  const apiKey = resolveApiKey(request);
+  if (!apiKey) {
+    return createAPIErrorResponse(
+      new Error('Service configuration error: API key not configured'),
+      500
+    );
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await makeGeminiRequest(
+      `https://generativelanguage.googleapis.com/v1beta/models/${getAIConfig().modelName}:streamGenerateContent?alt=sse`,
+      apiKey,
+      {
+        contents: [{
+          parts: [{ text: requestData.prompt }]
+        }],
+        generationConfig: {
+          temperature: requestData.config?.temperature || temperature,
+          topP: 1.0,
+          topK: 40,
+          maxOutputTokens: requestData.config?.maxTokens || maxTokens,
+          thinkingConfig: { thinkingBudget: 0 }
+        },
+        safetySettings: getSafetySettingsFromPrompt(requestData.prompt)
+      }
+    );
+  } catch (error) {
+    logger.error(`${errorContext} error:`, error);
+    return createAPIErrorResponse(
+      error instanceof Error ? error : new Error('Unknown error occurred'),
+      500,
+      error instanceof Error ? error.message : 'Unknown error'
+    );
+  }
+
+  if (!upstream.ok) {
+    const errorText = await upstream.text();
+    logger.error('Gemini API Error:', {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      errorText
+    });
+
+    const apiError = upstream.status === 429
+      ? new Error('429 rate limit exceeded')
+      : upstream.status === 401
+      ? new Error('401 unauthorized')
+      : new Error(`Service error: ${upstream.status} ${upstream.statusText}`);
+
+    return createAPIErrorResponse(apiError, upstream.status, errorText);
+  }
+
+  if (!upstream.body) {
+    return createAPIErrorResponse(
+      new Error('Service error: empty stream body'),
+      500
+    );
+  }
+
+  const encoder = new TextEncoder();
+  const upstreamReader = upstream.body.getReader();
+
+  const ndjsonStream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      for await (const event of consumeGeminiStreamEvents(upstreamReader, errorContext)) {
+        controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`));
+      }
+      controller.close();
+    },
+    cancel() {
+      upstreamReader.cancel().catch(() => {});
+    },
+  });
+
+  return new Response(ndjsonStream, {
+    headers: {
+      ...createRateLimitHeaders(rateLimitResult),
+      'Content-Type': 'application/x-ndjson; charset=utf-8',
+      'Cache-Control': 'no-cache, no-transform',
+    },
+  });
 }


### PR DESCRIPTION
## Description
The narrative panel says "Continuing your story..." for 5-8s and then the whole next beat pops in at once — it reads as streaming but nothing actually streams. PR #1695 added a client-side reveal effect over the finished response, which made the pop-in less jarring but didn't touch the underlying wait. The real primitive for this (#903's `streamResilience.ts`) was never wired into the render path, and got removed as dead code in #1507's structural sweep since nothing called it by the time that audit ran.

This wires real token-level streaming end to end:

- `/api/narrative/generate` now calls Gemini's `:streamGenerateContent` SSE endpoint and forwards prose to the client as newline-delimited JSON deltas. The narrative response is JSON-wrapped (`{"content": "...", "type": ..., "metadata": {...}}`), so a naive token passthrough would render escaped JSON fragments instead of prose — `extractStreamingContentPreview` incrementally recovers just the decodable prefix of the `content` field from the still-forming JSON buffer on each chunk.
- `ClientGeminiClient.generateContent` consumes that stream and resolves with the same `AIResponse` shape the non-streaming path used to return, so everything downstream of the network call — `parseNarrativeResponse`, the continuity guardrail, language-complexity enforcement, lore/item extraction — is unchanged.
- `NarrativeController` threads the growing preview up via a new `onStreamingPreviewChange` callback. That plumbing turned out to matter: the live play surface renders `NarrativeController` hidden (`hideHistory`) and shows history through a separate `NarrativeHistoryManager` reading straight from the store, so the preview has to reach that component instead of `NarrativeController`'s own (unused, in that context) `NarrativeHistory` render.
- `BUFFERED_STREAMING` (the #1695 fake typewriter) now defaults off. Real streaming covers the same "text should arrive progressively" goal for the live surface, and leaving both on would double the reveal instead of shortening it. Kept as an opt-in fallback (`NEXT_PUBLIC_FEATURE_BUFFERED_STREAMING=true`) for contexts where the stream's `onChunk` never fires.

Scoped to `/api/narrative/generate` only — the other Gemini text routes (choices, ending, summarize) have no progressive-reveal UI and stay on the simpler non-streaming path. Initial-scene generation (the pre-first-turn skeleton) also isn't wired to a visible streaming panel; that's a loading skeleton with no narrative UI mounted yet, so there's nothing to stream into.

Posted a status comment on #1476 before starting, correcting its body: the "nothing streams, it's a pop-in" framing predates #1695's client-side reveal and no longer matches `develop`.

## Related Issue
Closes #1476

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Tests were written alongside implementation, not strictly test-first — this wasn't run through the tdd-implement flow. Coverage: `extractStreamingContentPreview` (partial-JSON recovery, 8 cases), `consumeGeminiStreamEvents` (the SSE→ndjson translation, including a malformed-frame and a mid-stream-failure case), `processGeminiStreamingTextRequest`'s pre-stream error branches, `ClientGeminiClient.generateContent`'s stream consumption (onChunk forwarding, error propagation), and `NarrativeHistory`'s new `streamingContent` render branch (cold-start preview, appended-after-segments, spinner fallback, no stale preview after loading ends). `NarrativeController`/`ActiveGameSession`/`NarrativeHistoryManager`'s prop-threading isn't independently unit-tested — it's plumbing exercised indirectly by the existing suites for those components, all of which still pass.

## User Stories Addressed
As a player, the next story beat should start appearing as soon as the model starts producing it, not after the full ~5-8s generation finishes.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A — no new UI components, and the streaming preview reuses the existing `NarrativeDisplay` presentation exactly (same component, same CSS classes) rather than introducing a new visual treatment.

## Implementation Notes
- `apiHelpers.ts`, `narrativeGenerator.ts`, `NarrativeController.tsx`, and `ActiveGameSession.tsx` were already well over the file-size guideline before this change; the checklist item below is left unchecked for that reason, not because this PR grew them past a limit it should have respected. Didn't split them apart as part of this PR — that's a separate refactor with its own risk, out of scope here.
- The delta-extraction approach (regex/scan-based partial JSON recovery) mirrors the existing fallback logic in `narrativeGenerator.response.parse.ts` that already handles truncated/malformed responses, rather than introducing a different parsing strategy.
- `consumeGeminiStreamEvents` is written as a plain async generator over a structurally-typed reader (not the real `ReadableStream`/`Response` constructors) because this repo's Jest environment is `jsdom`, which doesn't expose those globals — keeping the actual parsing logic independent of them is what makes it unit-testable at all here.

## Screenshots
N/A — no visual change; the streaming preview renders through the same `NarrativeDisplay` component and CSS as a normal segment.

## Visual Baseline Changes
None.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit not run as part of this PR (no new external dependencies added).

## Testing Instructions
1. `npm run dev`, start or resume a play session with a real Gemini key configured.
2. Make a choice that triggers the next narrative beat.
3. Watch the narrative panel: prose should now grow progressively as the model generates it, instead of holding flat under the "Continuing your story..." indicator and then jumping in all at once. The indicator itself should still cover the brief gap before the first token arrives.
4. `npm test`, `npm run type-check`, `npm run lint`, `npm run build` all pass locally (see below).

## Checklist
- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

No new docs needed — this is an internal implementation change with no new user-facing surface to document. Accessibility: the streaming preview renders through the same `NarrativeDisplay` markup as a finished segment, so it carries the same semantics; no new interactive elements were added.

**Local verification (this worktree, `NEXT_PUBLIC_SITE_URL` set to match CI's build-step config):**
- `npm test`: 383/383 suites, 2614/2614 tests passing
- `npm run type-check`: clean
- `npm run lint`: 0 errors (pre-existing warnings only, none in touched files)
- `npm run deps:validate`: 2 pre-existing violations, both in files this PR doesn't touch (confirmed present on an unmodified `develop` checkout too)
- `npm run build`: clean, including the Storybook build step
