### PR TITLE
Name the type scale's three half-steps instead of hand-writing them 119 times

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -164,7 +164,7 @@ Use the utility classes when consuming in components:
 
 ### Sizes
 
-A named type scale exists as `--font-size-*` custom properties in [_shared-tokens.css](src/lib/theme/themes/_shared-tokens.css) (#1622). Steps are calibrated to real anchors already in use rather than forced onto one strict ratio, so adjacent steps span roughly a Major Second to Major Third (1.11-1.25):
+A named type scale exists as `--font-size-*` custom properties in [_shared-tokens.css](src/lib/theme/themes/_shared-tokens.css) (#1622). Steps are calibrated to real anchors already in use rather than forced onto one strict ratio, so adjacent whole steps span roughly a Major Second to Major Third (1.11-1.25):
 
 - `--font-size-3xl` (`2.125rem`) — the largest heading in the app (page-layout hero title)
 - `--font-size-2xl` (`1.875rem`)
@@ -172,11 +172,16 @@ A named type scale exists as `--font-size-*` custom properties in [_shared-token
 - `--font-size-lg` (`1.25rem`)
 - `--font-size-md` (`1.125rem`) — section headings
 - `--font-size-base` (`1rem`) — body and narrative default
+- `--font-size-sm_5` (`0.9375rem`) - one notch under body, for text sitting beside body copy without competing with it
 - `--font-size-sm` (`0.875rem`) — interface text, labels
+- `--font-size-xs_5` (`0.8125rem`) - dense interface text: HUD chrome, wizard helper copy, session metadata
 - `--font-size-xs` (`0.75rem`) — small metadata
+- `--font-size-2xs_5` (`0.6875rem`) - the tightest step that still reads, for stacked labels in the game-session HUD
 - `--font-size-2xs` (`0.625rem`) — badges and dense data tables only
 
-The highest-traffic hardcoded sizes across the app have been migrated onto these tokens; a handful of one-off in-between values (e.g. `1.0625rem`, `1.75rem`) haven't been touched yet — that's tracked as incremental follow-up, not a gap in the scale itself.
+The three `_5` steps are half-steps, the same suffix idiom the `--space-*` scale uses, and each one lands on the exact midpoint of the pair it sits between. They got names because 119 declarations across the app's densest surfaces had already settled on those sizes by hand, one at a time, with nowhere on the nine-step scale to move to. Reach for a whole step first; the half-steps are there for surfaces that genuinely land between two of them.
+
+A handful of genuine one-off sizes (`1.0625rem`, `1.75rem`, a few `clamp()` pairs) still sit outside the scale. Those are incremental follow-up, not a gap in the scale itself.
 
 ### Usage rules
 

--- a/src/app/about.css
+++ b/src/app/about.css
@@ -180,7 +180,7 @@
 .component-about-step-description {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   line-height: 1.55;
   color: var(--color-text-secondary);
 }
@@ -239,7 +239,7 @@
 
 .component-about-footer-link {
   font-family: var(--font-interface);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   color: var(--color-text-secondary);
   text-decoration: none;
 }
@@ -271,7 +271,7 @@
   align-items: center;
   gap: var(--space-2);
   font-family: var(--font-system);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   font-weight: 500;
   letter-spacing: 0.14em;
   text-transform: uppercase;

--- a/src/app/app-shell.css
+++ b/src/app/app-shell.css
@@ -505,7 +505,7 @@
   align-items: center;
   gap: var(--space-2);
   font-family: var(--font-interface);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   color: var(--color-text-muted);
   white-space: nowrap;
 }
@@ -765,7 +765,7 @@
   background: var(--color-surface);
   color: var(--color-text-secondary);
   font-family: var(--font-interface);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   font-weight: 500;
   cursor: pointer;
   transition: all 120ms ease;
@@ -865,7 +865,7 @@
   background: transparent;
   cursor: pointer;
   font-family: var(--font-interface);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   font-weight: 500;
   color: var(--color-text-primary);
   transition: background-color 120ms ease, border-color 120ms ease;
@@ -954,7 +954,7 @@
 .world-card-description-block p {
   color: var(--color-text-secondary);
   font-family: var(--font-interface);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   line-height: 1.5;
   margin: 0;
   display: -webkit-box;
@@ -1029,7 +1029,7 @@
 
 .world-list-empty-description {
   font-family: var(--font-interface);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   color: var(--color-text-muted);
   margin: 0;
   max-width: 36rem;
@@ -1051,7 +1051,7 @@
 
 .world-list-empty-guide-heading {
   font-family: var(--font-interface);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   font-weight: 600;
   color: var(--color-text-primary);
   margin: 0;
@@ -1065,7 +1065,7 @@
   margin: 0;
   color: var(--color-text-secondary);
   font-family: var(--font-interface);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   line-height: 1.5;
 }
 
@@ -1517,7 +1517,7 @@
   display: block;
   margin-bottom: var(--space-1);
   font-family: var(--font-system);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   font-weight: 500;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -1961,7 +1961,7 @@
 
 :root .settings-export-import-help {
   font-family: var(--font-system);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
 }
 
 :root .settings-export-import-help p + p {
@@ -2237,7 +2237,7 @@
 :root .journal-page .journal-list-header h2 {
   position: relative;
   font-family: var(--font-system);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   letter-spacing: 0.05em;
   text-transform: uppercase;
 }
@@ -2258,7 +2258,7 @@
   background-position: top left;
   padding-top: var(--space-4);
   font-family: var(--font-system);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   letter-spacing: 0.05em;
 }
 
@@ -2384,7 +2384,7 @@
   position: relative;
   padding-top: var(--space-2);
   font-family: var(--font-system);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   letter-spacing: 0.05em;
   color: var(--color-text-muted);
 }
@@ -2446,7 +2446,7 @@
 :root .component-section-wrapper-title {
   position: relative;
   font-family: var(--font-system);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   letter-spacing: 0.05em;
   text-transform: uppercase;
 }
@@ -2609,7 +2609,7 @@
 
 .component-ending-screen-achievement-description {
   font-family: var(--font-interface);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   color: var(--color-text-secondary);
 }
 
@@ -2625,7 +2625,7 @@
 
 :root .component-ending-screen-hero-meta {
   font-family: var(--font-system);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   letter-spacing: 0.05em;
   color: var(--color-text-muted);
 }
@@ -2754,7 +2754,7 @@
 .world-detail-npc-name {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   font-weight: 600;
   color: var(--color-text-primary);
 }
@@ -2762,7 +2762,7 @@
 .world-detail-npc-description {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   color: var(--color-text-secondary);
   line-height: 1.5;
 }
@@ -2861,7 +2861,7 @@
 
 .world-detail-meta-grid .component-data-field > span:first-child {
   font-family: var(--font-system);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   font-weight: 500;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -2873,13 +2873,13 @@
 .world-detail-meta-grid .component-data-field > div:last-child {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   color: var(--color-text-primary);
 }
 
 .world-detail-meta-grid .component-data-field-stacked > div:first-child {
   font-family: var(--font-system);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   font-weight: 500;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -2898,7 +2898,7 @@ section[aria-labelledby="image-details-heading"] .component-data-field-stacked {
 }
 
 section[aria-labelledby="image-details-heading"] .component-data-field-stacked > div:last-child {
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   line-height: 1.45;
 }
 
@@ -3047,7 +3047,7 @@ section[aria-labelledby="image-details-heading"] .component-data-field-stacked >
 .character-detail-background-heading {
   margin: 0 0 var(--space-2);
   font-family: var(--font-system);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   font-weight: 500;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -3057,7 +3057,7 @@ section[aria-labelledby="image-details-heading"] .component-data-field-stacked >
 .character-detail-background-text {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   line-height: 1.6;
   color: var(--color-text-primary);
 }
@@ -3072,7 +3072,7 @@ section[aria-labelledby="image-details-heading"] .component-data-field-stacked >
 
 .character-detail-background-list-item {
   font-family: var(--font-interface);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   line-height: 1.5;
   color: var(--color-text-primary);
 }
@@ -3257,7 +3257,7 @@ section[aria-labelledby="image-details-heading"] .component-data-field-stacked >
 }
 
 :root .component-world-card .component-hero-title {
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   font-style: italic;
   font-family: var(--font-narrative);
 
@@ -3289,7 +3289,7 @@ section[aria-labelledby="image-details-heading"] .component-data-field-stacked >
   grid-row: 2;
   padding: 0;
   font-family: var(--font-system);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   letter-spacing: 0.08em;
   color: var(--color-text-muted);
   border-top: 0;
@@ -3380,7 +3380,7 @@ section[aria-labelledby="image-details-heading"] .component-data-field-stacked >
   gap: var(--space-2);
   margin-top: var(--space-1);
   font-family: var(--font-system);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   letter-spacing: 0.08em;
   color: var(--color-text-muted);
 }
@@ -3390,7 +3390,7 @@ section[aria-labelledby="image-details-heading"] .component-data-field-stacked >
   margin: var(--space-1) 0 0;
   padding: 0;
   font-family: var(--font-interface);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   color: var(--color-text-secondary);
   display: -webkit-box;
   -webkit-line-clamp: 2;

--- a/src/app/badge.css
+++ b/src/app/badge.css
@@ -27,7 +27,7 @@
 
 .badge-md {
   padding: var(--space-0_5) var(--space-2);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
 }
 
 .badge-lg {

--- a/src/app/character-display.css
+++ b/src/app/character-display.css
@@ -167,7 +167,7 @@
 
 .attributes-form-constraint,
 .skills-form-constraint {
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   color: var(--color-warning);
   font-weight: 500;
 }

--- a/src/app/dashboard.css
+++ b/src/app/dashboard.css
@@ -99,7 +99,7 @@
 .dashboard-progress-stat-label {
   margin: 0;
   font-family: var(--font-system);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--color-text-muted);
@@ -150,7 +150,7 @@
 
 .dashboard-continue-card-field dt {
   font-family: var(--font-system);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--color-text-muted);
@@ -255,7 +255,7 @@
 .dashboard-recent-item span,
 .dashboard-recent-item p {
   font-family: var(--font-system);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   color: var(--color-text-muted);
   margin: 0;
 }
@@ -320,7 +320,7 @@
 .dashboard-recent-empty-state p {
   margin: 0;
   font-family: var(--font-system);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   color: var(--color-text-muted);
 }
 
@@ -391,7 +391,7 @@
 
 .dashboard-getting-started-step-label {
   font-family: var(--font-interface);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   color: var(--color-text-primary);
 }
 
@@ -679,7 +679,7 @@
   font-family: var(--font-system);
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
 }
 
 :root .dashboard-getting-started-steps {
@@ -729,14 +729,14 @@
 
 :root .world-card-description-block p {
   font-family: var(--font-system);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
 }
 
 :root .world-card-footer-meta time {
   font-family: var(--font-system);
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
 }
 
 :root .world-list-empty {
@@ -760,7 +760,7 @@
   align-items: center;
   gap: var(--space-2);
   font-family: var(--font-system);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   font-weight: 500;
   letter-spacing: 0.12em;
   text-transform: uppercase;

--- a/src/app/faq.css
+++ b/src/app/faq.css
@@ -138,7 +138,7 @@
   gap: var(--space-2);
   margin: 0;
   font-family: var(--font-system);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   font-weight: 500;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -186,7 +186,7 @@
 .component-faq-answer p {
   margin: 0;
   font-family: var(--font-system);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   line-height: 1.6;
   color: var(--color-text-secondary);
 }
@@ -222,7 +222,7 @@
 
 .component-faq-footer-link {
   font-family: var(--font-interface);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   color: var(--color-text-secondary);
   text-decoration: none;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -391,7 +391,7 @@ body > * {
   justify-content: space-between;
   gap: var(--space-2);
   font-family: var(--font-interface);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   color: var(--color-text-muted);
 }
 
@@ -535,7 +535,7 @@ body > * {
 
 .app-global-error-message {
   font-family: var(--font-interface);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   line-height: 1.5;
   max-width: 32rem;
   margin: 0;
@@ -543,7 +543,7 @@ body > * {
 
 .app-global-error-suggestion {
   font-family: var(--font-interface);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   line-height: 1.5;
   color: var(--color-text-secondary);
   max-width: 32rem;

--- a/src/app/legal.css
+++ b/src/app/legal.css
@@ -65,7 +65,7 @@
 .component-legal-updated {
   margin: 0;
   font-family: var(--font-system);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   color: var(--color-text-muted);
 }
 
@@ -88,7 +88,7 @@
   gap: var(--space-2);
   margin: 0;
   font-family: var(--font-system);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   font-weight: 500;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -114,7 +114,7 @@
 .component-legal-prose p {
   margin: 0;
   font-family: var(--font-system);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   line-height: 1.6;
   color: var(--color-text-secondary);
 }
@@ -147,7 +147,7 @@
 
 .component-legal-footer-link {
   font-family: var(--font-interface);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   color: var(--color-text-secondary);
   text-decoration: none;
 }

--- a/src/app/wizard.css
+++ b/src/app/wizard.css
@@ -993,7 +993,7 @@
 :root .wizard-page .wizard-progress-circle {
   border-radius: 3px;
   font-family: var(--font-system);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
 }
 
 :root .wizard-page .wizard-progress-connector {
@@ -1023,7 +1023,7 @@
 
 :root .wizard-page .wizard-progress-label {
   font-family: var(--font-system);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   letter-spacing: 0.05em;
 }
 
@@ -1045,7 +1045,7 @@
   display: block;
   margin-bottom: var(--space-1);
   font-family: var(--font-system);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   font-weight: 500;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -1396,7 +1396,7 @@
 
 .wizard-review-card-meta > span:nth-child(n + 2):not(.wizard-badge) {
   font-weight: 400;
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   color: var(--color-text-secondary);
 }
 
@@ -1476,7 +1476,7 @@
 
 .wizard-review-custom-heading p {
   margin: 0;
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   color: var(--color-text-secondary);
 }
 
@@ -1664,7 +1664,7 @@
 }
 
 .portrait-step-hint {
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   color: var(--color-text-muted);
 }
 
@@ -1711,7 +1711,7 @@
 
 .wizard-skill-card-info p {
   margin: 0;
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   color: var(--color-text-secondary);
 }
 
@@ -1975,7 +1975,7 @@
 .component-guided-first-time-step-description {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   color: var(--color-text-secondary);
 }
 
@@ -2038,7 +2038,7 @@
 
 :root .component-guided-first-time-step-num {
   font-family: var(--font-system);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   letter-spacing: 0.05em;
   text-transform: uppercase;
 }
@@ -2075,7 +2075,7 @@
 
 :root .component-guided-first-time-skip {
   font-family: var(--font-system);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   letter-spacing: 0.05em;
   text-transform: uppercase;
 }
@@ -2163,7 +2163,7 @@
 
 .component-world-creation-wizard .wizard-radio-option-desc {
   margin: 0;
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   color: var(--color-text-secondary);
 }
 
@@ -2183,7 +2183,7 @@
 }
 
 .component-world-creation-wizard .wizard-suggestion-hint {
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   color: var(--color-text-muted);
 }
 
@@ -2227,7 +2227,7 @@
 }
 
 .component-world-creation-wizard .wizard-suggestion-item-desc {
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   color: var(--color-text-secondary);
 }
 
@@ -2249,7 +2249,7 @@
 
 .component-world-creation-wizard .wizard-difficulty-legend-label {
   font-family: var(--font-interface);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   font-weight: 600;
   color: var(--color-text-secondary);
 }

--- a/src/components/devtools/DecisionConsoleSection/DecisionConsoleSection.css
+++ b/src/components/devtools/DecisionConsoleSection/DecisionConsoleSection.css
@@ -5,7 +5,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
 }
 
 .devtools-decision-console-controls {
@@ -18,7 +18,7 @@
 .devtools-decision-console-controls .form-input,
 .devtools-decision-console-controls .form-select {
   flex: 1 1 10rem;
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
 }
 
 .devtools-decision-console-patterns {

--- a/src/components/devtools/DecisionFlowSection/DecisionFlowSection.css
+++ b/src/components/devtools/DecisionFlowSection/DecisionFlowSection.css
@@ -5,7 +5,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
 }
 
 .devtools-decision-flow-controls {
@@ -17,7 +17,7 @@
 
 .devtools-decision-flow-controls .form-select {
   flex: 1 1 12rem;
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
 }
 
 .devtools-decision-flow-traces {
@@ -71,7 +71,7 @@
 }
 
 .devtools-decision-flow-step-label {
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;

--- a/src/components/devtools/DevToolsPanel/DevToolsPanel.css
+++ b/src/components/devtools/DevToolsPanel/DevToolsPanel.css
@@ -9,7 +9,7 @@
   background: var(--color-surface);
   color: var(--color-text-primary);
   font-family: var(--font-system);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
 }
 
 .devtools-panel-header {
@@ -71,7 +71,7 @@
 
 .devtools-panel-group-title {
   margin: 0;
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;

--- a/src/components/ui/EmptyState/EmptyState.css
+++ b/src/components/ui/EmptyState/EmptyState.css
@@ -48,7 +48,7 @@
 .component-empty-state-content p {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   line-height: 1.5;
   color: var(--color-text-secondary);
 }

--- a/src/components/ui/alert.css
+++ b/src/components/ui/alert.css
@@ -19,7 +19,7 @@
 
 .alert-title {
   margin: 0;
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   font-weight: 600;
   color: var(--color-text-primary);
 }

--- a/src/components/ui/card.css
+++ b/src/components/ui/card.css
@@ -46,7 +46,7 @@
   flex: 1;
   padding: var(--space-3) var(--space-4);
   font-family: var(--font-narrative);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   line-height: 1.6;
   color: var(--color-text-secondary);
 }

--- a/src/components/ui/toast/toast.css
+++ b/src/components/ui/toast/toast.css
@@ -42,7 +42,7 @@
 
 .toast-title {
   margin: 0;
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   font-weight: 600;
   line-height: 1.3;
   color: var(--color-text-primary);

--- a/src/lib/theme/themes/__tests__/typeScale.test.ts
+++ b/src/lib/theme/themes/__tests__/typeScale.test.ts
@@ -11,10 +11,15 @@ const sharedTokensCss = fs.readFileSync(
 // "values in active use" (badges/metadata, interface text, body, section
 // headings, page titles); --font-size-3xl matches the page-layout hero
 // title (app-shell.css .page-layout-title, ex-workshop.css:1810 per #1622).
+// The _5 steps are exact midpoints of the pair they sit between, covering
+// the dense surfaces that land between two named steps.
 const EXPECTED_SCALE: Array<[token: string, rem: number]> = [
   ['--font-size-2xs', 0.625],
+  ['--font-size-2xs_5', 0.6875],
   ['--font-size-xs', 0.75],
+  ['--font-size-xs_5', 0.8125],
   ['--font-size-sm', 0.875],
+  ['--font-size-sm_5', 0.9375],
   ['--font-size-base', 1],
   ['--font-size-md', 1.125],
   ['--font-size-lg', 1.25],

--- a/src/lib/theme/themes/__tests__/typeScaleMigration.test.ts
+++ b/src/lib/theme/themes/__tests__/typeScaleMigration.test.ts
@@ -9,8 +9,11 @@ const rootDir = path.join(__dirname, '../../../../..');
 // reference the token instead of repeating the literal.
 const MIGRATED_VALUES = [
   '0.625rem',
+  '0.6875rem',
   '0.75rem',
+  '0.8125rem',
   '0.875rem',
+  '0.9375rem',
   '1rem',
   '1.125rem',
   '1.25rem',
@@ -31,27 +34,49 @@ function findProductionCssFiles(): string[] {
   );
 }
 
+function findProductionTsxFiles(): string[] {
+  return globSync('src/**/*.tsx', { cwd: rootDir, absolute: true });
+}
+
+function findOffenders(files: string[], pattern: RegExp): string[] {
+  return files
+    .filter((file) => pattern.test(fs.readFileSync(file, 'utf-8')))
+    .map((file) => path.relative(rootDir, file));
+}
+
+function escapeValue(value: string): string {
+  return value.replace('.', '\\.');
+}
+
 describe('DS3 type scale migration: no re-introduced literals', () => {
   const cssFiles = findProductionCssFiles();
+  const tsxFiles = findProductionTsxFiles();
 
   it('found production CSS files to check (sanity check on the glob)', () => {
     expect(cssFiles.length).toBeGreaterThan(10);
   });
 
+  it('found production TSX files to check (sanity check on the glob)', () => {
+    expect(tsxFiles.length).toBeGreaterThan(10);
+  });
+
   it.each(MIGRATED_VALUES)(
-    'no font-size declaration hardcodes %s where a token now exists',
+    'no CSS font-size declaration hardcodes %s where a token now exists',
     (value) => {
-      const offenders: string[] = [];
-      const pattern = new RegExp(`font-size:\\s*${value.replace('.', '\\.')}\\b`);
+      const pattern = new RegExp(`font-size:\\s*${escapeValue(value)}\\b`);
+      expect(findOffenders(cssFiles, pattern)).toEqual([]);
+    }
+  );
 
-      for (const file of cssFiles) {
-        const contents = fs.readFileSync(file, 'utf-8');
-        if (pattern.test(contents)) {
-          offenders.push(path.relative(rootDir, file));
-        }
-      }
-
-      expect(offenders).toEqual([]);
+  // Inline styles in TSX bypass the CSS check entirely, which is how eight
+  // literals survived the first migration pass.
+  it.each(MIGRATED_VALUES)(
+    'no TSX inline fontSize hardcodes %s where a token now exists',
+    (value) => {
+      const pattern = new RegExp(
+        `fontSize:\\s*['"\`]${escapeValue(value)}['"\`]`
+      );
+      expect(findOffenders(tsxFiles, pattern)).toEqual([]);
     }
   );
 });

--- a/src/lib/theme/themes/_shared-tokens.css
+++ b/src/lib/theme/themes/_shared-tokens.css
@@ -28,10 +28,19 @@
    *   3xl matches the page-layout hero title (app-shell.css
    *     .page-layout-title), the largest real anchor in the app.
    * 2xs and 2xl fill the floor (dense data, below the badge threshold) and
-   * a step between page titles and the hero size. */
+   * a step between page titles and the hero size.
+   *   The three _5 steps are exact midpoints of the pair they sit between,
+   *   named with the same half-step suffix the --space-* scale uses. They
+   *   cover the dense end of the app -- HUD chrome, wizard helper text,
+   *   session metadata -- where the gap between adjacent named steps is a
+   *   visible jump rather than a nudge. Reach for a whole step first; these
+   *   exist because the dense surfaces genuinely land between them. */
   --font-size-2xs:  0.625rem;
+  --font-size-2xs_5: 0.6875rem;
   --font-size-xs:   0.75rem;
+  --font-size-xs_5: 0.8125rem;
   --font-size-sm:   0.875rem;
+  --font-size-sm_5: 0.9375rem;
   --font-size-base: 1rem;
   --font-size-md:   1.125rem;
   --font-size-lg:   1.25rem;

--- a/src/stories/00-foundation/DesignSystemShowcase.css
+++ b/src/stories/00-foundation/DesignSystemShowcase.css
@@ -92,7 +92,7 @@
 }
 
 .ds-showcase-field-error {
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   color: var(--color-danger);
 }
 
@@ -187,7 +187,7 @@
 }
 
 .ds-showcase-spacing-px {
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   color: var(--color-text-secondary);
 }
 

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -160,7 +160,7 @@ body.manuscript-overlay-open {
 
 .manuscript-play-entry-debug {
   font-family: var(--font-system);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   color: var(--color-text-secondary);
 }
 
@@ -213,7 +213,7 @@ body.manuscript-overlay-open {
 
 .play-page-shell > div > div > header p {
   font-family: var(--font-interface);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   line-height: 1.5;
   color: var(--color-text-secondary);
   margin: 0;
@@ -238,7 +238,7 @@ body.manuscript-overlay-open {
 
 .play-page-active > div > div > header p {
   font-family: var(--font-interface);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--color-text-muted);
@@ -256,7 +256,7 @@ body.manuscript-overlay-open {
 
 :root .play-page-shell > div > div > header p {
   font-family: var(--font-system);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--color-text-muted);
@@ -276,7 +276,7 @@ body.manuscript-overlay-open {
 
 :root .play-page-active > div > div > header p {
   font-family: var(--font-system);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--color-text-muted);
@@ -527,7 +527,7 @@ body.manuscript-overlay-open {
 .manuscript-characters-rail-label {
   margin: 0 0 var(--space-2);
   padding: 0;
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   font-family: var(--font-system);
   font-weight: 400;
   text-transform: uppercase;
@@ -794,7 +794,7 @@ body.manuscript-overlay-open {
 .manuscript-journal-snapshot-content {
   margin: 0;
   font-family: var(--font-narrative);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   line-height: 1.5;
   color: var(--color-text-secondary);
   display: -webkit-box;
@@ -1404,7 +1404,7 @@ body.manuscript-overlay-open {
 
 .manuscript-character-summary-subheading {
   margin: 0 0 var(--space-2);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--color-text-muted);
@@ -1569,7 +1569,7 @@ body.manuscript-overlay-open {
 .manuscript-inventory-item-name {
   font-family: var(--font-interface);
   font-weight: 600;
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   color: var(--color-text-primary);
 }
 
@@ -1581,7 +1581,7 @@ body.manuscript-overlay-open {
 
 .manuscript-inventory-item-description {
   font-family: var(--font-narrative);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   line-height: 1.5;
   color: var(--color-text-secondary);
   margin-bottom: var(--space-4);
@@ -1630,7 +1630,7 @@ body.manuscript-overlay-open {
 .manuscript-choice-history-choice {
   font-family: var(--font-interface);
   font-weight: 600;
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   color: var(--color-text-primary);
   margin-bottom: var(--space-2);
 }
@@ -1656,7 +1656,7 @@ body.manuscript-overlay-open {
 
 .manuscript-choice-history-outcome {
   font-family: var(--font-narrative);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   line-height: 1.5;
   color: var(--color-text-secondary);
   border-left: 2px solid var(--color-border);
@@ -1791,7 +1791,7 @@ body.manuscript-overlay-open {
 }
 
 .save-indicator-meta {
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   color: var(--color-text-muted);
   line-height: 1.1;
 }
@@ -2014,7 +2014,7 @@ body.manuscript-overlay-open {
 .manuscript-hud-panel-title {
   margin: 0 0 var(--space-2);
   font-family: var(--font-system), ui-monospace, monospace;
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   font-weight: 400;
   letter-spacing: 0.05em;
   color: var(--color-text-muted);
@@ -2038,7 +2038,7 @@ body.manuscript-overlay-open {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
 }
 
 .manuscript-character-snapshot-stats {
@@ -2073,7 +2073,7 @@ body.manuscript-overlay-open {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
 }
 
 .manuscript-character-snapshot-item-label {
@@ -2161,7 +2161,7 @@ body.manuscript-overlay-open {
 
 .choice-outcome-chip {
   font-family: var(--font-system), ui-monospace, monospace;
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   letter-spacing: 0.03em;
   padding: var(--space-0_5) var(--space-2);
   border: 1px solid var(--color-border);
@@ -2347,7 +2347,7 @@ body.manuscript-overlay-open {
 
 .manuscript-generation-error-suggestion {
   color: var(--color-text-muted);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
 }
 
 .manuscript-generation-error-retry {
@@ -2479,7 +2479,7 @@ body.manuscript-overlay-open {
 /* Alternative path offered once retries are exhausted — secondary styling so it
    reads as a different action from the destructive retry. */
 .error-display-fallback {
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   line-height: 1.5;
   color: var(--color-text-secondary);
   margin: 0 0 var(--space-2_5);
@@ -2510,7 +2510,7 @@ body.manuscript-overlay-open {
 
 /* Suggested next step — secondary to the message, same in every variant. */
 .error-display-suggestion {
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   line-height: 1.5;
   color: var(--color-text-secondary);
   margin: 0 0 var(--space-2_5);
@@ -2646,7 +2646,7 @@ body.manuscript-overlay-open {
   -webkit-backdrop-filter: blur(12px);
   color: var(--color-text-primary);
   font-family: var(--font-system);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   font-weight: 500;
   cursor: pointer;
   transition: all 120ms ease;
@@ -2769,7 +2769,7 @@ body.manuscript-overlay-open {
 }
 
 :root .manuscript-suggested-action-label {
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   line-height: 1.5;
   margin-bottom: var(--space-1);
 }
@@ -2795,7 +2795,7 @@ body.manuscript-overlay-open {
   background: transparent;
   box-shadow: none;
   font-family: var(--font-system);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   font-weight: 500;
   color: var(--color-text-muted);
   position: absolute;
@@ -2808,7 +2808,7 @@ body.manuscript-overlay-open {
 /* DS3 input counter (Pass 10, fix 3: color text-muted, drop letter-spacing per demo) */
 :root .manuscript-input-counter {
   font-family: var(--font-system);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   color: var(--color-text-muted);
   flex-shrink: 0;
 }
@@ -2925,7 +2925,7 @@ body.manuscript-overlay-open {
 }
 
 :root .choice-outcome-text {
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   line-height: 1.6;
 }
 
@@ -2945,7 +2945,7 @@ body.manuscript-overlay-open {
 
   /* Scale up pill and icon for desktop */
   :root .manuscript-hud-character-pill {
-    font-size: 0.8125rem;
+    font-size: var(--font-size-xs_5);
     padding: var(--space-2) var(--space-4);
   }
 
@@ -2978,7 +2978,7 @@ body.manuscript-overlay-open {
   }
 
   :root .choice-outcome-callout .choice-outcome-text {
-    font-size: 0.8125rem;
+    font-size: var(--font-size-xs_5);
     line-height: 1.5;
   }
 
@@ -3035,7 +3035,7 @@ body.manuscript-overlay-open {
 :root .manuscript-narrative-divider-label {
   flex-shrink: 0;
   font-family: var(--font-system);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   letter-spacing: 0.08em;
   color: var(--color-text-muted);
   white-space: nowrap;
@@ -3118,7 +3118,7 @@ body.manuscript-overlay-open {
 
 :root .manuscript-streaming-label {
   font-family: var(--font-system);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   color: var(--color-text-muted);
   letter-spacing: 0.04em;
 }
@@ -3157,7 +3157,7 @@ body.manuscript-overlay-open {
 
 :root .manuscript-evaluating-label {
   font-family: var(--font-system);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   color: var(--color-text-muted);
   letter-spacing: 0.04em;
 }
@@ -3382,7 +3382,7 @@ body.manuscript-overlay-open {
 
 :root .manuscript-inventory-item-description {
   font-family: var(--font-interface);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   margin-bottom: 0;
 }
 
@@ -3487,7 +3487,7 @@ body.manuscript-overlay-open {
 /* Term name — narrative font, slightly prominent */
 .manuscript-marginalia-name {
   font-family: var(--font-narrative);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   font-weight: 600;
   line-height: 1.3;
   color: var(--color-text-primary);
@@ -3499,7 +3499,7 @@ body.manuscript-overlay-open {
 .manuscript-marginalia-type {
   display: inline-block;
   font-family: var(--font-system);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   font-style: italic;
   color: var(--color-text-muted);
   margin-bottom: var(--space-1);
@@ -3509,7 +3509,7 @@ body.manuscript-overlay-open {
 /* Description body */
 .manuscript-marginalia-description {
   font-family: var(--font-narrative);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   line-height: 1.55;
   color: var(--color-text-secondary);
   margin: 0;
@@ -3578,7 +3578,7 @@ body.manuscript-overlay-open {
 
 .scene-status-location-label {
   font-family: var(--font-system);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   text-transform: uppercase;
   letter-spacing: 0.025em;
 
@@ -3589,7 +3589,7 @@ body.manuscript-overlay-open {
 
 .scene-status-location-value {
   font-family: var(--font-interface);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-xs_5);
   line-height: 1.3;
   color: var(--color-text-secondary);
 }
@@ -3671,7 +3671,7 @@ body.manuscript-overlay-open {
 
 :root .scene-status-badge {
   padding: var(--space-0_5) var(--space-2);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
 }
 
 /* Keyboard shortcuts help dialog (#276) — reference list of every binding

--- a/src/styles/session-recovery.css
+++ b/src/styles/session-recovery.css
@@ -69,7 +69,7 @@
 .game-session-recovery-prompt-lead {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   line-height: 1.5;
   color: var(--color-text-secondary);
 }
@@ -94,7 +94,7 @@
 
 .game-session-recovery-prompt-detail dt {
   font-family: var(--font-system);
-  font-size: 0.6875rem;
+  font-size: var(--font-size-2xs_5);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--color-text-muted);
@@ -103,7 +103,7 @@
 .game-session-recovery-prompt-detail dd {
   margin: 0;
   font-family: var(--font-interface);
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm_5);
   font-weight: 600;
   color: var(--color-text-primary);
   overflow: hidden;


### PR DESCRIPTION
## Description

The named type scale covered nine steps, and 119 `font-size` declarations across 19 files ignored it in favour of `0.6875rem`, `0.8125rem`, and `0.9375rem`. That's a second, unofficial ramp built by feel, one declaration at a time, with nowhere on the nine-step scale to move to.

Issue #1736 laid out two ways forward. This takes option 1: name the three steps and migrate onto them, which changes nothing about how the app looks. Option 2 (rounding each value onto a neighbouring step) would have moved rendered type across most of the app and churned nearly every visual baseline, so it stays rejected.

Each of the three values happens to be the exact arithmetic midpoint of the pair it sits between, which decided the naming. They use the `_5` half-step suffix the `--space-*` scale already uses, so nothing new gets invented:

| Token | Value | Sits between |
| --- | --- | --- |
| `--font-size-2xs_5` | `0.6875rem` (11px) | `2xs` (`0.625rem`) and `xs` (`0.75rem`) |
| `--font-size-xs_5` | `0.8125rem` (13px) | `xs` (`0.75rem`) and `sm` (`0.875rem`) |
| `--font-size-sm_5` | `0.9375rem` (15px) | `sm` (`0.875rem`) and `base` (`1rem`) |

Migrated declaration counts, which come in a little under the issue's numbers because PR #1738 had already swapped some of them onto existing tokens:

| Value | Declarations |
| --- | --- |
| `0.8125rem` | 56 |
| `0.9375rem` | 32 |
| `0.6875rem` | 31 |
| **Total** | **119** |

Heaviest files: `src/styles/manuscript-session.css` (37), `src/app/app-shell.css` (28), `src/app/wizard.css` (14), `src/app/dashboard.css` (9).

DESIGN.md's Typography section now lists twelve steps with a usage note for each half-step, and the sentence claiming the in-between values were "incremental follow-up" is scoped back to the 24 genuine one-offs it was always accurate about. The "adjacent steps span 1.11-1.25" claim became "adjacent whole steps", since the half-steps sit tighter than that by design.

The 24 genuine one-offs (`1.0625rem`, `2rem`, `1.1875rem`, `0.5625rem`, `1.75rem`, `1.625rem`, the `clamp()` pairs) are untouched, as the issue asks.

## Related Issue

Refs #1736. The base here is `develop` rather than the default branch, so a `Closes` keyword wouldn't fire - **#1736 needs closing by hand after merge.**

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Tests came after the token definitions rather than before, since the guard test only becomes writable once the tokens exist. `typeScale.test.ts` asserts the three new definitions and keeps the ascending/no-duplicate checks honest; `typeScaleMigration.test.ts` now guards all twelve values.

## User Stories Addressed

N/A - design-system debt, no user-facing story.

## Flow Diagrams

N/A.

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

No stories needed - no component changed shape. The foundation showcase doesn't enumerate `--font-size-*` tokens by name, so it needed no edit either. Visual consistency was verified by running the baselines rather than by eye (see Testing Instructions).

## Implementation Notes

The migration guard picked up a second half. `findProductionCssFiles` only ever looked at `.css`, which is exactly why eight TSX inline-style literals survived the first migration pass and had to be cleaned up separately in #1544. It now checks `.tsx` for `fontSize: '<literal>'` too. That turned up no pre-existing violations, so extending it stayed a clean addition and the diff didn't grow.

One judgement call worth flagging: `typeScale.test.ts` wasn't in the issue's scope, but adding three token definitions without asserting their values would have left them unguarded while their siblings are covered. It's a five-line addition.

Naming alternatives considered and dropped: `-plus` suffixes (`--font-size-xs-plus`) read fine but invent a convention this repo doesn't use anywhere; numeric names would have broken the t-shirt idiom the scale is built on.

## Screenshots

N/A - nothing renders differently, which is the point.

## Visual Baseline Changes

None. No file under `tests/visual/**-snapshots/**` is touched, and the working tree stayed clean of snapshot churn through a full local suite run.

## Code Review Summary

N/A.

## Chrome DevTools MCP Verification Summary

N/A - verified via the Playwright suite instead.

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit is unchecked because it wasn't run - no dependency or runtime code changed, so there was nothing for it to bite on. The four gate commands were each run separately with their real exit codes captured:

| Command | Exit code |
| --- | --- |
| `npm test` | 0 (397 suites, 2703 tests, all passing) |
| `npm run type-check` | 0 |
| `npm run lint` | 0 (148 pre-existing warnings, 0 errors) |
| `npm run lint:css` | 0 |

## Testing Instructions

The claim that needs proving here is "nothing renders differently", so it got checked three ways rather than asserted.

1. **Every swap is value-identical.** The diff contains exactly three kinds of changed line pair - each removed line is `font-size: <literal>;` and each added line is `font-size: var(--token);` for the token defined at that same literal. `git diff -U0 | grep -E '^[-+][^-+]' | sort | uniq -c` shows only those three pairs plus the token block and the docs. No other line kind changed.
2. **The tokens resolve.** `undefinedCustomProperties.test.ts` already fails on any `var()` with no definition, and it passes. `typeScale.test.ts` pins each new token to its exact rem value.
3. **The pixels match.** The full local chromium visual suite runs green against the existing baselines: **137 passed, exit 0**, no snapshot churn. That includes the three heaviest-hit surfaces - `main-pages.spec.ts` and `manuscript-layout.spec.ts` (app-shell + manuscript-session), and `world-creation.spec.ts` / `character-creation.spec.ts` (wizard).

To reproduce locally, start this worktree's dev server, then `TZ=UTC npx playwright test --project=chromium`. Nothing here needs `--update-snapshots`; if a baseline ever goes red on this branch, that means a value moved and the value is the thing to fix.

## Checklist

- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

The file-size box is unchecked because several touched stylesheets were already well past 300 lines (`manuscript-session.css`, `app-shell.css`, `wizard.css`). None of them grew here - the swap is line-for-line - but the limit isn't met either way, so claiming it would be false.

Accessibility is unchanged by construction - no rendered font size moved, so no text got smaller.
