### PR TITLE
Serve the tutorial visual suite from a production build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,7 +355,11 @@ jobs:
     # server: two workers hitting two uncompiled routes at once stall the
     # single-process dev server past the navigation timeout. One worker per shard
     # removes that contention entirely; sharding keeps wall-clock reasonable.
-    # Stays on `next dev` so rendering (and committed baselines) is unchanged.
+    #
+    # Still on `next dev`. The prod-server switch is opt-in per job (see
+    # playwright.config.ts) and the tutorial job took it first; moving this one
+    # is TODO(#1740), which is blocked on one spec that needs isPlaywrightEnv()
+    # to stay false while still reading a store off window.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/playwright-tutorials.yml
+++ b/.github/workflows/playwright-tutorials.yml
@@ -33,7 +33,22 @@ jobs:
         run: npm ci
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
+
+      # The tours are served from a production build, not `next dev`, so no spec
+      # races a first-hit compile (#1521). Building here rather than inside
+      # Playwright's webServer command keeps build failures readable and keeps
+      # build time out of the server-boot timeout.
+      - name: Build the app
+        # getSiteUrl() refuses to fall back to localhost in a production build,
+        # so metadataBase and the sitemap can't publish a dead origin. Under
+        # test the origin genuinely is localhost:3000, so say so.
+        env:
+          NEXT_PUBLIC_SITE_URL: http://localhost:3000
+        run: npm run build:app
+
       - name: Run tutorial visual tests
