### PR TITLE
Fix four undefined CSS custom properties that silently drop their declarations

### DIFF
--- a/src/app/app-shell.css
+++ b/src/app/app-shell.css
@@ -2198,7 +2198,7 @@
   width: 100%;
   border-radius: var(--radius-md);
   overflow: hidden;
-  background: var(--color-surface-recessed);
+  background: var(--color-canvas);
   color: var(--color-text-muted);
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -219,7 +219,7 @@ body > * {
 }
 
 .button-secondary:hover {
-  background: var(--color-surface-muted);
+  background: var(--color-surface-hover);
   border-color: var(--color-border-strong, var(--color-border));
 }
 

--- a/src/app/wizard.css
+++ b/src/app/wizard.css
@@ -243,7 +243,7 @@
   border-radius: var(--radius-md);
   background: var(--color-surface-hover);
   color: var(--color-text-muted);
-  font-family: var(--font-display);
+  font-family: var(--font-interface);
   font-size: var(--font-size-xl);
   font-weight: 600;
 }

--- a/src/lib/theme/themes/__tests__/undefinedCustomProperties.test.ts
+++ b/src/lib/theme/themes/__tests__/undefinedCustomProperties.test.ts
@@ -14,9 +14,17 @@ const rootDir = path.join(__dirname, '../../../../..');
 // out of scope for this guard.
 const BARE_VAR_PATTERN = /var\(\s*(--[a-zA-Z0-9-]+)\s*\)/g;
 const DEFINITION_PATTERN = /(--[a-zA-Z0-9-]+)\s*:/g;
