### PR TITLE
Stop the play surface clipping itself off the side of a phone

### DIFF
--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -1845,6 +1845,19 @@ body.manuscript-overlay-open {
     flex-wrap: wrap;
   }
 
+  /* Give the choice text its own line on a phone instead of leaving it to
+     fight the badges for one. Side by side, the title row is `flex: 1` (a zero
+     basis) while the badge row's basis is `auto`, so the badges claim their
+     max-content first and the label is left whatever remains. On a 375px
+     screen that remainder was 0px, which collapsed the text to a min-content
+     column and let the badges paint straight over it. Stacking removes the
+     competition rather than trying to referee it, and the badge row keeps its
+     natural width instead of being squeezed. */
+  .manuscript-suggested-action-content {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
 }
 
 @media (width >= 640px) and (width < 1024px) {

--- a/src/styles/manuscript-session.css
+++ b/src/styles/manuscript-session.css
@@ -701,9 +701,13 @@ body.manuscript-overlay-open {
   margin: 0;
 }
 
+/* minmax(0, 1fr) rather than 1fr, for the same reason as
+   .manuscript-main-stage below: bare `1fr` floors the track at the widest
+   choice's min-content, so the buttons render wider than the column meant to
+   hold them. */
 .manuscript-suggested-actions-grid {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: minmax(0, 1fr);
   gap: var(--space-2);
 }
 
@@ -1000,13 +1004,21 @@ body.manuscript-overlay-open {
 
 }
 
+/* Shrinkable and wrappable so a choice carrying both an alignment badge and a
+   skill check still fits a 320px phone. At `flex: 0 0 auto` with `nowrap` the
+   pair claimed 186px of a 200px button and spilled out the side. Each badge is
+   itself `white-space: nowrap`, so the row has to break between them rather
+   than inside one. Above roughly 360px both fit on one line and this changes
+   nothing. */
 .manuscript-suggested-action-badges {
 
-  flex: 0 0 auto;
+  flex: 0 1 auto;
 
   display: flex;
 
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
+
+  min-width: 0;
 
   gap: var(--space-1);
 
@@ -2601,9 +2613,16 @@ body.manuscript-overlay-open {
    DS3 "Mechanical Manuscript" — floating pill + icon HUD
    ═══════════════════════════════════════════════════════════════ */
 
-/* Grid: collapse to single column (floating pill replaces rail) */
+/* Grid: collapse to single column (floating pill replaces rail).
+
+   minmax(0, 1fr) rather than 1fr, because bare `1fr` means `minmax(auto, 1fr)`
+   and that `auto` floors the track at the widest item's min-content. The
+   widest item here is the scene-status bar, which floored the track at 432px
+   inside the 351px a 375px phone actually has. The column grew instead of the
+   text reflowing, and .manuscript-viewport-shell's `overflow: hidden` cut off
+   the excess with nowhere to scroll to. A 0 floor lets the content reflow. */
 :root .manuscript-main-stage {
-  grid-template-columns: 1fr;
+  grid-template-columns: minmax(0, 1fr);
 }
 
 /* Scene status as a compact console bar above the narrative. */
@@ -2723,7 +2742,7 @@ body.manuscript-overlay-open {
 
 /* Choices: vertical stack with accent left bar, tighter gap */
 :root .manuscript-suggested-actions-grid {
-  grid-template-columns: 1fr;
+  grid-template-columns: minmax(0, 1fr);
   gap: var(--space-2_5);
 }
 
@@ -2940,7 +2959,7 @@ body.manuscript-overlay-open {
 /* Desktop override: keep single column */
 @media (width >= 1024px) {
   :root .manuscript-suggested-actions-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   /* Scale up pill and icon for desktop */

--- a/tests/visual/manuscript-regression-assertions.spec.ts
+++ b/tests/visual/manuscript-regression-assertions.spec.ts
@@ -568,6 +568,37 @@ test.describe('Manuscript regression assertions', () => {
         };
       });
 
+      // Holding the column in isn't enough on its own: the badge row and the
+      // choice label sit in the same flex row, and the label's basis is 0
+      // while the badge row's is `auto`. Pull the badges back inside the
+      // viewport without stacking the two and the badges simply claim their
+      // max-content, leaving the label a zero-width column with the badges
+      // painted over the top of it. So measure both, per choice.
+      const choices = Array.from(
+        document.querySelectorAll('.manuscript-suggested-action')
+      ).map((el) => {
+        const action = el as HTMLElement;
+        const label = action.querySelector('.manuscript-suggested-action-label');
+        const badgeRow = action.querySelector('.manuscript-suggested-action-badges');
+        const actionRect = action.getBoundingClientRect();
+        const labelRect = label?.getBoundingClientRect();
+
+        let overlapArea = 0;
+        if (labelRect && badgeRow) {
+          const badgeRect = badgeRow.getBoundingClientRect();
+          const w = Math.min(labelRect.right, badgeRect.right) - Math.max(labelRect.left, badgeRect.left);
+          const h = Math.min(labelRect.bottom, badgeRect.bottom) - Math.max(labelRect.top, badgeRect.top);
+          overlapArea = w > 0 && h > 0 ? Math.round(w * h) : 0;
+        }
+
+        return {
+          actionWidth: actionRect.width,
+          labelWidth: labelRect?.width ?? 0,
+          labelShare: labelRect ? labelRect.width / actionRect.width : 0,
+          overlapArea,
+        };
+      });
+
       return {
         viewportWidth: window.innerWidth,
         stageWidth: stage.getBoundingClientRect().width,
@@ -577,6 +608,10 @@ test.describe('Manuscript regression assertions', () => {
         badgeCount: badges.length,
         badgesClipped: badges.filter((b) => b.clipped).length,
         badgesPastEdge: badges.filter((b) => b.right > window.innerWidth + 0.5).length,
+        choiceCount: choices.length,
+        narrowestLabelShare: Math.min(...choices.map((c) => c.labelShare)),
+        narrowestLabelWidth: Math.min(...choices.map((c) => c.labelWidth)),
+        maxLabelBadgeOverlap: Math.max(...choices.map((c) => c.overlapArea)),
       };
     });
 
@@ -594,9 +629,28 @@ test.describe('Manuscript regression assertions', () => {
       `Boxes past the right edge: ${geometry.overflowing.join(', ')}`
     ).toBe(0);
 
-    // Guard against the assertion above passing because no choices rendered.
+    // Guard against the assertions above passing because no choices rendered.
     expect(geometry.badgeCount).toBeGreaterThan(0);
+    expect(geometry.choiceCount).toBeGreaterThan(0);
+
     expect(geometry.badgesPastEdge).toBe(0);
     expect(geometry.badgesClipped).toBe(0);
+
+    // Nothing may be drawn over the choice text. Measured as real rectangle
+    // intersection rather than a shared-row check, because the two boxes
+    // overlap horizontally while their tops differ once the label wraps tall.
+    expect(
+      geometry.maxLabelBadgeOverlap,
+      'Badge row must not overlap the choice label'
+    ).toBe(0);
+
+    // And the text needs room to actually read as a sentence. Half the button
+    // is a floor, not a target: at 375px the label gets about 76% of it. The
+    // failure this catches is the label collapsing toward a min-content column
+    // one word wide, which stays technically unclipped the whole way down.
+    expect(
+      geometry.narrowestLabelShare,
+      `Narrowest choice label was ${Math.round(geometry.narrowestLabelWidth)}px`
+    ).toBeGreaterThan(0.5);
   });
 });

--- a/tests/visual/manuscript-regression-assertions.spec.ts
+++ b/tests/visual/manuscript-regression-assertions.spec.ts
@@ -513,4 +513,90 @@ test.describe('Manuscript regression assertions', () => {
 
     expect(geometry.decisionFollowsNarrative).toBe(true);
   });
+
+  test('Play surface fits a 375px viewport instead of being clipped past its right edge', async ({
+    page,
+  }) => {
+    // The surface's grid tracks were declared `1fr`, which means `minmax(auto,
+    // 1fr)`, an auto floor equal to the widest item's min-content. The stage's
+    // widest item is the scene-status bar, so the story column rendered 432px
+    // wide inside 351px of room and .manuscript-viewport-shell's `overflow:
+    // hidden` cut the excess off with nowhere to scroll to.
+    //
+    // This measures geometry rather than asserting on the resolved
+    // grid-template-columns. That value reads back fine while the column
+    // overflows, and pinning the declaration would go red on any other correct
+    // way of holding the column in. What a player notices is text disappearing
+    // off the right edge, so that is what gets measured.
+    await page.setViewportSize({ width: 375, height: 812 });
+    await seedTestData(page);
+    await mockApiEndpoints(page);
+
+    await page.goto('/worlds/world-cyberpunk-2077/play');
+    await page.waitForSelector('[data-testid="manuscript-session-shell"]', {
+      timeout: 10000,
+    });
+    await page.waitForSelector('.manuscript-suggested-action', { timeout: 10000 });
+
+    const geometry = await page.evaluate(() => {
+      const shell = document.querySelector('.manuscript-viewport-shell');
+      const stage = document.querySelector('.manuscript-main-stage');
+      const content = document.querySelector('.manuscript-main-content');
+      if (!shell || !stage || !content) return null;
+
+      // Every laid-out box whose right edge sits past the viewport. The shell
+      // clips rather than scrolls, so anything here is unreachable, not
+      // merely off-screen. `sr-only` boxes are 1px clipping wrappers by
+      // design and never render text.
+      const overflowing = Array.from(document.querySelectorAll('*'))
+        .filter((el) => {
+          if (el.closest('.sr-only')) return false;
+          const rect = el.getBoundingClientRect();
+          return rect.width > 0 && rect.right > window.innerWidth + 0.5;
+        })
+        .map((el) => `${el.tagName.toLowerCase()}.${el.className}`);
+
+      // A skill check reads "STEALTH · DC 4"; it is `white-space: nowrap`, so
+      // a column that is too narrow truncates the number rather than wrapping.
+      const badges = Array.from(
+        document.querySelectorAll('.manuscript-skill-check-badge')
+      ).map((el) => {
+        const badge = el as HTMLElement;
+        return {
+          right: badge.getBoundingClientRect().right,
+          clipped: badge.scrollWidth > badge.clientWidth + 1,
+        };
+      });
+
+      return {
+        viewportWidth: window.innerWidth,
+        stageWidth: stage.getBoundingClientRect().width,
+        contentWidth: content.getBoundingClientRect().width,
+        overflowingCount: overflowing.length,
+        overflowing: overflowing.slice(0, 5),
+        badgeCount: badges.length,
+        badgesClipped: badges.filter((b) => b.clipped).length,
+        badgesPastEdge: badges.filter((b) => b.right > window.innerWidth + 0.5).length,
+      };
+    });
+
+    expect(geometry).not.toBeNull();
+    if (!geometry) {
+      throw new Error('Expected play surface geometry to be measurable');
+    }
+
+    // The story column is held by its container rather than by its content.
+    expect(geometry.stageWidth).toBeLessThanOrEqual(geometry.viewportWidth);
+    expect(geometry.contentWidth).toBeLessThanOrEqual(geometry.stageWidth);
+
+    expect(
+      geometry.overflowingCount,
+      `Boxes past the right edge: ${geometry.overflowing.join(', ')}`
+    ).toBe(0);
+
+    // Guard against the assertion above passing because no choices rendered.
+    expect(geometry.badgeCount).toBeGreaterThan(0);
+    expect(geometry.badgesPastEdge).toBe(0);
+    expect(geometry.badgesClipped).toBe(0);
+  });
 });


### PR DESCRIPTION
## Description

On a 375px phone the play surface rendered wider than the screen and the right edge was simply gone, with no way to scroll over to it. The cause is that every grid track on the surface was declared `1fr`, which is shorthand for `minmax(auto, 1fr)`. That `auto` floors the track at the widest item's min-content rather than at zero, so the column grew to fit its contents instead of the contents reflowing to fit the column. `.manuscript-viewport-shell` has `overflow: hidden`, so everything past the edge was clipped and unreachable.

Four declarations move to `minmax(0, 1fr)`: `:root .manuscript-main-stage`, and all three rules for `.manuscript-suggested-actions-grid` (base, `:root`, and the `>= 1024px` override). Fixing only the two that currently win would have left the same trap sitting on the same selector, which is roughly how it survived this long.

Clamping the tracks alone moved the overflow inside the choice button rather than removing it, so `.manuscript-suggested-action-badges` got the matching treatment. An alignment badge plus a skill check claimed 186px of a 200px button and spilled out the side at 320px; the row is now `flex: 0 1 auto` with `flex-wrap: wrap` so the pair breaks onto two lines when there isn't room for one. Each badge stays `white-space: nowrap`, so nothing truncates mid-label, and above roughly 360px there's room for both on one line and nothing changes.

Measured against a live session on this worktree's dev server, at 375x812:

| | before | after |
|---|---|---|
| boxes rendering past the right edge | 49 | 0 |
| `.manuscript-main-stage` resolved track | 431.89px | 351px |
| `.manuscript-main-content` width | 432px | 351px |
| `.manuscript-characters-rail` width | 432px | 351px |
| `#manuscript-decision-block` right edge | 420px (45px off-screen) | 339px |
| `.manuscript-skill-check-badge` right edge | 375px, DC cut off | 294px, fully visible |

At 320px the same change takes boxes past the edge from 66 to 17 and clears the internal overflow the `mobile-overflow` guard checks.

### On the issue's cleanup half: verified stale, dropped from scope

The issue also asked to clean up two inert rules in the `@media (width < 640px)` block, on the grounds that `manuscript-hud-reset-button` is declared but unused. That's stale. `grep -rn "manuscript-hud-reset-button"` over the whole repo (excluding `.git` and `node_modules`) returns nothing at all, so there is no rule left to clean up. `manuscript-tools-menu-item-mobile-only` survives only as a negation inside a visual-test selector in `tests/visual/utils/manuscript-helpers.ts`, and touching it was explicitly out of scope here.

The issue's own diagnosis had also drifted. It named `.manuscript-viewport-inner` as the element with the missing track, and pinned the blame on the HUD header's 408px min-content. Neither reproduces on current `develop`: the header now fits at 351px, `.manuscript-viewport-inner` already resolves to 351px, and applying `minmax(0, 1fr)` there is a measured no-op with zero geometry change. The rail the issue describes (`#manuscript-action-rail`) no longer exists, having been removed in #1750/#1764. The mechanism the issue identified is real and is exactly what's fixed here, but it lives one level down, on `.manuscript-main-stage`.

### Follow-up from review: the badges were landing on the choice text

Codex flagged this on the first commit and it reproduced, so 6dfc920a fixes it. Clamping the track pulled the badges back inside the viewport, but `.manuscript-suggested-action-title-row` is `flex: 1` (a zero basis) while the badge row's basis is `auto`, so the badges claimed their max-content first and the label got the remainder. At 375px the remainder was 0px. The label fell back to min-content, wrapping the choice text into an 80px column inside a 255px button, and the badge row rendered over the top of it.

Real rectangle intersection between the label's box and the badge row's box, per seeded choice:

| viewport | choice 0 (skill) | choice 1 (align+skill) | choice 2 (align+skill) |
|---|---|---|---|
| 320px | 1258px2 | 2863px2 | 2656px2 |
| 375px | 268px2 | 2863px2 | 1083px2 |
| 414px | 0 | 610px2 | 381px2 |
| 768px | 0 | 0 | 0 |
| 1280px | 0 | 0 | 0 |

The fix stacks the label above the badges inside the existing `@media (width < 640px)` block, so the label gets the full column (193px at 375px, up from 80px) and the badge row keeps its natural width instead of being squeezed. Above 640px the measurements come back byte-identical. Two alternatives were measured and rejected: `flex: 1 1 auto` on the title row zeroes the overlap but crushes the badge row to 31-49px at 320px, and `flex-wrap` on the content row fixes some choices while shifting desktop layout for long labels.

Worth noting this was a regression introduced by this PR rather than a pre-existing one. Before the badge-row change the badges sat outside the viewport at x=189 with the label ending at 181, so they cleared each other by accident.

### Known residual, not fixed here

`.narrative-history-segments` sits inside a Radix ScrollArea whose viewport wrapper is `display: table; min-width: 100%`, which floors the prose column's min-content at 320px at every viewport. Once the outer column is correctly clamped, that floor becomes the binding constraint below 320px of column width and clips the story text by the difference. It's a different root cause, the fix needs an `!important` to beat a Radix inline style, and it changes every ScrollArea in the app, so it wants its own issue rather than riding along here.

## Related Issue

Closes #1751

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Not strictly test-first. The order here was measure, then fix, then assert: the overflow was reproduced and traced on a live 375px session before any CSS moved, and candidate fixes were applied as injected stylesheets and measured before being committed to source. The assertion was then checked in both directions, which is the part that matters. With the CSS reverted it fails at 431.89px against an expected 351; with the fix in it passes.

## User Stories Addressed

As a player on a phone, I can read the whole play surface, including the skill check on each suggested action, without part of it being cut off the side of the screen.

## Flow Diagrams

N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

No component changed, so there were no stories to update. This is four grid-track declarations and one flex row in `manuscript-session.css`. Visual consistency was verified by running the full chromium visual suite, which reported no snapshot diffs.

## Implementation Notes

The assertion deliberately measures geometry rather than reading back `grid-template-columns`, per the tier-1 convention in `public_docs/development/visual-testing-best-practices.md`. A resolved-value check would have been green for the entire life of this bug: `getComputedStyle` reported the track perfectly happily while the column overflowed. It would also pin the technique, going red on any other correct way of holding the column in. What a player notices is text disappearing off the right edge, so that's what gets measured: the stage's width against the viewport, the content's width against the stage, a count of every laid-out box whose right edge is past the viewport, and whether any skill-check badge is truncated. The badge count is asserted non-zero first so the whole thing can't pass by rendering no choices.

The new test lives in `tests/visual/manuscript-regression-assertions.spec.ts` alongside the existing tier-1 checks rather than in a new file. After the review finding above it also measures rectangle intersection between the label and the badge row, and asserts the narrowest label keeps more than half the button's width. A shared-row check wouldn't have caught the overlap, because the two boxes overlap horizontally while their tops diverge once the label wraps tall.

Worth flagging for review: `tests/visual/mobile-overflow.spec.ts` at 320px was passing for the wrong reason, exactly as the issue predicted. The blown-out column made `scrollWidth` and `clientWidth` equal on `#manuscript-decision-block`, so the comparison was vacuous. Clamping the track made it genuinely red, and the badge fix is what settles it. That guard is now measuring something real.

## Screenshots

None. The change is a layout clamp with no snapshot diff, and the before/after is better expressed as the measurement table above than as two nearly identical images.

## Visual Baseline Changes

None. No files under `tests/visual/**-snapshots/**` are touched by this PR. The full chromium suite was run three times locally and reported zero pixel diffs on all 74 snapshots, which is the useful surprise here: the clipped region was outside the framed area of every existing baseline, so none of them were capturing the bug.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

Verified over CDP with `bdg` against this worktree's dev server on port 3602, confirming the server actually rebuilt and is serving all four clamped declarations plus the badge row:

```
.manuscript-suggested-actions-grid { display: grid; grid-template-columns: minmax(0px, 1fr); ... }
.manuscript-suggested-action-badges { flex: 0 1 auto; display: flex; flex-wrap: wrap; min-width: 0px; ... }
:root .manuscript-main-stage { grid-template-columns: minmax(0px, 1fr); }
:root .manuscript-suggested-actions-grid { grid-template-columns: minmax(0px, 1fr); ... }
@media (width >= 1024px) { :root .manuscript-suggested-actions-grid { grid-template-columns: minmax(0px, 1fr); } }
```

The geometry numbers in the table above were measured in real Chromium against the same server, using the repo's own seeding helpers so a full play session with choices and badges was on screen.

## Quality Checks
- [x] Linting passed
- [ ] Security audit passed
- [x] Type checking passed
- [x] No console.log statements in production code
- [x] No unhandled promises

```
npm test           2792 passed, 404 suites          exit 0
npm run type-check tsc --noEmit                     exit 0
npm run lint       0 errors, 149 pre-existing warns exit 0
npm run lint:css   stylelint **/*.css               exit 0
npm run test:visual 142 passed, 0 snapshot diffs    exit 0
```

Security audit wasn't run; nothing here touches dependencies or any input path.

The visual suite needed two passes to land clean, for two separate and unrelated reasons. The first pass caught the `mobile-overflow` 320px case described above, which the badge fix resolved. The second pass then failed `main-pages.spec.ts` on the dashboard empty state, which is the known font-swap flake in that file rather than anything to do with this change: the dashboard doesn't consume `manuscript-session.css` at all, that same test passed on the first run, and re-running it in isolation went 3 for 3 green.

## Testing Instructions

Load a play session at a 375px-wide viewport and check the right edge of the suggested actions. The skill check on each choice should read in full, ending in its DC, and nothing should sit past the edge of the screen. Repeat at 320px, where a choice carrying both an alignment badge and a skill check should show the two badges stacked rather than running off the side. At 768px and above nothing should look any different from before.

For the automated version:

```bash
npx playwright test --project=chromium tests/visual/manuscript-regression-assertions.spec.ts
npx playwright test --project=chromium tests/visual/mobile-overflow.spec.ts
```

To confirm the new assertion isn't vacuous, revert the `:root .manuscript-main-stage` declaration to `grid-template-columns: 1fr` and re-run the first command. It should fail on a measured 431.89 against an expected 351.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

On the file size limit: `manuscript-session.css` is well over 300 lines already and this PR adds 5 declarations and 3 comments to it, so the limit is inherited rather than newly broken. No docs needed updating; the tier-1 assertion convention this follows is already written down in `public_docs/development/visual-testing-best-practices.md`. On accessibility, content that renders outside a clipped container is unreachable by pointer and by scroll, so getting it back on screen is the accessibility fix here.