+        env:
+          PLAYWRIGHT_PROD_SERVER: 'true'
         run: npm run test:visual:tutorials
       - name: Upload test results on failure
         uses: actions/upload-artifact@v4

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,6 +34,10 @@ function resolveBaseURL(): string {
  * across multiple browsers and viewports. Optimized for CI/CD environments.
  */
 
+// Opt a CI job into serving from a production build instead of `next dev`.
+// See the webServer block at the bottom of this file.
+const prodServer = process.env.PLAYWRIGHT_PROD_SERVER === 'true';
+
 // Shared Chromium settings for both the main visual project and the tutorial
 // project, so they render identically (viewport + font hinting).
 const chromiumUse = {
@@ -183,15 +187,23 @@ export default defineConfig({
   // Web server configuration for testing actual application pages
   // Note: webServer disabled for local development - assumes server is already running
   // CI will need this enabled for automated server management
+  //
+  // A job opts into a production server by setting PLAYWRIGHT_PROD_SERVER=true
+  // and running `npm run build:app` in an earlier step. `next dev` compiles a
+  // route's client chunks on first request, so whichever spec hits a cold route
+  // pays that cost inside its own timeouts — the root cause behind a long run
+  // of "flaky-red, zero pixel diffs" failures. A prebuilt server has nothing
+  // left to compile. The build is a separate CI step rather than part of this
+  // command so its cost sits in its own log and outside the boot timeout.
   webServer: process.env.CI ? {
-    command: 'npm run dev',
+    command: prodServer ? 'npm run start -- -p 3000' : 'npm run dev',
     url: 'http://localhost:3000',
     reuseExistingServer: true,
     // Increased timeout for server to start (especially in CI and app build)
     timeout: 240 * 1000,
     // Ensure server is fully ready before tests start
     env: {
-      NODE_ENV: 'development',
+      NODE_ENV: prodServer ? 'production' : 'development',
       PORT: '3000',
       NEXT_PUBLIC_DISABLE_TUTORIAL: 'true',
     },

--- a/src/components/ai/ProviderGate.tsx
+++ b/src/components/ai/ProviderGate.tsx
@@ -8,9 +8,10 @@ import { NoProviderModal } from './NoProviderModal';
 /**
  * Blocks AI-dependent screens when no provider is configured.
  *
- * Only the public production build blocks. Local dev and E2E (which runs `next
- * dev` and sets the Playwright flag) fall back to the server env key, so we
- * never block there — that also keeps the modal out of visual baselines. The
+ * Only the public production build blocks. Local dev and the test suites (which
+ * set the Playwright flag in-page, whichever server they're served from) fall
+ * back to the server env key, so we never block there — that also keeps the
+ * modal out of visual baselines. The
  * check waits for the store to hydrate so a saved provider doesn't briefly read
  * as missing.
  */

--- a/src/lib/utils/__tests__/shouldExposeStoreOnWindow.test.ts
+++ b/src/lib/utils/__tests__/shouldExposeStoreOnWindow.test.ts
@@ -1,0 +1,43 @@
+import { shouldExposeStoreOnWindow } from '../shouldExposeStoreOnWindow';
+import { isPlaywrightEnv } from '../isPlaywrightEnv';
+
+jest.mock('../isPlaywrightEnv', () => ({ isPlaywrightEnv: jest.fn() }));
+
+const mockIsPlaywrightEnv = isPlaywrightEnv as jest.Mock;
+
+const setNodeEnv = (value: string) => {
+  Object.defineProperty(process.env, 'NODE_ENV', {
+    value,
+    configurable: true,
+  });
+};
+
+describe('shouldExposeStoreOnWindow', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    setNodeEnv(originalNodeEnv as string);
+    jest.clearAllMocks();
+  });
+
+  it('exposes outside production regardless of Playwright', () => {
+    setNodeEnv('development');
+    mockIsPlaywrightEnv.mockReturnValue(false);
+
+    expect(shouldExposeStoreOnWindow()).toBe(true);
+  });
+
+  it('exposes in a production build when running under Playwright', () => {
+    setNodeEnv('production');
+    mockIsPlaywrightEnv.mockReturnValue(true);
+
+    expect(shouldExposeStoreOnWindow()).toBe(true);
+  });
+
+  it('stays closed for a real production visitor', () => {
+    setNodeEnv('production');
+    mockIsPlaywrightEnv.mockReturnValue(false);
+
+    expect(shouldExposeStoreOnWindow()).toBe(false);
+  });
+});

--- a/src/lib/utils/shouldExposeStoreOnWindow.ts
+++ b/src/lib/utils/shouldExposeStoreOnWindow.ts
@@ -1,0 +1,17 @@
+import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
+
+/**
+ * Whether a Zustand store should publish itself on `window` for seeding and
+ * debugging.
+ *
+ * Every store used to gate this on `NODE_ENV !== 'production'` alone, which is
+ * fine for a dev server but silently removes the seam from a `next build` —
+ * and the visual suites now serve from `next start`, where the specs still have
+ * to reach `window.useSessionStore` and friends to seed state.
+ *
+ * The Playwright escape hatch mirrors the tour hooks in TutorialProvider. It
+ * keys off an explicit in-page flag rather than the environment, so a real
+ * production visitor never trips it.
+ */
+export const shouldExposeStoreOnWindow = (): boolean =>
+  process.env.NODE_ENV !== 'production' || isPlaywrightEnv();

--- a/src/state/characterStore.ts
+++ b/src/state/characterStore.ts
@@ -26,6 +26,7 @@ const logger = new Logger('CharacterStore');
 // them without pulling in the store module. Re-exported here to keep the
 // existing import surface working.
 import type { Character, CharacterAttribute, CharacterSkill } from './characterStore.types';
+import { shouldExposeStoreOnWindow } from '@/lib/utils/shouldExposeStoreOnWindow';
 export type { Character, CharacterAttribute, CharacterSkill } from './characterStore.types';
 
 const addCharacterToRoster = (
@@ -725,7 +726,7 @@ export const useCharacterStore: UseBoundStore<StoreApi<CharacterStore>> =
   );
 
 // Expose store globally in development for testing and debugging
-if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
+if (typeof window !== 'undefined' && shouldExposeStoreOnWindow()) {
   window.useCharacterStore = useCharacterStore;
 }
 

--- a/src/state/inventoryStore.ts
+++ b/src/state/inventoryStore.ts
@@ -14,6 +14,7 @@ import { createEquipmentActions } from './inventoryStore.equipment';
 import { inventoryPersistOptions } from './inventoryStore.persistence';
 
 import Logger from '@/lib/utils/logger';
+import { shouldExposeStoreOnWindow } from '@/lib/utils/shouldExposeStoreOnWindow';
 const logger = new Logger('InventoryStore');
 
 export type {
@@ -46,7 +47,7 @@ export const useInventoryStore = create<InventoryStore>()(
 );
 
 // Expose store globally in development for easier debugging & manual seeding
-if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
+if (typeof window !== 'undefined' && shouldExposeStoreOnWindow()) {
   window.useInventoryStore = useInventoryStore;
 }
 

--- a/src/state/journalStore.ts
+++ b/src/state/journalStore.ts
@@ -14,6 +14,7 @@ import { generateUniqueId } from '../lib/utils/generateId';
 import { createIndexedDBStorage } from './persistence';
 import { safeTrim, getTimestamp } from '@/lib/utils';
 import { UserFriendlyError, createStoreError } from '@/lib/utils/errorUtils';
+import { shouldExposeStoreOnWindow } from '@/lib/utils/shouldExposeStoreOnWindow';
 
 
 /**
@@ -261,6 +262,6 @@ export const useJournalStore = create<JournalStore>()(
 ));
 
 // Expose store globally in development for easier debugging & manual seeding
-if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
+if (typeof window !== 'undefined' && shouldExposeStoreOnWindow()) {
   window.useJournalStore = useJournalStore;
 }

--- a/src/state/narrativeStore.ts
+++ b/src/state/narrativeStore.ts
@@ -11,6 +11,7 @@ import { createNarrativeSegmentActions } from './narrativeStore.segments';
 import { createNarrativeDecisionActions } from './narrativeStore.decisions';
 import { createNarrativeEndingActions } from './narrativeStore.endings';
 import { narrativePersistOptions } from './narrativeStore.persistence';
+import { shouldExposeStoreOnWindow } from '@/lib/utils/shouldExposeStoreOnWindow';
 
 const initialState = getInitialState();
 
@@ -45,7 +46,7 @@ export const useNarrativeStore = create<NarrativeStore>()(
 
 // Expose store globally in development for manual testing.
 // Typed in src/types/global.d.ts; matches the pattern used by sibling stores.
-if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
+if (typeof window !== 'undefined' && shouldExposeStoreOnWindow()) {
   window.useNarrativeStore = useNarrativeStore;
 }
 

--- a/src/state/npcStore.ts
+++ b/src/state/npcStore.ts
@@ -8,6 +8,7 @@ import { generateUniqueId } from '../lib/utils/generateId';
 import { createIndexedDBStorage } from './persistence';
 import { storeEvents, StoreEventTypes, type WorldDeletedEvent } from '@/lib/state/storePubSub';
 import { CrudStore } from './crudStore.types';
+import { shouldExposeStoreOnWindow } from '@/lib/utils/shouldExposeStoreOnWindow';
 
 export interface NPCStore extends CrudStore<NPC> {
   npcs: Record<EntityID, NPC>;
@@ -239,7 +240,7 @@ export const useNPCStore = create<NPCStore>()(
 
 // Expose store globally in development to support test data seeding
 // and debugging via window.useNPCStore in dev tools.
-if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
+if (typeof window !== 'undefined' && shouldExposeStoreOnWindow()) {
   window.useNPCStore = useNPCStore;
 }
 

--- a/src/state/sessionStore.ts
+++ b/src/state/sessionStore.ts
@@ -15,6 +15,7 @@ import {
   type SessionStartedEvent,
   type SessionEndedEvent,
 } from '@/lib/state/storePubSub';
+import { shouldExposeStoreOnWindow } from '@/lib/utils/shouldExposeStoreOnWindow';
 
 /**
  * Create logger instance for this store
@@ -737,6 +738,6 @@ export const useSessionStore = create<SessionStore>()(
 
 // Named export for consistent usage
 // Also expose store globally for dev/test to allow direct state seeding
-if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
+if (typeof window !== 'undefined' && shouldExposeStoreOnWindow()) {
   window.useSessionStore = useSessionStore;
 }

--- a/src/state/worldStore.ts
+++ b/src/state/worldStore.ts
@@ -14,6 +14,7 @@ import Logger from '@/lib/utils/logger';
 import { storeEvents, StoreEventTypes, type WorldDeletedEvent } from '@/lib/state/storePubSub';
 import { useSessionStore } from './sessionStore';
 import { trackFunnelStep } from '@/lib/analytics/trackFunnelStep';
+import { shouldExposeStoreOnWindow } from '@/lib/utils/shouldExposeStoreOnWindow';
 
 const logger = new Logger('WorldStore');
 
@@ -569,6 +570,6 @@ export const useWorldStore = create<WorldStore>()(
 
 // Expose store globally in development to support test data seeding
 // and debugging via window.useWorldStore in dev tools.
-if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
+if (typeof window !== 'undefined' && shouldExposeStoreOnWindow()) {
   window.useWorldStore = useWorldStore;
 }

--- a/tests/visual/utils/tutorial-helpers.ts
+++ b/tests/visual/utils/tutorial-helpers.ts
@@ -3,12 +3,15 @@ import { Page, expect } from '@playwright/test';
 /**
  * Navigate to a tutorial page without waiting for the `load` event.
  *
- * These specs run against `next dev`, which compiles client chunks on first
- * request. `load` waits for those chunks — app/layout.js alone measured ~12s on
- * a cold CI dev server — so a cold route can blow the 20s navigationTimeout even
- * though the document itself comes back in 0.6-1.6s. That's what turned the
- * Tutorial Visual Tests job into timeout roulette (#1519); #1344 is the same
- * failure mode in the main visual job.
+ * Written for `next dev`, which compiles client chunks on first request: `load`
+ * waits for those chunks — app/layout.js alone measured ~12s on a cold CI dev
+ * server — so a cold route could blow the 20s navigationTimeout even though the
+ * document itself came back in 0.6-1.6s. That's what turned the Tutorial Visual
+ * Tests job into timeout roulette (#1519).
+ *
+ * CI now serves these specs from a prebuilt server, so there's nothing left to
+ * compile and this is belt-and-braces rather than load-bearing. It stays for
+ * local runs, which still use whatever server the developer has up.
  *
  * Every caller follows this with waitForContentStable plus an explicit wait, so
  * dropping to domcontentloaded leaves nothing unsettled.
@@ -20,9 +23,11 @@ export const gotoTutorialPage = async (
   await page.goto(url, { waitUntil: 'domcontentloaded' });
 };
 
-// Hydration can't finish until `next dev` has compiled and served the client
-// chunks on first hit; app/layout.js alone has measured ~12s on a cold CI dev
-// server, so this budget covers compile + hydration, not hydration alone.
+// Sized for `next dev`, where hydration can't finish until the client chunks
+// have been compiled and served on first hit (app/layout.js alone has measured
+// ~12s on a cold CI dev server) — so the budget covers compile + hydration, not
+// hydration alone. CI's prebuilt server has no compile step left, but local runs
+// still hit a dev server, so the headroom stays.
 const STORE_READY_TIMEOUT_MS = 30000;
 
 export const waitForStoreReady = async (page: Page): Promise<void> => {


### PR DESCRIPTION
## Description

The Tutorial Visual Tests job now serves the app from a production build (`next build`, then `next start`) instead of `next dev`. `next dev` compiles a route's client chunks on the first request, so whichever spec hits a cold route pays that cost inside its own timeouts — that's the root cause behind the job's flaky-red-with-zero-pixel-diffs runs, and #1520's fix was a set of timeout budgets that *tolerate* the compile rather than remove it. A prebuilt server has nothing left to compile.

**Scope: the tutorial job only. The main E2E job stays on `next dev`, and #1740 carries it forward.** Reasoning is in the Implementation Notes — short version, the tutorial slice came out complete with zero baseline churn, and the main job has one spec with a genuine design conflict that deserves its own decision.

### The blocker, and how it's unlocked

The specs seed state through `window.useSessionStore` and friends. Every store gated that exposure on `process.env.NODE_ENV !== 'production'` alone, which is fine for a dev server and simply gone under `next start` — so `waitForStoreReady` and `setTutorialProgress` would hang and every tutorial spec would break.

`shouldExposeStoreOnWindow()` gives all seven stores the same escape hatch the tour hooks in `TutorialProvider` already had: `NODE_ENV !== 'production' || isPlaywrightEnv()`. `isPlaywrightEnv()` itself is untouched — it keys off an explicit in-page `window.__PLAYWRIGHT__` flag that the seeders set, not off the environment, so a real production visitor never trips it. The widening is at the seven call sites, not in the helper.

Proved rather than assumed, against a local `next start`:

| | `__PLAYWRIGHT__` set | no flag (a real visitor) |
|---|---|---|
| all 7 `window.use*Store` | present | absent |
| `window.__TEST_START_TOUR__` | `function` | absent |

Worth recording: the browser's UA under Playwright is `...HeadlessChrome/141...`, with no "Playwright" in it. The UA branch in `isPlaywrightEnv()` really is just a fallback — `window.__PLAYWRIGHT__` is what does the work.

### The switch

`playwright.config.ts` reads `PLAYWRIGHT_PROD_SERVER=true` and swaps the `webServer` command for `npm run start -- -p 3000`. It's opt-in per job, so `ci.yml`'s `e2e` job keeps its dev server with nothing conditional bolted onto it. `PORT` and `NEXT_PUBLIC_DISABLE_TUTORIAL` carry over unchanged.

The build is its own workflow step rather than part of the `webServer` command, so a build failure reads as a build failure and build time doesn't eat the 240s server-boot timeout. It needs `NEXT_PUBLIC_SITE_URL` — `getSiteUrl()` deliberately refuses to fall back to localhost in a production build so the sitemap and canonicals can't publish a dead origin. Under test the origin genuinely is `localhost:3000`, so the step says so.

## Related Issue

Closes #1521

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

`shouldExposeStoreOnWindow()` has three unit tests covering the case that mattered: closed for a real production visitor, open in a production build under Playwright, open outside production either way. They were written alongside the helper rather than before it — the change started from a measurement (does the seam survive `next start`?), and the helper is what that measurement asked for.

## User Stories Addressed

N/A — CI test infrastructure.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

No components changed. Visual consistency is the headline result below: all 38 tutorial baselines match the prod-server render with no edits.

## Implementation Notes

### Why the tutorial job only

The issue offered scoping to the tutorial job first as a proof. I measured both before choosing.

**Tutorials came out clean.** All 9 spec files, 38 snapshots, green against a local `next start` at `maxDiffPixels: 100` — the tightened budget from #1737, so this is a real result and not slack absorbing drift. `git status` after the run showed zero snapshot churn. The whole project ran in 13.9s. Nothing to adopt, nothing to review.

**The main suite is close but not free.** 128 of 131 chromium tests pass unchanged under the same conditions. The three failures:

- `characters-roster.spec.ts` seeds by hand and never sets `__PLAYWRIGHT__`, so the seam stays closed and its hydration wait times out. Small fix.
- `verify-fresh-session.spec.ts` is the real one. Its file header is explicit that `isPlaywrightEnv()` must stay **false** so `NarrativeController` generates the first scene live — and it *also* reads `window.useNarrativeStore` to assert segments arrived. Under a prod server those two needs are in direct conflict: no store seam without flipping the AI gate. Resolving it means either re-pointing the assertion at the DOM or splitting the seam onto a second flag. That's a design call, not a patch.
- `main-pages.spec.ts`'s `home-page.png` drifts 2103 px, a single 48x48 box where the seeded Cyberpunk world's thumbnail renders in the capture and is blank in the baseline. **This one isn't about prod at all** — I ran the same spec against a dev server and the two captures are pixel-identical to each other, both 2103 px off the baseline. It's a local-vs-CI divergence (CI's on-demand image optimization is slower than a Mac's), so I left the baseline alone.

So: a finished narrow slice with nothing to adopt, versus a broad one carrying an unresolved design question. Took the narrow one. #1740 has the full write-up, including the numbers above, so whoever picks it up starts from measurement rather than a blank page. The `e2e` job's comment in `ci.yml` points at it.

### What it bought, measured on CI

Comparing this PR's Tutorial Visual Tests run against the last one on `develop`, same runner type:

| | `develop` (`next dev`) | this PR (`next start`) |
|---|---|---|
| Playwright wall time | 1.1m | 37.7s |
| test step | 68s | 39s |
| build step | — | 45s |
| whole job | 2m24s | 2m42s |

Per-spec time drops by about 40% and the compile race is gone outright; the build step gives most of that back at the job level, so total wall clock is roughly flat. The win is determinism, not speed — no spec is racing a compiler inside its own timeout any more.

### Stale comments swept while in here

`ProviderGate`'s doc said E2E "runs `next dev`". `tutorial-helpers.ts` explained its `domcontentloaded` navigation and 30s store-ready budget purely as cold-compile cover. Both are now accurate: those budgets are belt-and-braces on CI and still load-bearing for local runs against a dev server.

`NEXT_PUBLIC_DISABLE_TUTORIAL` is kept as-is, but it's worth flagging that nothing in `src/` reads it — it appears exactly once in the repo, in the config block it's set from. Left alone rather than swept up with a server switch.

## Screenshots

N/A — no UI changes.

## Visual Baseline Changes

None. No file under `tests/visual/**-snapshots/**` is touched. That's the notable part: all 38 tutorial baselines match the production-server render as committed.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A — verified with Playwright directly against a local `next start`, since the point was to test the served build.

## Quality Checks (if applicable)

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

From the worktree, exit codes checked directly:

| Check | Result |
|---|---|
| `npm test` | 393 suites, 2681 tests, exit 0 |
| `npm run type-check` | exit 0 |
| `npm run lint` | exit 0 (143 pre-existing warnings, 0 errors) |
| `npm run build:app` | exit 0 |
| `npm run deps:validate` | exit 0, baseline holds at 17 |
| `npm run deps:check` | exit 0, all 17 still reproducing |
| `npx playwright test --project=tutorials` (vs `next start`) | 9/9 files, 38/38 snapshots, exit 0 |

## Testing Instructions

From this branch:

1. **Build and serve it the way CI now does.** `NEXT_PUBLIC_SITE_URL=http://localhost:<port> npm run build:app`, then `npx next start -p <port>`. The build should not need any other env var.
2. **Check the seam both ways.** With `window.__PLAYWRIGHT__` set before navigation, all seven `window.use*Store` handles and `window.__TEST_START_TOUR__` should be present. In an ordinary browser tab on the same server, none of them should exist — that's the property that keeps this out of a real production build.
3. **Run the tours against it.** `TZ=UTC PLAYWRIGHT_BASE_URL=http://localhost:<port> npx playwright test --project=tutorials`. Expect 9 passed and, importantly, a clean `git status` afterwards — no snapshot writes.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed
