### PR TITLE
Route devtools AI calls through the lib/api wrappers

### DIFF
--- a/src/components/devtools/EndingImageDebugSection/EndingImageDebugSection.tsx
+++ b/src/components/devtools/EndingImageDebugSection/EndingImageDebugSection.tsx
@@ -11,6 +11,7 @@ import { capitalize, getTimestamp } from '@/lib/utils';
 import { Select } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import { generateEndingImage, generateEndingImagePrompt } from '@/lib/api/endingImageApi';
 import Logger from '@/lib/utils/logger';
 
 const logger = new Logger('EndingImageDebug');
@@ -91,39 +92,21 @@ export function EndingImageDebugSection() {
         ];
       }
       
-      const requestBody = {
+      const params = {
         ending: mockEnding,
         world,
         character,
-        recentNarrative,
-        promptOnly: true // Flag to return only the prompt
+        recentNarrative
       };
-      
-      logger.debug('Calling ending image API with data:', requestBody);
-      
-      const response = await fetch('/api/generate-ending-image', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(requestBody)
-      });
-      
-      if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(`API request failed: ${response.status} - ${errorText}`);
-      }
-      
-      const result = await response.json();
+
+      logger.debug('Calling ending image API with data:', params);
+
+      const result = await generateEndingImagePrompt(params);
       logger.debug('API response result:', result);
-      
-      const prompt = result.prompt || result.imageGenerationPrompt || 'No prompt returned';
-      setGeneratedPrompt(prompt);
+
+      setGeneratedPrompt(result.prompt || result.imageGenerationPrompt || 'No prompt returned');
       setLastGenerationResult(result);
-      
-      // If an image was generated, show it
-      if (result.imageUrl && !result.placeholder) {
-        setLastGeneratedImage(result.imageUrl);
-      }
-      
+
     } catch (error) {
       setGeneratedPrompt(`Error generating prompt: ${error instanceof Error ? error.message : 'Unknown error'}`);
     } finally {
@@ -157,28 +140,17 @@ export function EndingImageDebugSection() {
         ];
       }
       
-      const requestBody = {
+      const params = {
         ending: mockEnding,
         world,
         character,
         recentNarrative
       };
-      
-      logger.debug('Generating full ending image with data:', requestBody);
-      
-      const response = await fetch('/api/generate-ending-image', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(requestBody)
-      });
-      
-      if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(`API request failed: ${response.status} - ${errorText}`);
-      }
-      
-      const result = await response.json();
-      
+
+      logger.debug('Generating full ending image with data:', params);
+
+      const result = await generateEndingImage(params);
+
       setGeneratedPrompt(result.imageGenerationPrompt || result.prompt || 'No prompt returned');
       setLastGeneratedImage(result.imageUrl);
       setLastGenerationResult(result);

--- a/src/components/devtools/EndingImageDebugSection/__tests__/EndingImageDebugSection.test.tsx
+++ b/src/components/devtools/EndingImageDebugSection/__tests__/EndingImageDebugSection.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { EndingImageDebugSection } from '../EndingImageDebugSection';
+import { generateEndingImage, generateEndingImagePrompt } from '@/lib/api/endingImageApi';
+
+jest.mock('@/lib/api/endingImageApi', () => ({
+  generateEndingImage: jest.fn(),
+  generateEndingImagePrompt: jest.fn(),
+}));
+
+jest.mock('@/state/narrativeStore', () => ({
+  useNarrativeStore: () => ({
+    currentEnding: null,
+    getSessionSegments: jest.fn(() => []),
+  }),
+}));
+
+jest.mock('@/state/characterStore', () => ({
+  useCharacterStore: (selector: (state: { characters: Record<string, unknown> }) => unknown) =>
+    selector({ characters: {} }),
+}));
+
+jest.mock('@/state/worldStore', () => ({
+  useWorldStore: (selector: (state: { worlds: Record<string, unknown> }) => unknown) =>
+    selector({ worlds: {} }),
+}));
+
+const mockGenerateEndingImage = generateEndingImage as jest.Mock;
+const mockGenerateEndingImagePrompt = generateEndingImagePrompt as jest.Mock;
+
+/** The panel ships collapsed, and a collapsed section is aria-hidden. */
+const renderExpanded = () => {
+  render(<EndingImageDebugSection />);
+  fireEvent.click(screen.getByTestId('collapsible-section-toggle'));
+};
+
+describe('EndingImageDebugSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the prompt the wrapper returns', async () => {
+    mockGenerateEndingImagePrompt.mockResolvedValue({ prompt: 'A hopeful vista at dawn' });
+
+    renderExpanded();
+    fireEvent.click(screen.getByRole('button', { name: 'Generate Prompt Preview' }));
+
+    expect(await screen.findByText('A hopeful vista at dawn')).toBeInTheDocument();
+    expect(mockGenerateEndingImagePrompt).toHaveBeenCalledTimes(1);
+    expect(mockGenerateEndingImage).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failed prompt preview and re-enables the buttons', async () => {
+    mockGenerateEndingImagePrompt.mockRejectedValue(new Error('prompt route down'));
+
+    renderExpanded();
+    fireEvent.click(screen.getByRole('button', { name: 'Generate Prompt Preview' }));
+
+    expect(await screen.findByText(/Error generating prompt: prompt route down/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Generate Prompt Preview' })).toBeEnabled();
+  });
+
+  it('surfaces a failed full generation and re-enables the buttons', async () => {
+    mockGenerateEndingImage.mockRejectedValue(new Error('image route down'));
+
+    renderExpanded();
+    fireEvent.click(screen.getByRole('button', { name: 'Test Full Generation' }));
+
+    expect(await screen.findByText(/Generation failed: image route down/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Test Full Generation' })).toBeEnabled();
+  });
+});

--- a/src/components/devtools/TestDataGeneratorSection/TestDataGeneratorSection.tsx
+++ b/src/components/devtools/TestDataGeneratorSection/TestDataGeneratorSection.tsx
@@ -7,6 +7,9 @@ import { generateUniqueId } from '@/lib/utils/generateId';
 import type { GeneratedImage } from '@/types/common.types';
 import { getTimestamp } from '@/lib/utils';
 import { ensureWorldNpcRoster } from '@/lib/services/worldCreationService';
+import { worldApi } from '@/lib/api/worldApi';
+import { characterApi } from '@/lib/api/characterApi';
+import { generatePortrait } from '@/lib/api/generatePortrait';
 import Logger from '@/lib/utils/logger';
 
 const logger = new Logger('TestDataGenerator');
@@ -65,26 +68,13 @@ async function generateWorldImageAsync(worldId: string, worldName: string): Prom
     const world = useWorldStore.getState().worlds[worldId];
     if (!world) return;
 
-    const response = await fetch('/api/generate-world-image', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ world }),
-    });
-
-    if (response.ok) {
-      const { imageUrl, aiGenerated } = await response.json();
-      const image: GeneratedImage = {
-        type: aiGenerated ? 'ai-generated' : 'placeholder',
-        url: imageUrl,
-        generatedAt: getTimestamp(),
-      };
-      useWorldStore.getState().updateWorld(worldId, { image });
-    } else {
-      const errorText = await response.text();
-      logger.warn(
-        `[DevTools] Failed to generate world image for "${worldName}": ${response.status} - ${errorText}`
-      );
-    }
+    const { imageUrl, aiGenerated } = await worldApi.generateWorldImage({ world });
+    const image: GeneratedImage = {
+      type: aiGenerated ? 'ai-generated' : 'placeholder',
+      url: imageUrl,
+      generatedAt: getTimestamp(),
+    };
+    useWorldStore.getState().updateWorld(worldId, { image });
   } catch (error) {
     logger.error(`Failed to generate world image for test world "${worldName}":`, error);
   }
@@ -109,21 +99,12 @@ export const TestDataGeneratorSection: React.FC = () => {
       const { reference, relationship } = pickRandomWorldType();
       const existingNames = Object.values(worlds).map((w) => w.name);
 
-      const response = await fetch('/api/generate-world', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          worldReference: reference,
-          worldRelationship: relationship,
-          existingNames,
-        }),
+      const testWorldData = await worldApi.generateWorld({
+        worldReference: reference,
+        worldRelationship: relationship,
+        existingNames,
       });
 
-      if (!response.ok) {
-        throw new Error('Failed to generate test world via API');
-      }
-
-      const testWorldData = await response.json();
       const worldId = createWorld(buildWorldDataForStore(testWorldData, reference, relationship));
       await ensureWorldNpcRoster(worldId);
 
@@ -152,21 +133,12 @@ export const TestDataGeneratorSection: React.FC = () => {
           ...createdWorlds.map((w) => w.name),
         ];
 
-        const response = await fetch('/api/generate-world', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            worldReference: reference,
-            worldRelationship: relationship,
-            existingNames: allExistingNames,
-          }),
+        const testWorldData = await worldApi.generateWorld({
+          worldReference: reference,
+          worldRelationship: relationship,
+          existingNames: allExistingNames,
         });
 
-        if (!response.ok) {
-          throw new Error('Failed to generate test world via API');
-        }
-
-        const testWorldData = await response.json();
         const worldId = createWorld(buildWorldDataForStore(testWorldData, reference, relationship));
         await ensureWorldNpcRoster(worldId);
         createdWorlds.push({ id: worldId, name: testWorldData.name });
@@ -240,27 +212,15 @@ export const TestDataGeneratorSection: React.FC = () => {
         const types: Array<'known' | 'original'> = ['known', 'original'];
         const characterType = types[Math.floor(Math.random() * types.length)];
 
-        // Use the AI character generator via API route (secure approach from develop)
-        const response: Response = await fetch('/api/generate-character', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            worldId: currentWorld.id,
-            characterType,
-            existingNames: [
-              ...existingCharacterNames,
-              ...createdCharacters.map((c) => c.name),
-            ],
-            world: currentWorld,
-          }),
+        const aiCharacterData = await characterApi.generateCharacter({
+          worldId: currentWorld.id,
+          characterType,
+          existingNames: [
+            ...existingCharacterNames,
+            ...createdCharacters.map((c) => c.name),
+          ],
+          world: currentWorld,
         });
