### PR TITLE
Check the OpenAI and OpenRouter presets against the live docs

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -38,6 +38,16 @@ Scripts that help with testing various parts of the project, especially data pro
 - **`test-update-stories.sh`** - Shell script to test the user story update process
 - **`testing/`** - Test files and utilities for testing the scripts themselves
 
+### Provider Verification
+
+- **`verify-openai-compatible-stream.mjs`** - Plays one streamed narrative turn against a live OpenAI-compatible provider, through the same adapter and stream consumer the narrative route uses. This is the check that has to pass before a preset in `src/lib/ai/presets.ts` can be marked `available: true`, since nothing in CI can call a paid endpoint. Reads the key from `OPENAI_COMPAT_API_KEY` at call time, and redacts it from anything it prints:
+
+  ```bash
+  OPENAI_COMPAT_API_KEY=<your key> node scripts/verify-openai-compatible-stream.mjs --preset openrouter
+  ```
+
+  `--preset <id>` takes the endpoint and default model from the preset; `--model` overrides the model, and `--endpoint` (with `--model`) points at a service that has no preset. Exits 0 on pass, 1 on fail.
+
 ### Documentation
 
 - **`github-project-setup.md`** - Documentation for setting up GitHub projects for this repository

--- a/scripts/verify-openai-compatible-stream.mjs
+++ b/scripts/verify-openai-compatible-stream.mjs
@@ -12,9 +12,9 @@
  * happened to write.
  *
  * It asserts, in order because each fails differently: the key was accepted,
- * deltas arrived BEFORE the terminal event (real progressive streaming rather
- * than one buffered blob dressed as a stream), the turn finished with prose
- * instead of an empty refusal, and that prose is the envelope the app parses.
+ * the turn arrived as more than one delta (real progressive streaming rather
+ * than a buffered blob dressed as a stream), it finished with prose instead of
+ * an empty refusal, and that prose is the envelope the app parses.
  *
  * The key is read from OPENAI_COMPAT_API_KEY at call time. It is never written
  * to disk, never passed as an argument, and every line this prints goes through
@@ -52,6 +52,13 @@ const DEFAULT_PRESET_ID = 'openai';
 /** Matches the app's generation config; see src/lib/ai/config.ts. */
 const TEMPERATURE = 0.7;
 const MAX_TOKENS = 2048;
+
+/**
+ * Wall-clock cap on reading the streamed body. Generous, because a slow model
+ * on a long turn is a pass and not a failure; it exists only so a provider that
+ * stops sending without closing the stream ends the run instead of parking it.
+ */
+const STREAM_BUDGET_MS = 120000;
 
 /** A throwaway world, small enough to read in the output and cheap to generate. */
 const VERIFICATION_WORLD = {
@@ -148,10 +155,11 @@ function resolveTarget(args, getPresetById) {
 /**
  * Play the turn and collect what the route's client would have seen.
  *
- * The delta count is the interesting one. A provider that returns the whole
- * completion in a single frame still produces a valid `done` event, so counting
- * deltas is the only thing separating streaming that works from streaming that
- * merely doesn't error.
+ * The delta count is the interesting one, and the threshold has to be more than
+ * one rather than more than zero. A provider that buffers the whole completion
+ * and hands it back in a single SSE frame still grows the preview once, so it
+ * still produces exactly one delta and then a terminal event. Counting "at
+ * least one" would pass the very response this check exists to catch.
  */
 async function playStreamedTurn(prod, descriptor, prompt) {
   const spec = {
@@ -172,17 +180,39 @@ async function playStreamedTurn(prod, descriptor, prompt) {
   const reader = upstream.body.getReader();
   const result = { deltas: 0, preview: '', done: null, error: null };
 
-  for await (const event of prod.consumeProviderStreamEvents(
-    reader,
-    prod.openAICompatibleAdapter,
-    'Provider verification'
-  )) {
-    if (event.error) result.error = event.error;
-    else if (event.done) result.done = event;
-    else if (typeof event.delta === 'string') {
-      result.deltas += 1;
-      result.preview += event.delta;
+  // sendProviderRequest's timeout is cleared the moment the response headers
+  // land, so nothing upstream bounds the body read. A provider that answers 200,
+  // opens an SSE body and then stalls without closing it would park this loop
+  // forever, which is a poor thing to hand somebody running the check by hand.
+  let timedOut = false;
+  const watchdog = setTimeout(() => {
+    timedOut = true;
+    reader.cancel().catch(() => {});
+  }, STREAM_BUDGET_MS);
+
+  try {
+    for await (const event of prod.consumeProviderStreamEvents(
+      reader,
+      prod.openAICompatibleAdapter,
+      'Provider verification'
+    )) {
+      if (event.error) result.error = event.error;
+      else if (event.done) result.done = event;
+      else if (typeof event.delta === 'string') {
+        result.deltas += 1;
+        result.preview += event.delta;
+      }
     }
+  } finally {
+    // Also stops a pending timer from holding the process open on the fast path.
+    clearTimeout(watchdog);
+  }
+
+  // Cancelling the reader ends the loop cleanly, so the consumer yields a
+  // normal terminal event carrying a partial turn. Naming the timeout here is
+  // what keeps that from being read as a provider that answered badly.
+  if (timedOut) {
+    result.error = `provider stalled: no end of stream within ${STREAM_BUDGET_MS / 1000}s`;
   }
 
   return result;
@@ -211,9 +241,12 @@ function evaluate(turn, prod) {
   return [
     { name: 'stream completed', passed: true, detail: '' },
     {
-      name: 'progressive deltas arrived before the terminal event',
-      passed: turn.deltas > 0,
-      detail: turn.deltas > 0 ? `${turn.deltas} deltas` : 'zero deltas, so nothing revealed progressively',
+      name: 'the turn was revealed progressively, not in one piece',
+      passed: turn.deltas > 1,
+      detail:
+        turn.deltas > 1
+          ? `${turn.deltas} deltas`
+          : `${turn.deltas} delta, so the reply was buffered and handed over whole`,
     },
     {
       name: 'turn produced content',

--- a/scripts/verify-openai-compatible-stream.mjs
+++ b/scripts/verify-openai-compatible-stream.mjs
@@ -1,0 +1,317 @@
+#!/usr/bin/env node
+/**
+ * Proves an OpenAI-compatible preset actually works, by playing one streamed
+ * narrative turn against the live provider.
+ *
+ * The presets ship marked `available: false` because nothing in CI can call a
+ * paid endpoint, so the only thing that can flip one is a human with a key.
+ * This is that check, written down. It drives the SAME two functions the
+ * narrative route drives - `openProviderTextStream` then
+ * `consumeProviderStreamEvents`, over `openAICompatibleAdapter` - so a pass
+ * here is a statement about the shipped path, not about a fetch this script
+ * happened to write.
+ *
+ * It asserts, in order because each fails differently: the key was accepted,
+ * deltas arrived BEFORE the terminal event (real progressive streaming rather
+ * than one buffered blob dressed as a stream), the turn finished with prose
+ * instead of an empty refusal, and that prose is the envelope the app parses.
+ *
+ * The key is read from OPENAI_COMPAT_API_KEY at call time. It is never written
+ * to disk, never passed as an argument, and every line this prints goes through
+ * a redactor first, since an upstream error body can echo the request back with
+ * the credential in it.
+ *
+ *   OPENAI_COMPAT_API_KEY=... node scripts/verify-openai-compatible-stream.mjs --preset openai
+ *   OPENAI_COMPAT_API_KEY=... node scripts/verify-openai-compatible-stream.mjs --preset openrouter --model openai/gpt-4o
+ *   OPENAI_COMPAT_API_KEY=... node scripts/verify-openai-compatible-stream.mjs --endpoint https://host/v1/chat/completions --model some-model
+ *
+ * Exits 0 on pass, 1 on fail. No dev server needed, it calls the provider
+ * directly the way the server would.
+ */
+
+import { writeFile, mkdtemp, rm } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * SECURITY: randomized, not a fixed path under the shared temp dir. The bundle
+ * written here gets import()ed, so a predictable name would let any other local
+ * user pre-create it and choose what this script executes.
+ */
+const BUILD_DIR_PREFIX = join(tmpdir(), 'narraitor-provider-verify-');
+
+const KEY_ENV_VAR = 'OPENAI_COMPAT_API_KEY';
+const DEFAULT_PRESET_ID = 'openai';
+
+/** Matches the app's generation config; see src/lib/ai/config.ts. */
+const TEMPERATURE = 0.7;
+const MAX_TOKENS = 2048;
+
+/** A throwaway world, small enough to read in the output and cheap to generate. */
+const VERIFICATION_WORLD = {
+  worldName: 'The Long Cold',
+  worldDescription:
+    'A research station on a frozen moon, three weeks after the last supply ship failed to arrive.',
+  genre: 'Science Fiction',
+  tone: 'serious',
+  playerCharacterName: 'Vance',
+  enhancedCharacterContext: 'Vance is the station engineer, and the only one still awake on night rotation.',
+};
+
+function parseArgs(argv) {
+  const args = { preset: DEFAULT_PRESET_ID, endpoint: null, model: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    if (flag === '--preset') args.preset = argv[++i];
+    else if (flag === '--endpoint') args.endpoint = argv[++i];
+    else if (flag === '--model') args.model = argv[++i];
+    else throw new Error(`Unknown argument: ${flag}`);
+  }
+  return args;
+}
+
+/**
+ * Replaces the key with a placeholder anywhere it appears in text bound for the
+ * terminal.
+ *
+ * SECURITY: not paranoia about our own console.log calls - a provider that
+ * echoes the failing request back puts the bearer credential in its error body,
+ * and that body reaches this script as `error.detail` (see
+ * MAX_UPSTREAM_DETAIL in providers/core/request.ts).
+ */
+function makeRedactor(apiKey) {
+  return (text) => String(text).split(apiKey).join('[redacted]');
+}
+
+/**
+ * The provider path is TypeScript using @/ aliases. Bundle it with the repo's
+ * own esbuild rather than reimplementing it, so this script cannot drift from
+ * what the app actually sends. Same approach as generate-homepage-showcase.mjs.
+ */
+async function bundleProductionModules() {
+  const buildDir = await mkdtemp(BUILD_DIR_PREFIX);
+  const entry = join(buildDir, 'entry.ts');
+  const out = join(buildDir, 'production.mjs');
+  await writeFile(
+    entry,
+    [
+      "export { getPresetById } from '@/lib/ai/presets';",
+      "export { openAICompatibleAdapter } from '@/lib/ai/providers/openai-compatible/adapter';",
+      "export { openProviderTextStream } from '@/lib/ai/providers/core/request';",
+      "export { consumeProviderStreamEvents } from '@/lib/ai/providers/core/streamConsumer';",
+      "export { parseContentRating } from '@/lib/ai/safety/contentRatingGuidance';",
+      "export { getNarrativeTemplate } from '@/lib/promptTemplates/narrativeTemplateManager';",
+      "export { parseJsonFromLLM } from '@/lib/ai/parseJSON';",
+    ].join('\n')
+  );
+  await execFileAsync(
+    join(REPO_ROOT, 'node_modules', '.bin', 'esbuild'),
+    [
+      entry,
+      '--bundle',
+      '--format=esm',
+      '--platform=node',
+      `--tsconfig=${join(REPO_ROOT, 'tsconfig.json')}`,
+      `--outfile=${out}`,
+    ],
+    { cwd: REPO_ROOT }
+  );
+  return { modules: await import(out), buildDir };
+}
+
+/** Endpoint and model for this run: explicit flags win, otherwise the preset's. */
+function resolveTarget(args, getPresetById) {
+  if (args.endpoint) {
+    if (!args.model) throw new Error('--endpoint requires --model.');
+    return { label: args.endpoint, endpoint: args.endpoint, model: args.model };
+  }
+
+  const preset = getPresetById(args.preset);
+  if (!preset) throw new Error(`No preset with id "${args.preset}".`);
+  if (preset.type !== 'openai-compatible') {
+    throw new Error(`Preset "${preset.id}" is ${preset.type}, not openai-compatible.`);
+  }
+
+  return {
+    label: preset.name,
+    endpoint: preset.endpoint,
+    model: args.model ?? preset.defaultModel,
+  };
+}
+
+/**
+ * Play the turn and collect what the route's client would have seen.
+ *
+ * The delta count is the interesting one. A provider that returns the whole
+ * completion in a single frame still produces a valid `done` event, so counting
+ * deltas is the only thing separating streaming that works from streaming that
+ * merely doesn't error.
+ */
+async function playStreamedTurn(prod, descriptor, prompt) {
+  const spec = {
+    prompt,
+    temperature: TEMPERATURE,
+    maxTokens: MAX_TOKENS,
+    contentRating: prod.parseContentRating(prompt),
+    stream: true,
+  };
+
+  const upstream = await prod.openProviderTextStream(
+    prod.openAICompatibleAdapter,
+    descriptor,
+    spec
+  );
+  if (!upstream.body) throw new Error('Provider answered 200 with an empty stream body.');
+
+  const reader = upstream.body.getReader();
+  const result = { deltas: 0, preview: '', done: null, error: null };
+
+  for await (const event of prod.consumeProviderStreamEvents(
+    reader,
+    prod.openAICompatibleAdapter,
+    'Provider verification'
+  )) {
+    if (event.error) result.error = event.error;
+    else if (event.done) result.done = event;
+    else if (typeof event.delta === 'string') {
+      result.deltas += 1;
+      result.preview += event.delta;
+    }
+  }
+
+  return result;
+}
+
+/** The prose inside the narrative envelope, or '' if the reply wasn't one. */
+function readEnvelopeProse(prod, content) {
+  try {
+    const prose = prod.parseJsonFromLLM(content)?.content;
+    return typeof prose === 'string' ? prose.trim() : '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * The checks, as a list so a failure names which one broke rather than just
+ * failing somewhere in a stream.
+ */
+function evaluate(turn, prod) {
+  if (turn.error) return [{ name: 'stream completed', passed: false, detail: turn.error }];
+
+  const content = turn.done?.content ?? '';
+  const prose = readEnvelopeProse(prod, content);
+
+  return [
+    { name: 'stream completed', passed: true, detail: '' },
+    {
+      name: 'progressive deltas arrived before the terminal event',
+      passed: turn.deltas > 0,
+      detail: turn.deltas > 0 ? `${turn.deltas} deltas` : 'zero deltas, so nothing revealed progressively',
+    },
+    {
+      name: 'turn produced content',
+      passed: content.trim().length > 0,
+      detail: `${content.length} chars`,
+    },
+    {
+      name: 'finish reason is a normal stop',
+      passed: turn.done?.finishReason === 'STOP',
+      detail: `finishReason=${turn.done?.finishReason ?? 'none'}`,
+    },
+    {
+      name: 'content parses as the narrative envelope',
+      passed: prose.length > 0,
+      detail: prose.length > 0 ? `${prose.length} chars of prose` : 'not the envelope the app parses',
+    },
+  ];
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  const apiKey = process.env[KEY_ENV_VAR];
+  if (!apiKey) {
+    console.error(
+      `${KEY_ENV_VAR} is not set. Run this as:\n\n` +
+        `  ${KEY_ENV_VAR}=<your key> node scripts/verify-openai-compatible-stream.mjs --preset <id>\n\n` +
+        'The key is read at call time and never written anywhere.'
+    );
+    return 1;
+  }
+  const redact = makeRedactor(apiKey);
+
+  const { modules: prod, buildDir } = await bundleProductionModules();
+  try {
+    const target = resolveTarget(args, prod.getPresetById);
+    console.log(`Provider : ${target.label}`);
+    console.log(`Endpoint : ${target.endpoint}`);
+    console.log(`Model    : ${target.model}`);
+    console.log('Playing one streamed opening scene...\n');
+
+    const prompt = prod.getNarrativeTemplate('narrative/initialScene')(VERIFICATION_WORLD);
+    const descriptor = {
+      type: 'openai-compatible',
+      endpoint: target.endpoint,
+      model: target.model,
+      apiKey,
+    };
+
+    let turn;
+    try {
+      turn = await playStreamedTurn(prod, descriptor, prompt);
+    } catch (error) {
+      // ProviderUpstreamError carries the upstream status and a slice of its
+      // body; both are worth printing, and both go through the redactor.
+      const status = error?.status ? ` (HTTP ${error.status})` : '';
+      const detail = error?.detail ? `\n${redact(error.detail)}` : '';
+      console.error(`FAIL  request never completed${status}: ${redact(error?.message ?? error)}${detail}`);
+      return 1;
+    }
+
+    const checks = evaluate(turn, prod);
+    for (const check of checks) {
+      const mark = check.passed ? 'pass' : 'FAIL';
+      console.log(`${mark}  ${check.name}${check.detail ? ` - ${redact(check.detail)}` : ''}`);
+    }
+
+    const usage = turn.done
+      ? `prompt ${turn.done.promptTokens ?? 'n/a'} / completion ${turn.done.completionTokens ?? 'n/a'}`
+      : 'n/a';
+    console.log(`\nTokens reported: ${usage}`);
+
+    if (turn.preview) {
+      console.log(`\nFirst of what a player would have watched appear:\n  ${redact(turn.preview.slice(0, 240))}...`);
+    }
+
+    const failed = checks.filter((check) => !check.passed);
+    if (failed.length > 0) {
+      console.log(`\nFAIL - ${failed.length} of ${checks.length} checks failed for ${target.label}.`);
+      return 1;
+    }
+
+    console.log(
+      `\nPASS - ${target.label} works end to end on the streamed narrative path.\n` +
+        'This is the evidence needed to flip its preset to available: true in src/lib/ai/presets.ts.'
+    );
+    return 0;
+  } finally {
+    await rm(buildDir, { recursive: true, force: true });
+  }
+}
+
+main()
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((error) => {
+    // Nothing here has the key in scope, so this path prints the message as-is.
+    console.error(`FAIL  ${error?.message ?? error}`);
+    process.exitCode = 1;
+  });

--- a/src/lib/ai/__tests__/presets.test.ts
+++ b/src/lib/ai/__tests__/presets.test.ts
@@ -1,0 +1,28 @@
+import { PROVIDER_PRESETS } from '../presets';
+import { supportsImages } from '../providers/capabilities';
+
+/**
+ * Guards the two things about a preset that can't be caught by reading it.
+ *
+ * `available` is a claim that somebody ran a real key through
+ * scripts/verify-openai-compatible-stream.mjs, and nothing in CI can make that
+ * call - so the test's job is to notice when one gets flipped, not to check it.
+ */
+describe('PROVIDER_PRESETS', () => {
+  it('marks only Gemini as available, because it is the only one verified live', () => {
+    const available = PROVIDER_PRESETS.filter((preset) => preset.available).map((p) => p.id);
+    expect(available).toEqual(['gemini']);
+  });
+
+  it('claims image support only where the provider path can actually generate images', () => {
+    for (const preset of PROVIDER_PRESETS) {
+      expect(preset.capabilities.images).toBe(supportsImages(preset.type));
+    }
+  });
+
+  it('offers a default model that is one of the models it lists', () => {
+    for (const preset of PROVIDER_PRESETS) {
+      expect(preset.models).toContain(preset.defaultModel);
+    }
+  });
+});

--- a/src/lib/ai/presets.ts
+++ b/src/lib/ai/presets.ts
@@ -14,6 +14,11 @@ import type { ProviderPreset } from '@/types/provider.types';
  * OpenRouter comes next because it's the only other option a player can reach
  * without a credit card, and one key there covers dozens of models. Everything
  * below it needs prepaid billing before it generates a single word.
+ *
+ * TODO(#895): flip a preset to `available: true` only after
+ * scripts/verify-openai-compatible-stream.mjs passes against it with a real
+ * key. Nothing in CI can make that call, so `available` is a claim about a
+ * live check somebody ran, not about the code compiling.
  */
 export const PROVIDER_PRESETS: ProviderPreset[] = [
   {
@@ -33,12 +38,21 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     id: 'openrouter',
     name: 'OpenRouter',
     type: 'openai-compatible',
-    // TODO(#895): re-check this model list when the provider goes live. OpenRouter's
-    // zero-cost ":free" ids rotate every few weeks, so none are pinned here.
-    models: ['openai/gpt-4o', 'anthropic/claude-3.5-sonnet', 'google/gemini-2.5-flash'],
+    // Each id below was checked against OpenRouter's live catalogue
+    // (https://openrouter.ai/api/v1/models), which is the only thing that knows
+    // what is actually servable. The catalogue keeps retired slugs resolvable
+    // with an empty `endpoints` array, so "the id still exists" and "something
+    // will answer it" are different questions.
+    //
+    // No zero-cost ":free" id is pinned here: OpenRouter documents that free
+    // availability changes frequently, so any one named here would rot.
+    models: ['openai/gpt-4o', 'anthropic/claude-sonnet-5', 'google/gemini-2.5-flash'],
     endpoint: 'https://openrouter.ai/api/v1/chat/completions',
     defaultModel: 'openai/gpt-4o',
-    capabilities: { text: true, images: true, streaming: true },
+    // Images here means generation, not vision input, and generation stays on
+    // Gemini. See supportsImages in providers/capabilities.ts, which is what
+    // the validate-provider route reports back whatever a preset claims.
+    capabilities: { text: true, images: false, streaming: true },
     helpUrl: 'https://openrouter.ai/keys',
     available: false,
     note: 'free tier, no card',
@@ -50,9 +64,16 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     name: 'OpenAI',
     type: 'openai-compatible',
     endpoint: 'https://api.openai.com/v1/chat/completions',
-    models: ['gpt-4o', 'gpt-4-turbo', 'gpt-3.5-turbo'],
-    defaultModel: 'gpt-4o',
-    capabilities: { text: true, images: true, streaming: true },
+    // The list this replaced was three models OpenAI has since moved off:
+    // gpt-4-turbo and gpt-3.5-turbo both carry a published shutdown date on
+    // the deprecations page, and gpt-4o has quietly left the models index. A
+    // preset is a menu a player picks from, so a shutdown date on two of three
+    // entries is a bug with a fuse on it rather than a cosmetic one.
+    models: ['gpt-5.6-terra', 'gpt-5.6-sol', 'gpt-5.6-luna'],
+    defaultModel: 'gpt-5.6-terra',
+    // OpenAI's chat models take images as INPUT; they don't generate them, and
+    // this flag has only ever meant generation here (providers/capabilities.ts).
+    capabilities: { text: true, images: false, streaming: true },
     helpUrl: 'https://platform.openai.com/api-keys',
     available: false,
     privacyNote:


### PR DESCRIPTION
## Description

Two of the model ids shipped in the OpenAI and OpenRouter presets have stopped working, and both presets claimed an image capability the code doesn't have. This corrects what was demonstrably wrong against each vendor's live docs, and adds a script that can actually prove a preset works before anybody marks it available.

The provider client, adapter, factory branch, presets and settings UI all landed in #890. Nothing here rebuilds any of that. This is verification plus the tooling to repeat it.

**What was wrong, and the evidence:**

`anthropic/claude-3.5-sonnet` on OpenRouter is retired. It's absent from the live catalogue at https://openrouter.ai/api/v1/models (411 models, checked directly), and the single-model endpoint still returns metadata for it but with an empty `endpoints` array, so the catalogue remembers it while nothing serves it. Replaced with `anthropic/claude-sonnet-5`, which is present in that same live list. `openai/gpt-4o` and `google/gemini-2.5-flash` both check out and stay.

On OpenAI, `gpt-4-turbo` and `gpt-3.5-turbo` both carry a published shutdown date of October 23 2026 on https://developers.openai.com/api/docs/deprecations, which is about ten weeks out. `gpt-4o` is a murkier case: it isn't in any deprecation table, but it has dropped off the current models index at https://developers.openai.com/api/docs/models, so it's no longer a model OpenAI promotes. Since all three were on a menu players pick from, the list moves to the current chat models, `gpt-5.6-terra` (the intelligence/cost balance, now the default), `gpt-5.6-sol` and `gpt-5.6-luna`.

Both presets also said `images: true`, which contradicts the shipped code rather than the docs. `supportsImages()` in `providers/capabilities.ts` returns true only for Gemini, and `/api/ai/validate-provider` reports that back through `toWireCapabilities()` whatever a preset claims, so the wizard could advertise image support from the preset and then deny it a moment later on validation. The vendor docs agree independently: OpenAI's chat models take images as input and don't generate them, and generation is a different endpoint shape entirely. Both are now `false`, which also makes the whole openai-compatible family consistent, since the other four presets already said false.

**What was checked and found correct, so left alone:**

Both endpoint URLs are still right. `https://api.openai.com/v1/chat/completions` is current and not deprecated (Responses is recommended in the docs, but chat completions remains fully supported), and `https://openrouter.ai/api/v1/chat/completions` appears in every current OpenRouter sample. Both `helpUrl` values still resolve, though `openrouter.ai/keys` now 307s to `/workspaces/default/keys`, so it works as a shortcut rather than as the destination. Streaming is confirmed OpenAI-shaped on both, `data:` frames with a `data: [DONE]` terminator, which is what the shipped stream consumer already assumes.

OpenRouter's custom headers are the one finding I deliberately did **not** act on. `HTTP-Referer` and `X-OpenRouter-Title` (the current name, with `X-Title` kept for backwards compatibility) are documented as optional for making a request and required only for app attribution on their rankings pages. Since nothing is broken without them, and `ProviderPreset` has no `customHeaders` field while the adapter's `buildHeaders` sends only auth and content type, wiring them up would mean changing shipped code for an attribution feature nobody asked for. Worth a separate issue if the rankings listing is ever wanted.

## Related Issue

Refs #895

Not "Closes", deliberately. The acceptance criteria include "all presets tested and validated" and an integration test against a real provider, and every preset stays `available: false` because flipping one is a claim that somebody ran a real key against a real endpoint. See the handback section below.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The preset corrections are data fixes, so the test came after the fact rather than driving it. It's deliberately small: it pins that Gemini is the only `available: true` preset, that `capabilities.images` matches `supportsImages()` for every preset (the contradiction this PR fixes), and that each `defaultModel` is in its own `models` list. The verification script itself has no unit test, because the only thing worth asserting about it needs a live provider.

## User Stories Addressed

From #895: "As a playtester, I want to use any OpenAI-compatible AI service so that I have maximum flexibility in choosing which models to use." This PR doesn't deliver that story, it removes two ways it would have failed on first contact and builds the check that decides when it's true.

## Flow Diagrams

N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A, no UI changes. The preset data feeds ProviderWizard, but no component was touched.

## Implementation Notes

The script deliberately drives the shipped path rather than a fetch of its own. It calls `openProviderTextStream(openAICompatibleAdapter, descriptor, spec)` and then `consumeProviderStreamEvents(...)`, which are the same two functions `processAIStreamingTextRequest` in `src/utils/apiHelpers.ts` calls. So a pass is a statement about what the app does, not about what the script does. The prompt comes from the production `narrative/initialScene` template, which matters more than it looks: the stream consumer runs `extractStreamingContentPreview` over the buffer to pull the `content` field out of a partial JSON envelope, so a prompt that didn't ask for that envelope would never exercise the preview path at all.

Getting `@/`-aliased TypeScript into a `.mjs` script follows the existing pattern from `generate-homepage-showcase.mjs`: write a tiny entry file re-exporting what's needed, bundle it with the repo's own esbuild into a randomized temp dir, import the result, delete it afterwards. The randomized temp path is copied from that script for the same reason it's there, a predictable name under a shared temp dir would let another local user pre-create the file this script imports.

On key handling: the key is read from `process.env.OPENAI_COMPAT_API_KEY` at call time, never read from a file, never accepted as an argument (which would put it in shell history and `ps` output), and never written anywhere. Everything the script prints goes through a redactor keyed on the actual value first. That last part isn't belt-and-braces about our own `console.log` calls, it's because `ProviderUpstreamError` carries up to 300 characters of the upstream error body, and a provider that echoes the failing request back would put the bearer credential in it.

One note against the file-size checkbox below: the script is 350 lines, over the 300 stated in the template. It's in `scripts/`, where the closest analogue (`generate-homepage-showcase.mjs`) is 561 and two others are over 360, so it's well within the norm there, but the box is left unticked rather than ticked loosely.

## Screenshots

N/A

## Visual Baseline Changes

None. This PR doesn't touch `tests/visual/**-snapshots/**`.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A, no browser-facing change.

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit wasn't run as a separate step, so that box stays unticked. The `console.log` calls are all in the CLI script, which is what a CLI script is for; nothing was added under `src/`. On secrets: no key, real or fake, appears anywhere in the diff.

## Testing Instructions

Stage one, the gate, all run in the worktree:

```bash
npm test          # 405 suites, 2795 tests, exit 0
npm run type-check  # exit 0
npm run lint        # exit 0, 149 pre-existing warnings, no errors
```

`lint:css` wasn't run because no CSS was touched.

Stage two, the script's own behaviour, neither of which needs a key:

```bash
node scripts/verify-openai-compatible-stream.mjs --preset openai
# exits 1 with instructions, because OPENAI_COMPAT_API_KEY isn't set

OPENAI_COMPAT_API_KEY='definitely-not-a-key-zz' node scripts/verify-openai-compatible-stream.mjs --preset openrouter
# exits 1 on a redacted HTTP 401
```

That second one is worth running, because it exercises everything except the generation itself: the esbuild bundle, the module wiring, the endpoint guard, the real request, and the error path. Against OpenRouter it comes back `{"error":{"message":"Missing Authentication header","code":401}}`, against OpenAI a 401 with the key masked by OpenAI's own redaction.

Stage three is the live check, which is the handback.

## HANDBACK: what still needs a human

Nothing in CI can call a paid endpoint, so **every preset in `src/lib/ai/presets.ts` remains `available: false`, and none of the openai-compatible ones has been proven to generate a turn.** Unverified: `openrouter`, `openai`, `deepseek`, `mistral`, `together`, `groq`. Only `gemini` is `available: true`, unchanged from before.

To finish verification for a given provider, get a key for it and run:

```bash
OPENAI_COMPAT_API_KEY='<your key>' node scripts/verify-openai-compatible-stream.mjs --preset openrouter
```

Swap `--preset` for whichever you're checking, and add `--model <id>` to try a specific model instead of the preset's default. OpenRouter is the cheapest place to start, since one key there reaches OpenAI, Anthropic and Google models, and its free tier needs no card.

A pass prints five green checks and exits 0, at which point that preset's `available: true` is a claim backed by something. A failure names which check broke. Two failure modes worth knowing before you read the output as a verdict on the provider:

- **One delta.** The turn worked but arrived buffered in a single frame rather than progressively. That's a streaming problem, not an auth or model problem.
- **Provider stalled.** The stream opened and then stopped without closing, and the run gave up after 120 seconds rather than hanging.
- **Content didn't parse as the narrative envelope.** The provider generated fine but ignored the JSON format the prompt asked for. That's a model-quality signal about that specific model, and worth trying a stronger one on the same provider before writing off the preset.

Two things I could not settle without a key, so please treat them as open rather than checked:

1. **The OpenAI model ids are doc-verified, not call-verified.** `gpt-5.6-terra` and its siblings come from OpenAI's current models index. The invalid-key run returns 401 before the model is ever validated, so a bad id would look identical. The script will settle it on the first real run.
2. **`gpt-4o` on the OpenAI direct preset.** It was dropped here because it's off the models index, not because it's formally deprecated, and OpenAI's own detail page for it still exists and contradicts the index. If you want it back, that's a judgement call rather than a correction.

If a run passes, the follow-up is a one-line change flipping that preset's `available` to `true`, and #895's remaining criteria (integration test against at least one real provider, all presets tested) can close with it.

## Checklist
- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed

File size is explained in Implementation Notes, the script is 350 lines. Accessibility is N/A here, nothing renders. Docs updated means `scripts/README.md`, which gained a section covering how to run the verification script and what its flags do.
