### PR TITLE
Use the model the player picked instead of always Flash

### DIFF
--- a/src/app/api/_shared/similarityCheck.ts
+++ b/src/app/api/_shared/similarityCheck.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { GeminiClient } from '@/lib/ai/geminiClient';
 import { getDefaultConfig } from '@/lib/ai/config';
 import { resolveApiKey } from '@/lib/ai/resolveApiKey';
+import { resolveModel } from '@/lib/ai/resolveModel';
 import { extractJsonObject } from '@/lib/ai/parseJSON';
 import { reportServerError } from '@/lib/telemetry/reportServerError';
 
@@ -54,7 +55,7 @@ export async function handleSimilarityCheck(
       });
     }
 
-    const config = getDefaultConfig(resolveApiKey(request));
+    const config = getDefaultConfig(resolveApiKey(request), resolveModel(request));
     const client = new GeminiClient(config);
     const response = await client.generateContent(buildPrompt(body));
     const text = response.content.trim();

--- a/src/app/api/ai/analyze-world/route.ts
+++ b/src/app/api/ai/analyze-world/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { resolveApiKey } from '@/lib/ai/resolveApiKey';
+import { resolveModel } from '@/lib/ai/resolveModel';
 import { analyzeWorldDescription } from '@/lib/ai/worldAnalyzer';
 import Logger from '@/lib/utils/logger';
 import { reportServerError } from '@/lib/telemetry/reportServerError';
