### PR TITLE
Fix two accent-band labels that fell under AA contrast

### DIFF
--- a/src/app/about.css
+++ b/src/app/about.css
@@ -291,6 +291,13 @@
   color: var(--color-text-secondary);
 }
 
+/* The CTA is the one section whose band is a --color-accent-soft fill rather
+   than canvas, and secondary ink only reaches 3.85:1 on it. accent-strong is
+   the token that exists for small text over that fill. */
+:root .component-about-cta .component-about-section-title {
+  color: var(--color-accent-strong);
+}
+
 :root .component-about-section-title::before {
   content: "";
   display: inline-block;

--- a/src/app/wizard.css
+++ b/src/app/wizard.css
@@ -1260,16 +1260,20 @@
   color: var(--color-on-accent);
 }
 
+/* --color-on-accent, not --color-text-inverse: the latter is white in both
+   modes, and the dark-mode accent is a light blue, so white lands at 2.81:1
+   there. on-accent flips to dark ink in dark mode, which is the whole reason
+   it exists. */
 :root .component-world-creation-wizard .wizard-progress-step-active .wizard-progress-label,
 :root .component-character-creation-wizard .wizard-progress-step-active .wizard-progress-label {
-  color: var(--color-text-inverse);
+  color: var(--color-on-accent);
 }
 
 :root .component-world-creation-wizard .wizard-progress-step-active .wizard-progress-circle-active,
 :root .component-character-creation-wizard .wizard-progress-step-active .wizard-progress-circle-active {
-  background: var(--color-text-inverse);
+  background: var(--color-on-accent);
   color: var(--color-accent);
-  border-color: var(--color-text-inverse);
+  border-color: var(--color-on-accent);
 }
 
 :root .component-world-creation-wizard .wizard-progress-circle,


### PR DESCRIPTION
## Description

Two labels sitting on accent-tinted fills fell under the 4.5:1 AA minimum, and both were token picks rather than layout problems. Each survived review because it passes in the other color mode.

The wizard's active step label used `--color-text-inverse`, which is white in both modes. The dark-mode accent is a light blue, so the label rendered white on light blue at 2.81:1. `--color-on-accent` is the token that flips to dark ink in dark mode, and the wrapper three lines above was already using it correctly.

The step circle beside it had the same mistake inverted, a white chip carrying an accent numeral. The issue reported that one as passing at 7.52:1, but that figure is the light-mode reading. Probing it in dark mode measures 2.81:1, so it's the same failure and it moved to the same token.

On the About page, five of the six section eyebrows sit on canvas and clear AA at 5.04:1. The sixth ("Ready to begin?") sits inside `.component-about-cta`, whose background is `--color-accent-soft` retinted to 18% on the brand register, and secondary ink only reaches 3.85:1 there. DESIGN.md's Colors -> Accent section already names `--color-accent-strong` as the token for small text over that fill, so the override is scoped to the CTA and leaves the other five eyebrows alone.

## Related Issue

Closes #1732

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

N/A. This is a two-token CSS change with no logic to test. Jest maps `*.css` through `identity-obj-proxy` (jest.config.cjs:10), so no unit test can observe a token swap. Verification is live contrast measurement plus the visual-regression suite, both below.

- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [ ] Test coverage maintained or improved

## User Stories Addressed

As a player using dark mode, I can read which step of the world wizard I'm on. As a player on the About page in light mode, the closing band's label is as legible as the five above it.

## Flow Diagrams

N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

No new components and no story changes. Consistency was checked in the running app rather than in isolation, since both bugs depend on the composited page background (the About band's alpha fill resolves against canvas, which Storybook wouldn't reproduce).

## Implementation Notes

Both changes are token swaps. No selectors were restructured, no new rules beyond the one CTA-scoped override, and no values hardcoded.

The About override is scoped `:root .component-about-cta .component-about-section-title` so it beats the base `:root .component-about-section-title` on specificity without touching the five instances on canvas.

## Screenshots

N/A. The evidence here is numeric, so the measured ratios below stand in for before/after images.