-
-        if (!response.ok) {
-          const errorData = await response.json();
-          throw new Error(errorData.error || 'Failed to generate character');
-        }
-
-        const aiCharacterData = await response.json();
 
         // Convert AI-generated data to character store format
         const characterData = {
@@ -334,75 +294,59 @@ export const TestDataGeneratorSection: React.FC = () => {
           const storeCharacter =
             useCharacterStore.getState().characters[characterId];
           if (storeCharacter) {
-            const response = await fetch('/api/generate-portrait', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                character: {
-                  id: storeCharacter.id,
-                  name: storeCharacter.name,
-                  worldId: storeCharacter.worldId,
-                  background: {
-                    history: storeCharacter.background.history,
-                    personality: storeCharacter.background.personality,
-                    physicalDescription:
-                      storeCharacter.background.physicalDescription || '',
-                    goals: storeCharacter.background.goals,
-                    fears: storeCharacter.background.fears,
-                    relationships: [],
-                  },
-                  attributes: storeCharacter.attributes.map(
-                    (attr: {
-                      id: string;
-                      name: string;
-                      baseValue: number;
-                    }) => ({
-                      attributeId:
-                        currentWorld.attributes.find(
-                          (wa) => wa.name === attr.name
-                        )?.id || attr.id,
-                      value: attr.baseValue,
-                    })
-                  ),
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  skills: storeCharacter.skills.map((skill: any) => ({
-                    skillId:
-                      currentWorld.skills.find((ws) => ws.name === skill.name)
-                        ?.id || skill.id,
-                    level: skill.level,
-                    experience: 0,
-                    isActive: true,
-                  })),
-                  inventory: {
-                    characterId: storeCharacter.id,
-                    items: [],
-                    capacity: 100,
-                    categories: [],
-                  },
-                  status: {
-                    health: storeCharacter.status.health,
-                    maxHealth: storeCharacter.status.maxHealth,
-                    conditions: storeCharacter.status.conditions,
-                    location: currentWorld.name,
-                  },
-                  createdAt: storeCharacter.createdAt,
-                  updatedAt: storeCharacter.updatedAt,
+            const { portrait } = await generatePortrait({
+              character: {
+                id: storeCharacter.id,
+                name: storeCharacter.name,
+                worldId: storeCharacter.worldId,
+                background: {
+                  history: storeCharacter.background.history,
+                  personality: storeCharacter.background.personality,
+                  physicalDescription:
+                    storeCharacter.background.physicalDescription || '',
+                  goals: storeCharacter.background.goals,
+                  fears: storeCharacter.background.fears,
+                  relationships: [],
                 },
-                world: currentWorld,
-              }),
+                attributes: storeCharacter.attributes.map(
+                  (attr: { id: string; name: string; baseValue: number }) => ({
+                    attributeId:
+                      currentWorld.attributes.find(
+                        (wa) => wa.name === attr.name
+                      )?.id || attr.id,
+                    value: attr.baseValue,
+                  })
+                ),
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                skills: storeCharacter.skills.map((skill: any) => ({
+                  skillId:
+                    currentWorld.skills.find((ws) => ws.name === skill.name)
+                      ?.id || skill.id,
+                  level: skill.level,
+                  experience: 0,
+                  isActive: true,
+                })),
+                inventory: {
+                  characterId: storeCharacter.id,
+                  items: [],
+                  capacity: 100,
+                  categories: [],
+                },
+                status: {
+                  health: storeCharacter.status.health,
+                  maxHealth: storeCharacter.status.maxHealth,
+                  conditions: storeCharacter.status.conditions,
+                  location: currentWorld.name,
+                },
+                createdAt: storeCharacter.createdAt,
+                updatedAt: storeCharacter.updatedAt,
+              },
+              world: currentWorld,
             });
 
-            if (response.ok) {
-              const { portrait } = await response.json();
-              // Update the character with the generated portrait
-              useCharacterStore
-                .getState()
-                .updateCharacter(characterId, { portrait });
-            } else {
-              logger.warn(
-                `[DevTools] Portrait generation failed for ${characterType} character "${characterData.name}"`
-              );
-            }
+            useCharacterStore
+              .getState()
+              .updateCharacter(characterId, { portrait });
           }
         } catch (error) {
           logger.error(

--- a/src/components/devtools/TestDataGeneratorSection/__tests__/TestDataGeneratorSection.test.tsx
+++ b/src/components/devtools/TestDataGeneratorSection/__tests__/TestDataGeneratorSection.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { TestDataGeneratorSection } from '../TestDataGeneratorSection';
+import { worldApi } from '@/lib/api/worldApi';
+import { characterApi } from '@/lib/api/characterApi';
+import { generatePortrait } from '@/lib/api/generatePortrait';
+
+jest.mock('@/lib/api/worldApi', () => ({
+  worldApi: { generateWorld: jest.fn(), generateWorldImage: jest.fn() },
+}));
+
+jest.mock('@/lib/api/characterApi', () => ({
+  characterApi: { generateCharacter: jest.fn() },
+}));
+
+jest.mock('@/lib/api/generatePortrait', () => ({
+  generatePortrait: jest.fn(),
+}));
+
+jest.mock('@/lib/services/worldCreationService', () => ({
+  ensureWorldNpcRoster: jest.fn(),
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => '/worlds',
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+const mockCreateWorld = jest.fn(() => 'world-1');
+const mockUpdateWorld = jest.fn();
+const mockSetCurrentWorld = jest.fn();
+const mockCreateCharacter = jest.fn(() => 'char-1');
+const mockUpdateCharacter = jest.fn();
+
+const mockWorld = {
+  id: 'world-1',
+  name: 'Test World',
+  description: 'A world for tests',
+  genre: 'fantasy',
+  attributes: [],
+  skills: [],
+};
+
+const mockStoredCharacter = {
+  id: 'char-1',
+  name: 'Hero',
+  worldId: 'world-1',
+  background: {
+    history: 'A history',
+    personality: 'Brave',
+    physicalDescription: 'Tall',
+    goals: [],
+    fears: [],
+  },
+  attributes: [],
+  skills: [],
+  status: { health: 100, maxHealth: 100, conditions: [] },
+  createdAt: '2026-08-14T00:00:00Z',
+  updatedAt: '2026-08-14T00:00:00Z',
+};
+
+const mockWorldStoreValue = {
+  worlds: { 'world-1': mockWorld },
+  currentWorldId: 'world-1',
+  createWorld: mockCreateWorld,
+  updateWorld: mockUpdateWorld,
+  setCurrentWorld: mockSetCurrentWorld,
+};
+
+const mockCharacterStoreValue = {
+  characters: { 'char-1': mockStoredCharacter },
+  createCharacter: mockCreateCharacter,
+  updateCharacter: mockUpdateCharacter,
+};
+
+jest.mock('@/state/worldStore', () => ({
+  useWorldStore: Object.assign(jest.fn(() => mockWorldStoreValue), {
+    getState: jest.fn(() => mockWorldStoreValue),
+  }),
+}));
+
+jest.mock('@/state/characterStore', () => ({
+  useCharacterStore: Object.assign(jest.fn(() => mockCharacterStoreValue), {
+    getState: jest.fn(() => mockCharacterStoreValue),
+  }),
+}));
+
+const mockGenerateWorld = worldApi.generateWorld as jest.Mock;
+const mockGenerateWorldImage = worldApi.generateWorldImage as jest.Mock;
+const mockGenerateCharacter = characterApi.generateCharacter as jest.Mock;
+const mockGeneratePortrait = generatePortrait as jest.Mock;
+
+const generatedWorld = { name: 'Test World', attributes: [], skills: [] };
+const generatedCharacter = {
+  name: 'Hero',
+  level: 1,
+  attributes: [],
+  skills: [],
+  background: {
+    description: 'A history',
+    personality: 'Brave',
+    motivation: 'Glory',
+    physicalDescription: 'Tall',
+    fears: [],
+  },
+};
+
+const clickButton = (name: string) => {
+  fireEvent.click(screen.getByRole('button', { name }));
+};
+
+describe('TestDataGeneratorSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.alert = jest.fn();
+    mockGenerateWorld.mockResolvedValue(generatedWorld);
+    mockGenerateWorldImage.mockResolvedValue({ imageUrl: 'image-url', aiGenerated: true });
+    mockGenerateCharacter.mockResolvedValue(generatedCharacter);
+    mockGeneratePortrait.mockResolvedValue({ portrait: { url: 'portrait-url' } });
+  });
+
+  it('creates a world and its image through the api wrappers', async () => {
+    render(<TestDataGeneratorSection />);
+    clickButton('Generate Diverse AI World');
+
+    await waitFor(() => expect(mockGenerateWorldImage).toHaveBeenCalledTimes(1));
+    expect(mockGenerateWorld).toHaveBeenCalledTimes(1);
+    expect(mockCreateWorld).toHaveBeenCalledTimes(1);
+    expect(mockUpdateWorld).toHaveBeenCalledWith('world-1', {
+      image: expect.objectContaining({ url: 'image-url', type: 'ai-generated' }),
+    });
+    expect(window.alert).not.toHaveBeenCalled();
+  });
+
+  it('reports a failed world generation instead of creating a world', async () => {
+    mockGenerateWorld.mockRejectedValue(new Error('world route down'));
+
+    render(<TestDataGeneratorSection />);
+    clickButton('Generate Diverse AI World');
+
+    await waitFor(() =>
+      expect(window.alert).toHaveBeenCalledWith(expect.stringContaining('world route down'))
+    );
+    expect(mockCreateWorld).not.toHaveBeenCalled();
+  });
+
+  it('keeps the world when its image generation fails', async () => {
+    mockGenerateWorldImage.mockRejectedValue(new Error('image route down'));
+
+    render(<TestDataGeneratorSection />);
+    clickButton('Generate Diverse AI World');
+
+    await waitFor(() => expect(mockGenerateWorldImage).toHaveBeenCalledTimes(1));
+    expect(mockCreateWorld).toHaveBeenCalledTimes(1);
+    expect(mockUpdateWorld).not.toHaveBeenCalled();
+    expect(window.alert).not.toHaveBeenCalled();
+  });
+
+  it('reports a failed character generation', async () => {
+    mockGenerateCharacter.mockRejectedValue(new Error('character route down'));
+
+    render(<TestDataGeneratorSection />);
+    clickButton('Generate 5 AI Characters for World');
+
+    await waitFor(() =>
+      expect(window.alert).toHaveBeenCalledWith(expect.stringContaining('character route down'))
+    );
+    expect(mockCreateCharacter).not.toHaveBeenCalled();
+  });
+
+  it('keeps the character when its portrait generation fails', async () => {
+    mockGeneratePortrait.mockRejectedValue(new Error('portrait route down'));
+
+    render(<TestDataGeneratorSection />);
+    clickButton('Generate 5 AI Characters for World');
+
+    await waitFor(() =>
+      expect(window.alert).toHaveBeenCalledWith(expect.stringContaining('Successfully generated'))
+    );
+    expect(mockCreateCharacter).toHaveBeenCalledTimes(5);
+    expect(mockUpdateCharacter).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/api/__tests__/endingImageApi.test.ts
+++ b/src/lib/api/__tests__/endingImageApi.test.ts
@@ -1,0 +1,73 @@
+jest.mock('@/lib/ai/aiFetch', () => ({
+  aiFetch: jest.fn(),
+}));
+
+import { generateEndingImage, generateEndingImagePrompt } from '../endingImageApi';
+import { aiFetch } from '@/lib/ai/aiFetch';
+import type { StoryEnding } from '@/types/narrative.types';
+
+const mockAiFetch = aiFetch as jest.MockedFunction<typeof aiFetch>;
+
+const params = {
+  ending: { id: 'ending-1', tone: 'hopeful' } as StoryEnding,
+  recentNarrative: ['The hero rested.'],
+};
+
+describe('endingImageApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('asks for the prompt alone without generating an image', async () => {
+    mockAiFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ prompt: 'A hopeful vista' }),
+    } as unknown as Response);
+
+    const result = await generateEndingImagePrompt(params);
+
+    expect(result.prompt).toBe('A hopeful vista');
+    const [url, init] = mockAiFetch.mock.calls[0];
+    expect(url).toBe('/api/generate-ending-image');
+    expect(JSON.parse(init?.body as string)).toMatchObject({ promptOnly: true });
+  });
+
+  it('omits the prompt-only flag for a full generation', async () => {
+    mockAiFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ imageUrl: 'image-url' }),
+    } as unknown as Response);
+
+    const result = await generateEndingImage(params);
+
+    expect(result.imageUrl).toBe('image-url');
+    const [, init] = mockAiFetch.mock.calls[0];
+    expect(JSON.parse(init?.body as string).promptOnly).toBeUndefined();
+  });
+
+  it('throws the server error message on a failed response', async () => {
+    mockAiFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'Unable to load ending image. Please try again.' }),
+    } as unknown as Response);
+
+    await expect(generateEndingImage(params)).rejects.toThrow(
+      'Unable to load ending image. Please try again.'
+    );
+  });
+
+  it('falls back to the status when the error body is unparseable', async () => {
+    mockAiFetch.mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: async () => {
+        throw new Error('bad json');
+      },
+    } as unknown as Response);
+
+    await expect(generateEndingImage(params)).rejects.toThrow(
+      'Failed to load ending image (502)'
+    );
+  });
+});

