### PR TITLE
Move the FAQ eyebrow dot onto mark ink

### DIFF
--- a/src/app/faq.css
+++ b/src/app/faq.css
@@ -145,13 +145,16 @@
   color: var(--color-text-secondary);
 }
 
+/* The FAQ spends its accent on the inline links inside answers, so the eyebrow
+   dots stay in mark ink. No focal accent mark here: the dot is the page's only
+   drafting mark, and there's no bracket to promote to a registration cross. */
 .component-faq .component-faq-group-title::before {
   content: "";
   display: inline-block;
   width: 6px;
   height: 6px;
   border-radius: var(--radius-full);
-  background: var(--color-accent);
+  background: var(--color-text-muted);
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
## Description

`/faq` was the last surface in the app drawing its bullet eyebrow dot in `--color-accent`. This moves it to `--color-text-muted`, which is what DESIGN.md's weight rule has always said every drafting mark uses.

#1733 fixed four identical sites (`dashboard.css` twice, `about.css`, `legal.css`) but its inventory never included `faq.css`, so the FAQ kept the accent dot while everything else went quiet. That's a worse state than before the fix, since the eyebrow now reads one way on five surfaces and another way here with nothing to explain the difference.

**The per-surface accent call: `/faq` keeps zero accent marks.** Its accent budget is already spent on the inline prose links inside answers (`.component-faq-answer a`), which is the same situation as the legal pages. A live audit of every element and pseudo-element on the page found 15 accent hits after the change, all of them bare `<a>` tags. There was also nothing to promote even if there had been room: the eyebrow dot is the page's only drafting mark, so there's no corner bracket available to become a registration cross. Inventing one to fill the slot would have re-created the exact problem this fixes in a different mark.

## Related Issue

Closes #1802

Follow-up to #1733 (PR #1801), which fixed the other four sites.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

N/A. This is a one-token CSS value swap with no behavior to drive out from a test. Verification is a computed-style read against the live route, recorded below.

- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed

N/A.

## Flow Diagrams

N/A.

## Component Development

No component changed, only the stylesheet behind it. The canon Drafting Marks showcase in Storybook renders production classes, so it picks this up without a story edit.

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

## Implementation Notes

The comment above the rule records the accent decision, since "why is there no accent mark on this page" is the question a future reader will actually have.

One thing deliberately left alone: `faq.css:52` sets a literal `1.75rem` font-size that's off DESIGN.md's type ramp. It predates this change and has nothing to do with the eyebrow, so fixing it here would just widen the diff. Worth its own issue if it bothers anyone.

## Screenshots

No screenshot, because a screenshot cannot show this change. See the note under Visual Baseline Changes.

## Visual Baseline Changes

**None.** No file under `tests/visual/**-snapshots/**` was touched and `--update-snapshots` was never run. Both specs that cover this route pass against their existing baselines:

```
TZ=UTC npx playwright test tests/visual/faq-page.spec.ts tests/visual/brand-register.spec.ts --project=chromium
23 passed (15.2s)   EXIT=0
```

That green run is not evidence the change landed, and it's worth being explicit about why. `playwright.config.ts` sets `threshold: 0.2`, so pixelmatch only counts a pixel once its squared YIQ delta clears roughly 7043. Accent `rgb(54 87 120)` against muted `rgb(125 113 99)` computes to about 1118, so no pixel on the 6px dot registers and `maxDiffPixels: 100` is never approached. #1733 shifted zero baselines for the same reason.

The practical consequence: **the visual suite is blind to this whole class of change.** A token swap between two colors of similar luminance won't trip it no matter how many marks it touches. That's why the evidence below is computed styles rather than a green visual job.

## Code Review Summary (if applicable)

N/A.

## Chrome DevTools MCP Verification Summary (if applicable)

Verified with `bdg` against this worktree's own dev server on port 3418, in an isolated Chrome profile.

All five group eyebrows now compute to the muted token:

| Group | `::before` background | Width |
|---|---|---|
| Getting started | `rgb(125, 113, 99)` | 6px |
| Your key, providers, and cost | `rgb(125, 113, 99)` | 6px |
| Privacy and your data | `rgb(125, 113, 99)` | 6px |
| How the game works | `rgb(125, 113, 99)` | 6px |
| When something goes wrong | `rgb(125, 113, 99)` | 6px |

`rgb(125 113 99)` is `--color-text-muted` in light mode, matching DESIGN.md.

Accent audit over every element and pseudo-element on the page after the change: 15 hits, every one a bare `<a>` (inline answer links, plus their inherited `::before` / `::after`). Zero accent drafting marks, which is the intended outcome.

## Quality Checks (if applicable)

| Check | Result |
|---|---|
| `npm run lint:css` | EXIT=0 |
| `npm run lint` | EXIT=0 (0 errors, 127 pre-existing warnings) |
| `npm run type-check` | EXIT=0 |
| `npm test` | EXIT=0, 406 suites / 2809 tests |

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit not run: no dependency, route, or server-side change here.

On the test run, one thing worth recording rather than hiding. The first full `npm test` came back with 3 failures in `SkillEditor.test.tsx`. That suite passed twice in isolation and the whole suite passed clean on a second full run (406/406, 2809/2809), and this diff is one CSS value that cannot reach a React component test. Reading it as suite-interaction flake under parallelism, not as anything this PR caused.

## Testing Instructions

1. `npm run dev` and open `/faq`.
2. Confirm every group eyebrow dot reads as muted grey-brown, the same ink as the corner brackets and dotted rules elsewhere in the app, rather than blue.
3. Confirm the inline links inside answers are still accent blue, so accent still means "this is clickable" on the page.
4. Toggle dark mode and confirm the dots follow the muted token rather than staying fixed.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

DESIGN.md needed no edit; the doc already stated the rule correctly and the CSS was what disagreed with it. On accessibility: the dot is decorative, sits behind `content: ""` with no text alternative, and carries no information the uppercase label doesn't already give, so lowering its contrast doesn't cost a reader anything.
