### PR TITLE
Suppress the header CTA on the brand register

### DIFF
--- a/src/components/Landing/Landing.tsx
+++ b/src/components/Landing/Landing.tsx
@@ -145,7 +145,11 @@ export default function Landing() {
             stays in your browser, and there&apos;s no account to make.
           </h2>
           <div className="component-landing-actions">
-            <Link href={START_HREF} className="component-landing-cta">
+            {/* Secondary, not the solid-accent style the hero CTA above
+                uses: the hero already spent the page's one primary action,
+                and the demo above it is the stronger case for building a
+                world than a repeated button down here. */}
+            <Link href={START_HREF} className="component-landing-cta-secondary">
               {START_LABEL}
             </Link>
             <a

--- a/src/components/Navigation/HeaderNavigation.tsx
+++ b/src/components/Navigation/HeaderNavigation.tsx
@@ -98,9 +98,14 @@ export function HeaderNavigation() {
     setMounted(true);
   }, []);
 
-  const suppressCta = CTA_SUPPRESSED_ROUTES.some((route) =>
-    route.test(pathname)
-  );
+  // Brand routes suppress the header CTA wholesale rather than joining the
+  // regex list above: every brand page either owns its own primary CTA
+  // (about's closing band) or intentionally has none (privacy, terms), so a
+  // per-path entry here would rot the moment a brand sub-route lands — same
+  // reasoning BREADCRUMB_SUPPRESSED_ROUTES already applies.
+  const suppressCta =
+    !isProductRegister ||
+    CTA_SUPPRESSED_ROUTES.some((route) => route.test(pathname));
 
   const cta = suppressCta ? null : currentWorld ? (
     <Button

--- a/src/components/Navigation/__tests__/Navigation.test.tsx
+++ b/src/components/Navigation/__tests__/Navigation.test.tsx
@@ -222,6 +222,32 @@ describe('HeaderNavigation', () => {
         ).not.toBeInTheDocument();
       }
     );
+
+    // The brand register (/, /about, /privacy, /terms) suppresses the CTA
+    // wholesale rather than via CTA_SUPPRESSED_ROUTES, so each brand page's
+    // own CTA (or lack of one) is the only primary action on screen (#1734).
+    it.each(['/', '/about', '/privacy', '/terms'])(
+      'suppresses the CTA on the brand route %s',
+      (pathname) => {
+        mockPathname = pathname;
+
+        render(<HeaderNavigation />);
+
+        expect(
+          screen.queryByRole('button', { name: /Create Your First World/ })
+        ).not.toBeInTheDocument();
+      }
+    );
+
+    it('still renders the CTA on a product route not on the suppression list', () => {
+      mockPathname = '/settings';
+
+      render(<HeaderNavigation />);
+
+      expect(
+        screen.getByRole('button', { name: /Create Your First World/ })
+      ).toBeInTheDocument();
+    });
   });
 
   describe('Breadcrumb suppression (#1655)', () => {


### PR DESCRIPTION
## Description
`HeaderNavigation` suppressed its contextual CTA with a hardcoded regex list that only covered product routes, so every brand page (`/`, `/about`, `/privacy`, `/terms`) got the header CTA stacked on top of whatever CTA the page already owned. The landing page shipped three solid-accent CTAs at once — header, hero, and closing band.

Fix: `HeaderNavigation` now asks `getSurfaceRegister()` whether the route is `'brand'` and suppresses the CTA wholesale when it is, the same pattern the file already uses for breadcrumb suppression (the comment even said so). `CTA_SUPPRESSED_ROUTES` is untouched — it still owns product-route suppression.

That leaves the landing page with two solid CTAs (hero + closing band) once the header one is gone. The hero's is the one true primary — it pairs with the page's own strongest argument, the world-switcher demo. The closing band's "Build your world" link is downgraded to `.component-landing-cta-secondary`, the outline/underline style already used by the other closing-band links on the same page.

`/about` needed no further change — its own closing-band CTA is already the only one once the header CTA is gone. `/privacy` and `/terms` have no page-owned CTA, so losing the header one there is intentional (they end up with zero, which is correct — neither page has an action to promote).

## Related Issue
Addresses #1734

This targets `develop`, not the default branch (`main`), so the `Closes` keyword wouldn't auto-link — noting it as `Addresses` instead.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified (checked `/`, `/about`, `/privacy`, `/terms` against the running dev server)

No new component or Storybook story — this reuses the existing `.component-landing-cta-secondary` class already in the same file.

## Implementation Notes
- `src/components/Navigation/HeaderNavigation.tsx` — `suppressCta` now also checks `!isProductRegister` (i.e. the brand register), ahead of the existing `CTA_SUPPRESSED_ROUTES` check.
- `src/components/Landing/Landing.tsx` — the closing band's "Build your world" link changed from `.component-landing-cta` to `.component-landing-cta-secondary`. No new CSS.
- `about.css`, `/privacy`, `/terms` — no changes needed; verified by curling the dev server's rendered HTML for each route.

## Screenshots
Not attached — see Testing Instructions below for how to reproduce locally. Landing hero after the fix shows the header without a CTA and one solid "Build your world" button in the hero.

## Visual Baseline Changes
None committed. This change visually alters `/` (closing band CTA style) and `/about` (header CTA gone). The Playwright visual baselines for those specs are macOS-only and this session didn't have a clean local Playwright run available — `npm run test:visual:update` for the landing and about specs should be run locally on macOS before merge, or accept the diff on the next intentional baseline refresh. Visual regression isn't one of the required branch-protection checks (E2E is excluded as flaky), so this doesn't block CI.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm run dev` from this worktree (auto-selects its own port).
2. Visit `/` — header has no CTA; only the hero's "Build your world" is solid-accent; the closing band's is now an outline/secondary link.
3. Visit `/about` — header has no CTA; the page's own closing-band CTA is the only one.
4. Visit `/privacy` and `/terms` — header has no CTA; neither page had one to begin with.
5. Visit a product route like `/worlds` or `/dashboard` — header CTA behavior is unchanged.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) — none of the touched docs (DESIGN.md, ADRs) needed edits
- [x] No new warnings generated
- [x] Accessibility considerations addressed — no change to link/button semantics, only which CTA renders and its visual weight
