### PR TITLE
docs: plain-language pass on gracefully, AI-tell copy, and vague errors

### DIFF
--- a/public_docs/api/character-creation-auto-save-api.md
+++ b/public_docs/api/character-creation-auto-save-api.md
@@ -274,7 +274,7 @@ const savedData = {
 
 ### Storage Errors
 
-The system gracefully handles localStorage errors:
+localStorage errors are caught and fail silently, without notifying the player:
 
 ```typescript
 try {
@@ -289,7 +289,7 @@ try {
 
 ### Data Corruption
 
-Corrupted save data is handled gracefully:
+Corrupted save data keeps the recovery flag set but clears the preview, instead of crashing the load:
 
 ```typescript
 try {

--- a/public_docs/api/goal-system-api.md
+++ b/public_docs/api/goal-system-api.md
@@ -63,7 +63,7 @@ clearSessionGoals(sessionId: EntityID): void
 ```
 
 #### AI Integration
-This is where the magic happens - automatically detecting goals from narrative content:
+Automatically detects goals from narrative content:
 
 ```typescript
 // Process narrative segment for goal extraction. Takes the segment object, not its ID,
@@ -198,7 +198,7 @@ interface GoalExtractionResult {
 
 ## Error Handling
 
-The goal system is designed to fail gracefully because we're dealing with AI that can be unpredictable and user content that can be messy.
+The goal system is designed to keep working when things go wrong, because we're dealing with AI that can be unpredictable and user content that can be messy.
 
 ### Validation
 - Goal creation requires title, description, and sessionId
@@ -209,7 +209,7 @@ The goal system is designed to fail gracefully because we're dealing with AI tha
 When the AI fails to extract goals properly, we fall back to pattern matching. It's not as smart, but it's reliable:
 
 - Pattern matching when AI extraction fails
-- Graceful degradation for missing data
+- Falls back to a default when data is missing
 - Silent failures for non-critical operations
 
 ### Error States

--- a/public_docs/architecture/ADR-009-guided-onboarding-system.md
+++ b/public_docs/architecture/ADR-009-guided-onboarding-system.md
@@ -19,7 +19,7 @@ Built a guided onboarding system for new users:
 1. **Automatically detects first-time users** using session state analysis
 2. **Simplifies world creation** to just 2 essential steps (concept + details) instead of the full complex flow
 3. **Uses AI to enhance user input** with contextually appropriate defaults so they don't have to figure everything out
-4. **Provides seamless progression** from world to character creation so there's no dead ends
+4. **Moves straight from world to character creation** with no dead end in between
 5. **Maintains professional UX standards** with responsive design and proper error handling
 
 ## Implementation Architecture
@@ -58,21 +58,18 @@ Built a guided onboarding system for new users:
 ## Benefits
 
 ### User Experience
-- **Reduced Time-to-Value**: Users can create a world and start playing within 2 minutes instead of getting stuck in setup
-- **Lower Cognitive Load**: Only 2 essential decisions required upfront instead of overwhelming them with options
-- **Contextual Guidance**: Examples and hints that actually relate to fictional universe RPGs, not generic stuff
-- **Seamless Flow**: Automatic progression from world to character creation so they never hit a dead end
+- Users can create a world and start playing within 2 minutes, instead of getting stuck in setup
+- Only 2 essential decisions required upfront, instead of the full attribute/skill flow
+- Examples and hints relate to the world being built, not generic placeholder text
+- Character creation follows immediately from world creation, with no dead end in between
 
 ### Technical Benefits
-- **Reusable Patterns**: Wizard framework applicable to other complex flows
-- **AI Integration**: Demonstrates effective use of AI for user enhancement
-- **Responsive Design**: Mobile-first approach with optimized placeholder text
-- **Error Handling**: Standardized patterns for consistent user experience
+- The wizard framework is reusable for other multi-step flows
+- Mobile-first layout with placeholder text sized for small screens
+- Error handling follows the same patterns as the rest of the app
 
 ### Business Impact
-- **Improved Conversion**: First-time users more likely to complete initial setup
-- **Reduced Support**: Self-explanatory interface reduces need for documentation
-- **Engagement**: Users start playing faster, increasing retention likelihood
+- Expected to improve first-time completion rate and reduce support requests, though this hasn't been measured yet
 
 ## Consequences
 

--- a/public_docs/features/ai-consistency-validation.md
+++ b/public_docs/features/ai-consistency-validation.md
@@ -2,7 +2,7 @@
 
 ## What This Solves
 
-Ever wonder why the AI suddenly forgets that your medieval world doesn't have spaceships? Or why it starts talking about magic when you're running a hard sci-fi campaign? This debugging tool is for figuring out what's going wrong when the AI goes off the rails.
+Sometimes the AI forgets that your medieval world doesn't have spaceships, or starts talking about magic in a hard sci-fi campaign. This debugging tool is for figuring out what's going wrong when the AI goes off the rails.
 
 The challenge with AI storytelling is that the AI needs constant reminders about your world's rules, and sometimes those reminders don't work as expected. This system lets you peek under the hood and see exactly how the AI is processing your lore facts and what consistency instructions it's generating for itself.
 

--- a/public_docs/features/narrative-consistency-tracking.md
+++ b/public_docs/features/narrative-consistency-tracking.md
@@ -144,7 +144,7 @@ Goals persist across browser sessions using IndexedDB:
 - **Caching**: Reuses context when appropriate
 
 ### Error Handling
-- **Graceful Degradation**: System continues without goals if needed
+- **Fallback**: System continues without goals if needed
 - **Fallback Mechanisms**: Pattern matching when AI fails
 - **Validation**: Ensures data integrity throughout lifecycle
 
@@ -204,7 +204,7 @@ const completionRate = completedGoals.length / (completedGoals.length + activeGo
 ### Error Resilience
 - Always provide fallback behavior
 - Validate goal data before processing
-- Handle AI service failures gracefully
+- Handle AI service failures instead of letting them crash the session
 - Log errors for debugging without breaking UX
 
 ### Testing Strategy

--- a/public_docs/features/personalized-narrative-system.md
+++ b/public_docs/features/personalized-narrative-system.md
@@ -2,7 +2,7 @@
 
 ## Why This Matters
 
-Ever notice how some players love getting into long conversations with NPCs while others just want to stab things and move on? Or how some people want every tiny detail described while others prefer to get straight to the action?
+Some players love long conversations with NPCs; others just want to stab things and move on. Some want every detail described; others prefer to get straight to the action.
 
 This system watches how players actually play and adapts the storytelling to match their style. Instead of manually calculating complex patterns, we send raw decision data to Gemini and let the LLM do what it's good at - recognizing patterns and adapting narratives.
 

--- a/public_docs/features/portrait-generation-guide.md
+++ b/public_docs/features/portrait-generation-guide.md
@@ -196,7 +196,7 @@ const handlePortraitGeneration = async (character: Character, world: World) => {
 };
 ```
 
-### Graceful Degradation
+### Fallback When Generation Fails
 ```tsx
 const PortraitSection = ({ character }: { character: Character }) => {
   const [portrait, setPortrait] = useState<Portrait | null>(null);

--- a/public_docs/systems/narrative-generation.md
+++ b/public_docs/systems/narrative-generation.md
@@ -9,7 +9,7 @@ updated: 2025-10-11
 
 # Narrative Generation System
 
-This is the heart of what makes Narraitor special - AI that doesn't just generate random text, but actually creates coherent stories that feel like they belong in your world. Whether you're in a cyberpunk dystopia or a medieval fantasy realm, the AI adapts its language, tone, and content to match.
+Narraitor's narrative generation creates coherent stories that feel like they belong in your world, rather than generic text. A cyberpunk dystopia and a medieval fantasy realm get different language, tone, and content from the same engine.
 
 ## Overview
 
@@ -75,7 +75,7 @@ import { NarrativeHistoryManager } from '@/components/Narrative/NarrativeHistory
 
 ### World-Specific Adaptation
 
-This is where the magic happens - the AI actually understands what kind of world you've created and adapts accordingly:
+The AI adapts to the kind of world you've created:
 
 1. **Theme-Based Content**: A Western world feels like the Wild West, not generic fantasy
 2. **Smart Starting Locations**: No more starting in taverns when you're on a space station:
@@ -132,7 +132,7 @@ The narrative system consistently uses second-person perspective ("you") to crea
 
 The system includes several safeguards to prevent common issues. Initial scene deduplication ensures you don't get multiple opening scenes generated for the same session - it happened during early testing and was confusing. Choice tracking prevents the same choice from triggering multiple narrative generations, which could happen if a player clicked quickly or if the UI re-rendered.
 
-Component lifecycle management prevents state updates after a component unmounts, which React will complain about loudly. Error recovery handles AI service failures gracefully instead of crashing, and JSON parsing includes fallbacks for different response formats since the AI doesn't always return perfectly structured JSON.
+Component lifecycle management prevents state updates after a component unmounts, which React will complain about loudly. Error recovery catches AI service failures instead of crashing, and JSON parsing includes fallbacks for different response formats since the AI doesn't always return perfectly structured JSON.
 
 ### AI API Call Patterns
 

--- a/public_docs/systems/world-creation-wizard.md
+++ b/public_docs/systems/world-creation-wizard.md
@@ -72,10 +72,10 @@ We keep the validation reasonable but firm - enough to prevent obviously broken 
 
 ### Error Handling
 
-Everything's designed to fail gracefully so users never get stuck:
+Errors are caught so users never get stuck:
 
 - Form validation errors display inline
-- AI failures gracefully fallback to defaults
+- AI failures fall back to defaults
 - Creation errors are caught and displayed
 
 ## API

--- a/public_docs/technical-guides/components/recovery-notification.md
+++ b/public_docs/technical-guides/components/recovery-notification.md
@@ -178,7 +178,7 @@ const getStepDescription = (step?: number) => {
 
 ### Timestamp Formatting
 
-Handles various timestamp formats and errors gracefully:
+Falls back to no timestamp if the format is invalid:
 
 ```typescript
 const formattedDate = lastSaved ? formatDateTime(lastSaved) : null;

--- a/public_docs/technical-guides/error-handling.md
+++ b/public_docs/technical-guides/error-handling.md
@@ -7,7 +7,7 @@ updated: 2025-06-26
 
 # Error Handling
 
-This error handling here focuses on being helpful to users rather than just logging technical details. The pattern is to catch errors gracefully, show user-friendly messages, and provide retry options when it makes sense.
+This error handling focuses on being helpful to users rather than just logging technical details. The pattern is to catch errors, show user-friendly messages, and provide retry options when it makes sense.
 
 ## Standard Pattern
 

--- a/public_docs/technical-guides/goal-system-integration.md
+++ b/public_docs/technical-guides/goal-system-integration.md
@@ -37,7 +37,7 @@ const processNewSegment = async (segment: NarrativeSegment) => {
 ```
 
 ### AI Context Integration
-Goals are automatically included in AI prompts through the context building system. This is where the magic happens - the AI gets a summary of active goals along with the regular prompt, so it can generate content that's actually relevant to what the player is trying to achieve.
+Goals are automatically included in AI prompts through the context building system. The AI gets a summary of active goals along with the regular prompt, so it can generate content that's actually relevant to what the player is trying to achieve.
 
 ```typescript
 // In narrative generation or AI calls
@@ -164,7 +164,7 @@ const initializeStores = async () => {
 
 ## Error Handling Integration
 
-### Graceful Degradation
+### Failing Without Breaking the Session
 The system continues to function even when goal operations fail. The philosophy is that goal tracking enhances the experience but shouldn't break it if something goes wrong.
 
 ```typescript

--- a/public_docs/technical-guides/goal-tracking-usage.md
+++ b/public_docs/technical-guides/goal-tracking-usage.md
@@ -220,7 +220,7 @@ try {
 }
 ```
 
-### Graceful Degradation
+### Fallback Context
 ```typescript
 // Always provide fallback context
 const context = await useAiContextStore.getState().buildContextForSession(sessionId);

--- a/public_docs/technical-guides/lore-tracking-system.md
+++ b/public_docs/technical-guides/lore-tracking-system.md
@@ -70,7 +70,7 @@ The lore system plugs into several places to maintain consistency:
 
 **Session Scoping** - Facts can be filtered by session or world-wide, depending on what context you need.
 
-**Error Handling** - Graceful degradation when AI services are unavailable. The story continues even if lore extraction fails.
+**Error Handling** - The story continues even if lore extraction fails or AI services are unavailable.
 
 ### AI Prompt Enhancement
 The lore system integrates with both narrative and choice generation:

--- a/public_docs/technical-guides/navigation-loading-system.md
+++ b/public_docs/technical-guides/navigation-loading-system.md
@@ -54,7 +54,7 @@ The system is smart about when to show loading indicators. There's a **minimum d
 **Focus Trapping** keeps keyboard focus in the loading modal, **ARIA Support** provides screen reader announcements, and **Keyboard Controls** let users hit Escape to cancel. Accessibility was built in from the start, not added as an afterthought.
 
 ### Error Handling
-There's **automatic cleanup** with a 30-second safety timeout in case something goes wrong, **graceful degradation** that continues navigation even if loading fails, and **error boundaries** that integrate with Next.js error handling. Basically, it fails gracefully instead of breaking the user experience.
+There's **automatic cleanup** with a 30-second safety timeout in case something goes wrong, navigation continues even if loading fails, and **error boundaries** integrate with Next.js error handling.
 
 ### Router Integration
 **Next.js App Router** integration works directly with router events, **route changes** are automatically detected for navigation start/end, and **client-side navigation** works with all Next.js navigation methods. It hooks into the router instead of trying to guess when navigation happens.

--- a/public_docs/technical-guides/navigation-persistence-guide.md
+++ b/public_docs/technical-guides/navigation-persistence-guide.md
@@ -52,4 +52,4 @@ Keep the navigation system fast and reliable:
 - History is capped at `preferences.maxRecentPages` (default 10) and dedupes by path, so revisiting a page moves it to the top rather than duplicating it
 - Read recent pages through `getRecentPages(limit?)` and check prior visits with `hasVisited(path)` rather than poking at `history` directly
 - Store minimal data in navigation state - just what you need to reconstruct context
-- Handle storage quota limits gracefully with fallbacks
+- Handle storage quota limits with fallbacks

--- a/public_docs/technical-guides/state-management-usage.md
+++ b/public_docs/technical-guides/state-management-usage.md
@@ -214,7 +214,7 @@ const useWorldStats = (worldId: string) => {
 
 **Reset state** in tests to avoid test pollution - one test's data shouldn't affect another.
 
-**Handle errors** gracefully with error states - the stores provide error handling, use it.
+**Handle errors** with error states - the stores provide error handling, use it.
 
 **Batch updates** when making multiple changes - don't trigger a re-render for every tiny change.
 

--- a/public_docs/templates/feature-implementation-template.md
+++ b/public_docs/templates/feature-implementation-template.md
@@ -44,7 +44,7 @@ Explain what's being tested and why, not just a checklist of test types.
 
 **Integration Tests**: How components work together or interact with stores/APIs. Explain what scenarios are covered.
 
-**Edge Cases**: Specific weird situations that needed test coverage, like "handles missing data gracefully" or "recovers from network failures."
+**Edge Cases**: Specific weird situations that needed test coverage — describe what actually happens, like "shows a placeholder when the avatar fails to load" or "retries once before showing an error banner."
 
 ## Verification Steps
 

--- a/src/app/README.md
+++ b/src/app/README.md
@@ -1,6 +1,6 @@
 # Narraitor Routes (App Router)
 
-This directory uses the Next.js App Router architecture, which replaced the previous Pages Router implementation. So basically, we migrated from the old file-based routing to the new App Router because it gives us better layouts, loading states, and nested routing capabilities.
+This directory uses the Next.js App Router, which replaced the old Pages Router — better layouts, loading states, and nested routing.
 
 ## How the Routes Work
 
@@ -30,7 +30,7 @@ The wizard is fully implemented:
 - **5 steps**: Basic Info, Description, Attributes, Skills, Finalize
 - **6 default attributes**: Strength, Intelligence, Agility, Charisma, Dexterity, Constitution
 - **12 default skills** with "Learning Curve" instead of "Difficulty" (which tested better with users)
-- **Smart navigation** to `/worlds` on completion or cancellation
+- **Navigates** to `/worlds` on completion or cancellation
 - **State persistence** between steps so you don't lose your work
 - **Local storage integration** for created worlds
 

--- a/src/app/api/generate-ending-image/README.md
+++ b/src/app/api/generate-ending-image/README.md
@@ -45,7 +45,7 @@ This API endpoint generates AI-powered image prompts for story ending visualizat
 ## Features
 
 - **AI-First Approach:** Uses Google Gemini to generate contextual image prompts
-- **Graceful Degradation:** Falls back to tone-appropriate prompts when AI fails
+- **Fallback prompts:** Tone-appropriate prompts are used when AI generation fails
 - **Tone-Aware Fallbacks:** Different fallback prompts for each ending tone
 - **Accessibility:** Always includes descriptive alt text
 

--- a/src/app/characters/page.tsx
+++ b/src/app/characters/page.tsx
@@ -427,7 +427,7 @@ export default function CharactersPage() {
     } catch {
       addToast({
         title: 'Delete Failed',
-        description: 'Failed to delete character. Please try again.',
+        description: "Couldn't delete this character. Try again in a moment.",
         variant: 'error',
       });
       setDeleteDialog((prev) => ({ ...prev, isDeleting: false }));

--- a/src/app/dev/lore-viewer/page.tsx
+++ b/src/app/dev/lore-viewer/page.tsx
@@ -141,9 +141,9 @@ export default function LoreViewerTestPage() {
       const afterCount = getFacts({ worldId }).length;
       const extracted = afterCount - beforeCount;
 
-      status.show(`AI extraction successful! Added ${extracted} facts with robust error handling.`);
+      status.show(`AI extraction successful! Added ${extracted} facts.`);
     } catch (error) {
-      status.show(`AI extraction failed gracefully: ${error}`);
+      status.show(`AI extraction failed: ${error}`);
     }
   };
 

--- a/src/components/CharacterEditor/CharacterEditor.tsx
+++ b/src/components/CharacterEditor/CharacterEditor.tsx
@@ -138,7 +138,7 @@ const CharacterEditor: React.FC<CharacterEditorProps> = ({ characterId }) => {
       useCharacterStore.getState().updateCharacter(characterId, { portrait });
     } catch (error) {
       logger.error('Failed to generate portrait:', error);
-      setPortraitError('Failed to generate portrait. Please try again.');
+      setPortraitError("Couldn't generate a portrait. Try again in a moment.");
     } finally {
       setGeneratingPortrait(false);
     }

--- a/src/components/CharacterPortrait/README.md
+++ b/src/components/CharacterPortrait/README.md
@@ -4,7 +4,7 @@ This component handles displaying character portraits throughout the app. The ch
 
 ## What It Does
 
-The component shows character portraits using actual AI-generated images when available, but gracefully handles all the edge cases:
+The component shows character portraits using actual AI-generated images when available, and covers the edge cases:
 
 - **Real AI-Generated Portraits**: Uses Google's Imagen 3.0 API for actual character portraits
 - **Intelligent Fallbacks**: Character-specific SVG placeholders when API unavailable

--- a/src/components/GameSession/README.md
+++ b/src/components/GameSession/README.md
@@ -78,12 +78,12 @@ Each component is tested:
 
 ## AI Choice Generation Features
 
-The `ActiveGameSession` component includes some pretty sophisticated AI features:
+The `ActiveGameSession` component includes these AI features:
 
 ### Core AI Features
 - **Automated Choice Generation**: AI-powered player choices based on narrative context
 - **Contextual Integration**: Choices reflect recent story segments and world themes
-- **Smart Loading States**: Smooth transitions with "Generating your choices..." feedback
+- **Loading States**: Smooth transitions with "Generating your choices..." feedback
 - **Error Recovery**: Graceful fallbacks when AI generation fails
 
 ### Technical Implementation

--- a/src/components/GuidedFirstTimeExperience/README.md
+++ b/src/components/GuidedFirstTimeExperience/README.md
@@ -6,7 +6,7 @@ This gets new players from "I have no idea what this app does" to "I'm playing a
 
 **Just three steps** - Welcome (explains the value), World Concept (describe what you want), World Details (pick a name and theme). That's it.
 
-**Smart defaults everywhere** - Most settings are pre-filled with sensible choices, so you only have to make the decisions that actually matter for your experience.
+**Sensible defaults** - Most settings are pre-filled, so you only have to make the decisions that actually matter.
 
 **Real-time validation** - No surprises at the end. If something's wrong, you know immediately.
 
@@ -47,9 +47,9 @@ export function QuickPlay() {
 
 **Reuses existing wizard infrastructure** - Built on the shared `useWizardFlow` hook, so it handles step navigation, validation, and persistence automatically.
 
-**Smart user detection** - Hooks into the session store to detect first-time users and track when they've completed onboarding.
+**First-time user detection** - Hooks into the session store to detect first-time users and track when they've completed onboarding.
 
-**Progressive Tutorial System** - After completing the intro wizard, the `GuidedFirstTimeExperience` seamlessly hands off to the `TutorialProvider`, initiating a contextual tour that guides you through the rest of the world and character creation process. This creates a continuous onboarding journey from first click to first gameplay.
+**Tutorial handoff** - After the intro wizard, `GuidedFirstTimeExperience` hands off to `TutorialProvider`, which walks through the rest of world and character creation.
 
 **Simple three-step flow** - Welcome (sets expectations), Concept (captures your idea), Details (finalizes the basics). Then you're off to character creation with your new world ready to go.
 

--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -459,7 +459,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
       setError(null);
       resetStreamingPreview();
 
-      // Race AI generation with a timeout so we can fallback gracefully.
+      // Race AI generation against a timeout so a slow response falls back instead of hanging.
       // Losing the race must also ABORT the generation: without the signal,
       // the abandoned request keeps running (and spending) until aiFetch's
       // ceiling, then mutates lore/inventory/NPC state when it settles.

--- a/src/components/Narrative/README.md
+++ b/src/components/Narrative/README.md
@@ -1,6 +1,6 @@
 # Narrative Component System
 
-This is the heart of the storytelling engine - where your choices turn into new story segments and the AI keeps everything feeling consistent with your world's tone and rules. The challenge was building something that feels like playing with a really good game master who remembers everything.
+Turns your choices into new story segments while keeping things consistent with your world's tone and rules — the goal was something that feels like a game master who remembers everything.
 
 ## Components Overview
 
@@ -38,7 +38,7 @@ This handles showing individual story segments with the right formatting and sty
 **What it does:**
 - Formats different types of content appropriately (description, dialogue, action)
 - Shows a nice loading animation while the AI is thinking
-- Handles errors gracefully with clear messages
+- Shows clear error messages instead of a blank screen
 - Parses content that comes back as JSON and extracts the actual story text
 - Displays location info when the AI includes it
 
@@ -145,7 +145,7 @@ The system actually pays attention to the world you've created and generates con
 
 **Optimized rendering** - Components are built to avoid unnecessary re-renders, which keeps things smooth even with long story histories.
 
-**Flexible parsing** - Handles different AI response formats gracefully, so slight variations in the AI's output don't break the experience.
+**Flexible parsing** - Accepts different AI response formats, so slight variations in the AI's output don't break the experience.
 
 ## AI Choice Generation
 
@@ -165,7 +165,7 @@ The system also creates your next set of choices automatically, which keeps the 
 
 **Complete context** - Assembles world data, recent narrative history, and character info to give the AI the full picture.
 
-**Resilient design** - Built to handle failures gracefully so one broken AI call doesn't stop your game.
+**Resilient design** - One broken AI call doesn't stop your game; it retries or falls back instead.
 
 **Persistent storage** - Generated choices are saved to the store so they survive page refreshes and can be referenced later.
 

--- a/src/components/WorldCreationWizard/README.md
+++ b/src/components/WorldCreationWizard/README.md
@@ -71,9 +71,9 @@ Each step includes validation:
 
 ### Error Handling
 
-The wizard handles errors gracefully:
+The wizard handles errors without losing your progress:
 - Form validation errors display inline
-- AI failures gracefully fallback to default suggestions
+- AI failures fall back to default suggestions
 - Network errors are caught and displayed to users
 
 ## Testing

--- a/src/components/devtools/JsonViewer/JsonViewer.tsx
+++ b/src/components/devtools/JsonViewer/JsonViewer.tsx
@@ -108,7 +108,7 @@ function syntaxHighlight(json: string): string {
       }
     );
   } catch (error) {
-    // Fail gracefully if highlighting encounters an error
+    // Skip syntax highlighting if it throws, and fall back to escaped plain text
     logger.error('Error while highlighting JSON:', error);
     return json
       .replace(/&/g, '&amp;')

--- a/src/components/shared/ChoiceSelector/README.md
+++ b/src/components/shared/ChoiceSelector/README.md
@@ -16,7 +16,7 @@ This handles player choice selection in all its forms - from simple "go left or 
 
 **Full accessibility** - Keyboard navigation, screen reader support, proper ARIA labels throughout.
 
-**Input validation** - Prevents empty submissions, enforces character limits, handles edge cases gracefully.
+**Input validation** - Prevents empty submissions, enforces character limits, and covers edge cases.
 
 ## Basic Usage
 

--- a/src/components/shared/ExportImportControls.tsx
+++ b/src/components/shared/ExportImportControls.tsx
@@ -47,7 +47,7 @@ export function ExportImportControls({ className = '' }: ExportImportControlsPro
       await downloadGameState();
       showMessage('Export completed successfully', 'success');
     } catch {
-      showMessage('Export failed. Please try again.', 'error');
+      showMessage("Couldn't export your data. Try again in a moment.", 'error');
     } finally {
       setIsExporting(false);
     }

--- a/src/components/shared/__tests__/ExportImportControls.test.tsx
+++ b/src/components/shared/__tests__/ExportImportControls.test.tsx
@@ -58,7 +58,7 @@ describe('ExportImportControls', () => {
       fireEvent.click(exportButton);
 
       await waitFor(() => {
-        expect(screen.getByText(/export failed/i)).toBeInTheDocument();
+        expect(screen.getByText(/couldn't export your data/i)).toBeInTheDocument();
       });
     });
   });

--- a/src/components/shared/cards/README.md
+++ b/src/components/shared/cards/README.md
@@ -155,14 +155,11 @@ The design principles behind these components:
 4. **Type Safety**: Full TypeScript support so you can't accidentally pass the wrong data
 5. **Testing**: Components include proper data-testid attributes
 
-## Recent Improvements
+## Layout Integration
 
-These components got some love as part of the walkthrough improvements:
-
-- **Better Navigation Integration**: Cards now work seamlessly with the improved Navigation component
-- **Enhanced Visual Design**: Updated button styling and spacing that actually looks professional
-- **Smarter Action Button Layouts**: More intuitive groupings of primary vs secondary actions
-- **PageLayout Integration**: Everything plays nicely with the new PageLayout component structure
+- **Navigation**: Cards integrate with the Navigation component for consistent world switching and actions
+- **Button layout**: Primary and secondary actions are grouped separately so the main action stands out
+- **PageLayout**: Cards compose with the shared PageLayout component for consistent page structure
 
 ## Related Components
 

--- a/src/lib/ai/README-image-generation.md
+++ b/src/lib/ai/README-image-generation.md
@@ -103,7 +103,7 @@ https://generativelanguage.googleapis.com/v1beta/models/${getAIConfig().imageMod
 
 ## Error Handling
 
-The system gracefully handles various error scenarios:
+The system handles these error scenarios:
 
 - **Invalid API Key**: Falls back to intelligent placeholder
 - **API Rate Limits**: Shows fallback with retry suggestion

--- a/src/lib/storage/indexedDBAdapter.ts
+++ b/src/lib/storage/indexedDBAdapter.ts
@@ -4,8 +4,8 @@
  * 
  * This adapter implements a basic CRUD interface for persisting state in IndexedDB.
  * It follows a factory pattern with async initialization to prevent race conditions.
- * Error handling is designed for graceful degradation - operations fail silently 
- * to allow the application to continue functioning when persistence is unavailable.
+ * Operations fail silently instead of throwing, so the app keeps working when
+ * persistence is unavailable — it just won't save.
  */
 export class IndexedDBAdapter {
   private dbName = 'narraitor-state';
@@ -34,11 +34,11 @@ export class IndexedDBAdapter {
   /**
    * Initialize the IndexedDB database
    * Creates the database and object store if they don't exist
-   * Handles environments without IndexedDB gracefully
+   * Returns early in environments without IndexedDB, instead of throwing
    */
   async initialize(): Promise<void> {
     if (typeof indexedDB === 'undefined') {
-      return; // Gracefully handle environments without IndexedDB
+      return; // No IndexedDB (private mode, SSR, old browsers) - skip init
     }
 
     return new Promise((resolve) => {
@@ -167,7 +167,7 @@ export class IndexedDBAdapter {
   /**
    * Remove an item from storage
    * @param key - The key to remove
-   * @returns Promise that resolves when the item is removed (or if removal fails gracefully)
+   * @returns Promise that resolves whether removal succeeds or fails - failures are swallowed, not thrown
    */
   async removeItem(key: string): Promise<void> {
     if (!this.db) {

--- a/src/lib/storage/masterKeyStore.ts
+++ b/src/lib/storage/masterKeyStore.ts
@@ -11,9 +11,8 @@
  * The CryptoKey is stored with `extractable: false`, so even if hostile script
  * gets a reference it cannot `exportKey` the raw bytes out of the browser.
  *
- * Everything degrades gracefully: with no IndexedDB (private mode, SSR, old
- * browsers) load/clear are no-ops and the caller falls back to an in-memory key
- * for the session.
+ * With no IndexedDB (private mode, SSR, old browsers), load/clear are no-ops
+ * and the caller falls back to an in-memory key for the session.
  */
 
 const DB_NAME = 'narraitor-secure';

--- a/src/lib/utils/formatters.ts
+++ b/src/lib/utils/formatters.ts
@@ -342,7 +342,7 @@ export function capitalize(text: string): string {
  * Converts text to title case (capitalizes first letter of each word)
  * 
  * Transforms text so that each word starts with a capital letter.
- * For headings, titles, and proper names. Collapses multiple spaces into one.
+ * For headings, titles, and proper names. Extra spaces between words are left as-is.
  * 
  * @param text - Text to convert
  * @returns Text in title case

--- a/src/lib/utils/formatters.ts
+++ b/src/lib/utils/formatters.ts
@@ -342,7 +342,7 @@ export function capitalize(text: string): string {
  * Converts text to title case (capitalizes first letter of each word)
  * 
  * Transforms text so that each word starts with a capital letter.
- * Perfect for headings, titles, and proper names. Handles multiple spaces gracefully.
+ * For headings, titles, and proper names. Collapses multiple spaces into one.
  * 
  * @param text - Text to convert
  * @returns Text in title case

--- a/src/state/persistence.ts
+++ b/src/state/persistence.ts
@@ -18,7 +18,7 @@ let resilientStoragePromise: Promise<ResilientStorageMiddleware> | null = null;
 /**
  * Get ResilientStorageMiddleware instance with lazy initialization.
  * This ensures the middleware is only initialized once and properly shared.
- * Handles initialization failures gracefully with memory fallback.
+ * Falls back to memory-only storage if initialization fails.
  */
 const getResilientStorage = async (): Promise<ResilientStorageMiddleware> => {
   if (!resilientStoragePromise) {


### PR DESCRIPTION
## Description

Fixes every finding from the weekly plain-language sweep (#1759): 38 sites where "gracefully" stood in for a sentence about what actually happens on failure, five docs opening on "this is the heart of" / "where the magic happens", three player-facing error messages that said nothing ("Failed to X. Please try again."), a stale changelog masquerading as documentation, and a scatter of paired rhetorical-question openers, "smart" filler, and one ADR's pitch-deck Benefits section. Text-only — no behavior changes except the three error message strings, which are copy swaps with the same trigger conditions.

## Related Issue
Closes #1759

## Type of Change
- [x] Documentation update

## TDD Compliance
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Not applicable in the usual sense — this is a copy pass, not new logic. One existing test (`ExportImportControls.test.tsx`) asserted on the old error string and needed its assertion updated to match the new copy; no new test cases were needed since no new branches were introduced.

## User Stories Addressed
N/A — documentation and copy quality, not a feature.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A — no component structure or styling changed, only string literals and prose.

## Implementation Notes

Every "gracefully" was replaced with a sentence describing the actual fallback behavior (checked against the surrounding code, not guessed), rather than a synonym swap. A few examples: `indexedDBAdapter.ts`'s doc comment now says operations fail silently so the app keeps working without persistence; `navigation-loading-system.md`'s triple-"gracefully" paragraph collapsed to one sentence since two of the three clauses were already saying the same thing.

The three UI error messages (`CharacterEditor.tsx`, `characters/page.tsx`, `ExportImportControls.tsx`) now follow the tone already established in `errorUtils.ts` ("That didn't work" style) instead of the generic "Failed to X. Please try again." pattern.

ADR-009's Benefits section kept its three subsections but dropped the pitch-deck framing ("Reduced Time-to-Value", "Improved Conversion", "Engagement... increasing retention") in favor of plain statements; the unmeasured Business Impact claims are now explicitly flagged as expected-but-unmeasured rather than stated as fact.

## Screenshots
N/A — no visual changes.

## Visual Baseline Changes
None.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed (not run — no dependency or logic changes)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

1. `npm run lint && npm run type-check && npm test` — all green.
2. Spot-check a few of the touched files against the sweep issue (#1759) findings list to confirm the fix matches what was flagged: `src/lib/storage/indexedDBAdapter.ts`, `src/components/shared/cards/README.md`, `public_docs/architecture/ADR-009-guided-onboarding-system.md`.
3. No dev-server verification needed — none of the changes touch rendered UI structure, only string content already covered by existing component tests.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic (N/A — simplifying existing comments, not adding logic)
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed (N/A — no markup or ARIA changes)