@@ -27,7 +28,11 @@ export async function POST(request: NextRequest) {
     logger.debug('analyze-world API', 'Analyzing world description...');
 
     // Analyze the world description using the AI service
-    const analysis = await analyzeWorldDescription(body.description, resolveApiKey(request));
+    const analysis = await analyzeWorldDescription(
+      body.description,
+      resolveApiKey(request),
+      resolveModel(request)
+    );
     
     logger.debug('analyze-world API', 'Analysis completed successfully');
 

--- a/src/app/api/ai/validate-provider/route.ts
+++ b/src/app/api/ai/validate-provider/route.ts
@@ -2,7 +2,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { makeGeminiRequest } from '@/utils/apiHelpers';
-import { getSafetySettings } from '@/lib/ai/config';
+import { DEFAULT_TEXT_MODEL, getSafetySettings } from '@/lib/ai/config';
 import { PROVIDER_API_KEY_HEADER } from '@/lib/ai/providerKeyHeader';
 
 /**
@@ -21,7 +21,6 @@ import { PROVIDER_API_KEY_HEADER } from '@/lib/ai/providerKeyHeader';
 export const maxDuration = 60;
 
 const GEMINI_MODELS_BASE = 'https://generativelanguage.googleapis.com/v1beta/models';
-const DEFAULT_MODEL = 'gemini-2.5-flash';
 
 type ValidationError =
   | 'NO_KEY'
@@ -56,7 +55,7 @@ export async function POST(request: NextRequest) {
     return fail('UNSUPPORTED_PROVIDER');
   }
 
-  const model = body.model || DEFAULT_MODEL;
+  const model = body.model || DEFAULT_TEXT_MODEL;
   const endpoint = `${GEMINI_MODELS_BASE}/${encodeURIComponent(model)}:generateContent`;
 
   try {

--- a/src/app/api/generate-character/route.ts
+++ b/src/app/api/generate-character/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { resolveApiKey } from '@/lib/ai/resolveApiKey';
+import { resolveModel } from '@/lib/ai/resolveModel';
 import { createAPIErrorResponse } from '@/lib/utils/createAPIErrorResponse';
 import { generateAICharacter } from '@/lib/generators/characterGenerator';
 import { World } from '@/types/world.types';
@@ -43,7 +44,8 @@ export async function POST(request: NextRequest) {
       suggestedName as string | undefined,
       (characterType as 'original' | 'known' | 'specific') || 'original',
       typeof concept === 'string' ? concept : undefined,
-      resolveApiKey(request)
+      resolveApiKey(request),
+      resolveModel(request)
     );
 
     return NextResponse.json(generatedCharacter);

--- a/src/app/api/generate-world/route.ts
+++ b/src/app/api/generate-world/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { resolveApiKey } from '@/lib/ai/resolveApiKey';
+import { resolveModel } from '@/lib/ai/resolveModel';
 import { createAPIErrorResponse } from '@/lib/utils/createAPIErrorResponse';
 import { generateWorld } from '@/lib/generators/worldGenerator';
 import Logger from '@/lib/utils/logger';
@@ -36,7 +37,7 @@ export async function POST(request: NextRequest) {
       relationship: body.worldRelationship || 'inspired_by',
       existingNames: body.existingNames,
       suggestedName: body.suggestedName
-    }, resolveApiKey(request));
+    }, resolveApiKey(request), resolveModel(request));
     
     // Validate generated world structure
     if (!generatedWorld.name || !generatedWorld.description || !generatedWorld.genre) {

--- a/src/app/api/inventory/categorize/__tests__/route.test.ts
+++ b/src/app/api/inventory/categorize/__tests__/route.test.ts
@@ -17,6 +17,7 @@ import { NextRequest } from 'next/server';
 import { POST } from '../route';
 import { categorizeInventoryItems } from '@/lib/ai/inventoryCategorizer';
 import type { InventoryCategorizationResult } from '@/lib/ai/inventoryCategorizer';
+import { DEFAULT_TEXT_MODEL } from '@/lib/ai/config';
 
 const mockCategorize = categorizeInventoryItems as jest.MockedFunction<
   typeof categorizeInventoryItems
@@ -70,13 +71,15 @@ describe('POST /api/inventory/categorize', () => {
     const data = await response.json();
 
     // Only valid items are sent to the categorizer, with the request-resolved
-    // key (null here: no BYO header and the env key is the MOCK sentinel).
+    // key (null here: no BYO header and the env key is the MOCK sentinel) and
+    // the resolved model, which is the default without a configured provider.
     expect(mockCategorize).toHaveBeenCalledWith(
       [
         { name: 'Iron Sword', description: 'A blade', context: undefined },
         { name: 'Gold Coins', description: 'Currency', context: undefined },
       ],
-      null
+      null,
+      DEFAULT_TEXT_MODEL
     );
 
     // Response is full-length and positionally aligned to the input.

--- a/src/app/api/inventory/categorize/route.ts
+++ b/src/app/api/inventory/categorize/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { resolveApiKey } from '@/lib/ai/resolveApiKey';
+import { resolveModel } from '@/lib/ai/resolveModel';
 import { categorizeInventoryItems } from '@/lib/ai/inventoryCategorizer';
 import type { InventoryCategorizationResult } from '@/lib/ai/inventoryCategorizer';
 import Logger from '@/lib/utils/logger';
@@ -49,7 +50,11 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const categorizations = await categorizeInventoryItems(validItems, resolveApiKey(request));
+    const categorizations = await categorizeInventoryItems(
+      validItems,
+      resolveApiKey(request),
+      resolveModel(request)
+    );
     const classifiedAt = getTimestamp();
 
     // Map each categorization back to its original input slot, then emit a

--- a/src/app/api/narrative/ending/route.ts
+++ b/src/app/api/narrative/ending/route.ts
@@ -2,6 +2,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { resolveApiKey } from '@/lib/ai/resolveApiKey';
+import { resolveModel } from '@/lib/ai/resolveModel';
 import { generateEnding } from '@/lib/ai/endingGenerator';
 import { logger } from '@/lib/utils/logger';
 import type { EndingGenerationRequest, EndingType, EndingTone } from '@/types/narrative.types';
@@ -64,7 +65,7 @@ export async function POST(request: NextRequest) {
     });
 
     // Generate the ending
-    const result = await generateEnding(endingRequest, resolveApiKey(request));
+    const result = await generateEnding(endingRequest, resolveApiKey(request), resolveModel(request));
 
     logger.info('Story ending generated successfully', { 
       sessionId,

--- a/src/app/api/narrative/story-checkpoint/__tests__/route.test.ts
+++ b/src/app/api/narrative/story-checkpoint/__tests__/route.test.ts
@@ -7,6 +7,7 @@ jest.mock('@/lib/ai/storyCheckpointGenerator');
 import { NextRequest } from 'next/server';
 import { POST } from '../route';
 import { generateStoryCheckpointSummary } from '@/lib/ai/storyCheckpointGenerator';
+import { DEFAULT_TEXT_MODEL } from '@/lib/ai/config';
 
 const mockGenerateStoryCheckpointSummary = generateStoryCheckpointSummary as jest.MockedFunction<typeof generateStoryCheckpointSummary>;
 
@@ -77,7 +78,8 @@ describe('/api/narrative/story-checkpoint', () => {
     expect(data.summary).toBe('Recap');
     expect(mockGenerateStoryCheckpointSummary).toHaveBeenCalledWith(
       expect.objectContaining({ worldId: 'world-1', sessionId: 'session-1' }),
-      null
+      null,
+      DEFAULT_TEXT_MODEL
     );
   });
 

--- a/src/app/api/narrative/story-checkpoint/route.ts
+++ b/src/app/api/narrative/story-checkpoint/route.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { resolveApiKey } from '@/lib/ai/resolveApiKey';
+import { resolveModel } from '@/lib/ai/resolveModel';
 import { StoryCheckpointRequestBody } from '@/types/story-checkpoint.types';
 import { ToneSettings } from '@/types/tone-settings.types';
 import { generateStoryCheckpointSummary } from '@/lib/ai/storyCheckpointGenerator';
@@ -167,7 +168,11 @@ export async function POST(request: NextRequest) {
       toneSettings: sanitizeToneSettings(rawBody?.toneSettings),
     };
 
-    const summary = await generateStoryCheckpointSummary(payload, resolveApiKey(request));
+    const summary = await generateStoryCheckpointSummary(
+      payload,
+      resolveApiKey(request),
+      resolveModel(request)
+    );
     return NextResponse.json(summary);
   } catch (error) {
     logger.error('[story-checkpoint] Failed to generate summary', error);

--- a/src/app/api/narrative/summarize/route.ts
+++ b/src/app/api/narrative/summarize/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
 import { resolveApiKey } from '@/lib/ai/resolveApiKey';
+import { resolveModel } from '@/lib/ai/resolveModel';
 
 import Logger from '@/lib/utils/logger';
 import { reportServerError } from '@/lib/telemetry/reportServerError';
@@ -27,7 +28,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const geminiClient = createDefaultGeminiClient(resolveApiKey(request));
+    const geminiClient = createDefaultGeminiClient(resolveApiKey(request), resolveModel(request));
     
     const prompt = `${instructions}
 

--- a/src/app/api/narrative/validate-event-significance/route.ts
+++ b/src/app/api/narrative/validate-event-significance/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { resolveApiKey } from '@/lib/ai/resolveApiKey';
+import { resolveModel } from '@/lib/ai/resolveModel';
 import { validateEventSignificance, ValidationContext } from '@/lib/ai/eventSignificanceValidator';
 
 import Logger from '@/lib/utils/logger';
@@ -25,7 +26,12 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const result = await validateEventSignificance(majorEvent, context, resolveApiKey(request));
+    const result = await validateEventSignificance(
+      majorEvent,
+      context,
+      resolveApiKey(request),
+      resolveModel(request)
+    );
 
     return NextResponse.json(result);
   } catch (error) {

--- a/src/lib/ai/__tests__/aiFetch.test.ts
+++ b/src/lib/ai/__tests__/aiFetch.test.ts
@@ -1,14 +1,17 @@
 jest.mock('@/state/providerStore', () => ({
   getActiveProviderKey: jest.fn(),
+  getActiveProviderModel: jest.fn(),
 }));
 
 import { aiFetch } from '../aiFetch';
-import { getActiveProviderKey } from '@/state/providerStore';
+import { getActiveProviderKey, getActiveProviderModel } from '@/state/providerStore';
 
 const mockGetKey = getActiveProviderKey as jest.MockedFunction<typeof getActiveProviderKey>;
+const mockGetModel = getActiveProviderModel as jest.MockedFunction<typeof getActiveProviderModel>;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockGetModel.mockReturnValue(null);
   global.fetch = jest.fn(async () => ({ ok: true })) as unknown as typeof fetch;
 });
 
@@ -30,6 +33,21 @@ describe('aiFetch', () => {
     await aiFetch('/api/narrative/generate');
 
     expect(lastFetchHeaders().has('x-provider-api-key')).toBe(false);
+  });
+
+  test('attaches the configured model header', async () => {
+    mockGetKey.mockResolvedValue('byo-key');
+    mockGetModel.mockReturnValue('gemini-2.5-pro');
+    await aiFetch('/api/narrative/generate', { method: 'POST' });
+
+    expect(lastFetchHeaders().get('x-provider-model')).toBe('gemini-2.5-pro');
+  });
+
+  test('sends no model header when no model is configured', async () => {
+    mockGetKey.mockResolvedValue('byo-key');
+    await aiFetch('/api/narrative/generate');
+
+    expect(lastFetchHeaders().has('x-provider-model')).toBe(false);
   });
 
   test('preserves caller-supplied headers', async () => {

--- a/src/lib/ai/__tests__/config.test.ts
+++ b/src/lib/ai/__tests__/config.test.ts
@@ -1,0 +1,11 @@
+import { DEFAULT_TEXT_MODEL, getDefaultConfig } from '../config';
+
+describe('getDefaultConfig', () => {
+  test('runs on the model the caller resolved from the request', () => {
+    expect(getDefaultConfig('key', 'gemini-2.5-pro').modelName).toBe('gemini-2.5-pro');
+  });
+
+  test('falls back to the default model when none was resolved', () => {
+    expect(getDefaultConfig('key').modelName).toBe(DEFAULT_TEXT_MODEL);
+  });
+});

--- a/src/lib/ai/__tests__/resolveModel.test.ts
+++ b/src/lib/ai/__tests__/resolveModel.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+import { PROVIDER_MODEL_HEADER } from '../providerKeyHeader';
+import { resolveModel } from '../resolveModel';
+import { DEFAULT_TEXT_MODEL } from '../config';
+
+function requestWithModel(model?: string): NextRequest {
+  const headers: Record<string, string> = {};
+  if (model) headers[PROVIDER_MODEL_HEADER] = model;
+  return new NextRequest('http://localhost/api/x', { headers });
+}
+
+describe('resolveModel', () => {
+  test('uses the model the player configured', () => {
+    expect(resolveModel(requestWithModel('gemini-2.5-pro'))).toBe('gemini-2.5-pro');
+  });
+
+  test('falls back to the default when no model header is present', () => {
+    expect(resolveModel(requestWithModel())).toBe(DEFAULT_TEXT_MODEL);
+  });
+
+  test('falls back to the default with no request at all', () => {
+    expect(resolveModel()).toBe(DEFAULT_TEXT_MODEL);
+  });
+
+  test('rejects a header that could steer the request at another path', () => {
+    expect(resolveModel(requestWithModel('../../models/other:generateContent'))).toBe(
+      DEFAULT_TEXT_MODEL
+    );
+  });
+});

--- a/src/lib/ai/__tests__/resolveModel.test.ts
+++ b/src/lib/ai/__tests__/resolveModel.test.ts
@@ -2,23 +2,24 @@
  * @jest-environment node
  */
 import { NextRequest } from 'next/server';
-import { PROVIDER_MODEL_HEADER } from '../providerKeyHeader';
+import { PROVIDER_API_KEY_HEADER, PROVIDER_MODEL_HEADER } from '../providerKeyHeader';
 import { resolveModel } from '../resolveModel';
 import { DEFAULT_TEXT_MODEL } from '../config';
 
-function requestWithModel(model?: string): NextRequest {
+function requestWith(model?: string, key: string | null = 'byo-key'): NextRequest {
   const headers: Record<string, string> = {};
   if (model) headers[PROVIDER_MODEL_HEADER] = model;
+  if (key) headers[PROVIDER_API_KEY_HEADER] = key;
   return new NextRequest('http://localhost/api/x', { headers });
 }
 
 describe('resolveModel', () => {
   test('uses the model the player configured', () => {
-    expect(resolveModel(requestWithModel('gemini-2.5-pro'))).toBe('gemini-2.5-pro');
+    expect(resolveModel(requestWith('gemini-2.5-pro'))).toBe('gemini-2.5-pro');
   });
 
   test('falls back to the default when no model header is present', () => {
-    expect(resolveModel(requestWithModel())).toBe(DEFAULT_TEXT_MODEL);
+    expect(resolveModel(requestWith())).toBe(DEFAULT_TEXT_MODEL);
   });
 
   test('falls back to the default with no request at all', () => {
@@ -26,8 +27,12 @@ describe('resolveModel', () => {
   });
 
   test('rejects a header that could steer the request at another path', () => {
-    expect(resolveModel(requestWithModel('../../models/other:generateContent'))).toBe(
+    expect(resolveModel(requestWith('../../models/other:generateContent'))).toBe(
       DEFAULT_TEXT_MODEL
     );
+  });
+
+  test('ignores a model sent without a key, which would spend the server env key', () => {
+    expect(resolveModel(requestWith('gemini-2.5-pro', null))).toBe(DEFAULT_TEXT_MODEL);
   });
 });

--- a/src/lib/ai/aiFetch.ts
+++ b/src/lib/ai/aiFetch.ts
@@ -1,7 +1,7 @@
 // src/lib/ai/aiFetch.ts
 
-import { PROVIDER_API_KEY_HEADER } from './providerKeyHeader';
-import { getActiveProviderKey } from '@/state/providerStore';
+import { PROVIDER_API_KEY_HEADER, PROVIDER_MODEL_HEADER } from './providerKeyHeader';
+import { getActiveProviderKey, getActiveProviderModel } from '@/state/providerStore';
 import { anySignal, timeoutSignal } from './abortTimeout';
 import { RETRYING_ROUTE_TIMEOUT_MS } from '@/lib/constants/aiTimeouts';
 
@@ -9,10 +9,11 @@ import { RETRYING_ROUTE_TIMEOUT_MS } from '@/lib/constants/aiTimeouts';
  * fetch() wrapper for browser -> our own AI routes.
  *
  * Just-in-time pulls the active provider's decrypted key and attaches it as a
- * header, only when one exists. When there's no configured key, this is a plain
- * fetch and the server falls back to the env key — so dev, tests, and E2E are
- * unchanged. The plaintext key lives only in this closure for the duration of
- * the call; it's never stored or logged.
+ * header, only when one exists, along with the model that provider is
+ * configured to use. With nothing configured this is a plain fetch and the
+ * server falls back to the env key and the default model, so dev, tests, and
+ * E2E are unchanged. The plaintext key lives only in this closure for the
+ * duration of the call; it's never stored or logged.
  */
 
 export interface AiFetchOptions {
@@ -41,12 +42,14 @@ export async function aiFetch(
       timeoutSignal(options.timeoutMs ?? RETRYING_ROUTE_TIMEOUT_MS)
     ),
   };
-  // No configured key -> identical to a plain fetch (env fallback applies
-  // server-side). This keeps aiFetch a true drop-in: dev, tests, and E2E behave
-  // exactly as before, and only a configured BYO key adds the header.
-  if (!key) return fetch(input, withTimeout);
+  const model = getActiveProviderModel();
+  // Nothing configured -> identical to a plain fetch (env key and default model
+  // apply server-side). This keeps aiFetch a true drop-in: dev, tests, and E2E
+  // behave exactly as before.
+  if (!key && !model) return fetch(input, withTimeout);
 
   const headers = new Headers(withTimeout.headers);
-  headers.set(PROVIDER_API_KEY_HEADER, key);
+  if (key) headers.set(PROVIDER_API_KEY_HEADER, key);
+  if (model) headers.set(PROVIDER_MODEL_HEADER, model);
   return fetch(input, { ...withTimeout, headers });
 }

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -4,6 +4,12 @@ import { AIConfig, GenerationConfig, SafetySetting } from './types';
 import { GEMINI_ATTEMPT_TIMEOUT_MS } from '@/lib/constants/aiTimeouts';
 
 /**
+ * Text model used when the player has not configured one of their own. Every
+ * fallback path resolves here, so the default lives in exactly one place.
+ */
+export const DEFAULT_TEXT_MODEL = 'gemini-2.5-flash';
+
+/**
  * Gets AI configuration from environment variables.
  * A missing key falls back to '' here rather than throwing, because config is
  * also read in mock/test contexts; callers that make real requests validate it
@@ -13,7 +19,7 @@ import { GEMINI_ATTEMPT_TIMEOUT_MS } from '@/lib/constants/aiTimeouts';
 export const getAIConfig = (): AIConfig => {
   return {
     geminiApiKey: process.env.GEMINI_API_KEY || '',
-    modelName: 'gemini-2.5-flash',
+    modelName: DEFAULT_TEXT_MODEL,
     imageModelName: 'gemini-2.5-flash-image',
     maxRetries: 3,
     timeout: GEMINI_ATTEMPT_TIMEOUT_MS

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -59,14 +59,19 @@ export const getSafetySettings = (): SafetySetting[] => {
  * Gets default configuration for AI service.
  * @param apiKeyOverride - the player's bring-your-own key for this request; when
  *   omitted, falls back to the server env key (today's behavior).
+ * @param modelOverride - the model the player picked (see resolveModel); when
+ *   omitted, falls back to the default text model.
  * @returns Complete AI service configuration
  */
-export const getDefaultConfig = (apiKeyOverride?: string | null) => {
+export const getDefaultConfig = (
+  apiKeyOverride?: string | null,
+  modelOverride?: string | null
+) => {
   const aiConfig = getAIConfig();
   return {
     // The player's resolved key (passed by the route) -> server env key.
     apiKey: apiKeyOverride ?? aiConfig.geminiApiKey,
-    modelName: aiConfig.modelName,
+    modelName: modelOverride ?? aiConfig.modelName,
     maxRetries: aiConfig.maxRetries,
     timeout: aiConfig.timeout,
     generationConfig: getGenerationConfig(),

--- a/src/lib/ai/defaultGeminiClient.ts
+++ b/src/lib/ai/defaultGeminiClient.ts
@@ -14,8 +14,13 @@ import { getDefaultConfig } from './config';
  * @param apiKeyOverride - the player's bring-your-own key, resolved from the
  *   request (see resolveApiKey). When present, the server real client uses it;
  *   otherwise it falls back to the env key, exactly as before.
+ * @param modelOverride - the model the player picked, resolved from the request
+ *   (see resolveModel). Omitted means the default text model.
  */
-export const createDefaultGeminiClient = (apiKeyOverride?: string | null) => {
+export const createDefaultGeminiClient = (
+  apiKeyOverride?: string | null,
+  modelOverride?: string | null
+) => {
   // In test environment, Jest will automatically use the mock from __mocks__/geminiClient.mock.ts
   if (process.env.NODE_ENV === 'test' || process.env.JEST_WORKER_ID) {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -35,7 +40,7 @@ export const createDefaultGeminiClient = (apiKeyOverride?: string | null) => {
       : null;
   const effectiveKey = apiKeyOverride ?? envKey;
   if (effectiveKey) {
-    return new GeminiClient(getDefaultConfig(effectiveKey));
+    return new GeminiClient(getDefaultConfig(effectiveKey, modelOverride));
   }
 
   // Server-side fallback: use mock for local development without API key

--- a/src/lib/ai/endingGenerator.ts
+++ b/src/lib/ai/endingGenerator.ts
@@ -135,7 +135,11 @@ function parseResponse(response: string): EndingGenerationResult {
   }
 }
 
-export async function generateEnding(request: EndingGenerationRequest, apiKey?: string | null): Promise<EndingGenerationResult> {
+export async function generateEnding(
+  request: EndingGenerationRequest,
+  apiKey?: string | null,
+  model?: string | null
+): Promise<EndingGenerationResult> {
   try {
     logger.debug('Generating story ending', { request });
 
@@ -175,7 +179,7 @@ export async function generateEnding(request: EndingGenerationRequest, apiKey?: 
     // (config.maxRetries with backoff) — an outer loop here multiplied the
     // attempts. Parse failures throw straight to the caller, matching how
     // narrativeGenerator and choiceGenerator handle them.
-    const client = createDefaultGeminiClient(apiKey);
+    const client = createDefaultGeminiClient(apiKey, model);
     const response = await client.generateContent(finalPrompt);
     const result = parseResponse(response.content);
 

--- a/src/lib/ai/eventSignificanceValidator.ts
+++ b/src/lib/ai/eventSignificanceValidator.ts
@@ -36,7 +36,8 @@ export interface ValidationContext {
 export async function validateEventSignificance(
   majorEvent: string,
   context: ValidationContext = {},
-  apiKey?: string | null
+  apiKey?: string | null,
+  modelOverride?: string | null
 ): Promise<SignificanceValidationResult> {
   const startTime = Date.now();
 
@@ -60,7 +61,7 @@ export async function validateEventSignificance(
     }
 
     const genAI = new GoogleGenAI({ apiKey: effectiveKey });
-    const model = getAIConfig().modelName;
+    const model = modelOverride ?? getAIConfig().modelName;
 
     const result = await genAI.models.generateContent({
       model,

--- a/src/lib/ai/inventoryCategorizer.ts
+++ b/src/lib/ai/inventoryCategorizer.ts
@@ -103,10 +103,12 @@ function parseAIResponse(raw: string): AIResponseShape | null {
 
 async function categorizeInventoryItem(
   input: CategorizeInventoryItemInput,
-  apiKey?: string | null
+  apiKey?: string | null,
+  model?: string | null
 ): Promise<InventoryCategorizationResult> {
   const config = getAIConfig();
   const effectiveKey = apiKey ?? config.geminiApiKey;
+  const effectiveModel = model ?? config.modelName;
   const baseLogContext = {
     name: input.name,
     description: truncate(input.description ?? '', 100),
@@ -120,7 +122,7 @@ async function categorizeInventoryItem(
   try {
     const client = new GeminiClient({
       apiKey: effectiveKey,
-      modelName: config.modelName,
+      modelName: effectiveModel,
       maxRetries: config.maxRetries,
       timeout: config.timeout,
       generationConfig: getGenerationConfig(),
@@ -156,7 +158,7 @@ Additional Context: ${input.context ? JSON.stringify(input.context) : 'none'}
       categoryId: parsed.category,
       confidence: Math.min(Math.max(parsed.confidence ?? 0.8, 0), 1),
       rationale: parsed.rationale,
-      model: config.modelName,
+      model: effectiveModel,
       source: 'ai',
     };
   } catch (error) {
@@ -188,18 +190,20 @@ function parseAIBatchResponse(raw: string): AIBatchEntryShape[] | null {
  */
 export async function categorizeInventoryItems(
   inputs: CategorizeInventoryItemInput[],
-  apiKey?: string | null
+  apiKey?: string | null,
+  model?: string | null
 ): Promise<InventoryCategorizationResult[]> {
   if (inputs.length === 0) {
     return [];
   }
 
   if (inputs.length === 1) {
-    return [await categorizeInventoryItem(inputs[0], apiKey)];
+    return [await categorizeInventoryItem(inputs[0], apiKey, model)];
   }
 
   const config = getAIConfig();
   const effectiveKey = apiKey ?? config.geminiApiKey;
+  const effectiveModel = model ?? config.modelName;
 
   if (!effectiveKey) {
     logger.warn(
@@ -213,7 +217,7 @@ export async function categorizeInventoryItems(
   try {
     const client = new GeminiClient({
       apiKey: effectiveKey,
-      modelName: config.modelName,
+      modelName: effectiveModel,
       maxRetries: config.maxRetries,
       timeout: config.timeout,
       generationConfig: getGenerationConfig(),
@@ -265,7 +269,7 @@ ${itemList}
           categoryId: entry.category,
           confidence: Math.min(Math.max(entry.confidence ?? 0.8, 0), 1),
           rationale: entry.rationale,
-          model: config.modelName,
+          model: effectiveModel,
           source: 'ai',
         };
       }

--- a/src/lib/ai/narrativeGenerator.ts
+++ b/src/lib/ai/narrativeGenerator.ts
@@ -46,6 +46,8 @@ import {
   type NarrativeStaticContentCache,
 } from './narrativeGenerator.prompt';
 import { formatNarrativeResponse } from './narrativeGenerator.response';
+import { getActiveProviderModel } from '@/state/providerStore';
+import { DEFAULT_TEXT_MODEL } from './config';
 import { enforceLanguageComplexity } from './narrativeGenerator.languageComplexity';
 import { buildNpcRoster, syncNpcMetadata } from './narrativeGenerator.npc';
 import {
@@ -299,7 +301,7 @@ export class NarrativeGenerator {
           previousSegmentContent: previousSegment?.content,
           previousSegmentType: previousSegment?.type,
           tokenUsage: result.tokenUsage,
-          modelUsed: 'gemini-2.5-flash',
+          modelUsed: getActiveProviderModel() ?? DEFAULT_TEXT_MODEL,
         };
 
         result.metadata.debugInfo = buildPromptDebugInfo(debugInfoContext);

--- a/src/lib/ai/providerKeyHeader.ts
+++ b/src/lib/ai/providerKeyHeader.ts
@@ -5,3 +5,10 @@
  * server (resolution side) so the name can't drift.
  */
 export const PROVIDER_API_KEY_HEADER = 'x-provider-api-key';
+
+/**
+ * Header carrying the model the player picked in their provider configuration.
+ * It rides alongside the key rather than in each route's body so the routes'
+ * request schemas stay about the generation, not about provider plumbing.
+ */
+export const PROVIDER_MODEL_HEADER = 'x-provider-model';

--- a/src/lib/ai/resolveModel.ts
+++ b/src/lib/ai/resolveModel.ts
@@ -1,0 +1,27 @@
+// src/lib/ai/resolveModel.ts
+
+import type { NextRequest } from 'next/server';
+import { PROVIDER_MODEL_HEADER } from './providerKeyHeader';
+import { DEFAULT_TEXT_MODEL } from './config';
+
+/**
+ * SECURITY: the model name is interpolated into the Gemini REST URL, so an
+ * arbitrary header value could steer a request at some other path. Only
+ * Google's own model-id shape gets through; anything else is treated as absent.
+ */
+const MODEL_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9.\-_]{0,63}$/;
+
+/**
+ * Resolve the model for a request, mirroring resolveApiKey.
+ *
+ * Priority: the model the player picked in their provider configuration (sent
+ * per request in PROVIDER_MODEL_HEADER) -> the default text model. A player
+ * with no provider configured, and every existing session, keeps running on the
+ * default, so nothing changes underneath them.
+ */
+export function resolveModel(request?: NextRequest): string {
+  const headerModel = request?.headers.get(PROVIDER_MODEL_HEADER)?.trim();
+  if (headerModel && MODEL_ID_PATTERN.test(headerModel)) return headerModel;
+
+  return DEFAULT_TEXT_MODEL;
+}

--- a/src/lib/ai/resolveModel.ts
+++ b/src/lib/ai/resolveModel.ts
@@ -1,7 +1,7 @@
 // src/lib/ai/resolveModel.ts
 
 import type { NextRequest } from 'next/server';
-import { PROVIDER_MODEL_HEADER } from './providerKeyHeader';
+import { PROVIDER_API_KEY_HEADER, PROVIDER_MODEL_HEADER } from './providerKeyHeader';
 import { DEFAULT_TEXT_MODEL } from './config';
 
 /**
@@ -18,8 +18,16 @@ const MODEL_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9.\-_]{0,63}$/;
  * per request in PROVIDER_MODEL_HEADER) -> the default text model. A player
  * with no provider configured, and every existing session, keeps running on the
  * default, so nothing changes underneath them.
+ *
+ * SECURITY: the model only counts when the caller supplied their own key in the
+ * same request. A deployment with a server env key would otherwise let any
+ * anonymous caller name an expensive model and spend that key on it, since
+ * resolveApiKey falls back to the env key on its own.
  */
 export function resolveModel(request?: NextRequest): string {
+  const hasProviderKey = Boolean(request?.headers.get(PROVIDER_API_KEY_HEADER)?.trim());
+  if (!hasProviderKey) return DEFAULT_TEXT_MODEL;
+
   const headerModel = request?.headers.get(PROVIDER_MODEL_HEADER)?.trim();
   if (headerModel && MODEL_ID_PATTERN.test(headerModel)) return headerModel;
 

--- a/src/lib/ai/storyCheckpointGenerator.ts
+++ b/src/lib/ai/storyCheckpointGenerator.ts
@@ -117,7 +117,7 @@ const sanitizeString = (value?: unknown, fallback = ''): string => {
   return safeTrim(value);
 };
 
-const parseResponse = (content: string): StoryCheckpointResponseBody => {
+const parseResponse = (content: string, model: string): StoryCheckpointResponseBody => {
   let payload = stripMarkdownFences(content);
   const extracted = extractJsonObject(payload);
   if (extracted) {
@@ -143,15 +143,16 @@ const parseResponse = (content: string): StoryCheckpointResponseBody => {
     // Record the model the default client actually runs on, not whatever the AI
     // echoed back. The prompt used to carry a stale "gemini-1.5-pro" example and
     // the model dutifully repeated it, mislabelling every checkpoint (#1430 F37).
-    model: getAIConfig().modelName,
+    model,
   };
 };
 
 export const generateStoryCheckpointSummary = async (
   payload: StoryCheckpointRequestBody,
   apiKey?: string | null,
+  model?: string | null,
 ): Promise<StoryCheckpointResponseBody> => {
-  const client = createDefaultGeminiClient(apiKey);
+  const client = createDefaultGeminiClient(apiKey, model);
   const prompt = buildPrompt(payload);
 
   const response = await client.generateContent(prompt);
@@ -161,7 +162,7 @@ export const generateStoryCheckpointSummary = async (
   }
 
   try {
-    return parseResponse(response.content);
+    return parseResponse(response.content, model ?? getAIConfig().modelName);
   } catch {
     // Fallback: create a simple segment from event descriptions
     const eventText = payload.events

--- a/src/lib/ai/worldAnalyzer.ts
+++ b/src/lib/ai/worldAnalyzer.ts
@@ -31,14 +31,19 @@ interface AIAnalysisResponse {
   skills: AISkill[];
 }
 
-export async function analyzeWorldDescription(description: string, apiKey?: string | null): Promise<WorldAnalysisResult> {
+export async function analyzeWorldDescription(
+  description: string,
+  apiKey?: string | null,
+  model?: string | null
+): Promise<WorldAnalysisResult> {
   logger.debug('analyzeWorldDescription called with:', truncate(description, 100));
 
   try {
     const config = getAIConfig();
     const effectiveKey = apiKey ?? config.geminiApiKey;
+    const effectiveModel = model ?? config.modelName;
     logger.debug('Using AI config:', {
-      modelName: config.modelName,
+      modelName: effectiveModel,
       timeout: config.timeout,
       hasApiKey: !!effectiveKey
     });
@@ -99,7 +104,7 @@ export async function analyzeWorldDescription(description: string, apiKey?: stri
     // Call the AI service directly with proper configuration
     const client = new GeminiClient({
       apiKey: effectiveKey,
-      modelName: config.modelName,
+      modelName: effectiveModel,
       maxRetries: config.maxRetries,
       timeout: config.timeout,
       generationConfig: getGenerationConfig(),

--- a/src/lib/generators/characterGenerator.ts
+++ b/src/lib/generators/characterGenerator.ts
@@ -44,7 +44,11 @@ const logger = new Logger('CharacterGenerator');
 /**
  * Generate character using AI
  */
-async function generateWithAI(options: CharacterGenerationOptions, apiKey?: string | null): Promise<GeneratedCharacterData> {
+async function generateWithAI(
+  options: CharacterGenerationOptions,
+  apiKey?: string | null,
+  model?: string | null
+): Promise<GeneratedCharacterData> {
   const { world, existingNames = [], suggestedName, generationType = 'known', concept } = options;
   
   // Validate the world data first
@@ -129,7 +133,7 @@ CRITICAL INSTRUCTIONS:
 
     // Import and use the AI client directly for server-side usage
     const { createDefaultGeminiClient } = await import('@/lib/ai/defaultGeminiClient');
-    const client = createDefaultGeminiClient(apiKey);
+    const client = createDefaultGeminiClient(apiKey, model);
     
     // Generate with AI
     const response = await client.generateContent(prompt);
@@ -373,7 +377,8 @@ export async function generateAICharacter(
   suggestedName?: string,
   generationType: CharacterGenerationType = 'known',
   concept?: string,
-  apiKey?: string | null
+  apiKey?: string | null,
+  model?: string | null
 ): Promise<GeneratedCharacterData> {
   return generateWithAI({
     world,
@@ -381,5 +386,5 @@ export async function generateAICharacter(
     suggestedName,
     generationType,
     concept
-  }, apiKey);
+  }, apiKey, model);
 }

--- a/src/lib/generators/worldGenerator.ts
+++ b/src/lib/generators/worldGenerator.ts
@@ -53,15 +53,23 @@ export interface WorldGenerationOptions {
 /**
  * Unified world generation function
  */
-export async function generateWorld(options: WorldGenerationOptions, apiKey?: string | null): Promise<GeneratedWorldData> {
+export async function generateWorld(
+  options: WorldGenerationOptions,
+  apiKey?: string | null,
+  model?: string | null
+): Promise<GeneratedWorldData> {
   // Always use AI generation, but with TV/movie inspiration
-  return generateWithAI(options, apiKey);
+  return generateWithAI(options, apiKey, model);
 }
 
 /**
  * Generate world using AI through secure API
  */
-async function generateWithAI(options: WorldGenerationOptions, apiKey?: string | null): Promise<GeneratedWorldData> {
+async function generateWithAI(
+  options: WorldGenerationOptions,
+  apiKey?: string | null,
+  model?: string | null
+): Promise<GeneratedWorldData> {
   // Handle different world generation types
   let prompt: string;
   
@@ -232,7 +240,7 @@ Make the world interesting and playable with concepts appropriate to the setting
     try {
       // Import the AI client for server-side usage
       const { createDefaultGeminiClient } = await import('@/lib/ai/defaultGeminiClient');
-      const client = createDefaultGeminiClient(apiKey);
+      const client = createDefaultGeminiClient(apiKey, model);
       
       // Add retry context to prompt for subsequent attempts
       const retryPrompt = attempt > 1 

--- a/src/state/__tests__/providerStore.test.ts
+++ b/src/state/__tests__/providerStore.test.ts
@@ -18,6 +18,7 @@ jest.mock('@/lib/storage/encryption', () => ({
 import {
   useProviderStore,
   getActiveProviderKey,
+  getActiveProviderModel,
   type AddProviderInput,
 } from '../providerStore';
 import { clearEncryptionKey } from '@/lib/storage/encryption';
@@ -62,6 +63,15 @@ describe('providerStore', () => {
 
   test('getActiveProviderKey returns null with no active provider', async () => {
     expect(await getActiveProviderKey()).toBeNull();
+  });
+
+  test('getActiveProviderModel returns the model the player picked', async () => {
+    await useProviderStore.getState().addProvider(makeInput({ model: 'gemini-2.5-pro' }));
+    expect(getActiveProviderModel()).toBe('gemini-2.5-pro');
+  });
+
+  test('getActiveProviderModel returns null with no active provider', () => {
+    expect(getActiveProviderModel()).toBeNull();
   });
 
   test('removeProvider clears the master key once the last provider is gone', async () => {

--- a/src/state/providerStore.ts
+++ b/src/state/providerStore.ts
@@ -240,3 +240,15 @@ export async function getActiveProviderKey(): Promise<string | null> {
 
   return decryptKey(config.encryptedApiKey);
 }
+
+/**
+ * The model the active provider is configured to run on, or null when there is
+ * no provider or it never got one. Null means "use the server's default", which
+ * is what every session before provider configuration existed still does.
+ */
+export function getActiveProviderModel(): string | null {
+  const { providers, activeProviderId } = useProviderStore.getState();
+  if (!activeProviderId) return null;
+
+  return providers[activeProviderId]?.model?.trim() || null;
+}

--- a/src/utils/__tests__/apiHelpers.test.ts
+++ b/src/utils/__tests__/apiHelpers.test.ts
@@ -21,9 +21,9 @@ import {
   consumeGeminiStreamEvents,
   processGeminiStreamingTextRequest,
 } from '../apiHelpers';
-import { getAIConfig } from '../../lib/ai/config';
+import { DEFAULT_TEXT_MODEL, getAIConfig } from '../../lib/ai/config';
 import { GEMINI_ATTEMPT_TIMEOUT_MS } from '../../lib/constants/aiTimeouts';
-import { PROVIDER_API_KEY_HEADER } from '../../lib/ai/providerKeyHeader';
+import { PROVIDER_API_KEY_HEADER, PROVIDER_MODEL_HEADER } from '../../lib/ai/providerKeyHeader';
 import { globalRateLimiter } from '../rateLimiter';
 import { NextResponse, type NextRequest } from 'next/server';
 
@@ -277,9 +277,13 @@ describe('consumeGeminiStreamEvents', () => {
 });
 
 describe('processGeminiStreamingTextRequest', () => {
-  function fakeRequest(body: unknown, headerKey?: string): NextRequest {
+  function fakeRequest(body: unknown, headerKey?: string, headerModel?: string): NextRequest {
+    const headers: Record<string, string | undefined> = {
+      [PROVIDER_API_KEY_HEADER]: headerKey,
+      [PROVIDER_MODEL_HEADER]: headerModel,
+    };
     return {
-      headers: { get: (name: string) => (name === PROVIDER_API_KEY_HEADER ? headerKey ?? null : null) },
+      headers: { get: (name: string) => headers[name] ?? null },
       json: async () => body,
     } as unknown as NextRequest;
   }
@@ -332,6 +336,44 @@ describe('processGeminiStreamingTextRequest', () => {
     expect(NextResponse.json).toHaveBeenCalledWith(
       expect.any(Object),
       expect.objectContaining({ status: 429 })
+    );
+  });
+
+  it('generates with the model the player configured', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+      text: async () => 'upstream boom',
+    });
+
+    await processGeminiStreamingTextRequest(
+      fakeRequest({ prompt: 'hello' }, 'player-supplied-key', 'gemini-2.5-pro'),
+      { errorContext: 'Test' }
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/models/gemini-2.5-pro:streamGenerateContent'),
+      expect.any(Object)
+    );
+  });
+
+  it('generates with the default model when none is configured', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+      text: async () => 'upstream boom',
+    });
+
+    await processGeminiStreamingTextRequest(
+      fakeRequest({ prompt: 'hello' }, 'player-supplied-key'),
+      { errorContext: 'Test' }
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining(`/models/${DEFAULT_TEXT_MODEL}:streamGenerateContent`),
+      expect.any(Object)
     );
   });
 });

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -2,8 +2,8 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { globalRateLimiter, RateLimiter, type RateLimitResult } from './rateLimiter';
-import { getAIConfig } from '../lib/ai/config';
 import { resolveApiKey } from '../lib/ai/resolveApiKey';
+import { resolveModel } from '../lib/ai/resolveModel';
 import { createAPIErrorResponse } from '../lib/utils/createAPIErrorResponse';
 import { GEMINI_ATTEMPT_TIMEOUT_MS } from '../lib/constants/aiTimeouts';
 import { extractStreamingContentPreview } from '../lib/ai/narrativeStreamPreview';
@@ -239,7 +239,7 @@ export async function processGeminiTextRequest(
 
     // Call Google's Gemini API from the server using secure header authentication
     const response = await makeGeminiRequest(
-      `https://generativelanguage.googleapis.com/v1beta/models/${getAIConfig().modelName}:generateContent`,
+      `https://generativelanguage.googleapis.com/v1beta/models/${resolveModel(request)}:generateContent`,
       apiKey,
       {
         contents: [{
@@ -481,7 +481,7 @@ export async function processGeminiStreamingTextRequest(
   let upstream: Response;
   try {
     upstream = await makeGeminiRequest(
-      `https://generativelanguage.googleapis.com/v1beta/models/${getAIConfig().modelName}:streamGenerateContent?alt=sse`,
+      `https://generativelanguage.googleapis.com/v1beta/models/${resolveModel(request)}:streamGenerateContent?alt=sse`,
       apiKey,
       {
         contents: [{


### PR DESCRIPTION
## Description

The provider setup screen lets you pick a Gemini model and then quietly ignored it. `ProviderConfig.model` was persisted per provider, but the only code that ever read it was `validateProvider`, which used it for the validation ping and nothing else. Every actual generation went out on the hardcoded `gemini-2.5-flash` in `src/lib/ai/config.ts`, and the debug panel reported that same string as `modelUsed` no matter what ran. So picking `gemini-2.5-pro` got you a successful ping against Pro and then a whole game on Flash.

The fix threads the model the same way the BYO key already travels. `aiFetch` attaches the active provider's model in a new `x-provider-model` header, and a new `resolveModel(request)` picks it up server-side exactly like `resolveApiKey` picks up the key. Nothing configured means the default model, so existing sessions and the env-key dev path behave as before.

Two guards on that header, since it's player-controlled input that lands in a URL path segment. It only gets through if it matches a model-id shape, and only when the same request carries a provider key. Without the second guard, a deployment with a server `GEMINI_API_KEY` would let any anonymous caller name an expensive model and spend the app's own key on it, because `resolveApiKey` falls back to the env key on its own.

Every text route now carries the model: narrative generation and choices through the two `apiHelpers` helpers, and the rest (endings, summaries, story checkpoints, world and character generation, world analysis, event significance, inventory categorization, similarity checks) by threading a `model` parameter alongside the `apiKey` parameter those generators already take. The image routes are deliberately untouched - they run on `imageModelName`, which the provider picker doesn't set.

## Related Issue

Fixes #1745. This targets `develop`, so GitHub won't auto-close the issue on merge - it needs closing by hand (or by the post-merge pass).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Implementation and tests went in together rather than strictly red-first, so that first box stays unchecked. The tests do assert the acceptance criteria rather than the mechanics: a configured model reaches the generation call, the default still applies when none is set, a junk header can't steer the request, and a model sent without a key is ignored.

## User Stories Addressed

As a player who brings their own Gemini key, the model I pick in provider configuration is the model my story actually runs on.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

No UI changes - this is all request plumbing.

## Implementation Notes

| File | What changed |
| --- | --- |
| `src/lib/ai/providerKeyHeader.ts` | Adds `PROVIDER_MODEL_HEADER` next to the key header |
| `src/lib/ai/resolveModel.ts` | New. Header model, validated and key-bound, falling back to the default |
| `src/lib/ai/config.ts` | `DEFAULT_TEXT_MODEL` replaces the inline literal; `getDefaultConfig` takes a model override |
| `src/lib/ai/defaultGeminiClient.ts` | `createDefaultGeminiClient` takes a model override |
| `src/lib/ai/aiFetch.ts` | Sends the active provider's model alongside the key |
| `src/state/providerStore.ts` | `getActiveProviderModel()` beside `getActiveProviderKey()` |
| `src/utils/apiHelpers.ts` | Both Gemini text helpers use `resolveModel(request)` |
| `src/lib/ai/narrativeGenerator.ts` | `modelUsed` reports the resolved model |
| Nine text routes + their generators | Pass `resolveModel(request)` next to `resolveApiKey(request)` |
| `src/app/api/ai/validate-provider/route.ts` | Uses the shared default instead of its own copy of the literal |

Two details worth flagging. The model rides in a header rather than each route's request body so route schemas stay about the generation instead of provider plumbing. And `aiFetch` now sends headers when either a key or a model exists, where before it short-circuited to a plain fetch on a missing key - a keyless provider with a model configured still gets its model through.

This stops short of #890: no provider `type` or `endpoint` plumbing, just the model.

## Screenshots

N/A

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit wasn't run locally; CI covers it. The one security-relevant bit here is deliberate: `resolveModel` refuses any header value that isn't a plain model id, because it lands in the Gemini REST path.

## Testing Instructions

```bash
npm test               # exit 0
npm run type-check     # exit 0
npm run lint           # exit 0 (146 pre-existing warnings, no errors)
npm run deps:validate  # exit 0
```

Manually: open provider configuration, save a Gemini key with `gemini-2.5-pro` selected, then start a session and take a turn. The network request to `/api/narrative/generate` carries `x-provider-model: gemini-2.5-pro`, and with debug info enabled the prompt debug panel reports Pro rather than Flash. Switch the provider back to `gemini-2.5-flash`, or clear the provider entirely, and generation falls back to the default with no header sent.

## Checklist

- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

The file-size box is unchecked because `apiHelpers.ts` and `narrativeGenerator.ts` were already well past 300 lines before this touched them; the changes here are one-liners inside both and the new file is 27 lines. No docs needed - nothing user-facing changed in the setup flow, the picker just works now. Accessibility is N/A for request plumbing.
