### PR TITLE
Clear the 12 dead eslint-disable directives and the unused test locals

### DIFF
--- a/scripts/audit-css.mjs
+++ b/scripts/audit-css.mjs
@@ -107,17 +107,13 @@ async function main() {
     ].sort();
     grandTotal += rejected.length;
     const file = path.relative(rootDir, result.file ?? '(unknown)');
-    // eslint-disable-next-line no-console
     console.log(`\n${file} - ${rejected.length} potentially unused`);
     for (const selector of rejected) {
-      // eslint-disable-next-line no-console
       console.log(`  ${selector}`);
     }
   }
 
-  // eslint-disable-next-line no-console
   console.log(`\n==== TOTAL potentially-unused selectors: ${grandTotal} ====`);
-  // eslint-disable-next-line no-console
   console.log(
     'NOTE: "rejected" = no usage found in scanned content. Review manually; ' +
       'safelist genuinely-dynamic classes and re-run. DO NOT auto-delete.',
@@ -125,7 +121,6 @@ async function main() {
 }
 
 main().catch((error) => {
-  // eslint-disable-next-line no-console
   console.error(error);
   process.exit(1);
 });

--- a/scripts/clean-visual-snapshots.cjs
+++ b/scripts/clean-visual-snapshots.cjs
@@ -89,10 +89,8 @@ function removePngs(snapshotDir, shouldDelete) {
     try {
       fs.unlinkSync(full);
       deleted++;
-      // eslint-disable-next-line no-console
       console.log(`Pruned orphan snapshot: ${path.relative(ROOT, full)}`);
     } catch (e) {
-      // eslint-disable-next-line no-console
       console.warn(`Failed to delete ${full}: ${e.message}`);
     }
   }
@@ -102,7 +100,6 @@ function removePngs(snapshotDir, shouldDelete) {
   if (remaining.length === 0) {
     try {
       fs.rmdirSync(snapshotDir);
-      // eslint-disable-next-line no-console
       console.log(`Removed empty snapshot dir: ${path.relative(ROOT, snapshotDir)}`);
     } catch {}
   }
@@ -121,7 +118,6 @@ function pruneOrphanDirs() {
   for (const dir of snapshotDirs) {
     const siblingSpec = dir.replace(/-snapshots$/, '');
     if (fs.existsSync(siblingSpec)) continue;
-    // eslint-disable-next-line no-console
     console.log(`Orphan snapshot dir (no sibling spec): ${path.relative(ROOT, dir)}`);
     deleted += removePngs(dir, () => true);
   }
@@ -152,7 +148,6 @@ function pruneSnapshots() {
     );
   }
 
-  // eslint-disable-next-line no-console
   console.log(`Snapshot prune complete. Checked ${checked} files, deleted ${deleted}.`);
 }
 

--- a/scripts/github/simple-close-issue.js
+++ b/scripts/github/simple-close-issue.js
@@ -39,7 +39,7 @@ async function makeApiRequest(path, method, data, token) {
         if (res.statusCode >= 200 && res.statusCode < 300) {
           try {
             resolve(JSON.parse(responseData));
-          } catch (err) {
+          } catch {
             if (responseData.trim()) {
               resolve(responseData);
             } else {

--- a/scripts/github/update-related-issues.js
+++ b/scripts/github/update-related-issues.js
@@ -56,7 +56,7 @@ async function makeApiRequest(path, method, data, token) {
         if (res.statusCode >= 200 && res.statusCode < 300) {
           try {
             resolve(JSON.parse(responseData));
-          } catch (err) {
+          } catch {
             if (responseData.trim()) {
               resolve(responseData);
             } else {

--- a/src/app/dev/guided-first-time-experience/page.tsx
+++ b/src/app/dev/guided-first-time-experience/page.tsx
@@ -16,7 +16,6 @@ export default function GuidedFirstTimeExperienceTestHarness() {
     isFirstTimeUser,
   } = useSessionStore();
 
-  const isCompleted = !shouldShowOnboarding();
   const showOnboarding = shouldShowOnboarding();
 
   const handleReset = () => {

--- a/src/components/GameSession/__tests__/ChoiceHistorySection.test.tsx
+++ b/src/components/GameSession/__tests__/ChoiceHistorySection.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { ChoiceHistorySection } from '../ChoiceHistorySection';
 import type { DecisionHistoryEntry, DecisionOption, NarrativeSegment } from '@/types/narrative.types';
 

--- a/src/components/GameSession/__tests__/StorySummarySection.test.tsx
+++ b/src/components/GameSession/__tests__/StorySummarySection.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { StorySummarySection } from '../StorySummarySection';
 import { useStoryCheckpointManager } from '../hooks/useStoryCheckpointManager';
 import { useWorldStore } from '@/state/worldStore';

--- a/src/components/Narrative/__tests__/PromptDebugSection.test.tsx
+++ b/src/components/Narrative/__tests__/PromptDebugSection.test.tsx
@@ -171,10 +171,6 @@ describe('PromptDebugSection', () => {
     const user = userEvent.setup();
     render(<PromptDebugSection debugInfo={mockDebugInfo} />);
 
-    // Section starts collapsed - content should be hidden
-    const allContents = screen.getAllByTestId('collapsible-section-content');
-    const mainContent = allContents[0]; // First collapsible is the main section
-
     // Click to expand using the toggle button
     const toggleButton = screen.getByRole('button', { name: /Expand.*Prompt Debug Info/i });
     await user.click(toggleButton);
@@ -194,10 +190,6 @@ describe('PromptDebugSection', () => {
     // Full prompt section should now be visible but still collapsed
     const nestedToggle = screen.getByRole('button', { name: /Expand Full Prompt Text/i });
     expect(nestedToggle).toBeInTheDocument();
-
-    // Full prompt text starts collapsed - find the nested content
-    const allContents = screen.getAllByTestId('collapsible-section-content');
-    const nestedContent = allContents[1]; // Second collapsible is the nested one
 
     // Click the nested toggle to expand
     await user.click(nestedToggle);

--- a/src/lib/ai/__tests__/choiceGenerator.prompt.test.ts
+++ b/src/lib/ai/__tests__/choiceGenerator.prompt.test.ts
@@ -2,7 +2,6 @@ import { buildChoicePrompt } from '../choiceGenerator.prompt';
 import type { NarrativeContext } from '@/types/narrative.types';
 import { createMockWorld } from '@/lib/test-utils/testDataFactory';
 import { playerDecisionTracker } from '../playerDecisionTracker';
-import { getLoreContextForPrompt } from '../loreContextHelper';
 
 jest.mock('../../promptTemplates/narrativeTemplateManager', () => ({
   getNarrativeTemplate: jest.fn().mockReturnValue((context: { worldName: string }) =>

--- a/tests/visual/game-session.spec.ts
+++ b/tests/visual/game-session.spec.ts
@@ -137,7 +137,7 @@ test.describe('Game Session Visual Tests', () => {
         { timeout: 5000 }
       );
       console.log('✅ NarrativeHistoryManager finished loading');
-    } catch (e) {
+    } catch {
       console.log('⏰ NarrativeHistoryManager still loading after 5s timeout');
     }
     
@@ -228,7 +228,7 @@ test.describe('Game Session Visual Tests', () => {
           const store = (window as any).useSessionStore;
           store.persist.rehydrate();
         }
-      } catch (e) {
+      } catch {
         console.log('Store rehydration not available, using fallback...');
       }
 

--- a/tests/visual/setup/console-logging.setup.ts
+++ b/tests/visual/setup/console-logging.setup.ts
@@ -10,13 +10,11 @@ test.beforeEach(async ({ page }, testInfo) => {
       const loc = msg.location();
       const location = loc?.url ? `${loc.url}:${loc.lineNumber || 0}:${loc.columnNumber || 0}` : 'unknown';
       // Log to stdout so CI captures it
-      // eslint-disable-next-line no-console
       console.error(`PW[console.error] ${testName} @ ${page.url()} :: ${location}\n${msg.text()}`);
     }
   });
 
   page.on('pageerror', (error) => {
-    // eslint-disable-next-line no-console
     console.error(`PW[pageerror] ${testName} @ ${page.url()}\n${error?.stack || error?.message || String(error)}`);
   });
 });


### PR DESCRIPTION
## Description

Lint drops from 149 warnings to 127. Everything cleared here was noise that made the real warnings harder to find.

The twelve `eslint-disable-next-line no-console` directives were dead because `eslint.config.mjs` already turns `no-console` off for the `scripts/**` and `tests/**` globs, so the rule they suppress never fires in those files. I did not take the issue's word for that: `npm run lint` reports unused disable directives on its own (ESLint 9 flat config defaults `reportUnusedDisableDirectives` to warn), and it flagged all twelve by name before I removed any of them. The `console.log` and `console.error` calls themselves are untouched, so the visual-test console capture in `tests/visual/setup/console-logging.setup.ts` logs exactly what it logged before.

The rest is unused locals and imports, plus four catch bindings nobody reads. The two script-side ones in `scripts/github/` are `JSON.parse` failures on a 2xx response, which is the expected path when the GitHub API returns a non-JSON body. The surrounding code already handles it by resolving the raw string. Logging there would be noise on the normal path, so a bare `catch` is the honest version, and it matches the `} catch {}` already used in `clean-visual-snapshots.cjs`.

## Related Issue

Refs #1757. Base is `develop`, so the `Closes` keyword will not auto-close it; the issue gets closed on merge.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

N/A. No behavior changed, so there is nothing to write a failing test against. The existing suite is the regression check.

- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed

N/A. Tooling and lint hygiene.

## Flow Diagrams

N/A.

## Component Development

N/A. No component rendering or styling changed.

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes

Where the drift landed, since the issue's line numbers had moved since it was filed:

| Site | What went | Why |
|---|---|---|
| `scripts/audit-css.mjs` | 5 `no-console` directives | ESLint reported all 5 unused |
| `scripts/clean-visual-snapshots.cjs` | 5 `no-console` directives | ESLint reported all 5 unused |
| `tests/visual/setup/console-logging.setup.ts` | 2 `no-console` directives | ESLint reported both unused; console calls kept |
| `scripts/github/simple-close-issue.js` | `catch (err)` to `catch` | Parse failure on a 2xx body, already handled |
| `scripts/github/update-related-issues.js` | `catch (err)` to `catch` | Same |
| `ChoiceHistorySection.test.tsx`, `StorySummarySection.test.tsx` | unused `fireEvent` import | Neither file calls it |
| `PromptDebugSection.test.tsx` | `mainContent`, `nestedContent` and their `getAllByTestId` lookups | Results were discarded; the `getByRole` and `toBeVisible` assertions that carry the tests are untouched |
| `src/app/dev/guided-first-time-experience/page.tsx` | `isCompleted` | Duplicate of `!showOnboarding`, which is what the JSX actually uses |
| `src/lib/ai/__tests__/choiceGenerator.prompt.test.ts` | unused `getLoreContextForPrompt` import | The `jest.mock` on the same module is by path and does not need the binding |
| `tests/visual/game-session.spec.ts` | 2 unused `catch (e)` bindings | Same reasoning as the script sites |

Three of those were not in the issue's list: the `getLoreContextForPrompt` import, and the two catch bindings in `game-session.spec.ts`. They are the same class of warning and the issue's target is a near-zero actionable count, so they went with the rest. Nothing on the issue's list turned out to be load-bearing, so nothing was kept.

One warning stays: `jest/expect-expect` in `src/lib/theme/themes/__tests__/undefinedCustomProperties.test.ts`. That test deliberately throws with a formatted list of undefined custom properties instead of calling `expect`, which gives a far better failure message than `toHaveLength(0)` would. Clearing it means changing what the test asserts, which is a test-design call rather than lint hygiene. Left for a separate decision.

## Screenshots

N/A.

## Visual Baseline Changes

None. No file under `tests/visual/**-snapshots/**` is touched, and the visual suite was deliberately not run: its baselines are macOS-specific and orthogonal to a comment-and-import cleanup.

## Code Review Summary (if applicable)

N/A.

## Chrome DevTools MCP Verification Summary (if applicable)

N/A.

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

```
npm run lint        # exit 0, 127 warnings (was 149)
npm run type-check  # exit 0
npm test            # exit 0, 404 suites / 2792 tests
```

All three run clean locally. To confirm the directives really were dead rather than trusting the diff:

```
npx eslint 'scripts/**/*.{js,cjs,mjs}' 'tests/**/*.{js,jsx,ts,tsx}'
```

on `develop` reports the twelve "Unused eslint-disable directive" warnings; on this branch it reports none.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed
