### PR TITLE
Add turn-level analytics events so play depth is measurable

### DIFF
--- a/src/app/worlds/[id]/play/__tests__/page.sessionEnded.test.tsx
+++ b/src/app/worlds/[id]/play/__tests__/page.sessionEnded.test.tsx
@@ -1,9 +1,10 @@
 /**
  * Tests for the session-ended funnel event's "leaving an active session"
- * trigger: tab close/reload (beforeunload) and navigating away from the play
- * route in-app (unmount). The "reached an ending" trigger lives in
- * narrativeStore.markSessionEnded and is covered separately in
- * narrativeStore.tracking.test.ts.
+ * trigger: tab close/reload (beforeunload), backgrounding/OS termination on
+ * mobile (visibilitychange/pagehide), and navigating away from the play
+ * route in-app (unmount) - plus dedup across those paths. The "reached an
+ * ending" trigger lives in narrativeStore.markSessionEnded and is covered
+ * separately in narrativeStore.tracking.test.ts.
  */
 
 import React from 'react';
@@ -15,6 +16,16 @@ import { useSessionStore } from '@/state/sessionStore';
 import { useNarrativeStore } from '@/state/narrativeStore';
 
 const mockTrack = track as jest.Mock;
+
+// jsdom's document.visibilityState is a read-only getter defaulting to
+// 'visible' - redefine it per test so visibilitychange can simulate the
+// backgrounded/hidden state a mobile OS suspend produces.
+const setVisibilityState = (state: DocumentVisibilityState) => {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => state,
+  });
+};
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn() }),
@@ -41,6 +52,7 @@ describe('Play Page - session-ended funnel tracking', () => {
     cleanup();
     useSessionStore.setState({ id: null });
     useNarrativeStore.setState({ currentEnding: null });
+    setVisibilityState('visible');
   });
 
   test('beforeunload fires session-ended for an active, unfinished session', () => {
@@ -82,5 +94,67 @@ describe('Play Page - session-ended funnel tracking', () => {
     unmount();
 
     expect(mockTrack).not.toHaveBeenCalledWith('session-ended');
+  });
+
+  test('visibilitychange (hidden) fires session-ended - covers mobile backgrounding/OS termination', () => {
+    useSessionStore.setState({ id: 'session-active' });
+    render(<PlayPage />);
+
+    act(() => {
+      setVisibilityState('hidden');
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(mockTrack).toHaveBeenCalledWith('session-ended');
+  });
+
+  test('visibilitychange back to visible does not fire session-ended', () => {
+    useSessionStore.setState({ id: 'session-active' });
+    render(<PlayPage />);
+
+    act(() => {
+      setVisibilityState('visible');
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(mockTrack).not.toHaveBeenCalledWith('session-ended');
+  });
+
+  test('pagehide fires session-ended', () => {
+    useSessionStore.setState({ id: 'session-active' });
+    render(<PlayPage />);
+
+    act(() => {
+      window.dispatchEvent(new Event('pagehide'));
+    });
+
+    expect(mockTrack).toHaveBeenCalledWith('session-ended');
+  });
+
+  test('dedupes across triggers - hidden then unmount only fires once', () => {
+    useSessionStore.setState({ id: 'session-active' });
+    const { unmount } = render(<PlayPage />);
+
+    act(() => {
+      setVisibilityState('hidden');
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    unmount();
+
+    expect(mockTrack).toHaveBeenCalledTimes(1);
+    expect(mockTrack).toHaveBeenCalledWith('session-ended');
+  });
+
+  test('dedupes across triggers - pagehide then beforeunload only fires once', () => {
+    useSessionStore.setState({ id: 'session-active' });
+    render(<PlayPage />);
+
+    act(() => {
+      window.dispatchEvent(new Event('pagehide'));
+      window.dispatchEvent(new Event('beforeunload'));
+    });
+
+    expect(mockTrack).toHaveBeenCalledTimes(1);
+    expect(mockTrack).toHaveBeenCalledWith('session-ended');
   });
 });

--- a/src/app/worlds/[id]/play/__tests__/page.sessionEnded.test.tsx
+++ b/src/app/worlds/[id]/play/__tests__/page.sessionEnded.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Tests for the session-ended funnel event's "leaving an active session"
+ * trigger: tab close/reload (beforeunload) and navigating away from the play
+ * route in-app (unmount). The "reached an ending" trigger lives in
+ * narrativeStore.markSessionEnded and is covered separately in
+ * narrativeStore.tracking.test.ts.
+ */
+
+import React from 'react';
+import { render, cleanup, act } from '@testing-library/react';
+import { track } from '@vercel/analytics';
+import PlayPage from '../page';
+import { useParams } from 'next/navigation';
+import { useSessionStore } from '@/state/sessionStore';
+import { useNarrativeStore } from '@/state/narrativeStore';
+
+const mockTrack = track as jest.Mock;
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  useParams: jest.fn().mockReturnValue({ id: 'world-1' }),
+  useSearchParams: jest.fn().mockReturnValue(new URLSearchParams()),
+  notFound: jest.fn(),
+}));
+
+jest.mock('@/components/GameSession/GameSession', () => {
+  return function DummyGameSession({ worldId }: { worldId: string }) {
+    return <div data-testid="mock-game-session">Game Session for {worldId}</div>;
+  };
+});
+
+describe('Play Page - session-ended funnel tracking', () => {
+  beforeEach(() => {
+    jest.spyOn(React, 'useState').mockImplementationOnce(() => [true, jest.fn()]);
+    (useParams as jest.Mock).mockReturnValue({ id: 'world-1' });
+    mockTrack.mockClear();
+    useNarrativeStore.setState({ currentEnding: null });
+  });
+
+  afterEach(() => {
+    cleanup();
+    useSessionStore.setState({ id: null });
+    useNarrativeStore.setState({ currentEnding: null });
+  });
+
+  test('beforeunload fires session-ended for an active, unfinished session', () => {
+    useSessionStore.setState({ id: 'session-active' });
+    render(<PlayPage />);
+
+    act(() => {
+      window.dispatchEvent(new Event('beforeunload'));
+    });
+
+    expect(mockTrack).toHaveBeenCalledWith('session-ended');
+  });
+
+  test('unmounting (navigating away) fires session-ended for an active, unfinished session', () => {
+    useSessionStore.setState({ id: 'session-active' });
+    const { unmount } = render(<PlayPage />);
+
+    unmount();
+
+    expect(mockTrack).toHaveBeenCalledWith('session-ended');
+  });
+
+  test('does not fire when there is no active session', () => {
+    useSessionStore.setState({ id: null });
+    const { unmount } = render(<PlayPage />);
+
+    unmount();
+
+    expect(mockTrack).not.toHaveBeenCalledWith('session-ended');
+  });
+
+  test('does not double-fire when an ending was already reached', () => {
+    useSessionStore.setState({ id: 'session-active' });
+    useNarrativeStore.setState({
+      currentEnding: { id: 'ending-1' } as ReturnType<typeof useNarrativeStore.getState>['currentEnding'],
+    });
+    const { unmount } = render(<PlayPage />);
+
+    unmount();
+
+    expect(mockTrack).not.toHaveBeenCalledWith('session-ended');
+  });
+});

--- a/src/app/worlds/[id]/play/page.tsx
+++ b/src/app/worlds/[id]/play/page.tsx
@@ -54,30 +54,49 @@ export default function PlayPage() {
     setIsClient(true);
   }, []);
 
-  // session-ended: fires when the player leaves an active session, via tab
-  // close/reload (beforeunload) or navigating away from the play route
-  // in-app (unmount). The listener is set up once, so it reads the latest
-  // session/ending state off a ref rather than closing over stale React
-  // state. Reaching an ending already reports its own session-ended event
-  // (narrativeStore's markSessionEnded), so this skips firing when an
-  // ending is already set.
+  // session-ended: fires when the player leaves an active session. Covers
+  // three exit paths, since no single one is reliable on its own:
+  //   - beforeunload: tab close/reload on desktop
+  //   - visibilitychange (hidden): backgrounding on mobile, where the OS can
+  //     kill the page before beforeunload or unmount ever runs
+  //   - unmount: navigating away from the play route in-app
+  // The listeners are set up once, so they read the latest session/ending
+  // state off a ref rather than closing over stale React state. A "fired"
+  // ref dedupes across the three paths so a single exit (e.g. background
+  // then later unmount) only reports once. Reaching an ending already
+  // reports its own session-ended event (narrativeStore's markSessionEnded),
+  // so this skips firing when an ending is already set.
   const sessionEndTrackingRef = useRef({ currentSessionId, currentEnding });
   useEffect(() => {
     sessionEndTrackingRef.current = { currentSessionId, currentEnding };
   }, [currentSessionId, currentEnding]);
 
   useEffect(() => {
+    const hasFiredRef = { current: false };
+
     const trackSessionEndedIfActive = () => {
+      if (hasFiredRef.current) return;
       const { currentSessionId, currentEnding } = sessionEndTrackingRef.current;
       if (currentSessionId && !currentEnding) {
+        hasFiredRef.current = true;
         trackFunnelStep('session-ended');
       }
     };
 
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        trackSessionEndedIfActive();
+      }
+    };
+
     window.addEventListener('beforeunload', trackSessionEndedIfActive);
+    window.addEventListener('pagehide', trackSessionEndedIfActive);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
 
     return () => {
       window.removeEventListener('beforeunload', trackSessionEndedIfActive);
+      window.removeEventListener('pagehide', trackSessionEndedIfActive);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
       trackSessionEndedIfActive();
     };
   }, []);