--- a/src/lib/api/endingImageApi.ts
+++ b/src/lib/api/endingImageApi.ts
@@ -10,20 +10,59 @@ export interface EndingImageParams {
   recentNarrative: string[];
 }
 
+/** The illustration plus the diagnostic fields the route reports alongside it. */
+export interface EndingImageResult {
+  imageUrl: string;
+  prompt?: string;
+  imageGenerationPrompt?: string;
+  description?: string;
+  tone?: string;
+  aiGenerated?: boolean;
+  placeholder?: boolean;
+  service?: string;
+}
+
+/** What the route returns when asked for the prompt alone: no image, no image fields. */
+export interface EndingImagePromptResult {
+  prompt?: string;
+  imageGenerationPrompt?: string;
+  description?: string;
+}
+
+async function postEndingImage(body: Record<string, unknown>) {
+  const response = await aiFetch('/api/generate-ending-image', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(
+      (errorData as { error?: string }).error ||
+        `Failed to load ending image (${response.status})`
+    );
+  }
+
+  return response.json();
+}
+
 /**
  * Request the AI-generated ending illustration (worldApi pattern) —
  * components call this instead of hand-rolling the fetch + error handling.
  */
-export async function generateEndingImage(params: EndingImageParams): Promise<{ imageUrl: string }> {
-  const response = await aiFetch('/api/generate-ending-image', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(params),
-  });
+export async function generateEndingImage(
+  params: EndingImageParams
+): Promise<EndingImageResult> {
+  return postEndingImage({ ...params });
+}
 
