### PR TITLE
Drop the dead grid-column from the wizard save-indicator rule

### DIFF
--- a/src/app/wizard.css
+++ b/src/app/wizard.css
@@ -1153,8 +1153,10 @@
 
 /* ─── Shared wizard flow hooks ─── */
 
+/* The character wizard renders its auto-save indicator as an unclassed first
+   grid child, so there's no class to hook. Right-aligning it keeps it reading
+   as status chrome instead of the first row of the form. */
 :root .component-character-creation-wizard > :not(.wizard-header) > :first-child:not(.component-wizard-progress) {
-  grid-column: 1 / -1;
   justify-self: end;
 }
 


### PR DESCRIPTION
## Description

Half of a rule in `wizard.css` was dead, so that half is gone and the other half stays with a comment explaining it.

Issue #1728 was a verify-then-tidy: confirm the left gutter the parent reported is really fixed, then clear the leftover two-column CSS. The verification came back clean, and the tidy turned out to be narrower than the issue assumed.

The rule at `wizard.css:1156` carried `grid-column: 1 / -1` and `justify-self: end`. The issue guessed both were dead weight from the two-column era. Only the first one is. The second is what right-aligns the character wizard's auto-save indicator, so removing the whole rule would have been a visible regression.

## Related Issue

Closes #1728

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

No test was written first, because there is no new behavior to drive out. This removes a declaration that provably renders identically, so the meaningful coverage is the existing wizard visual baselines, which pass unchanged. Writing a unit test asserting a CSS property string would test the stylesheet rather than the layout, which this repo deliberately avoids.

## User Stories Addressed

None directly. This is backlog hygiene on a P3 nit, keeping `wizard.css` honest for whoever reads it next.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

No component changed, so no story needed. Visual consistency was verified by running the two wizard specs, both of which pass with no baseline movement.

## Implementation Notes

The rule does match live DOM, which is worth recording since the issue implied it might be a no-op selector. `CharacterCreationWizard.tsx:282` renders an unclassed `<div>` wrapping `SaveIndicator` as the grid's first child, so `:first-child:not(.component-wizard-progress)` hits it. There is no class to target it by, which is why the selector is shaped the way it is.

Proof came from deleting the real rule out of the CSSOM in a live page and re-measuring geometry, one declaration at a time, on the character wizard's attributes step:

| State | Indicator left (desktop) | Wrapper width | Indicator left (mobile) |
|---|---|---|---|
| as shipped | 1196 | 52 | 293 |
| `grid-column` removed, `justify-self` kept | 1196 | 52 | 293 |
| whole rule removed | 178 | 1070 | 45 |

Row two is the change in this PR, and it is pixel-identical to row one. Row three is what the issue originally proposed, and it drags the auto-save chip 1018px left on desktop (248px on mobile) from top-right to top-left. In a one-track grid `1 / -1` resolves to the same area as auto-placement, which is why the first declaration costs nothing and the second one does real work.

The surviving declaration now carries a short comment, since the reason it exists is not obvious from the selector.

## Screenshots

None. The point of this change is that nothing moves, so a before/after pair would be two identical images. The geometry tables above are the evidence instead.

## Visual Baseline Changes

None. No file under `tests/visual/**-snapshots/**` changed. `git status` after running both wizard specs shows only `src/app/wizard.css` modified, which is the expected result given the removed declaration is pixel-identical.

## Code Review Summary

Ran the local `narraitor-pattern-alignment-skill` pass over the diff. No findings: no colors or hardcoded values touched, no `!important`, the new comment explains why rather than what and carries no issue number, and `justify-self: end` is retained so there is no visual or accessibility change.

## Chrome DevTools MCP Verification Summary

Verified over CDP against this worktree's dev server on port 3869, using an isolated headless Chrome rather than the shared debug instance, since sibling worktrees were driving that one.

Browser check for AC item 1, both wizards walked to a genuinely long step at both widths:

| Wizard | Width | Step | Page height | Grid columns | Children |
|---|---|---|---|---|---|
| World | 1440 | `attribute-review-step` | 1947px | `1070px` | all dx=0, w=1070 |
| World | 390 | `attribute-review-step` | 2452px | `300px` | all dx=0, w=300 |
| Character | 1440 | Allocate Attribute Points | 1285px | `1070px` | all dx=0, w=1070 |
| Character | 390 | Allocate Attribute Points | 1695px | `300px` | all dx=0, w=300 |

`dx` is each grid child's left offset from the grid's content-box edge, which is where a gutter would show. Progress rail, step content, and nav container all sit at 0 and span the full column. No gutter reproduces, so no re-scope was needed.

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit is unchecked because it was not run. This is a one-line CSS deletion with no dependency or code surface, so there was nothing for it to inspect.

## Testing Instructions

```
npm run lint:css     # EXIT=0
npm run lint         # EXIT=0 (127 pre-existing warnings, 0 errors, none in touched files)
npm run type-check   # EXIT=0
npm test             # EXIT=0, 406 suites / 2809 tests passed
```

Visual, against a running dev server for this worktree:

```
TZ=UTC npx playwright test --project=chromium \
  tests/visual/world-creation.spec.ts tests/visual/character-creation.spec.ts
# EXIT=0, 2 passed, no baseline changes
```

To check the surviving declaration by hand, open `/characters/create?worldId=<id>` and confirm the "Saved" chip sits at the top right of the wizard panel. If it jumps to the top left, `justify-self: end` went missing.

## Checklist

- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

`wizard.css` is about 2266 lines and has been over the limit since long before this PR, which removes a line rather than adding one. Splitting it is its own piece of work, not something to smuggle into a one-line deletion. Documentation is unchecked because nothing in the docs describes this rule. Accessibility is unaffected: the chip's rendered position and size are unchanged, and no markup or semantics moved.