--- a/src/app/worlds/[id]/play/page.tsx
+++ b/src/app/worlds/[id]/play/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import dynamic from 'next/dynamic';
 import { notFound, useParams, useSearchParams, useRouter } from 'next/navigation';
 import { useSessionStore } from '@/state/sessionStore';
@@ -8,6 +8,7 @@ import { useNarrativeStore } from '@/state/narrativeStore';
 import { useWorldStore } from '@/state/worldStore';
 import { GameSessionConfirmationDialog } from '@/components/GameSession/GameSessionConfirmationDialog';
 import { ProviderGate } from '@/components/ai/ProviderGate';
+import { trackFunnelStep } from '@/lib/analytics/trackFunnelStep';
 
 // GameSession pulls the heaviest chain in the app (ActiveGameSession ->
 // NarrativeController -> @google/genai + every drawer panel). The page already
@@ -51,6 +52,34 @@ export default function PlayPage() {
   // Set isClient to true once component mounts
   useEffect(() => {
     setIsClient(true);
+  }, []);
+
+  // session-ended: fires when the player leaves an active session, via tab
+  // close/reload (beforeunload) or navigating away from the play route
+  // in-app (unmount). The listener is set up once, so it reads the latest
+  // session/ending state off a ref rather than closing over stale React
+  // state. Reaching an ending already reports its own session-ended event
+  // (narrativeStore's markSessionEnded), so this skips firing when an
+  // ending is already set.
+  const sessionEndTrackingRef = useRef({ currentSessionId, currentEnding });
+  useEffect(() => {
+    sessionEndTrackingRef.current = { currentSessionId, currentEnding };
+  }, [currentSessionId, currentEnding]);
+
+  useEffect(() => {
+    const trackSessionEndedIfActive = () => {
+      const { currentSessionId, currentEnding } = sessionEndTrackingRef.current;
+      if (currentSessionId && !currentEnding) {
+        trackFunnelStep('session-ended');
+      }
+    };
+
+    window.addEventListener('beforeunload', trackSessionEndedIfActive);
+
+    return () => {
+      window.removeEventListener('beforeunload', trackSessionEndedIfActive);
+      trackSessionEndedIfActive();
+    };
   }, []);
 
   // Handle Start New button click with confirmation

--- a/src/lib/analytics/__tests__/trackFunnelStep.test.ts
+++ b/src/lib/analytics/__tests__/trackFunnelStep.test.ts
@@ -36,4 +36,20 @@ describe('trackFunnelStep (#1367)', () => {
 
     expect(mockTrack).not.toHaveBeenCalled();
   });
+
+  it('accepts the turn-level events and gates them the same as the others', () => {
+    trackFunnelStep('narrative-turn');
+    trackFunnelStep('session-ended');
+
+    expect(mockTrack).toHaveBeenNthCalledWith(1, 'narrative-turn');
+    expect(mockTrack).toHaveBeenNthCalledWith(2, 'session-ended');
+
+    mockIsPlaywright.mockReturnValue(true);
+    mockTrack.mockClear();
+
+    trackFunnelStep('narrative-turn');
+    trackFunnelStep('session-ended');
+
+    expect(mockTrack).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/analytics/trackFunnelStep.ts
+++ b/src/lib/analytics/trackFunnelStep.ts
@@ -5,7 +5,13 @@ import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
  * The funnel steps we measure. Names only — this union is the entire
  * vocabulary that ever leaves the browser.
  */
-type FunnelStep = 'landing' | 'session-started' | 'return-visit' | 'world-created';
+type FunnelStep =
+  | 'landing'
+  | 'session-started'
+  | 'return-visit'
+  | 'world-created'
+  | 'narrative-turn'
+  | 'session-ended';
 
 /**
  * Fire an anonymous funnel-step event to Vercel Web Analytics.

--- a/src/state/__tests__/narrativeStore.tracking.test.ts
+++ b/src/state/__tests__/narrativeStore.tracking.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for the turn-level funnel events wired into narrativeStore:
+ *   - narrative-turn: fired from addSegment, next to the state commit
+ *   - session-ended: fired from markSessionEnded, the chokepoint both
+ *     generateEnding paths (success and fallback) funnel through
+ *
+ * jest.setup.ts globally auto-mocks '@/state/narrativeStore' for component
+ * tests; unmock it here so these tests exercise the real store.
+ */
+
+jest.unmock('../narrativeStore');
+
+import { track } from '@vercel/analytics';
+import { useNarrativeStore } from '../narrativeStore';
+import { useWorldStore } from '../worldStore';
+import { useSessionStore } from '../sessionStore';
+
+const mockTrack = track as jest.Mock;
+
+describe('narrativeStore - turn-level funnel tracking', () => {
+  let worldId: string;
+  const sessionId = 'session-tracking-test';
+
+  beforeEach(() => {
+    jest.useRealTimers();
+    useWorldStore.getState().reset();
+    useNarrativeStore.getState().reset();
+    mockTrack.mockClear();
+
+    worldId = useWorldStore.getState().create({
+      name: 'Test World',
+      description: 'A test world',
+      genre: 'fantasy',
+      attributes: [],
+      skills: [],
+      settings: {
+        maxAttributes: 5,
+        maxSkills: 5,
+        attributePointPool: 10,
+        skillPointPool: 10,
+      },
+    });
+    useSessionStore.getState().upsertSessionLifecycle({
+      id: sessionId,
+      worldId,
+      characterId: 'char-test',
+      status: 'active',
+      lastActivity: new Date().toISOString(),
+    });
+  });
+
+  afterEach(() => {
+    useNarrativeStore.getState().reset();
+    useWorldStore.getState().reset();
+  });
+
+  test('addSegment fires the narrative-turn funnel event exactly once', () => {
+    useNarrativeStore.getState().addSegment(sessionId, {
+      worldId,
+      content: 'You step into the tavern.',
+      type: 'scene',
+      timestamp: new Date(),
+      updatedAt: new Date().toISOString(),
+      metadata: { tags: [] },
+    });
+
+    expect(mockTrack).toHaveBeenCalledTimes(1);
+    expect(mockTrack).toHaveBeenCalledWith('narrative-turn');
+  });
+
+  test('markSessionEnded fires the session-ended funnel event exactly once', () => {
+    useNarrativeStore.getState().markSessionEnded(sessionId);
+
+    expect(mockTrack).toHaveBeenCalledTimes(1);
+    expect(mockTrack).toHaveBeenCalledWith('session-ended');
+  });
+});

--- a/src/state/narrativeStore.endings.ts
+++ b/src/state/narrativeStore.endings.ts
@@ -8,6 +8,7 @@ import { logger } from '../lib/utils/logger';
 import { aiFetch } from '@/lib/ai/aiFetch';
 import { useSessionStore } from './sessionStore';
 import { useJournalStore } from './journalStore';
+import { trackFunnelStep } from '@/lib/analytics/trackFunnelStep';
 import type { NarrativeStoreSet, NarrativeStoreGet } from './narrativeStore.types';
 
 const FALLBACK_ENDING_TONE: EndingTone = 'hopeful';
@@ -291,5 +292,9 @@ export const createNarrativeEndingActions = (
     } catch (error) {
       logger.warn('Failed to propagate session lifecycle status on ending', error);
     }
+
+    // Single chokepoint for reaching an ending - both the success and
+    // fallback paths in generateEnding funnel through here.
+    trackFunnelStep('session-ended');
   },
 });

--- a/src/state/narrativeStore.segments.ts
+++ b/src/state/narrativeStore.segments.ts
@@ -6,6 +6,7 @@ import { normalizeText, NORM_DESC } from '../lib/utils/textNormalization';
 import { applyWorldStateThreadUpdates } from '../lib/narrative/applyWorldStateThreadUpdates';
 import { useSessionStore } from './sessionStore';
 import { useGoalStore } from './goalStore';
+import { trackFunnelStep } from '@/lib/analytics/trackFunnelStep';
 import type { NarrativeStoreSet, NarrativeStoreGet } from './narrativeStore.types';
 
 const normalizeDecisionText = (text: string) => {
@@ -158,6 +159,10 @@ export const createNarrativeSegmentActions = (
         },
       };
     });
+
+    // A generated narrative segment just landed in state and is on its way
+    // to the player - this is the turn-level play-depth signal.
+    trackFunnelStep('narrative-turn');
 
     // Update the saved session's narrative count
     try {


### PR DESCRIPTION
## Description
Adds two funnel-step events so play depth is measurable, not just page entry. `session-started` fires on route entry — it means a play route rendered, nothing more. This adds `narrative-turn` (a story segment actually got generated and shown) and `session-ended` (the player reached an ending or left an active session).

Both are plain extensions to the existing closed union in `trackFunnelStep.ts` — same shape as the four events already there: no payload, no identifiers, gated off outside the browser and under Playwright.

## Related Issue
Addresses #1747

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — internal analytics instrumentation, not a user-facing feature.

## Flow Diagrams
N/A

## Component Development
N/A — no UI components added or changed.
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes
- `trackFunnelStep.ts`: extended the `FunnelStep` union with `narrative-turn` and `session-ended`.
- `narrative-turn`: fires from `narrativeStore.segments.ts`'s `addSegment`, right next to the `set()` call that commits a generated segment to state. Every caller of `addSegment` funnels through this one chokepoint (AI-generated segments, the intro bootstrap fallback, and item-usage narration all go through it), matching the existing `world-created` pattern where the store action is the single point of instrumentation rather than each call site.
- `session-ended`, ending trigger: fires from `narrativeStore.endings.ts`'s `markSessionEnded`, which both the success and fallback paths in `generateEnding` already call — one chokepoint, no new branching.
- `session-ended`, leave-session trigger: a `beforeunload` listener plus unmount cleanup scoped to `src/app/worlds/[id]/play/page.tsx` (the primary play route). It reads the latest session/ending state off a ref rather than closing over stale React state or reaching into store internals via `.getState()` — some existing tests fully replace the store hooks with plain mocks that don't carry a `getState` static, so the ref keeps this test-compatible. Skips firing if an ending was already reached, so a normal end-of-story exit doesn't double-count.

## Screenshots
N/A — no visual changes.

## Visual Baseline Changes
None.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed — not run, no dependency changes
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm test` — new coverage in `src/state/__tests__/narrativeStore.tracking.test.ts` (narrative-turn on `addSegment`, session-ended on `markSessionEnded`), `src/app/worlds/[id]/play/__tests__/page.sessionEnded.test.tsx` (beforeunload + unmount triggers, plus the no-active-session and already-ended no-op cases), and an added case in `trackFunnelStep.test.ts` confirming both new events go through the same Playwright/browser gating as the existing four.
2. Manual: play through a session locally, generate a turn, and watch the dev console/network tab for the `narrative-turn` beacon; reach an ending or navigate away mid-session and confirm `session-ended` fires once.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) — N/A, no public docs describe the funnel event list
- [x] No new warnings generated
- [x] Accessibility considerations addressed — N/A, no UI/markup changes