-  if (!response.ok) {
-    throw new Error('Failed to load ending image');
-  }
-
-  return response.json();
+/**
+ * Ask the route for the prompt it would send to the image model and stop there,
+ * skipping the image generation itself.
+ */
+export async function generateEndingImagePrompt(
+  params: EndingImageParams
+): Promise<EndingImagePromptResult> {
+  return postEndingImage({ ...params, promptOnly: true });
 }


### PR DESCRIPTION
## Description

The devtools panel was calling the AI endpoints with raw `fetch`, which meant the one surface built for debugging AI requests was the only surface not sending them the way the app does. No BYO provider key header, no timeout ceiling. A developer with a key configured got env-key behavior in the panel while the app running next to it used their key.

Seven call sites now go through the wrappers that already existed for these endpoints, all of which run on `aiFetch`:

| Call site | Endpoint | Wrapper |
| --- | --- | --- |
| `TestDataGeneratorSection.generateWorldImageAsync` | `/api/generate-world-image` | `worldApi.generateWorldImage` |
| `TestDataGeneratorSection.handleGenerateWorld` | `/api/generate-world` | `worldApi.generateWorld` |
| `TestDataGeneratorSection.handleGenerate5Worlds` | `/api/generate-world` | `worldApi.generateWorld` |
| `TestDataGeneratorSection.handleGenerate5Characters` | `/api/generate-character` | `characterApi.generateCharacter` |
| `TestDataGeneratorSection` portrait step | `/api/generate-portrait` | `generatePortrait` |
| `EndingImageDebugSection.generatePromptPreview` | `/api/generate-ending-image` | `generateEndingImagePrompt` |
| `EndingImageDebugSection.testFullGeneration` | `/api/generate-ending-image` | `generateEndingImage` |

Each site's hand-rolled `res.ok` check and `res.json()` parsing went with the swap, since the wrappers return parsed values and throw on failure. That's a net 183 deletions against the two components.

`endingImageApi` needed a small extension. The route has two modes and the wrapper only covered one: the panel's prompt preview posts `promptOnly: true` and gets back a prompt with no image, so there's now a `generateEndingImagePrompt` alongside `generateEndingImage`, both on one shared request helper. The result type also grew the diagnostic fields the route has always returned next to the image (`tone`, `aiGenerated`, `placeholder`, `service`), which the panel displays. Failed responses now surface the server's own error message instead of a flat "Failed to load ending image", so the debug panel keeps the detail it had from reading the response body directly.

## Related Issue

Closes #1755

Note that `develop` isn't the default branch, so GitHub won't auto-close on merge - the issue needs closing by hand.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Tests came after the swap here rather than before it, so that box stays unchecked. Both devtools components had no test file at all before this.

## User Stories Addressed

As a developer debugging AI generation, the devtools panel should send requests the same way the app does, so what the panel shows reflects what players actually get.

## Flow Diagrams

N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A - no rendered output changed, only what happens behind the buttons.

## Implementation Notes

The failure paths needed reading, not find-and-replace. Two behaviors were deliberately preserved: a failed world image still leaves the created world in place (the wrapper's throw lands in the same catch that used to swallow the non-ok branch), and a failed portrait still leaves the character in place. Both catches now log a single error instead of splitting between a warn for HTTP failures and an error for thrown ones.

The prompt-preview path dropped its `result.imageUrl && !result.placeholder` branch. The route never returns either field in prompt-only mode, so that check was dead.

Out of scope on purpose: `PortraitDebugSection` and `clientFactory`, which are #1754's territory.

## Screenshots

N/A

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

```
npm test          exit 0    407 suites, 2804 tests
npm run type-check exit 0
npm run lint       exit 0    0 errors, 149 pre-existing warnings
npm run deps:validate exit 0
```

## Testing Instructions

1. Open the devtools panel with a BYO provider key configured, then run "Generate Diverse AI World" and "Generate Prompt Preview". Both requests should now carry the provider key header.
2. With no key configured, the same buttons should behave exactly as before - `aiFetch` is a plain fetch when nothing is set, so dev and CI are unchanged.
3. `npx jest src/components/devtools src/lib/api` covers the converted sites, including what the panel does when a wrapper rejects.

## Checklist
- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

`TestDataGeneratorSection.tsx` is still over 300 lines, though this PR takes it from 742 down to 686. Splitting it is a separate job.
