### PR TITLE
Draw the bullet eyebrows in mark ink instead of accent

### DIFF
--- a/src/app/about.css
+++ b/src/app/about.css
@@ -285,13 +285,16 @@
   color: var(--color-accent-strong);
 }
 
+/* About spends its accent on the CTA button, so the eyebrow dots stay in mark
+   ink. That holds on the CTA band too, where the label goes accent-strong for
+   text contrast a decorative 6px dot doesn't need. */
 :root .component-about-section-title::before {
   content: "";
   display: inline-block;
   width: 6px;
   height: 6px;
   border-radius: var(--radius-full);
-  background: var(--color-accent);
+  background: var(--color-text-muted);
   flex-shrink: 0;
 }
 

--- a/src/app/dashboard.css
+++ b/src/app/dashboard.css
@@ -602,7 +602,9 @@
   color: var(--color-text-secondary);
 }
 
-/* Canonical DS3 dot bullet — rhymes with the dot-grid background. */
+/* Canonical DS3 dot bullet, in the mark ink the whole drafting-marks family uses
+   and rhyming with the dot-grid background. The dashboard spends its one accent
+   mark on the continue card's registration cross, so these stay quiet. */
 :root .component-dashboard-progress-card h2::before,
 :root .component-dashboard-continue-card h2::before,
 :root .component-dashboard-recent-worlds h2::before,
@@ -613,7 +615,7 @@
   width: 6px;
   height: 6px;
   border-radius: var(--radius-full);
-  background: var(--color-accent);
+  background: var(--color-text-muted);
   flex-shrink: 0;
 }
 
@@ -773,7 +775,7 @@
   width: 6px;
   height: 6px;
   border-radius: var(--radius-full);
-  background: var(--color-accent);
+  background: var(--color-text-muted);
   flex-shrink: 0;
 }
 

--- a/src/app/legal.css
+++ b/src/app/legal.css
@@ -101,7 +101,7 @@
   width: 6px;
   height: 6px;
   border-radius: var(--radius-full);
-  background: var(--color-accent);
+  background: var(--color-text-muted);
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
## Description

The bullet eyebrow is one of DS3's five drafting marks, and the weight rule in DESIGN.md is explicit that every mark is drawn in `--color-text-muted`, never accent, with at most one focal accent mark per surface. Four rules were drawing the eyebrow dot in `var(--color-accent)` instead, which put twelve-plus accent decorations across the app's highest-traffic surfaces and left the primary button competing with them for the same signal.

This moves all four onto `--color-text-muted`:

| File | Selector | Surface |
|---|---|---|
| `src/app/dashboard.css:605` | five `h2::before` marks in one rule | `/dashboard` |
| `src/app/dashboard.css:773` | `.world-list-empty-title::before` | `/worlds` empty state |
| `src/app/about.css:288` | `.component-about-section-title::before` | `/about` |
| `src/app/legal.css:98` | `.component-legal .component-legal-section-title::before` | `/privacy`, `/terms` |

The per-surface design call, which was the part that actually needed judgment:

**`/dashboard` keeps one accent mark, and it already had it.** The continue card's registration cross at `dashboard.css:540-551` is drawn in accent, and the registration cross is the mark DESIGN.md nominates for exactly this role. Nothing was added; the five eyebrow dots just stopped competing with it.

**`/about` ends up with zero accent marks.** Its accent is already spent on the CTA button, which is the one thing on the page a reader is meant to act on. Promoting a bracket to a cross somewhere up the page would re-create the same problem in a different mark. The dot stays muted on the CTA band too, where the label above it uses `accent-strong` for text contrast that a decorative 6px dot doesn't need.

**`/worlds` empty state ends up with zero.** Same reasoning: the empty state exists to push you at the Create World button, and that button is the accent.

**Legal pages end up with zero.** There are no cards and no focal action, just prose and accent inline links. A trim mark there would be decoration on a page whose whole job is to be read.

Zero was a legitimate outcome on three of the four surfaces, so nothing was invented to fill the slot.

Worth flagging separately: `/faq` has a fifth identical accent eyebrow at `src/app/faq.css:148`, same shape as the legal one. The issue never listed it and it's outside this PR's scope, so it's left alone and needs its own follow-up. It's now the only surface still drawing an eyebrow dot in accent.

DESIGN.md needed no edit. The doc already stated the rule correctly; the CSS was the thing out of line.

## Related Issue

Closes #1733

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

N/A. This is a three-token CSS swap with no testable behavior of its own. The rule it enforces lives in DESIGN.md, and the existing visual specs already cover all four surfaces.

- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [ ] Test coverage maintained or improved

## User Stories Addressed

N/A. Design-system consistency work, not a user-facing feature.

## Flow Diagrams

N/A

## Component Development

No component changed, only the CSS behind existing ones. The canon rendering for this family is the "Drafting Marks" section in `DesignSystemShowcase.stories.tsx`, which renders the production classes rather than copies, so it picks the change up without a story edit.

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

