### PR TITLE
Let a preset ask for extra request headers, and add Perplexity

### DIFF
--- a/scripts/verify-openai-compatible-stream.mjs
+++ b/scripts/verify-openai-compatible-stream.mjs
@@ -108,7 +108,7 @@ async function bundleProductionModules() {
   await writeFile(
     entry,
     [
-      "export { getPresetById } from '@/lib/ai/presets';",
+      "export { getPresetById, presetHeadersForEndpoint, presetMaxOutputTokensParamForEndpoint } from '@/lib/ai/presets';",
       "export { openAICompatibleAdapter } from '@/lib/ai/providers/openai-compatible/adapter';",
       "export { openProviderTextStream } from '@/lib/ai/providers/core/request';",
       "export { consumeProviderStreamEvents } from '@/lib/ai/providers/core/streamConsumer';",
@@ -289,11 +289,17 @@ async function main() {
     console.log('Playing one streamed opening scene...\n');
 
     const prompt = prod.getNarrativeTemplate('narrative/initialScene')(VERIFICATION_WORLD);
+    // Built the way resolveProvider builds it, using the same lookups, rather
+    // than by hand. A descriptor assembled here would be missing whatever the
+    // server derives from the endpoint, and the run would quietly prove out a
+    // request the app never sends.
     const descriptor = {
       type: 'openai-compatible',
       endpoint: target.endpoint,
       model: target.model,
       apiKey,
+      customHeaders: prod.presetHeadersForEndpoint(target.endpoint),
+      maxOutputTokensParam: prod.presetMaxOutputTokensParamForEndpoint(target.endpoint),
     };
 
     let turn;

--- a/src/app/api/ai/validate-provider/__tests__/route.test.ts
+++ b/src/app/api/ai/validate-provider/__tests__/route.test.ts
@@ -188,6 +188,31 @@ describe('POST /api/ai/validate-provider — OpenAI-compatible providers', () =>
     expect((init.headers as Record<string, string>).Authorization).toBe(`Bearer ${KEY}`);
   });
 
+  test("sends the preset's declared headers on the validation ping too", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(fakeResponse(200));
+
+    await POST(openAIRequest({ endpoint: ENDPOINT, model: 'openai/gpt-4o' }));
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    const headers = init.headers as Record<string, string>;
+    // A service that requires its headers would otherwise fail verification
+    // while generating fine, since only the generation path supplied them.
+    expect(headers['HTTP-Referer']).toBe('https://narraitor-six.vercel.app');
+    expect(headers['X-OpenRouter-Title']).toBe('Narraitor');
+    expect(headers.Authorization).toBe(`Bearer ${KEY}`);
+  });
+
+  test('sends no extra headers for an endpoint no preset claims', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(fakeResponse(200));
+
+    await POST(
+      openAIRequest({ endpoint: 'https://api.example.com/v1/chat/completions', model: 'some-model' })
+    );
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(init.headers as Record<string, string>).not.toHaveProperty('HTTP-Referer');
+  });
+
   test('refuses a public hostname that resolves to a private address', async () => {
     // The string check passes — this is the DNS-level bypass it cannot catch.
     (lookup as jest.Mock).mockResolvedValueOnce([{ address: '169.254.169.254', family: 4 }]);

--- a/src/app/api/ai/validate-provider/route.ts
+++ b/src/app/api/ai/validate-provider/route.ts
@@ -6,6 +6,7 @@ import { DEFAULT_TEXT_MODEL, getSafetySettings } from '@/lib/ai/config';
 import { PROVIDER_API_KEY_HEADER } from '@/lib/ai/providerKeyHeader';
 import { getProviderAdapter } from '@/lib/ai/providers/adapterRegistry';
 import { isSafeProviderEndpoint } from '@/lib/ai/providers/endpointGuard';
+import { presetHeadersForEndpoint } from '@/lib/ai/presets';
 import { sendProviderRequest } from '@/lib/ai/providers/core/request';
 import { supportsImages } from '@/lib/ai/providers/capabilities';
 import type { ProviderType } from '@/types/provider.types';
@@ -138,7 +139,14 @@ async function validateOpenAICompatible(
         messages: [{ role: 'user', content: 'ping' }],
         max_tokens: 1,
       },
-      { timeoutMs: PING_TIMEOUT_MS, playerSuppliedEndpoint: true }
+      {
+        timeoutMs: PING_TIMEOUT_MS,
+        playerSuppliedEndpoint: true,
+        // A service that requires its declared headers has to get them in the
+        // check that decides whether the key works, not only once play starts,
+        // or the wizard rejects a key that would generate fine.
+        customHeaders: presetHeadersForEndpoint(endpoint),
+      }
     );
 
     if (response.ok) {

--- a/src/lib/ai/__tests__/presets.test.ts
+++ b/src/lib/ai/__tests__/presets.test.ts
@@ -25,4 +25,31 @@ describe('PROVIDER_PRESETS', () => {
       expect(preset.models).toContain(preset.defaultModel);
     }
   });
+
+  it('covers every service the multi-provider work set out to list', () => {
+    expect(PROVIDER_PRESETS.map((preset) => preset.id).sort()).toEqual([
+      'deepseek',
+      'gemini',
+      'groq',
+      'mistral',
+      'openai',
+      'openrouter',
+      'perplexity',
+      'together',
+    ]);
+  });
+
+  /**
+   * The request layer drops these names before they reach fetch, so a preset
+   * naming one is not a vulnerability. It is a preset whose author believed it
+   * was setting something it isn't, which is worth failing a build over.
+   */
+  it('asks for no header that would carry the key or declare the body', () => {
+    for (const preset of PROVIDER_PRESETS) {
+      const names = Object.keys(preset.customHeaders ?? {}).map((name) => name.toLowerCase());
+
+      expect(names).not.toContain('authorization');
+      expect(names).not.toContain('content-type');
+    }
+  });
 });

--- a/src/lib/ai/__tests__/presets.test.ts
+++ b/src/lib/ai/__tests__/presets.test.ts
@@ -9,9 +9,12 @@ import { supportsImages } from '../providers/capabilities';
  * call - so the test's job is to notice when one gets flipped, not to check it.
  */
 describe('PROVIDER_PRESETS', () => {
-  it('marks only Gemini as available, because it is the only one verified live', () => {
+  it('marks available exactly the presets someone has driven a live turn through', () => {
     const available = PROVIDER_PRESETS.filter((preset) => preset.available).map((p) => p.id);
-    expect(available).toEqual(['gemini']);
+    // OpenRouter joined Gemini after a real streamed turn on openai/gpt-4o came
+    // back in 152 deltas with a parseable envelope. Adding an id here without
+    // that run is the thing this test exists to make somebody think twice about.
+    expect(available).toEqual(['gemini', 'openrouter']);
   });
 
   it('claims image support only where the provider path can actually generate images', () => {

--- a/src/lib/ai/__tests__/presets.test.ts
+++ b/src/lib/ai/__tests__/presets.test.ts
@@ -17,6 +17,22 @@ describe('PROVIDER_PRESETS', () => {
     expect(available).toEqual(['gemini', 'openrouter']);
   });
 
+  it('asks OpenAI for max_completion_tokens, which is the only name it accepts', () => {
+    const openai = PROVIDER_PRESETS.find((preset) => preset.id === 'openai');
+    expect(openai?.maxOutputTokensParam).toBe('max_completion_tokens');
+  });
+
+  it('leaves every other preset on max_tokens, which is what they still speak', () => {
+    const moved = PROVIDER_PRESETS.filter((preset) => preset.maxOutputTokensParam).map((p) => p.id);
+    expect(moved).toEqual(['openai']);
+  });
+
+  it('defaults each preset to a model it actually lists', () => {
+    for (const preset of PROVIDER_PRESETS) {
+      expect(preset.models).toContain(preset.defaultModel);
+    }
+  });
+
   it('claims image support only where the provider path can actually generate images', () => {
     for (const preset of PROVIDER_PRESETS) {
       expect(preset.capabilities.images).toBe(supportsImages(preset.type));

--- a/src/lib/ai/__tests__/resolveProvider.test.ts
+++ b/src/lib/ai/__tests__/resolveProvider.test.ts
@@ -78,6 +78,35 @@ describe('resolveProvider', () => {
     expect(resolution.ok && resolution.descriptor.customHeaders).toBeUndefined();
   });
 
+  it("carries OpenAI's renamed output cap onto the descriptor, keyed off the endpoint", () => {
+    const resolution = resolveProvider(
+      requestWith({
+        [PROVIDER_API_KEY_HEADER]: 'byo-key',
+        [PROVIDER_TYPE_HEADER]: 'openai-compatible',
+        [PROVIDER_ENDPOINT_HEADER]: 'https://api.openai.com/v1/chat/completions',
+        [PROVIDER_MODEL_HEADER]: 'gpt-5.6-luna',
+      })
+    );
+
+    // Without this the adapter sends max_tokens and OpenAI 400s the request.
+    expect(resolution.ok && resolution.descriptor.maxOutputTokensParam).toBe(
+      'max_completion_tokens'
+    );
+  });
+
+  it('leaves the output cap unnamed for a service that never moved off max_tokens', () => {
+    const resolution = resolveProvider(
+      requestWith({
+        [PROVIDER_API_KEY_HEADER]: 'byo-key',
+        [PROVIDER_TYPE_HEADER]: 'openai-compatible',
+        [PROVIDER_ENDPOINT_HEADER]: OPENROUTER,
+        [PROVIDER_MODEL_HEADER]: 'openai/gpt-4o',
+      })
+    );
+
+    expect(resolution.ok && resolution.descriptor.maxOutputTokensParam).toBeUndefined();
+  });
+
   it('reports NO_KEY when neither a header nor a usable env key exists', () => {
     process.env.GEMINI_API_KEY = 'MOCK_API_KEY';
 

--- a/src/lib/ai/__tests__/resolveProvider.test.ts
+++ b/src/lib/ai/__tests__/resolveProvider.test.ts
@@ -54,8 +54,28 @@ describe('resolveProvider', () => {
         // Vendor-prefixed ids are the norm off Gemini and must survive.
         model: 'meta-llama/Llama-3.3-70B-Instruct-Turbo',
         apiKey: 'byo-key',
+        // Attached from the OpenRouter preset because that is where this
+        // request is going, not because anything in it said so.
+        customHeaders: {
+          'HTTP-Referer': 'https://narraitor-six.vercel.app',
+          'X-OpenRouter-Title': 'Narraitor',
+        },
       },
     });
+  });
+
+  it('attaches no preset headers to an endpoint it does not ship a preset for', () => {
+    const resolution = resolveProvider(
+      requestWith({
+        [PROVIDER_API_KEY_HEADER]: 'byo-key',
+        [PROVIDER_TYPE_HEADER]: 'openai-compatible',
+        [PROVIDER_ENDPOINT_HEADER]: 'https://some-other-service.test/v1/chat/completions',
+        [PROVIDER_MODEL_HEADER]: 'some-model',
+      })
+    );
+
+    expect(resolution.ok).toBe(true);
+    expect(resolution.ok && resolution.descriptor.customHeaders).toBeUndefined();
   });
 
   it('reports NO_KEY when neither a header nor a usable env key exists', () => {

--- a/src/lib/ai/presets.ts
+++ b/src/lib/ai/presets.ts
@@ -164,3 +164,28 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
 /** Look up a preset by its stable id. */
 export const getPresetById = (id: string): ProviderPreset | undefined =>
   PROVIDER_PRESETS.find((preset) => preset.id === id);
+
+/**
+ * The extra headers the service at this endpoint asks for, from its preset.
+ *
+ * Keyed on the endpoint rather than on anything the caller declares about
+ * itself, which is what stops one service's headers from riding along to
+ * another, say a preset id claiming to be OpenRouter next to an endpoint
+ * pointing somewhere else. An endpoint with no matching preset gets none, which
+ * is the right answer: we have nothing to say about a service we don't ship.
+ *
+ * Match is on the exact endpoint string, which is what a player who picked a
+ * preset ends up with. A hand-typed variation misses and simply sends no extra
+ * headers, and every header in play is optional.
+ *
+ * Lives here rather than beside either caller because both the generation path
+ * and the validation ping need the same answer — a preset whose service
+ * requires a header must get it in the check that decides whether the key
+ * works, not only once play starts.
+ */
+export const presetHeadersForEndpoint = (
+  endpoint: string | undefined
+): Record<string, string> | undefined => {
+  if (!endpoint) return undefined;
+  return PROVIDER_PRESETS.find((preset) => preset.endpoint === endpoint)?.customHeaders;
+};

--- a/src/lib/ai/presets.ts
+++ b/src/lib/ai/presets.ts
@@ -5,15 +5,15 @@ import type { ProviderPreset } from '@/types/provider.types';
 /**
  * Provider presets shown in the configuration wizard.
  *
- * Only Google Gemini works end-to-end in this release (`available: true`). The
- * others are listed so players can see what's coming and so the schema is ready
- * for the post-1.0 multi-provider work — they're marked unavailable and the UI
- * keeps them out of reach for now.
+ * Gemini and OpenRouter work end-to-end (`available: true`). The rest are
+ * listed so players can see what's coming and so the schema is ready for the
+ * remaining multi-provider work — they're marked unavailable and the UI keeps
+ * them out of reach until someone runs a live check against each.
  *
- * Order is deliberate. Gemini leads because it's the only one that works today.
- * OpenRouter comes next because it's the only other option a player can reach
- * without a credit card, and one key there covers dozens of models. Everything
- * below it needs prepaid billing before it generates a single word.
+ * Order is deliberate. Gemini leads because it's the longest-proven. OpenRouter
+ * comes next because it's the only other option a player can reach without a
+ * credit card, and one key there covers dozens of models. Everything below it
+ * needs prepaid billing before it generates a single word.
  *
  * TODO(#895): flip a preset to `available: true` only after
  * scripts/verify-openai-compatible-stream.mjs passes against it with a real
@@ -65,7 +65,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     // the validate-provider route reports back whatever a preset claims.
     capabilities: { text: true, images: false, streaming: true },
     helpUrl: 'https://openrouter.ai/keys',
-    available: false,
+    available: true,
     note: 'free tier, no card',
     privacyNote:
       'OpenRouter routes your prompts to whichever upstream model you pick, and each of those has its own data-retention terms. Their free models in particular may allow training on your prompts.',

--- a/src/lib/ai/presets.ts
+++ b/src/lib/ai/presets.ts
@@ -49,6 +49,17 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     models: ['openai/gpt-4o', 'anthropic/claude-sonnet-5', 'google/gemini-2.5-flash'],
     endpoint: 'https://openrouter.ai/api/v1/chat/completions',
     defaultModel: 'openai/gpt-4o',
+    // Attribution only: OpenRouter uses these to list the app on its public
+    // rankings, and a request without them succeeds exactly as it does with
+    // them. `X-OpenRouter-Title` is the current name for the title header;
+    // `X-Title` still works as a backwards-compatible alias, so it is not worth
+    // sending both. The URL is written out rather than read from getSiteUrl()
+    // because this module is imported by client components and that one is
+    // server-only, where it would quietly resolve to localhost.
+    customHeaders: {
+      'HTTP-Referer': 'https://narraitor-six.vercel.app',
+      'X-OpenRouter-Title': 'Narraitor',
+    },
     // Images here means generation, not vision input, and generation stays on
     // Gemini. See supportsImages in providers/capabilities.ts, which is what
     // the validate-provider route reports back whatever a preset claims.
@@ -124,6 +135,29 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     capabilities: { text: true, images: false, streaming: true },
     helpUrl: 'https://console.groq.com/keys',
     available: false,
+  },
+  {
+    id: 'perplexity',
+    name: 'Perplexity',
+    type: 'openai-compatible',
+    // Perplexity has two surfaces and only one of them belongs here. The
+    // search-grounded `sonar-*` models answer on /v1/sonar in a shape that is
+    // not OpenAI's, and their chat-completions form carries a published
+    // shutdown date, the same fuse the OpenAI list above was corrected for.
+    // The Gateway is the one Perplexity documents as a drop-in replacement for
+    // an OpenAI integration, so it is the one an openai-compatible preset can
+    // honestly point at. Note the /router segment: there is no bare
+    // /chat/completions on this host.
+    endpoint: 'https://api.perplexity.ai/router/v1/chat/completions',
+    models: ['perplexity/kimi-k3', 'perplexity/glm-5.2', 'perplexity/deepseek-v4-flash-0731'],
+    defaultModel: 'perplexity/kimi-k3',
+    // Perplexity takes images as input and can return them as search results;
+    // it generates none. Generation stays on Gemini (see providers/capabilities).
+    capabilities: { text: true, images: false, streaming: true },
+    helpUrl: 'https://console.perplexity.ai/group/keys',
+    available: false,
+    privacyNote:
+      'Perplexity states that it keeps no record of prompts or responses sent to its chat completions API, and does not use them for training. It retains billing metrics only.',
   },
 ];
 

--- a/src/lib/ai/presets.ts
+++ b/src/lib/ai/presets.ts
@@ -80,8 +80,17 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     // the deprecations page, and gpt-4o has quietly left the models index. A
     // preset is a menu a player picks from, so a shutdown date on two of three
     // entries is a bug with a fuse on it rather than a cosmetic one.
-    models: ['gpt-5.6-terra', 'gpt-5.6-sol', 'gpt-5.6-luna'],
-    defaultModel: 'gpt-5.6-terra',
+    models: ['gpt-5.6-luna', 'gpt-5.6-terra', 'gpt-5.6-sol'],
+    // Luna leads for the same reason gemini-2.5-flash does above: it is the
+    // cheap fast tier, and a narrative turn is long output on a short prompt,
+    // which is exactly where the price gap bites. Luna runs $0.20/$1.20 per
+    // MTok against Terra's $2/$12 and Sol's $5/$30 - a tenfold difference on a
+    // default nobody changes. Sol is the one to reach for if prose quality
+    // disappoints.
+    defaultModel: 'gpt-5.6-luna',
+    // Not cosmetic: OpenAI rejects max_tokens outright on these models rather
+    // than ignoring it, so the request 400s without this.
+    maxOutputTokensParam: 'max_completion_tokens',
     // OpenAI's chat models take images as INPUT; they don't generate them, and
     // this flag has only ever meant generation here (providers/capabilities.ts).
     capabilities: { text: true, images: false, streaming: true },
@@ -172,11 +181,8 @@ export const getPresetById = (id: string): ProviderPreset | undefined =>
  * itself, which is what stops one service's headers from riding along to
  * another, say a preset id claiming to be OpenRouter next to an endpoint
  * pointing somewhere else. An endpoint with no matching preset gets none, which
- * is the right answer: we have nothing to say about a service we don't ship.
- *
- * Match is on the exact endpoint string, which is what a player who picked a
- * preset ends up with. A hand-typed variation misses and simply sends no extra
- * headers, and every header in play is optional.
+ * is the right answer: we have nothing to say about a service we don't ship,
+ * and every header in play is optional anyway.
  *
  * Lives here rather than beside either caller because both the generation path
  * and the validation ping need the same answer — a preset whose service
@@ -185,7 +191,28 @@ export const getPresetById = (id: string): ProviderPreset | undefined =>
  */
 export const presetHeadersForEndpoint = (
   endpoint: string | undefined
-): Record<string, string> | undefined => {
-  if (!endpoint) return undefined;
-  return PROVIDER_PRESETS.find((preset) => preset.endpoint === endpoint)?.customHeaders;
-};
+): Record<string, string> | undefined => presetForEndpoint(endpoint)?.customHeaders;
+
+/**
+ * What the service at this endpoint calls the output-length cap, when it is not
+ * the usual `max_tokens`.
+ *
+ * Endpoint-keyed for the same reason the headers are: it describes where the
+ * request is going, not what the caller claims about itself. Undefined is the
+ * common answer and means "the ordinary name" — the adapter supplies it — so a
+ * descriptor only carries this field when a service has genuinely moved.
+ */
+export const presetMaxOutputTokensParamForEndpoint = (
+  endpoint: string | undefined
+): 'max_tokens' | 'max_completion_tokens' | undefined =>
+  presetForEndpoint(endpoint)?.maxOutputTokensParam;
+
+/**
+ * The preset whose endpoint this exactly is, if we ship one.
+ *
+ * Match is on the exact endpoint string, which is what a player who picked a
+ * preset ends up with. A hand-typed variation misses and falls back to the
+ * neutral defaults above.
+ */
+const presetForEndpoint = (endpoint: string | undefined): ProviderPreset | undefined =>
+  endpoint ? PROVIDER_PRESETS.find((preset) => preset.endpoint === endpoint) : undefined;

--- a/src/lib/ai/providers/__tests__/adapters.test.ts
+++ b/src/lib/ai/providers/__tests__/adapters.test.ts
@@ -109,6 +109,18 @@ describe('openAICompatibleAdapter', () => {
     expect(body.stream).toBeUndefined();
   });
 
+  it('renames the output cap when the descriptor says the service moved off max_tokens', () => {
+    // OpenAI 400s on max_tokens rather than ignoring it, so this is the
+    // difference between a working provider and one that never generates.
+    const body = openAICompatibleAdapter.buildBody(
+      { ...OPENAI, maxOutputTokensParam: 'max_completion_tokens' },
+      SPEC
+    ) as Record<string, unknown>;
+
+    expect(body.max_completion_tokens).toBe(2048);
+    expect(body).not.toHaveProperty('max_tokens');
+  });
+
   it('folds the guidance into the user turn for a model with no system role', () => {
     const gemma = { ...OPENAI, model: 'google/gemma-3-27b-it' };
     const body = openAICompatibleAdapter.buildBody(gemma, SPEC) as {

--- a/src/lib/ai/providers/__tests__/request.test.ts
+++ b/src/lib/ai/providers/__tests__/request.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * The endpoint guard does DNS and network-policy work that has nothing to do
+ * with headers, and has its own suite. Stubbed so these tests are about what
+ * gets sent rather than about where.
+ */
+jest.mock('../endpointGuard', () => ({
+  assertPublicProviderEndpoint: jest.fn().mockResolvedValue(undefined),
+  isSafeProviderEndpoint: jest.fn().mockReturnValue(true),
+}));
+
+import { generateProviderText, sendProviderRequest } from '../core/request';
+import { openAICompatibleAdapter } from '../openai-compatible/adapter';
+import type { ProviderDescriptor, TextGenerationSpec } from '../types';
+
+const ENDPOINT = 'https://openrouter.ai/api/v1/chat/completions';
+
+const SPEC: TextGenerationSpec = {
+  prompt: 'Continue the story.',
+  temperature: 0.7,
+  maxTokens: 2048,
+  contentRating: 'pg-13',
+  stream: false,
+};
+
+const DESCRIPTOR: ProviderDescriptor = {
+  type: 'openai-compatible',
+  endpoint: ENDPOINT,
+  model: 'openai/gpt-4o',
+  apiKey: 'player-key',
+};
+
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = mockFetch as unknown as typeof fetch;
+  mockFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      choices: [{ message: { content: 'A scene.' }, finish_reason: 'stop' }],
+    }),
+  });
+});
+
+/** The headers the last fetch actually went out with. */
+function headersSent(): Record<string, string> {
+  return mockFetch.mock.calls[0][1].headers as Record<string, string>;
+}
+
+const AUTH_HEADERS = { 'Content-Type': 'application/json', Authorization: 'Bearer player-key' };
+
+describe('custom headers', () => {
+  it('sends them alongside the headers the adapter built', async () => {
+    await sendProviderRequest(ENDPOINT, AUTH_HEADERS, { model: 'x' }, {
+      customHeaders: { 'HTTP-Referer': 'https://narraitor-six.vercel.app', 'X-OpenRouter-Title': 'Narraitor' },
+    });
+
+    expect(headersSent()).toEqual({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer player-key',
+      'HTTP-Referer': 'https://narraitor-six.vercel.app',
+      'X-OpenRouter-Title': 'Narraitor',
+    });
+  });
+
+  /**
+   * The casing cases are the point. HTTP header names are case-insensitive but
+   * object keys are not, so a lowercased `authorization` would survive a plain
+   * spread and reach fetch beside the real one.
+   */
+  it.each([
+    ['Authorization', 'Bearer stolen'],
+    ['authorization', 'Bearer stolen'],
+    ['AUTHORIZATION', 'Bearer stolen'],
+  ])('refuses to let a preset set %s', async (name, value) => {
+    await sendProviderRequest(ENDPOINT, AUTH_HEADERS, { model: 'x' }, {
+      customHeaders: { [name]: value, 'HTTP-Referer': 'https://narraitor-six.vercel.app' },
+    });
+
+    const sent = headersSent();
+    expect(Object.values(sent)).not.toContain('Bearer stolen');
+    expect(sent.Authorization).toBe('Bearer player-key');
+    // The rest of the preset's headers still go — one bad name is dropped, not the batch.
+    expect(sent['HTTP-Referer']).toBe('https://narraitor-six.vercel.app');
+  });
+
+  it.each(['Content-Type', 'content-type'])('refuses to let a preset set %s', async (name) => {
+    await sendProviderRequest(ENDPOINT, AUTH_HEADERS, { model: 'x' }, {
+      customHeaders: { [name]: 'text/plain' },
+    });
+
+    const sent = headersSent();
+    expect(Object.values(sent)).not.toContain('text/plain');
+    expect(sent['Content-Type']).toBe('application/json');
+  });
+
+  it("carries a descriptor's custom headers through a real generation", async () => {
+    await generateProviderText(
+      openAICompatibleAdapter,
+      { ...DESCRIPTOR, customHeaders: { 'HTTP-Referer': 'https://narraitor-six.vercel.app' } },
+      SPEC
+    );
+
+    const sent = headersSent();
+    expect(sent['HTTP-Referer']).toBe('https://narraitor-six.vercel.app');
+    expect(sent.Authorization).toBe('Bearer player-key');
+  });
+
+  it('sends only the adapter\'s headers when the preset asks for none', async () => {
+    await generateProviderText(openAICompatibleAdapter, DESCRIPTOR, SPEC);
+
+    expect(headersSent()).toEqual(AUTH_HEADERS);
+  });
+});

--- a/src/lib/ai/providers/core/request.ts
+++ b/src/lib/ai/providers/core/request.ts
@@ -46,6 +46,51 @@ export interface SendProviderRequestOptions {
    * call path can reach `fetch` having skipped it.
    */
   playerSuppliedEndpoint?: boolean;
+  /**
+   * Extra headers the destination service asks for, from its preset. Merged
+   * beneath `headers`; see applyCustomHeaders for what they cannot set.
+   */
+  customHeaders?: Record<string, string>;
+}
+
+/**
+ * Header names a preset can never set.
+ *
+ * Compared lowercased because HTTP header names are case-insensitive while a
+ * JavaScript object's keys are not. Spread order alone would let a preset
+ * naming `authorization` in lower case sit alongside the adapter's
+ * `Authorization`: two entries in the object, both reaching `fetch`, and the
+ * player's key either replaced or combined with whatever the preset supplied.
+ * Matching on the lowercased name is what makes "the adapter's auth wins" true
+ * rather than nearly true.
+ */
+const RESERVED_HEADERS = new Set(['authorization', 'content-type']);
+
+/**
+ * Merge a preset's custom headers underneath the adapter's own.
+ *
+ * SECURITY: done here at the sink for the same reason the endpoint guard is:
+ * no call path can reach `fetch` having skipped it, so a future adapter cannot
+ * forget to do this correctly. The adapter's headers carry the player's key and
+ * declare how the body is encoded; a preset must not be able to redirect that
+ * credential or change how the request is read, so reserved names are dropped
+ * outright rather than merely losing the merge.
+ *
+ * Header values are never logged here or anywhere below, since Authorization
+ * is the player's plaintext key.
+ */
+function applyCustomHeaders(
+  headers: Record<string, string>,
+  customHeaders?: Record<string, string>
+): Record<string, string> {
+  if (!customHeaders) return headers;
+
+  const allowed = Object.entries(customHeaders).filter(
+    ([name]) => !RESERVED_HEADERS.has(name.trim().toLowerCase())
+  );
+  if (allowed.length === 0) return headers;
+
+  return { ...Object.fromEntries(allowed), ...headers };
 }
 
 /**
@@ -61,11 +106,13 @@ export async function sendProviderRequest(
   body: object,
   options: SendProviderRequestOptions = {}
 ): Promise<Response> {
-  const { timeoutMs = GEMINI_ATTEMPT_TIMEOUT_MS, playerSuppliedEndpoint = false } = options;
+  const { timeoutMs = GEMINI_ATTEMPT_TIMEOUT_MS, playerSuppliedEndpoint = false, customHeaders } = options;
 
   if (playerSuppliedEndpoint) {
     await assertPublicProviderEndpoint(url);
   }
+
+  const requestHeaders = applyCustomHeaders(headers, customHeaders);
 
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
@@ -90,7 +137,7 @@ export async function sendProviderRequest(
     // would look like a control while being decoration.
     const response = await fetch(url, {
       method: 'POST',
-      headers,
+      headers: requestHeaders,
       body: JSON.stringify(body),
       redirect: 'error',
       signal: controller.signal,
@@ -155,7 +202,11 @@ export async function openProviderTextStream(
     adapter.buildUrl(descriptor, spec),
     adapter.buildHeaders(descriptor),
     adapter.buildBody(descriptor, spec),
-    { timeoutMs, playerSuppliedEndpoint: adapter.playerSuppliedEndpoint }
+    {
+      timeoutMs,
+      playerSuppliedEndpoint: adapter.playerSuppliedEndpoint,
+      customHeaders: descriptor.customHeaders,
+    }
   );
 
   if (!response.ok) throw await toUpstreamError(adapter, response);
@@ -178,7 +229,11 @@ export async function generateProviderText(
     adapter.buildUrl(descriptor, spec),
     adapter.buildHeaders(descriptor),
     adapter.buildBody(descriptor, spec),
-    { timeoutMs, playerSuppliedEndpoint: adapter.playerSuppliedEndpoint }
+    {
+      timeoutMs,
+      playerSuppliedEndpoint: adapter.playerSuppliedEndpoint,
+      customHeaders: descriptor.customHeaders,
+    }
   );
 
   if (!response.ok) throw await toUpstreamError(adapter, response);

--- a/src/lib/ai/providers/openai-compatible/adapter.ts
+++ b/src/lib/ai/providers/openai-compatible/adapter.ts
@@ -105,7 +105,11 @@ export const openAICompatibleAdapter: ProviderAdapter = {
       model: descriptor.model,
       messages: buildMessages(descriptor, spec),
       temperature: spec.temperature,
-      max_tokens: spec.maxTokens,
+      // OpenAI renamed this and now rejects the old name outright instead of
+      // ignoring it, while the rest of the ecosystem still speaks max_tokens.
+      // The name travels on the descriptor rather than being branched on here,
+      // so this stays one adapter over one request shape.
+      [descriptor.maxOutputTokensParam ?? 'max_tokens']: spec.maxTokens,
       top_p: 1.0,
       ...(spec.stream
         ? {

--- a/src/lib/ai/providers/types.ts
+++ b/src/lib/ai/providers/types.ts
@@ -20,6 +20,16 @@ export interface ProviderDescriptor {
   endpoint: string;
   model: string;
   apiKey: string | null;
+  /**
+   * Extra headers the service at `endpoint` asks for, taken from its preset.
+   *
+   * SECURITY: resolved server-side from the endpoint, never read off the
+   * request. The endpoint already travels from the browser and is guarded; a
+   * second header channel carrying arbitrary names and values would let a
+   * caller shape the outbound request itself. Keyed on where the request is
+   * going, so one service's headers cannot ride along to another.
+   */
+  customHeaders?: Record<string, string>;
 }
 
 /**

--- a/src/lib/ai/providers/types.ts
+++ b/src/lib/ai/providers/types.ts
@@ -30,6 +30,12 @@ export interface ProviderDescriptor {
    * going, so one service's headers cannot ride along to another.
    */
   customHeaders?: Record<string, string>;
+  /**
+   * What this service calls the output-length cap. Resolved from the endpoint's
+   * preset; absent means `max_tokens`, which is what nearly every
+   * OpenAI-compatible service still takes. See presets.ts.
+   */
+  maxOutputTokensParam?: 'max_tokens' | 'max_completion_tokens';
 }
 
 /**

--- a/src/lib/ai/resolveApiKey.ts
+++ b/src/lib/ai/resolveApiKey.ts
@@ -8,6 +8,7 @@ import {
   PROVIDER_TYPE_HEADER,
 } from './providerKeyHeader';
 import { DEFAULT_TEXT_MODEL } from './config';
+import { PROVIDER_PRESETS } from './presets';
 import { isProviderSupported } from './providers/adapterRegistry';
 import { isSafeProviderEndpoint } from './providers/endpointGuard';
 import type { ProviderDescriptor } from './providers/types';
@@ -96,7 +97,34 @@ export function resolveProvider(request?: NextRequest): ProviderResolution {
   const endpoint = readEndpoint(request, type);
   if (endpoint === null) return { ok: false, reason: 'INVALID_ENDPOINT' };
 
-  return { ok: true, descriptor: { type, endpoint, model, apiKey: headerKey } };
+  return {
+    ok: true,
+    descriptor: {
+      type,
+      endpoint,
+      model,
+      apiKey: headerKey,
+      customHeaders: presetHeadersFor(endpoint),
+    },
+  };
+}
+
+/**
+ * The extra headers the service at this endpoint asks for, from its preset.
+ *
+ * Keyed on the endpoint rather than on anything the caller declares about
+ * itself, which is what stops one service's headers from riding along to
+ * another, say a preset id claiming to be OpenRouter next to an endpoint
+ * pointing somewhere else. An endpoint with no matching preset gets none, which
+ * is the right answer: we have nothing to say about a service we don't ship.
+ *
+ * Match is on the exact endpoint string, which is what a player who picked a
+ * preset ends up with. A hand-typed variation misses and simply sends no extra
+ * headers, and every header in play is optional (see presets.ts).
+ */
+function presetHeadersFor(endpoint: string): Record<string, string> | undefined {
+  if (!endpoint) return undefined;
+  return PROVIDER_PRESETS.find((preset) => preset.endpoint === endpoint)?.customHeaders;
 }
 
 /**

--- a/src/lib/ai/resolveApiKey.ts
+++ b/src/lib/ai/resolveApiKey.ts
@@ -8,7 +8,7 @@ import {
   PROVIDER_TYPE_HEADER,
 } from './providerKeyHeader';
 import { DEFAULT_TEXT_MODEL } from './config';
-import { presetHeadersForEndpoint } from './presets';
+import { presetHeadersForEndpoint, presetMaxOutputTokensParamForEndpoint } from './presets';
 import { isProviderSupported } from './providers/adapterRegistry';
 import { isSafeProviderEndpoint } from './providers/endpointGuard';
 import type { ProviderDescriptor } from './providers/types';
@@ -105,6 +105,7 @@ export function resolveProvider(request?: NextRequest): ProviderResolution {
       model,
       apiKey: headerKey,
       customHeaders: presetHeadersForEndpoint(endpoint),
+      maxOutputTokensParam: presetMaxOutputTokensParamForEndpoint(endpoint),
     },
   };
 }

--- a/src/lib/ai/resolveApiKey.ts
+++ b/src/lib/ai/resolveApiKey.ts
@@ -8,7 +8,7 @@ import {
   PROVIDER_TYPE_HEADER,
 } from './providerKeyHeader';
 import { DEFAULT_TEXT_MODEL } from './config';
-import { PROVIDER_PRESETS } from './presets';
+import { presetHeadersForEndpoint } from './presets';
 import { isProviderSupported } from './providers/adapterRegistry';
 import { isSafeProviderEndpoint } from './providers/endpointGuard';
 import type { ProviderDescriptor } from './providers/types';
@@ -104,27 +104,9 @@ export function resolveProvider(request?: NextRequest): ProviderResolution {
       endpoint,
       model,
       apiKey: headerKey,
-      customHeaders: presetHeadersFor(endpoint),
+      customHeaders: presetHeadersForEndpoint(endpoint),
     },
   };
-}
-
-/**
- * The extra headers the service at this endpoint asks for, from its preset.
- *
- * Keyed on the endpoint rather than on anything the caller declares about
- * itself, which is what stops one service's headers from riding along to
- * another, say a preset id claiming to be OpenRouter next to an endpoint
- * pointing somewhere else. An endpoint with no matching preset gets none, which
- * is the right answer: we have nothing to say about a service we don't ship.
- *
- * Match is on the exact endpoint string, which is what a player who picked a
- * preset ends up with. A hand-typed variation misses and simply sends no extra
- * headers, and every header in play is optional (see presets.ts).
- */
-function presetHeadersFor(endpoint: string): Record<string, string> | undefined {
-  if (!endpoint) return undefined;
-  return PROVIDER_PRESETS.find((preset) => preset.endpoint === endpoint)?.customHeaders;
 }
 
 /**

--- a/src/types/provider.types.ts
+++ b/src/types/provider.types.ts
@@ -68,6 +68,18 @@ export interface ProviderPreset {
    * applyCustomHeaders in providers/core/request.ts.
    */
   customHeaders?: Record<string, string>;
+  /**
+   * What this service calls the output-length cap, when it isn't `max_tokens`.
+   *
+   * OpenAI retired `max_tokens` on its current models and rejects the request
+   * outright rather than ignoring the field, so this is a hard requirement
+   * there, not a preference. Most OpenAI-compatible services still take
+   * `max_tokens`, which is why it stays the default and this is opt-in.
+   *
+   * Keyed to the service rather than the model: every model an OpenAI preset
+   * offers is a current one, and a service that has moved has moved wholesale.
+   */
+  maxOutputTokensParam?: 'max_tokens' | 'max_completion_tokens';
   /** Short pitch shown under the name, e.g. what a key costs to get. */
   note?: string;
   /**

--- a/src/types/provider.types.ts
+++ b/src/types/provider.types.ts
@@ -60,6 +60,14 @@ export interface ProviderPreset {
   capabilities: ProviderCapabilities;
   helpUrl: string;
   available: boolean;
+  /**
+   * Extra request headers this service wants, e.g. OpenRouter's attribution
+   * pair. Attached server-side by matching the endpoint (see resolveProvider)
+   * rather than travelling from the browser, and applied under the adapter's
+   * own headers, so a preset can never set Authorization or Content-Type. See
+   * applyCustomHeaders in providers/core/request.ts.
+   */
+  customHeaders?: Record<string, string>;
   /** Short pitch shown under the name, e.g. what a key costs to get. */
   note?: string;
   /**


### PR DESCRIPTION
## Description

Started as the last two acceptance criteria on #895 that didn't need a live key - per-preset custom headers and the missing Perplexity preset - then grew to cover the live verification itself. **Three providers now work end to end: Gemini, OpenRouter and OpenAI.** The OpenAI-compatible client, its adapter, the factory branch, the settings UI, and the verification script all shipped in #890 and #1794, and none of them are touched here.

**Custom headers.** A preset can now declare extra headers the service wants, and OpenRouter's attribution pair (`HTTP-Referer` + `X-OpenRouter-Title`) is the first consumer. Three things about the shape are deliberate:

They're resolved server-side by matching the endpoint, in `resolveProvider`, rather than travelling in from the browser as another `x-provider-*` header. The endpoint is already an attacker-reachable URL that the *server* dereferences, and it's guarded for exactly that reason. A second channel carrying arbitrary header names and values would let a caller shape the outbound request itself, which is a bigger hole than the one the endpoint guard exists to close. Keying on where the request is going also means one service's headers can't ride along to another.

The merge happens inside `sendProviderRequest`, at the same sink the endpoint guard uses, so no call path can reach `fetch` having skipped it and a future adapter can't forget to do it correctly.

Reserved names (`Authorization`, `Content-Type`) are dropped by lowercased comparison, not merely outranked by spread order. That's the part worth reading twice: object keys are case-sensitive and HTTP header names aren't, so a preset naming `authorization` in lower case would have survived a plain spread and reached `fetch` alongside the real one. Three of the new tests fail if you take the lowercasing out, which is how I checked the guard was load-bearing rather than decorative.

**Perplexity.** The endpoint the issue body assumed (`https://api.perplexity.ai/chat/completions`) isn't documented anywhere on docs.perplexity.ai today. Perplexity has two surfaces now: the search-grounded `sonar-*` models on `/v1/sonar` in a non-OpenAI shape, whose chat-completions form carries a published sunset of 27 September 2026, and the Gateway at `/router/v1/chat/completions`, which their docs describe as a drop-in replacement for an OpenAI integration. The Gateway is the only one an `openai-compatible` preset can honestly point at, and shipping the deprecated one would repeat exactly the problem #1794 corrected in the OpenAI model list. Endpoint, model ids, help URL, and the retention note all come from the live docs rather than from the issue body, which is from 2025.

`capabilities.images` is `false`: Perplexity takes images as input and can return them as search results, but generates none, and `supportsImages()` returns true only for Gemini, so anything else would lie to `/api/ai/validate-provider`.

**OpenAI's request shape, found by calling rather than reading.** Two 400s from a real key, each of which would have broken every OpenAI call the app made:

- `Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.` OpenAI renamed the output cap and rejects the old name rather than ignoring it.
- `Unsupported value: 'temperature' does not support 0.7 with this model.` Its current models are reasoning models running their own generate-and-select rounds, so `temperature` and `top_p` are locked. Both are now omitted rather than sent at their defaults, because the presence of the field is what gets rejected. We were sending `top_p: 1.0` too, so that was the next failure either way.

Both are declared per-preset and resolved from the endpoint exactly like the headers, so the shared adapter stays one adapter over one request shape rather than growing a vendor branch. Consequence worth stating: narrative turns on OpenAI run at the model's own temperature.

**The script was testing a request the app doesn't send.** It built its descriptor by hand, so it carried neither the preset's headers nor the renamed parameter. It now uses the same lookups `resolveProvider` does, and OpenRouter was re-verified afterwards so its pass reflects what ships.

**OpenAI's default model is `gpt-5.6-luna`**, not the flagship - matching Gemini's use of the cheap fast tier. A narrative turn is long output on a short prompt, which is where the gap bites: $0.20/$1.20 per MTok against Terra's $2/$12 and Sol's $5/$30.

**Verified live:**

| Preset | Model | Deltas | Result |
|---|---|---|---|
| OpenRouter | `openai/gpt-4o` | 133 | pass, with headers sent |
| OpenAI | `gpt-5.6-luna` | 104 | pass |

Deepseek, Mistral, Together, Groq and Perplexity stay `available: false`. Each needs its own key and its own run.

## Related Issue

Refs #895

Deliberately not `Closes` — two criteria remain, listed under Implementation Notes.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Not TDD in the strict sense: the plumbing went in first and the tests followed. The header-clobbering guard was verified the other way round though, by removing the lowercasing and confirming three assertions went red before putting it back.

## User Stories Addressed

From #895: "As a playtester, I want to use any OpenAI-compatible AI service so that I have maximum flexibility in choosing which models to use without needing provider-specific implementations." This PR covers the preset coverage and the custom-header support that story depends on. Actually playing a turn through one of these still waits on a verified key.

## Flow Diagrams

N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A, no UI in this change. `ProviderPresets` and `ProviderWizard` read `PROVIDER_PRESETS` and pick up the Perplexity entry without any change of their own.

## Implementation Notes

What's still open on #895 after this:

- **All presets tested and validated.** Deepseek, Mistral, Together, Groq and Perplexity each need their own key and their own run of `scripts/verify-openai-compatible-stream.mjs`. Perplexity is doc-verified only, and the OpenAI experience here suggests that is worth very little.
- **Works with all existing API routes through the provider factory.** The runs prove the streamed narrative path - the same two calls `processAIStreamingTextRequest` makes. Character, world and ending generation share the machinery but haven't been driven against a non-Gemini key. Playing a full session closes this.

The other criteria are ticked. Content rating guidance was already satisfied by #890's adapter via `getContentRatingGuidance` and is covered in `adapters.test.ts`; it needed re-checking rather than new work.

A design call worth flagging: OpenAI now carries two per-preset carve-outs (`maxOutputTokensParam`, `hasFixedSamplingControls`), and the shared adapter's own comment says a vendor's own needs belong in its own adapter. Both stayed as flags because they're declarative data about the request shape rather than behaviour, and a dedicated adapter for two fields would be more structure than the problem has. A third would change that answer.

One thing I noticed and left alone: `ProviderConfig.customHeaders` in `src/types/provider.types.ts` has existed since #890 and nothing reads it. It's a different thing from the new `ProviderPreset.customHeaders` (user-saved config vs. what the service needs), and threading the stored one browser-to-server is the path this PR deliberately avoids, so it stayed as-is rather than getting quietly repurposed.

## Screenshots

N/A

## Visual Baseline Changes

None. This PR doesn't touch `tests/visual/**-snapshots/**`.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

`npm run lint` exits 0 with 127 pre-existing warnings, all `no-explicit-any` in `tests/visual/**` and one `expect-expect` in a theme test. None are in files this PR touches. No separate security audit was run; `npm run deps:validate` and `npm run deps:check` both pass and the baseline still holds at 17.

## Testing Instructions

```bash
npm test                # 74 suites, 507 tests under src/lib/ai; full suite green
npm run type-check
npm run lint
npm run deps:validate
npm run deps:check
```

The header behaviour is in `src/lib/ai/providers/__tests__/request.test.ts`. To confirm the guard is real rather than decorative, replace the filter predicate in `applyCustomHeaders` with `() => true` and re-run that file: the three case-variant assertions fail, the exact-case ones still pass on spread order alone.

`src/lib/ai/__tests__/resolveProvider.test.ts` covers the other end, that OpenRouter's endpoint picks up its preset's headers and an endpoint with no preset picks up none.

No CSS in this change, so `lint:css` wasn't run. No visual or E2E suites either.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed

No docs change: the preset list documents itself in-file, and `scripts/README.md` already describes the verification flow from #1794. No accessibility surface in this change.

