### PR TITLE
Audit DS3 against the corrected DESIGN.md, and swap 49 literals onto tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -444,7 +444,7 @@ body > * {
 }
 
 .dark-mode-toggle-option-compact {
-  padding: 0.1875rem 0.375rem;
+  padding: 0.1875rem var(--space-1_5);
   font-size: 0.5625rem;
 }
 

--- a/src/app/wizard.css
+++ b/src/app/wizard.css
@@ -768,7 +768,7 @@
   align-items: center;
   justify-content: center;
   min-width: var(--space-3);
-  padding-top: 1rem;
+  padding-top: var(--space-4);
 }
 
 /* ─── Button rows ─── */
@@ -1151,13 +1151,13 @@
 :root .wizard-page .form-input,
 :root .wizard-page .form-textarea,
 :root .wizard-page .form-select {
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   font-family: var(--font-interface);
 }
 
 :root .wizard-page .wizard-card,
 :root .wizard-page .wizard-panel {
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 
 :root .wizard-page .wizard-nav-container {
@@ -1186,7 +1186,7 @@
 
 :root .wizard-page .wizard-nav-primary,
 :root .wizard-page .wizard-nav-secondary {
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 
 /* DS3 step content — monospace card titles, dotted divider/action-row
@@ -1259,18 +1259,18 @@
 }
 
 :root .wizard-page .wizard-toggle {
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   font-family: var(--font-system);
   font-size: var(--font-size-xs);
 }
 
 :root .wizard-page .wizard-info-banner {
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   border-style: dashed;
 }
 
 :root .wizard-page .wizard-empty-state {
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   font-family: var(--font-system);
 }
 
@@ -1942,12 +1942,12 @@
 }
 
 :root .wizard-page .wizard-skill-attr-option {
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   padding: var(--space-1_5);
 }
 
 :root .wizard-page .wizard-custom-editor {
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   padding: var(--space-3);
 }
 
@@ -1960,7 +1960,7 @@
 :root .wizard-page .wizard-custom-editor input,
 :root .wizard-page .wizard-custom-editor textarea,
 :root .wizard-page .wizard-custom-editor select {
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 
 :root .wizard-page .wizard-slot-cell {
@@ -1975,7 +1975,7 @@
 }
 
 :root .wizard-page .wizard-dialog-panel {
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   border-style: dashed;
 }
 
@@ -1984,16 +1984,16 @@
 }
 
 :root .wizard-page .component-portrait-step .component-character-portrait {
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 
 :root .wizard-page .component-portrait-step button {
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   padding: var(--space-1_5) var(--space-3);
 }
 
 :root .wizard-page .portrait-step-success {
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   border-style: dashed;
 }
 
@@ -2002,7 +2002,7 @@
 }
 
 :root .wizard-page .component-point-pool-manager .point-pool-allocation {
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   padding: var(--space-2_5);
 }
 
@@ -2012,7 +2012,7 @@
 }
 
 :root .wizard-page .wizard-error-container {
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   border-style: dashed;
 }
 

--- a/src/components/devtools/DevToolsPanel/DevToolsPanel.css
+++ b/src/components/devtools/DevToolsPanel/DevToolsPanel.css
@@ -36,7 +36,7 @@
 .devtools-panel-prompts-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: var(--space-1_5);
   color: var(--color-text-secondary);
   white-space: nowrap;
 }

--- a/src/components/devtools/SectionVisibilityControls/SectionVisibilityControls.css
+++ b/src/components/devtools/SectionVisibilityControls/SectionVisibilityControls.css
@@ -39,7 +39,7 @@
 .section-visibility-menu-list {
   display: flex;
   flex-direction: column;
-  gap: 0.125rem;
+  gap: var(--space-0_5);
 }
 
 /* Menu items are shared DS Buttons; left-align and fill the menu width.

--- a/src/components/devtools/TokenBudgetPanel/TokenBudgetPanel.css
+++ b/src/components/devtools/TokenBudgetPanel/TokenBudgetPanel.css
@@ -11,7 +11,7 @@
 
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--space-3);
   font-size: 0.8125rem;
 }
 
@@ -19,27 +19,27 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  gap: 0.5rem;
+  gap: var(--space-2);
   color: var(--color-text-muted);
 }
 
 .token-budget-panel-rows {
   display: flex;
   flex-direction: column;
-  gap: 0.625rem;
+  gap: var(--space-2_5);
 }
 
 .token-budget-panel-row {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--space-1);
 }
 
 .token-budget-panel-row-head {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.375rem;
+  gap: var(--space-1_5);
 }
 
 .token-budget-panel-component {
@@ -56,14 +56,14 @@
 .token-budget-panel-bar {
   width: 100%;
   height: 0.5rem;
-  border-radius: 9999px;
+  border-radius: var(--radius-full);
   background: var(--color-surface-muted, var(--color-border));
   overflow: hidden;
 }
 
 .token-budget-panel-bar-fill {
   height: 100%;
-  border-radius: 9999px;
+  border-radius: var(--radius-full);
   transition: width 0.2s ease;
 }
 
@@ -92,8 +92,8 @@
 .token-budget-panel-calibration {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  padding-top: 0.5rem;
+  gap: var(--space-1);
+  padding-top: var(--space-2);
   border-top: 1px solid var(--color-border);
 }
 
@@ -107,7 +107,7 @@
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  gap: 0.5rem;
+  gap: var(--space-2);
 }
 
 .token-budget-panel-empty {

--- a/src/components/devtools/shared/DevToolsSection.css
+++ b/src/components/devtools/shared/DevToolsSection.css
@@ -26,5 +26,5 @@
 .devtools-section-body {
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: var(--space-1_5);
 }

--- a/src/stories/01-atoms/navigation/SkipLinks.stories.tsx
+++ b/src/stories/01-atoms/navigation/SkipLinks.stories.tsx
@@ -18,7 +18,7 @@ const meta: Meta<typeof SkipLinks> = {
     (Story) => (
       <div className="story-skiplinks">
         <Story />
-        <main id="main-content" tabIndex={-1} style={{ padding: 'var(--spacing-4, 1rem)' }}>
+        <main id="main-content" tabIndex={-1} style={{ padding: 'var(--space-4)' }}>
           Press Tab to reveal the skip links above.
         </main>
       </div>

--- a/src/stories/01-atoms/ui/Dialog.stories.tsx
+++ b/src/stories/01-atoms/ui/Dialog.stories.tsx
@@ -18,7 +18,7 @@ export const Open: Story = {
       <DialogContent className="story-dialog">
         <DialogTitle>Delete this world?</DialogTitle>
         <p>This removes the world and every character in it. This can&apos;t be undone.</p>
-        <div style={{ display: 'flex', gap: 'var(--spacing-2, 0.5rem)', justifyContent: 'flex-end' }}>
+        <div style={{ display: 'flex', gap: 'var(--space-2)', justifyContent: 'flex-end' }}>
           <Button variant="secondary">Cancel</Button>
           <Button variant="destructive">Delete</Button>
         </div>

--- a/src/stories/02-molecules/narrative/RequirementBadges.stories.tsx
+++ b/src/stories/02-molecules/narrative/RequirementBadges.stories.tsx
@@ -15,7 +15,7 @@ type Story = StoryObj;
 
 export const Alignments: Story = {
   render: () => (
-    <div style={{ display: 'flex', gap: 'var(--spacing-2, 0.5rem)' }}>
+    <div style={{ display: 'flex', gap: 'var(--space-2)' }}>
       <AlignmentBadge alignment="lawful" />
       <AlignmentBadge alignment="chaotic" />
     </div>

--- a/src/stories/02-molecules/world-forms/WorldFormFields.stories.tsx
+++ b/src/stories/02-molecules/world-forms/WorldFormFields.stories.tsx
@@ -12,7 +12,7 @@ type Story = StoryObj;
 
 export const Fields: Story = {
   render: () => (
-    <div style={{ display: 'grid', gap: 'var(--spacing-4, 1rem)', maxWidth: '480px' }}>
+    <div style={{ display: 'grid', gap: 'var(--space-4)', maxWidth: '480px' }}>
       <WorldFormFields.NameInput value="The Shattered Isles" onChange={() => {}} />
       <WorldFormFields.GenreSelect value="fantasy" onChange={() => {}} />
       <WorldFormFields.DescriptionTextArea

--- a/src/stories/03-organisms/game-session/ManuscriptActionRail.stories.tsx
+++ b/src/stories/03-organisms/game-session/ManuscriptActionRail.stories.tsx
@@ -22,7 +22,7 @@ type Story = StoryObj<typeof ManuscriptActionRail>;
 
 const choiceButtonStyle: React.CSSProperties = {
   padding: '0.5rem 1rem',
-  fontSize: '0.875rem',
+  fontSize: 'var(--font-size-sm)',
   border: '1px solid var(--color-border)',
   borderRadius: 'var(--radius-md)',
   fontFamily: 'var(--font-interface)',
@@ -53,7 +53,7 @@ export const Streaming: Story = {
     isStreaming: true,
     children: (
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem', padding: '1rem', background: 'color-mix(in srgb, var(--color-surface) 80%, transparent)', backdropFilter: 'blur(4px)', borderTop: '1px solid var(--color-border)' }}>
-        <span style={{ fontSize: '0.75rem', fontFamily: 'var(--font-system)', color: 'var(--color-accent)' }}>Generating narrative...</span>
+        <span style={{ fontSize: 'var(--font-size-xs)', fontFamily: 'var(--font-system)', color: 'var(--color-accent)' }}>Generating narrative...</span>
       </div>
     ),
   },

--- a/src/stories/03-organisms/game-session/ManuscriptDrawer.stories.tsx
+++ b/src/stories/03-organisms/game-session/ManuscriptDrawer.stories.tsx
@@ -40,7 +40,7 @@ export const CharacterSheet: Story = {
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
           <h4 style={{ fontFamily: 'var(--font-narrative)', fontWeight: 700 }}>Attributes</h4>
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.5rem', fontSize: '0.875rem' }}>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.5rem', fontSize: 'var(--font-size-sm)' }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', borderBottom: '1px solid var(--color-border)', paddingBottom: '0.25rem' }}><span>Strength</span><span>14</span></div>
             <div style={{ display: 'flex', justifyContent: 'space-between', borderBottom: '1px solid var(--color-border)', paddingBottom: '0.25rem' }}><span>Dexterity</span><span>12</span></div>
             <div style={{ display: 'flex', justifyContent: 'space-between', borderBottom: '1px solid var(--color-border)', paddingBottom: '0.25rem' }}><span>Intelligence</span><span>16</span></div>
@@ -68,10 +68,10 @@ export const Inventory: Story = {
         ].map((item) => (
           <div key={item.name} style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', borderBottom: '1px solid var(--color-border)', paddingBottom: '0.5rem' }}>
             <div>
-              <div style={{ fontSize: '0.875rem', fontWeight: 500 }}>{item.name}</div>
-              <div style={{ fontSize: '0.75rem', color: 'var(--color-text-muted)' }}>{item.desc}</div>
+              <div style={{ fontSize: 'var(--font-size-sm)', fontWeight: 500 }}>{item.name}</div>
+              <div style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-text-muted)' }}>{item.desc}</div>
             </div>
-            <span style={{ fontSize: '0.75rem', color: 'var(--color-text-muted)', marginLeft: '0.5rem' }}>x{item.qty}</span>
+            <span style={{ fontSize: 'var(--font-size-xs)', color: 'var(--color-text-muted)', marginLeft: '0.5rem' }}>x{item.qty}</span>
           </div>
         ))}
       </div>

--- a/src/stories/03-organisms/game-session/ManuscriptFloatingHud.stories.tsx
+++ b/src/stories/03-organisms/game-session/ManuscriptFloatingHud.stories.tsx
@@ -39,8 +39,8 @@ export const CharacterPanelOpen: Story = {
     characterSummaryPanel: (
       <div style={{ padding: '1rem', background: 'var(--color-surface)', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-lg)', boxShadow: 'var(--shadow-drawer)' }}>
         <h4 style={{ fontFamily: 'var(--font-narrative)', fontWeight: 700, marginBottom: '0.5rem' }}>The Archivist</h4>
-        <div style={{ fontSize: '0.875rem', color: 'var(--color-text-muted)' }}>Level 4 Scholar</div>
-        <div style={{ marginTop: '0.75rem', display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.75rem' }}>
+        <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-muted)' }}>Level 4 Scholar</div>
+        <div style={{ marginTop: '0.75rem', display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: 'var(--font-size-xs)' }}>
           <div style={{ display: 'flex', justifyContent: 'space-between' }}><span>Strength</span><span>8</span></div>
           <div style={{ display: 'flex', justifyContent: 'space-between' }}><span>Intelligence</span><span>16</span></div>
           <div style={{ display: 'flex', justifyContent: 'space-between' }}><span>Wisdom</span><span>14</span></div>

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -2823,7 +2823,7 @@ body.manuscript-overlay-open {
    ~193px empty band between short narrative content and the docked choices
    rail on tall viewports. */
 :root .manuscript-main-content {
-  padding: 3rem 1.5rem 4rem;
+  padding: 3rem var(--space-6) 4rem;
 }
 
 /* Dot grid background overlay — same canonical pattern as the app surface
@@ -2937,7 +2937,7 @@ body.manuscript-overlay-open {
 
 :root .manuscript-suggested-action {
   position: relative;
-  padding: var(--space-4) 1.25rem var(--space-4) 2.5rem;
+  padding: var(--space-4) var(--space-5) var(--space-4) 2.5rem;
   border-radius: var(--radius-lg);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
@@ -2973,7 +2973,7 @@ body.manuscript-overlay-open {
 :root .manuscript-suggested-action-label {
   font-size: 0.9375rem;
   line-height: 1.5;
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--space-1);
 }
 
 /* Rotate accent bar colors across choices — hover only */
@@ -3020,7 +3020,7 @@ body.manuscript-overlay-open {
   background: transparent;
   border: 1px solid var(--color-text-muted);
   border-radius: var(--radius-md);
-  padding: var(--space-2_5) 0.875rem;
+  padding: var(--space-2_5) var(--space-3_5);
   height: auto;
 }
 
@@ -3097,7 +3097,7 @@ body.manuscript-overlay-open {
   font-size: var(--font-size-2xs);
   font-weight: 600;
   letter-spacing: 0.1em;
-  padding: 2px 8px;
+  padding: var(--space-0_5) var(--space-2);
   background: var(--color-accent-soft);
   border-radius: var(--radius-sm);
 }
@@ -3209,13 +3209,13 @@ body.manuscript-overlay-open {
 :root .manuscript-ds3-controls {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-0_5);
   background: var(--color-surface);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
-  padding: 4px;
+  padding: var(--space-1);
 }
 
 :root .manuscript-ds3-controls .manuscript-hud-icon-button {


### PR DESCRIPTION
## Description

#1544 was blocked on having a `DESIGN.md` worth auditing against — priming a design critique off stale numbers just re-litigates the doc. With #1721 (Colors, Typography, Drafting Marks) and #1723 (Shapes, Elevation) both merged, that precondition's met, so this is the audit pass.

I ran Impeccable's critique across the app's surfaces in both color modes on this worktree's own dev server, primed with the corrected `DESIGN.md` plus ADR-013, and cross-checked every finding against the source with grep before believing it. The detector turned up 166 findings; most of them are noise once you know what's deliberate.

The diff here is deliberately narrow. It carries only the swaps where a literal resolves *identically* to a token that already exists — 49 of them, zero rendered pixels changed. Everything with a judgment call in it went to an issue instead, because a token-drift PR that also quietly changes what renders is the kind of thing nobody can review.

**Filed from this pass:**

- #1731 — [BUG] Eight undefined CSS custom properties silently drop their declarations. The worst is `.button-secondary:hover { background: var(--color-surface-muted) }` at `globals.css:233` — that token has zero definition sites, so hovering any secondary button drops its background to transparent.
- #1732 — [BUG] Two labels on accent bands fail WCAG AA: the wizard's active step in dark mode (measured 2.81:1 live) and the About CTA eyebrow in light (3.85:1).
- #1733 — Bullet eyebrows are drawn in accent across four surfaces, against DS3's drafting-marks weight rule. Twelve-plus accent marks where the rule allows one focal mark per surface.
- #1734 — The brand register doesn't suppress the header CTA, so `/` and `/about` each ship two accent primaries with near-identical labels.
- #1735 — [BUG] Plain links get Chrome's default focus ring (the DS rule only selects `.button`), and `.button` never resets the global link underline.
- #1736 — The type scale has an undocumented shadow ramp: 124 literal font-sizes on three off-scale steps.

**What I rejected as context-blind false positives** — the detector flags these, `DESIGN.md` documents them as deliberate:

- 149 `design-system-font-size` findings, mostly the 13/11/15px values. Real signal, wrong framing: they're not individually fixable anti-patterns, they're one systemic decision. Filed once as #1736 rather than 149 times.
- Four hex colors in `src/lib/utils/logger.ts:33-36`. Those are `console.log("%c…")` format strings — devtools output, not a rendered surface, and the console can't read custom properties anyway.
- `hsl(0 0% 96%)` in three story files — fallbacks behind `var(--color-surface-muted, …)`. The fallback color isn't the bug; the missing token is, and that's #1731.
- Off-scale radii (`1px`, `2px`, `3px`) in the wizard and manuscript CSS — hairlines and tick marks, not shapes. No radius token expresses a 1px hairline.
- The chrome-free play-entry states, the dot grid, drafting marks at one weight, and the brand/product register split — all named as deliberate in `DESIGN.md`, all flagged anyway by one lens or another.
- `src/app/opengraph-image.tsx`'s hardcoded hex — satori can't resolve custom properties, and the file says so. (One of its five values *is* stale: `#5B7A8C` is the pre-Ink-Blue accent, now `--color-info`. Left alone; it's a value decision on a surface with no theming, and #1710 already has that file open.)

## Related Issue

Closes #1544

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

No new tests. Every change is a substitution whose resolved value is provably identical, and `src/lib/theme/themes/__tests__/typeScaleMigration.test.ts` already guards the CSS half of the type scale. Extending that guard to `.tsx` — which is why the eight story literals survived this long — is written up in #1736 rather than smuggled in here.

## User Stories Addressed

N/A — design-system maintenance.

## Flow Diagrams

N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

Four story files change, but only their inline-style literals — no story structure, no new variants. Verified consistency by confirming each token's resolved value matches the literal it replaces, and by walking the app in both modes on this worktree's server (`:3580`).

## Implementation Notes

The five buckets:

| what | count | where |
|---|---|---|
| `border-radius: 4px` -> `var(--radius-sm)` | 15 | `src/app/wizard.css` |
| `border-radius: 9999px` -> `var(--radius-full)` | 2 | `TokenBudgetPanel.css` |
| padding/margin/gap literals -> `--space-*` | 20 | 7 files, mostly `TokenBudgetPanel.css` and `manuscript-session.css` |
| story `fontSize` literals -> `--font-size-sm`/`-xs` | 8 | 3 game-session story files |
| `--spacing-N` -> `--space-N` | 4 | 4 story files |

The `--spacing-N` ones are worth a note: `--spacing-2` and `--spacing-4` don't exist and never did. Those four stories have been running on their fallbacks (`0.5rem`, `1rem`) since they were written, which happen to equal `--space-2` and `--space-4` — so the fix is free, and the typo stops looking like a real token to the next person who greps for it.

Three declarations come out half-tokenized on purpose: `globals.css:447` (`0.1875rem` is 3px, off-scale), and `manuscript-session.css:2826` / `:2940` (`3rem`, `4rem`, `2.5rem`, same). Swapping only the values with an exact token is the whole point — rounding the rest onto a token would change what renders, which puts it in issue territory.

Radius targets were checked against the corrected `DESIGN.md` from #1723, not the version this branch started on.

## Screenshots

N/A — no rendered output changes.

## Visual Baseline Changes

None. No file under `tests/visual/**-snapshots/**` is touched, and by construction nothing this PR changes can move a baseline: every substituted token resolves to the byte-identical value the literal had.

## Code Review Summary (if applicable)

Ran `narraitor-pattern-alignment-skill` over the diff. Clean: token consumption via `var()` only, no color tokens touched (so no `hsl()` wrapping question), no `!important`, no Tailwind, no hardcoded values introduced, no comments added, nothing crossing a domain boundary.

## Chrome DevTools MCP Verification Summary (if applicable)

Used live browser probes during the audit rather than for verifying this diff. Two measurements worth recording, both now filed:

- `/worlds/create` in dark: `.wizard-progress-step-active .wizard-progress-label` renders `rgb(255,255,255)` on `rgb(119,158,197)` = **2.81:1**. (#1732)
- `/about` in light: five `.component-about-section-title` instances measure 5.04:1 on canvas; the sixth, on the `--color-accent-soft` CTA band, measures **3.85:1**. (#1732)

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Run from this worktree, exit codes checked directly:

- `npm test` — 385 suites, 2635 tests, exit 0
- `npm run type-check` — exit 0
- `npm run lint` — exit 0 (143 pre-existing warnings, none from this diff)
- `npm run lint:css` — exit 0

Security audit unchecked: no dependency or auth surface here.

## Testing Instructions

1. `npm run lint:css` and `npm test` from the worktree — both should be green.
2. Open `/worlds/create` and compare the input and step-indicator corners against `develop`. They should be pixel-identical; `--radius-sm` is `4px`.
3. In Storybook, open the three `03-organisms/game-session` Manuscript stories. Type sizes should be unchanged — `--font-size-sm` is `0.875rem`, `--font-size-xs` is `0.75rem`.
4. Confirm nothing collapsed: `grep -rn -- "--spacing-" src/` should return nothing.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

No comments added — none of these swaps needs explaining, and the rationale belongs in this PR rather than in the CSS. `DESIGN.md` needed no update: the audit confirmed its Colors, Typography, Drafting Marks, Shapes and Elevation sections all match the CSS after #1721 and #1723. The one claim the pass did contradict — Typography's "a handful of one-off in-between values" against an actual count of 148 — is #1736, because the correct replacement sentence depends on which way that decision goes. Accessibility findings (#1732, #1735) are filed rather than fixed here; both change rendered output.