## Implementation Notes

The comment above the dashboard rule used to read "Canonical DS3 dot bullet, rhymes with the dot-grid background," which predates the weight rule rather than disagreeing with it. It's been rewritten to say where the dashboard's one accent mark actually goes, and About got a short note explaining why its dot stays muted on the accent-soft CTA band.

The muted dot is decorative (`content: ""`, carrying nothing the uppercase label doesn't already say), so WCAG's non-text contrast minimum doesn't apply to it. `--color-text-muted` lands around 4.6:1 on a card in both modes anyway, which is the same weight every other drafting mark renders at.

## Screenshots

N/A. The change is a 6px dot moving from blue to muted brown; a screenshot pair would be less legible than the computed-style values in the verification section below.

## Visual Baseline Changes

None. No file under `tests/visual/**-snapshots/**` changed.

That surprised me, so it's worth writing down. Every affected spec passes against its existing baseline:

```
tests/visual/about-page.spec.ts
tests/visual/privacy-page.spec.ts
tests/visual/terms-page.spec.ts        3 passed (4.3s)

tests/visual/main-pages.spec.ts
tests/visual/mobile-layouts.spec.ts
tests/visual/brand-register.spec.ts   35 passed (28.1s)
```

The reason is the per-pixel tolerance, not luck. `playwright.config.ts` sets `threshold: 0.2`, and pixelmatch only counts a pixel as different once its squared YIQ delta clears `0.2 * 35215`, about 7043. Accent `rgb(54 87 120)` against muted `rgb(125 113 99)` computes to roughly 1118, so those pixels never register as changed and `maxDiffPixels: 100` is never reached.

Which means the visual suite is blind to this whole class of change: a token swap between two colors of similar luminance won't trip it no matter how many marks it touches. Not something to fix here, but it's the reason this PR carries computed-style evidence instead of leaning on a green visual run.

No snapshots were updated, and `--update-snapshots` was not run.

## Code Review Summary (if applicable)

Ran the local `narraitor-pattern-alignment-skill` over the diff. No issues: tokens are used bare as `var(--color-*)` per the design-tokens doc, no hardcoded or named colors, no `!important`, no Tailwind, no ticket numbers in comments, and no `simple`/`enhanced` variants. It matches the eyebrows that already followed the rule at `wizard.css:1146` and `:2238`.

## Chrome DevTools MCP Verification Summary (if applicable)

Verified with `bdg` against the worktree's own dev server on port 3202, reading computed `::before` styles rather than screenshots. `--color-accent` resolves to `rgb(54 87 120)` and `--color-text-muted` to `rgb(125 113 99)` in light mode, so the two are easy to tell apart in the output.

| Surface | Selector | Computed `::before` background |
|---|---|---|
| `/about` | `.component-about-section-title` (6 of them) | `rgb(125, 113, 99)` |
| `/privacy` | `.component-legal-section-title` (6) | `rgb(125, 113, 99)` |
| `/terms` | `.component-legal-section-title` (6) | `rgb(125, 113, 99)` |
| `/worlds` | `.world-list-empty-title` | `rgb(125, 113, 99)` |
| `/dashboard` | all five card `h2` marks | `rgb(125, 113, 99)` |
| `/dashboard` | continue card registration cross | `linear-gradient(rgb(54, 87, 120), ...)` |

One caveat on the dashboard row. A fresh browser profile has no worlds, so `/dashboard` renders the first-run onboarding and none of the five cards mount. Those five values come from injecting matching markup into the live `/dashboard` page and reading the computed style back, which exercises the real cascade on the real route but is not the real render. The seeded `main-pages.spec.ts` and `mobile-layouts.spec.ts` runs cover the actual dashboard, and both pass.

The last row is the point of the whole change: after it, the continue card's cross is the only accent mark left on the dashboard.

## Quality Checks (if applicable)

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

```
npm run lint:css     exit 0
npm run lint         exit 0  (0 errors, 127 pre-existing warnings)
npm run type-check   exit 0
npm test             exit 0  (406 suites, 2809 tests, all passed, 33.3s)
```

Security audit is unchecked because it wasn't run, not because it failed. No dependency or route change here for it to have an opinion about.

## Testing Instructions

1. Start the dev server and open `/about`, `/privacy`, `/terms`, and `/worlds` on a profile with no worlds.
2. The bullet before each mono-uppercase section label should be the same muted brown as the corner brackets on the cards, not blue. It should read as the same hand as the rest of the drafting marks.
3. Create a world so `/dashboard` renders its cards. The five section eyebrows should be muted, and the only blue mark on the page should be the registration cross in the continue card's corners.

If you'd rather read numbers than eyeball a 6px dot, `getComputedStyle(el, '::before').backgroundColor` should return `rgb(125, 113, 99)` in light mode on every eyebrow above.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
