### PR TITLE
Fix stale radius and shadow values in DESIGN.md

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -235,19 +235,19 @@ This collapsed a three-surface split (#1655). The retired third surface — a 28
 
 Two shadow tokens:
 
-- **shadow-overlay** — centered shadow for modals, popovers, floating elements. DS1 light: `0 6px 18px rgb(0 0 0 / 8%)`. Dark mode increases opacity to 40% for visibility.
-- **shadow-drawer** — directional shadow for side panels with a `-12px` x-offset to keep the shadow on the leading edge.
+- **shadow-overlay** — centered shadow for modals, popovers, floating elements. `0 4px 12px rgb(0 0 0 / 10%)` in light mode; dark mode increases opacity to 35% for visibility.
+- **shadow-drawer** — directional shadow for side panels with a `-12px` x-offset to keep the shadow on the leading edge. `-12px 0 12px rgb(0 0 0 / 10%)` in light mode, 35% opacity in dark.
 
 Depth is conveyed primarily through **borders and tonal shifts**, not shadows. Cards sit on `surface` over a `canvas` background; the contrast does the work. Shadows are reserved for genuinely elevated UI (modals, drawers, dropdowns).
 
 ## Shapes
 
-DS3's radius scale — tight, drafted: `--radius-sm: 4px`, `--radius-md: 6px`, `--radius: 0.375rem`.
+DS3's radius scale — tight, drafted: `--radius-sm: 4px`, `--radius-md: 6px`, `--radius-lg: 8px`, `--radius-full: 9999px`.
 
 ### Usage rules
 
 - **Buttons** use `var(--radius-md)` (`6px`).
-- **Cards and inputs** use `var(--radius)` (`0.375rem`, the default).
+- **Cards and inputs** use `var(--radius-md)` (`6px`).
 - **Pills and badges** use `var(--radius-full)` (`9999px`).
 - **Pin tokens, not values.** Code that hardcodes `border-radius: 8px` will look right today and wrong the moment the token changes.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -267,7 +267,7 @@ Component rules apply to DS3. The token references resolve automatically.
 
 ### Card
 
-- Background `surface`, border `1px solid var(--color-border)`, radius `var(--radius)`, padding `var(--space-md)` (16px).
+- Background `surface`, border `1px solid var(--color-border)`, radius `var(--radius-md)` (6px), padding `var(--space-md)` (16px).
 - No drop shadows. Depth comes from the surface contrast against `canvas`.
 
 ### Input


### PR DESCRIPTION
## Description
DESIGN.md's Shapes section claimed a `--radius: 0.375rem` token that doesn't exist anywhere in the codebase, and said cards/inputs default to it. Cards and inputs actually use `--radius-md` (6px), the same token buttons use. The radius scale was also missing `--radius-lg` and `--radius-full`, both of which are real tokens in `_shared-tokens.css` / `ds3.css`. The Elevation & Depth section right above it still labeled its shadow values "DS1 light" with numbers that don't match `ds3.css` — replaced with the real light/dark values for both `--shadow-overlay` and `--shadow-drawer`.

Flagged as an out-of-scope follow-up while working #1626 (DESIGN.md rewrite) — same kind of doc rot, different section, so it's a separate small PR rather than folded into that one.

## Related Issue
No tracked issue — a drive-by doc-accuracy fix found during #1626.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [ ] Test coverage maintained or improved

N/A — documentation-only change, no code or behavior to test.

## User Stories Addressed
N/A

## Flow Diagrams
N/A

## Component Development
N/A — no UI changes.

## Implementation Notes
Verified every claim against the actual codebase before editing:
- `grep -rn -- "--radius"` across `src/lib/theme/themes/_shared-tokens.css` and `ds3.css` confirms the real scale: `--radius-sm: 4px`, `--radius-md: 6px`, `--radius-lg: 8px`, `--radius-full: 9999px`. No `--radius` bare token exists anywhere.
- `grep -rn "var(--radius)"` across `src/` returns nothing — it's never used.
- `src/components/ui/card.css` and `src/app/wizard.css` both use `border-radius: var(--radius-md)` for cards/inputs.
- `ds3.css` shadow tokens: `--shadow-overlay: 0 4px 12px rgb(0 0 0 / 10%)` (light) / 35% opacity (dark); `--shadow-drawer: -12px 0 12px rgb(0 0 0 / 10%)` (light) / 35% opacity (dark).

## Screenshots
N/A — documentation-only.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
Read the updated "Elevation & Depth" and "Shapes" sections of `DESIGN.md` and cross-check against `src/lib/theme/themes/ds3.css` and `_shared-tokens.css` — all values now match.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed
