### PR TITLE
Stop telling OpenAI's reasoning models how to sample, and turn OpenAI on

### DIFF
--- a/scripts/verify-openai-compatible-stream.mjs
+++ b/scripts/verify-openai-compatible-stream.mjs
@@ -108,7 +108,7 @@ async function bundleProductionModules() {
   await writeFile(
     entry,
     [
-      "export { getPresetById, presetHeadersForEndpoint, presetMaxOutputTokensParamForEndpoint } from '@/lib/ai/presets';",
+      "export { getPresetById, presetHeadersForEndpoint, presetMaxOutputTokensParamForEndpoint, presetHasFixedSamplingControlsForEndpoint } from '@/lib/ai/presets';",
       "export { openAICompatibleAdapter } from '@/lib/ai/providers/openai-compatible/adapter';",
       "export { openProviderTextStream } from '@/lib/ai/providers/core/request';",
       "export { consumeProviderStreamEvents } from '@/lib/ai/providers/core/streamConsumer';",
@@ -300,6 +300,7 @@ async function main() {
       apiKey,
       customHeaders: prod.presetHeadersForEndpoint(target.endpoint),
       maxOutputTokensParam: prod.presetMaxOutputTokensParamForEndpoint(target.endpoint),
+      hasFixedSamplingControls: prod.presetHasFixedSamplingControlsForEndpoint(target.endpoint),
     };
 
     let turn;

--- a/src/app/api/ai/validate-provider/__tests__/route.test.ts
+++ b/src/app/api/ai/validate-provider/__tests__/route.test.ts
@@ -202,6 +202,35 @@ describe('POST /api/ai/validate-provider — OpenAI-compatible providers', () =>
     expect(headers.Authorization).toBe(`Bearer ${KEY}`);
   });
 
+  test("names the output cap the way the generation path does, not always max_tokens", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(fakeResponse(200));
+
+    await POST(
+      openAIRequest({
+        endpoint: 'https://api.openai.com/v1/chat/completions',
+        model: 'gpt-5.6-luna',
+      })
+    );
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(init.body as string);
+    // Hardcoding max_tokens here made the wizard reject a key that generates
+    // fine, so the provider looked enabled and could never be configured.
+    expect(body).not.toHaveProperty('max_tokens');
+    expect(body.max_completion_tokens).toBeGreaterThan(0);
+  });
+
+  test('still says max_tokens for a service that never renamed it', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(fakeResponse(200));
+
+    await POST(openAIRequest({ endpoint: ENDPOINT, model: 'openai/gpt-4o' }));
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(init.body as string);
+    expect(body.max_tokens).toBeGreaterThan(0);
+    expect(body).not.toHaveProperty('max_completion_tokens');
+  });
+
   test('sends no extra headers for an endpoint no preset claims', async () => {
     (global.fetch as jest.Mock).mockResolvedValue(fakeResponse(200));
 

--- a/src/app/api/ai/validate-provider/route.ts
+++ b/src/app/api/ai/validate-provider/route.ts
@@ -6,7 +6,10 @@ import { DEFAULT_TEXT_MODEL, getSafetySettings } from '@/lib/ai/config';
 import { PROVIDER_API_KEY_HEADER } from '@/lib/ai/providerKeyHeader';
 import { getProviderAdapter } from '@/lib/ai/providers/adapterRegistry';
 import { isSafeProviderEndpoint } from '@/lib/ai/providers/endpointGuard';
-import { presetHeadersForEndpoint } from '@/lib/ai/presets';
+import {
+  presetHeadersForEndpoint,
+  presetMaxOutputTokensParamForEndpoint,
+} from '@/lib/ai/presets';
 import { sendProviderRequest } from '@/lib/ai/providers/core/request';
 import { supportsImages } from '@/lib/ai/providers/capabilities';
 import type { ProviderType } from '@/types/provider.types';
@@ -30,6 +33,14 @@ const GEMINI_MODELS_BASE = 'https://generativelanguage.googleapis.com/v1beta/mod
 
 /** One ping should answer "does this key work", not generate anything. */
 const PING_TIMEOUT_MS = 10000;
+
+/**
+ * Small, but not 1. On a reasoning model this cap counts the model's own
+ * reasoning tokens as well as the visible ones, so a cap of 1 leaves it no room
+ * to do anything before it stops. The answer we want here is the HTTP status,
+ * not the text, and a handful of tokens costs nothing.
+ */
+const PING_MAX_OUTPUT_TOKENS = 16;
 
 type ValidationError =
   | 'NO_KEY'
@@ -137,7 +148,10 @@ async function validateOpenAICompatible(
       {
         model: requestedModel,
         messages: [{ role: 'user', content: 'ping' }],
-        max_tokens: 1,
+        // Same name the generation path uses. Hardcoding max_tokens here made
+        // the wizard refuse a key that generates fine, which is the third time
+        // this ping has diverged from the real request and broken a provider.
+        [presetMaxOutputTokensParamForEndpoint(endpoint) ?? 'max_tokens']: PING_MAX_OUTPUT_TOKENS,
       },
       {
         timeoutMs: PING_TIMEOUT_MS,

--- a/src/lib/ai/__tests__/presets.test.ts
+++ b/src/lib/ai/__tests__/presets.test.ts
@@ -27,6 +27,13 @@ describe('PROVIDER_PRESETS', () => {
     expect(moved).toEqual(['openai']);
   });
 
+  it('marks OpenAI as fixing its sampling controls, since its models reject ours', () => {
+    const fixed = PROVIDER_PRESETS.filter((preset) => preset.hasFixedSamplingControls).map(
+      (p) => p.id
+    );
+    expect(fixed).toEqual(['openai']);
+  });
+
   it('defaults each preset to a model it actually lists', () => {
     for (const preset of PROVIDER_PRESETS) {
       expect(preset.models).toContain(preset.defaultModel);

--- a/src/lib/ai/__tests__/presets.test.ts
+++ b/src/lib/ai/__tests__/presets.test.ts
@@ -11,10 +11,11 @@ import { supportsImages } from '../providers/capabilities';
 describe('PROVIDER_PRESETS', () => {
   it('marks available exactly the presets someone has driven a live turn through', () => {
     const available = PROVIDER_PRESETS.filter((preset) => preset.available).map((p) => p.id);
-    // OpenRouter joined Gemini after a real streamed turn on openai/gpt-4o came
-    // back in 152 deltas with a parseable envelope. Adding an id here without
-    // that run is the thing this test exists to make somebody think twice about.
-    expect(available).toEqual(['gemini', 'openrouter']);
+    // OpenRouter and OpenAI each joined Gemini after a real streamed turn came
+    // back in more than one delta with a parseable envelope - 152 deltas on
+    // openai/gpt-4o and 104 on gpt-5.6-luna. Adding an id here without that run
+    // is the thing this test exists to make somebody think twice about.
+    expect(available).toEqual(['gemini', 'openrouter', 'openai']);
   });
 
   it('asks OpenAI for max_completion_tokens, which is the only name it accepts', () => {

--- a/src/lib/ai/presets.ts
+++ b/src/lib/ai/presets.ts
@@ -88,9 +88,12 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     // default nobody changes. Sol is the one to reach for if prose quality
     // disappoints.
     defaultModel: 'gpt-5.6-luna',
-    // Not cosmetic: OpenAI rejects max_tokens outright on these models rather
-    // than ignoring it, so the request 400s without this.
+    // Neither of these is cosmetic. OpenAI rejects max_tokens outright on these
+    // models rather than ignoring it, and locks temperature and top_p because
+    // they are reasoning models running their own generate-and-select rounds.
+    // Both produce a 400, and both were found by a real call, not by reading.
     maxOutputTokensParam: 'max_completion_tokens',
+    hasFixedSamplingControls: true,
     // OpenAI's chat models take images as INPUT; they don't generate them, and
     // this flag has only ever meant generation here (providers/capabilities.ts).
     capabilities: { text: true, images: false, streaming: true },
@@ -206,6 +209,16 @@ export const presetMaxOutputTokensParamForEndpoint = (
   endpoint: string | undefined
 ): 'max_tokens' | 'max_completion_tokens' | undefined =>
   presetForEndpoint(endpoint)?.maxOutputTokensParam;
+
+/**
+ * Whether the service at this endpoint refuses to be told how to sample.
+ *
+ * Endpoint-keyed like the two above. Undefined means the ordinary case, where
+ * temperature and top_p are ours to set.
+ */
+export const presetHasFixedSamplingControlsForEndpoint = (
+  endpoint: string | undefined
+): boolean | undefined => presetForEndpoint(endpoint)?.hasFixedSamplingControls;
 
 /**
  * The preset whose endpoint this exactly is, if we ship one.

--- a/src/lib/ai/presets.ts
+++ b/src/lib/ai/presets.ts
@@ -5,10 +5,10 @@ import type { ProviderPreset } from '@/types/provider.types';
 /**
  * Provider presets shown in the configuration wizard.
  *
- * Gemini and OpenRouter work end-to-end (`available: true`). The rest are
- * listed so players can see what's coming and so the schema is ready for the
- * remaining multi-provider work — they're marked unavailable and the UI keeps
- * them out of reach until someone runs a live check against each.
+ * Gemini, OpenRouter and OpenAI work end-to-end (`available: true`). The rest
+ * are listed so players can see what's coming and so the schema is ready for
+ * the remaining multi-provider work — they're marked unavailable and the UI
+ * keeps them out of reach until someone runs a live check against each.
  *
  * Order is deliberate. Gemini leads because it's the longest-proven. OpenRouter
  * comes next because it's the only other option a player can reach without a
@@ -98,7 +98,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     // this flag has only ever meant generation here (providers/capabilities.ts).
     capabilities: { text: true, images: false, streaming: true },
     helpUrl: 'https://platform.openai.com/api-keys',
-    available: false,
+    available: true,
     privacyNote:
       'OpenAI states that API inputs and outputs are not used to train their models by default, and are retained for up to 30 days for abuse monitoring.',
   },

--- a/src/lib/ai/providers/__tests__/adapters.test.ts
+++ b/src/lib/ai/providers/__tests__/adapters.test.ts
@@ -121,6 +121,19 @@ describe('openAICompatibleAdapter', () => {
     expect(body).not.toHaveProperty('max_tokens');
   });
 
+  it('omits the sampling controls entirely for a service that fixes them', () => {
+    // Sending temperature: 1 is not the workaround - a reasoning model rejects
+    // the field being present at all, so both have to be absent.
+    const body = openAICompatibleAdapter.buildBody(
+      { ...OPENAI, hasFixedSamplingControls: true },
+      SPEC
+    ) as Record<string, unknown>;
+
+    expect(body).not.toHaveProperty('temperature');
+    expect(body).not.toHaveProperty('top_p');
+    expect(body.messages).toBeDefined();
+  });
+
   it('folds the guidance into the user turn for a model with no system role', () => {
     const gemma = { ...OPENAI, model: 'google/gemma-3-27b-it' };
     const body = openAICompatibleAdapter.buildBody(gemma, SPEC) as {

--- a/src/lib/ai/providers/openai-compatible/adapter.ts
+++ b/src/lib/ai/providers/openai-compatible/adapter.ts
@@ -104,13 +104,17 @@ export const openAICompatibleAdapter: ProviderAdapter = {
     return {
       model: descriptor.model,
       messages: buildMessages(descriptor, spec),
-      temperature: spec.temperature,
       // OpenAI renamed this and now rejects the old name outright instead of
       // ignoring it, while the rest of the ecosystem still speaks max_tokens.
-      // The name travels on the descriptor rather than being branched on here,
-      // so this stays one adapter over one request shape.
+      // Both this and the sampling controls below travel on the descriptor
+      // rather than being branched on here, so this stays one adapter over one
+      // request shape.
       [descriptor.maxOutputTokensParam ?? 'max_tokens']: spec.maxTokens,
-      top_p: 1.0,
+      // Omitted entirely, not sent at their defaults: a reasoning model rejects
+      // the presence of these fields, not just values it dislikes.
+      ...(descriptor.hasFixedSamplingControls
+        ? {}
+        : { temperature: spec.temperature, top_p: 1.0 }),
       ...(spec.stream
         ? {
             stream: true,

--- a/src/lib/ai/providers/types.ts
+++ b/src/lib/ai/providers/types.ts
@@ -36,6 +36,11 @@ export interface ProviderDescriptor {
    * OpenAI-compatible service still takes. See presets.ts.
    */
   maxOutputTokensParam?: 'max_tokens' | 'max_completion_tokens';
+  /**
+   * Whether this service fixes temperature and top_p and rejects being told
+   * otherwise. Resolved from the endpoint's preset. See presets.ts.
+   */
+  hasFixedSamplingControls?: boolean;
 }
 
 /**

--- a/src/lib/ai/resolveApiKey.ts
+++ b/src/lib/ai/resolveApiKey.ts
@@ -8,7 +8,11 @@ import {
   PROVIDER_TYPE_HEADER,
 } from './providerKeyHeader';
 import { DEFAULT_TEXT_MODEL } from './config';
-import { presetHeadersForEndpoint, presetMaxOutputTokensParamForEndpoint } from './presets';
+import {
+  presetHasFixedSamplingControlsForEndpoint,
+  presetHeadersForEndpoint,
+  presetMaxOutputTokensParamForEndpoint,
+} from './presets';
 import { isProviderSupported } from './providers/adapterRegistry';
 import { isSafeProviderEndpoint } from './providers/endpointGuard';
 import type { ProviderDescriptor } from './providers/types';
@@ -106,6 +110,7 @@ export function resolveProvider(request?: NextRequest): ProviderResolution {
       apiKey: headerKey,
       customHeaders: presetHeadersForEndpoint(endpoint),
       maxOutputTokensParam: presetMaxOutputTokensParamForEndpoint(endpoint),
+      hasFixedSamplingControls: presetHasFixedSamplingControlsForEndpoint(endpoint),
     },
   };
 }

--- a/src/types/provider.types.ts
+++ b/src/types/provider.types.ts
@@ -80,6 +80,17 @@ export interface ProviderPreset {
    * offers is a current one, and a service that has moved has moved wholesale.
    */
   maxOutputTokensParam?: 'max_tokens' | 'max_completion_tokens';
+  /**
+   * Whether this service's models fix the sampling controls and refuse to be
+   * told otherwise.
+   *
+   * OpenAI's current models are reasoning models: they run their own rounds of
+   * generation and selection, so temperature and top_p are locked and the API
+   * rejects the request rather than clamping. Sending the default value is not
+   * a workaround — the field's presence is what some endpoints reject — so the
+   * only correct move is to omit both.
+   */
+  hasFixedSamplingControls?: boolean;
   /** Short pitch shown under the name, e.g. what a key costs to get. */
   note?: string;
   /**


### PR DESCRIPTION
## Description

The tail of #1797, which merged while these two commits were still being written. Everything here was on that branch; it just missed the merge.

`develop` currently sits in a coherent but incomplete state: OpenAI carries `max_completion_tokens` and the cheap default, but not the sampling-controls fix, and is `available: false`. Those two facts cancel out, so nothing is broken today - OpenAI cannot be selected, so nothing can hit the wrong request shape. This PR completes the pair.

**Sampling controls.** A second 400 from a real key: `Unsupported value: 'temperature' does not support 0.7 with this model. Only the default (1) value is supported.` OpenAI's current models are reasoning models running their own generate-and-select rounds, so `temperature` and `top_p` are locked and the API rejects being told otherwise.

Both fields are now omitted for a preset that declares its sampling fixed - omitted rather than sent at the default, because the presence of the field is what gets rejected, not only a value it dislikes. We were sending `top_p: 1.0` as well, so this would have been the next failure regardless.

The consequence is worth stating rather than burying: narrative turns on OpenAI run at the model's own temperature. That is not a knob available by asking differently.

**OpenAI turned on.** A live key on `gpt-5.6-luna` passed all five checks - stream completed, 104 deltas, 1023 characters, normal stop, prose parsed as the narrative envelope. That is the whole bar `available` was ever making a claim about.

Both fixes were found by calling, not by reading. The model ids were never the problem: the docs describe `max_tokens` and `temperature` as if they work, and only a real request said otherwise.

## Related Issue

Refs #895

Not `Closes` - two criteria remain, and both need work beyond this PR. See Implementation Notes.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Not TDD: a live 400 drove the change, and the tests were written to pin the behaviour afterwards.

## User Stories Addressed

From #895: "As a playtester, I want to use any OpenAI-compatible AI service so that I have maximum flexibility in choosing which models to use." Three services now work: Gemini, OpenRouter, OpenAI.

## Flow Diagrams

N/A

## Component Development

N/A - no components. The change is in the provider adapter and the preset table.

## Implementation Notes

`hasFixedSamplingControls` is declared per-preset and resolved from the endpoint, the same way `customHeaders` and `maxOutputTokensParam` already are, so the shared adapter stays one adapter over one request shape.

**A review catch worth recording.** Codex found that the wizard's validation ping hardcoded `max_tokens: 1`, so selecting OpenAI would 400 at the point of saving the key - a provider marked available that could never be configured. It now uses the same endpoint-keyed lookup the generation path does, and the cap is 16 rather than 1, because on a reasoning model that number counts the model's own reasoning tokens and 1 leaves no room to produce anything.

That is the third time this ping has diverged from the request it is meant to be checking: first the preset headers (fixed in #1797), now the parameter name. Both had the same symptom, the wizard rejecting a key that generates fine, and both were caught by review rather than by a test, because the ping builds its body by hand in the route. The two builders stay separate here on purpose - the ping deliberately sends one throwaway message, no content-rating prompt and a tiny cap, so reusing `buildBody` would mean a full narrative-shaped request just to ask whether a key works. A fourth divergence should collapse them anyway.

Worth flagging as a judgement call: OpenAI now carries two per-preset carve-outs, and the shared adapter's own comment says a vendor's own needs belong in its own adapter. Both stayed as flags because they are declarative data about the request shape rather than behaviour, and a dedicated adapter for two fields would be more structure than the problem has. A third carve-out would change that answer.

Still open on #895 after this:

- **All presets tested and validated.** Deepseek, Mistral, Together, Groq and Perplexity stay `available: false`. Each needs its own key and its own run of `scripts/verify-openai-compatible-stream.mjs`. Perplexity is doc-verified only, and the OpenAI experience here suggests that is worth very little.
- **Works with all existing API routes through the provider factory.** The verification runs prove the streamed narrative path - the same two calls `processAIStreamingTextRequest` makes. Character, world and ending generation share the machinery but have not been driven against a non-Gemini key. Playing a full session on an OpenAI or OpenRouter key is what closes this.

## Screenshots

N/A

## Visual Baseline Changes

None. No files under `tests/visual/**-snapshots/**` are touched.

## Code Review Summary (if applicable)

N/A - the Codex finding on #1797 (preset headers missing from the validation ping) was addressed there and merged.

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

`npm run lint` exits 0 with 127 pre-existing warnings, all `no-explicit-any` under `tests/visual/**` plus one `expect-expect` in a theme test. None are in files this PR touches. No separate security audit run.

## Testing Instructions

```bash
npm test
npm run type-check
npm run lint
```

2807 tests across 406 suites, green on this branch.

The behaviour is pinned in two places. `src/lib/ai/providers/__tests__/adapters.test.ts` asserts the body carries neither `temperature` nor `top_p` when the descriptor declares sampling fixed. `src/lib/ai/__tests__/presets.test.ts` asserts OpenAI is the only preset making that declaration, and that the available set is exactly the three verified live.

To reproduce the live check, with a key you supply at call time:

```bash
OPENAI_COMPAT_API_KEY='<key>' node scripts/verify-openai-compatible-stream.mjs --preset openai
```

No CSS, so `lint:css` was not run. No visual or E2E suites.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed

No docs change: the preset table documents itself in-file and `scripts/README.md` already describes the verification flow. No accessibility surface.