-// next/font (src/app/layout.tsx) injects custom properties via a `variable:
-// '--font-x'` config option rather than a literal CSS declaration.
+// next/font injects custom properties via a `variable: '--font-x'` config
+// option rather than a literal CSS declaration. This is the one file that
+// actually wires them up at runtime.
+const NEXT_FONT_LAYOUT_FILE = 'src/app/layout.tsx';
 const NEXT_FONT_VARIABLE_PATTERN = /variable:\s*['"](--[a-zA-Z0-9-]+)['"]/g;
+
+// Strip /* ... */ comments so a token name mentioned in prose (e.g.
+// "--color-x: was never defined") can't be mistaken for a real declaration.
+function stripCssComments(contents: string): string {
+  return contents.replace(/\/\*[\s\S]*?\*\//g, '');
+}
 
 function findSourceFiles(): string[] {
   return [
@@ -43,15 +51,22 @@ function findBareVarReferences(files: string[]): Map<string, string[]> {
   return references;
 }
 
+// Only real CSS declarations (and the one known runtime injection site)
+// count as a definition — not a token name mentioned in a test assertion,
+// fixture, or comment anywhere else under src/.
 function findDefinedProperties(): Set<string> {
   const defined = new Set<string>();
-  const files = globSync('src/**/*.{css,ts,tsx}', { cwd: rootDir, absolute: true });
 
-  for (const file of files) {
-    const contents = fs.readFileSync(file, 'utf-8');
+  for (const file of globSync('src/**/*.css', { cwd: rootDir, absolute: true })) {
+    const contents = stripCssComments(fs.readFileSync(file, 'utf-8'));
     for (const match of contents.matchAll(DEFINITION_PATTERN)) {
       defined.add(match[1]);
     }
+  }
+
+  const layoutPath = path.join(rootDir, NEXT_FONT_LAYOUT_FILE);
+  if (fs.existsSync(layoutPath)) {
+    const contents = fs.readFileSync(layoutPath, 'utf-8');
     for (const match of contents.matchAll(NEXT_FONT_VARIABLE_PATTERN)) {
       defined.add(match[1]);
     }

--- a/src/lib/theme/themes/__tests__/undefinedCustomProperties.test.ts
+++ b/src/lib/theme/themes/__tests__/undefinedCustomProperties.test.ts
@@ -1,0 +1,84 @@
+import fs from 'fs';
+import path from 'path';
+import { globSync } from 'glob';
+
+// Guard for #1731: a var(--name) reference with no fallback silently drops
+// its declaration if --name is never defined anywhere. Every bare var()
+// reference in production CSS (and story files, since Storybook decorators
+// hit the same bug) must resolve to a real definition site.
+
+const rootDir = path.join(__dirname, '../../../../..');
+
+// Matches a var() call with no fallback: var(--some-name). A var() call
+// with a fallback (a comma before the closing paren) is already safe and
+// out of scope for this guard.
+const BARE_VAR_PATTERN = /var\(\s*(--[a-zA-Z0-9-]+)\s*\)/g;
+const DEFINITION_PATTERN = /(--[a-zA-Z0-9-]+)\s*:/g;
+// next/font (src/app/layout.tsx) injects custom properties via a `variable:
+// '--font-x'` config option rather than a literal CSS declaration.
+const NEXT_FONT_VARIABLE_PATTERN = /variable:\s*['"](--[a-zA-Z0-9-]+)['"]/g;
+
+function findSourceFiles(): string[] {
+  return [
+    ...globSync('src/**/*.css', { cwd: rootDir, absolute: true }),
+    ...globSync('src/**/*.stories.tsx', { cwd: rootDir, absolute: true }),
+  ];
+}
+
+function findBareVarReferences(files: string[]): Map<string, string[]> {
+  const references = new Map<string, string[]>();
+
+  for (const file of files) {
+    const contents = fs.readFileSync(file, 'utf-8');
+    const relativePath = path.relative(rootDir, file);
+
+    for (const match of contents.matchAll(BARE_VAR_PATTERN)) {
+      const name = match[1];
+      const existing = references.get(name) ?? [];
+      existing.push(relativePath);
+      references.set(name, existing);
+    }
+  }
+
+  return references;
+}
+
+function findDefinedProperties(): Set<string> {
+  const defined = new Set<string>();
+  const files = globSync('src/**/*.{css,ts,tsx}', { cwd: rootDir, absolute: true });
+
+  for (const file of files) {
+    const contents = fs.readFileSync(file, 'utf-8');
+    for (const match of contents.matchAll(DEFINITION_PATTERN)) {
+      defined.add(match[1]);
+    }
+    for (const match of contents.matchAll(NEXT_FONT_VARIABLE_PATTERN)) {
+      defined.add(match[1]);
+    }
+  }
+
+  return defined;
+}
+
+describe('no undefined CSS custom properties referenced without a fallback', () => {
+  const files = findSourceFiles();
+  const references = findBareVarReferences(files);
+  const defined = findDefinedProperties();
+
+  it('found source files to check (sanity check on the glob)', () => {
+    expect(files.length).toBeGreaterThan(10);
+  });
+
+  it('every bare var(--name) reference has a matching --name: definition', () => {
+    const undefinedProperties = [...references.keys()]
+      .filter((name) => !defined.has(name))
+      .sort();
+
+    if (undefinedProperties.length > 0) {
+      const details = undefinedProperties
+        .map((name) => `${name} (used in: ${references.get(name)!.join(', ')})`)
+        .join('\n');
+      throw new Error(`Undefined custom properties:\n${details}`);
+    }
+  });
+});

--- a/src/stories/02-molecules/forms/ImageGenerationSection.stories.tsx
+++ b/src/stories/02-molecules/forms/ImageGenerationSection.stories.tsx
@@ -7,7 +7,7 @@ const placeholder = (
     style={{
       width: '160px',
       height: '160px',
-      background: 'var(--color-surface-raised)',
+      background: 'var(--color-surface)',
       border: '1px solid var(--color-border)',
       borderRadius: 'var(--radius-md, 0.5rem)',
     }}


### PR DESCRIPTION
## Description
Fixes four CSS custom properties that were referenced with `var(--x)` and no fallback, but never defined anywhere — an invalid reference at computed-value time, so the browser silently drops the whole declaration. Worst case: hovering any secondary button dropped its background to transparent, since `.button-secondary:hover` pointed at `--color-surface-muted`, a token that doesn't exist.

**Scope correction:** the issue as filed listed eight undefined properties. Re-verified against `develop` before starting — four of the eight (`--color-accent-fill`, `--shadow-float`, `--font-mono`, `--color-text`) are already fixed by an earlier PR and no longer appear as bare references. Only four are still broken. I corrected the issue body and title to match (`Eight` → `Four`) rather than fix eight things where four don't exist anymore: https://github.com/jerseycheese/Narraitor/issues/1731

Each fix points the reference at a real, already-defined token — not just a fallback that silences the symptom:

- `--color-surface-muted` → `--color-surface-hover` (`src/app/globals.css`) — matches the base (non-hover) rule right above it, and matches the fallback `badge.css` already had (`var(--color-surface-muted, var(--color-surface-hover))`).
- `--color-surface-recessed` → `--color-canvas` (`src/app/app-shell.css`) — no "recessed" token exists in DS3; `--color-canvas` is what the app already uses elsewhere as the sunken/inset background inside a bordered well (dashboard, wizard, app-shell all do this).
- `--font-display` → `--font-interface` (`src/app/wizard.css`) — no display token exists; DS3 only has `--font-narrative` / `--font-system` / `--font-interface`. The sibling `.component-character-portrait-placeholder` rule right below it already uses `--font-interface` for the same kind of placeholder.
- `--color-surface-raised` → `--color-surface` (Storybook decorator only, `ImageGenerationSection.stories.tsx`) — no "raised" token exists; `--color-surface` + `--shadow-drawer` is the elevated-panel pattern other Storybook decorators already use.

## Related Issue
Addresses #1731

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — infrastructure/design-token bug fix, not a user-facing feature.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

One existing Storybook story (`ImageGenerationSection.stories.tsx`) had its decorator's background token corrected; no new stories needed.

## Implementation Notes
Added a guard test, `src/lib/theme/themes/__tests__/undefinedCustomProperties.test.ts`, in the same shape as the existing `typeScaleMigration.test.ts` precedent: it collects every fallback-free `var(--x)` reference in `src/**/*.css` and `src/**/*.stories.tsx`, and asserts each referenced name has a real `--x:` definition site somewhere under `src/` (it also recognizes `next/font`'s `variable: '--font-x'` config as a valid definition, since those three font tokens are injected at build time rather than declared in CSS literal text). Confirmed the test fails on exactly the four properties above before the fix (verified by stashing the fix and re-running) and passes clean after.

## Screenshots
N/A — no visual change beyond the hover state now actually rendering (was invisible before).

## Visual Baseline Changes
None.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
Started this worktree's dev server and confirmed in the live app (both light and dark mode) via the browser's own computed styles: `.button-secondary:hover`'s `background` declaration now resolves `--color-surface-hover` to a real color (`rgb(239 233 224)` light / `rgb(18 15 12)` dark), where the old `--color-surface-muted` reference resolved to an empty string.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed (not run — no dependency changes)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm test` — guard test at `src/lib/theme/themes/__tests__/undefinedCustomProperties.test.ts` passes; confirms no other bare-undefined custom properties exist.
2. `npm run dev`, open `/settings` or any wizard step with a secondary button, hover it — background now shifts to the hover surface instead of disappearing.
3. Toggle light/dark mode and repeat — both resolve to real colors.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic (none needed — one-line token swaps)
- [x] Documentation updated (if required) — issue #1731 body and title corrected to match verified scope
- [x] No new warnings generated
- [x] Accessibility considerations addressed — fix restores an existing hover affordance that was silently broken; no new a11y surface