## Visual Baseline Changes

None. Both macOS visual shards and the tutorial visual job passed on the first run with no snapshot touched, which was not what I expected from a change that shifts rendered color, so it's worth saying why rather than just banking the green.

The wizard change only bites in dark mode, and no visual spec captures the wizard there. `world-creation.spec.ts` shoots the progress rail in light mode, where the label measures 7.52:1 before and after. Nothing to move.

The About change is a light-mode change and `about-page.spec.ts` does shoot that band in light mode, but the color shift lands just under Playwright's comparison threshold. At `threshold: 0.2` (playwright.config.ts:78) pixelmatch's cutoff is `35215 * 0.2^2` = 1408.6, and the eyebrow's `rgb(115,102,88)` to `rgb(41,66,91)` swap computes to a YIQ delta of 1303.4. Under the bar, so not a single pixel counts as different. The dark-mode reading is further under at 705.6.

That's a real coverage gap rather than evidence the change is cosmetic (the same probe that reports 3.85:1 before and 7.17:1 after is reading the live composited pixel). It's out of scope for a token swap, so I'm leaving it alone here rather than retuning a threshold that guards the whole manuscript baseline set.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

Measured with `bdg` against a dev server on this worktree, reading computed foreground and background, compositing every alpha layer up the ancestor chain, then computing the WCAG ratio. Every value below is a live reading, taken before and after the change in the same session.

| Surface | Mode | Before | After |
|---|---|---|---|
| `.wizard-progress-step-active .wizard-progress-label` | dark | 2.81:1 | 6.58:1 |
| `.wizard-progress-step-active .wizard-progress-label` | light | 7.52:1 | 7.52:1 |
| `.wizard-progress-step-active .wizard-progress-circle-active` | dark | 2.81:1 | 6.58:1 |
| `.wizard-progress-step-active .wizard-progress-circle-active` | light | 7.52:1 | 7.52:1 |
| `.component-about-cta .component-about-section-title` | light | 3.85:1 | 7.17:1 |
| `.component-about-cta .component-about-section-title` | dark | 5.42:1 | 5.19:1 |
| `.component-about-section-title` (on canvas, control) | light | 5.04:1 | 5.04:1 |
| `.component-about-section-title` (on canvas, control) | dark | 6.87:1 | 6.87:1 |

Four failures fixed, nothing regressed. The dark About eyebrow drops from 5.42 to 5.19 because accent-strong is a slightly lower-contrast ink than secondary on that band in dark mode, which is the value `_register-brand.css:134` already documents for this exact composite. It clears AA with room to spare.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Exit codes from the worktree: `lint:css` 0, `type-check` 0, `lint` 0 (146 pre-existing warnings, 0 errors), `npm test` 1.

That test exit needs explaining. Two suites fail under full-suite parallel load, and they're not the same two between runs: run one failed `ImageUploadPicker` and `SkillEditor`, run two failed `CharacterCreationWizard.portrait` and `SkillEditor`. The `SkillEditor` failure is a userEvent interleaving flake (the assertion receives `"aSawaiamamaianagaaaa"` where it expected `"Swimming"`, i.e. characters landing at a stale cursor position). All of them pass when run on their own, both with and without this change. Since jest stubs CSS, neither edited file is reachable from any unit test.

## Testing Instructions

Run the dev server and open `/worlds/create` with Appearance set to Dark. The current step's label and its numeral chip should read as dark ink on the blue pill rather than white on blue.

Then open `/about` in Light and scroll to the closing "Ready to begin?" band. That eyebrow should now read at the same strength as the five above it rather than washing out against the tinted fill.

To check the numbers rather than eyeball them, probe `getComputedStyle` on the two selectors in the table above and composite the background up the ancestor chain, since both fills are alpha values over canvas.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

DESIGN.md needed no update: it already documents both tokens and the reasoning behind them, which is how the fix was chosen. The two CSS files are over 300 lines, but both predate this change and it adds seven lines to one and four to the other.
