### PR TITLE
Move the other four image routes onto the shared fallback helper

### DIFF
--- a/src/app/api/generate-ending-image/__tests__/route.test.ts
+++ b/src/app/api/generate-ending-image/__tests__/route.test.ts
@@ -1,0 +1,159 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('@/lib/ai/defaultGeminiClient');
+jest.mock('@/lib/ai/geminiImageGenerator', () => ({
+  generateImageWithGemini: jest.fn(),
+}));
+jest.mock('@/lib/utils/logger', () => {
+  return jest.fn().mockImplementation(() => ({
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  }));
+});
+jest.mock('@/lib/utils/genrePromptGuide', () => ({
+  getGenreStyleGuidance: jest.fn((genre: string, context: string) => `style for ${genre} ${context}`),
+  getGenreFallbackImage: jest.fn((genre: string, seed: string) => `https://picsum.photos/seed/${seed}/1200/400`),
+}));
+
+import { NextRequest } from 'next/server';
+import { POST } from '../route';
+import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
+import { generateImageWithGemini } from '@/lib/ai/geminiImageGenerator';
+import type { StoryEnding } from '@/types/narrative.types';
+import type { World } from '@/types/world.types';
+
+const mockCreateClient = createDefaultGeminiClient as jest.MockedFunction<typeof createDefaultGeminiClient>;
+const mockGenerate = generateImageWithGemini as jest.MockedFunction<typeof generateImageWithGemini>;
+const mockClient = { generateContent: jest.fn() };
+
+const mockEnding = {
+  id: 'ending-1',
+  sessionId: 'session-1',
+  characterId: 'char-1',
+  tone: 'hopeful',
+  epilogue: 'The city rebuilt itself over the following winter.',
+  characterLegacy: 'Remembered as the one who stayed.',
+  worldImpact: 'The bridge district never burned again.',
+  timestamp: '2024-01-01T00:00:00.000Z',
+} as unknown as StoryEnding;
+
+const mockWorld: World = {
+  id: 'world-1',
+  name: 'Test Realm',
+  description: 'A fantasy realm',
+  genre: 'fantasy',
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+  attributes: [],
+  skills: [],
+  settings: { maxAttributes: 10, maxSkills: 20, attributePointPool: 25, skillPointPool: 30 },
+};
+
+const makeRequest = (body: unknown) =>
+  new NextRequest('http://localhost:3000/api/generate-ending-image', {
+    method: 'POST',
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+
+describe('/api/generate-ending-image', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateClient.mockReturnValue(mockClient as unknown as ReturnType<typeof createDefaultGeminiClient>);
+    mockClient.generateContent.mockResolvedValue({ content: 'A sunrise over rebuilt rooftops.' });
+    process.env.GEMINI_API_KEY = 'test-api-key';
+  });
+
+  afterEach(() => {
+    delete process.env.GEMINI_API_KEY;
+  });
+
+  it('returns 400 when no ending is provided', async () => {
+    const response = await POST(makeRequest({ world: mockWorld }));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Ending data is required');
+  });
+
+  it('returns the generated image with its diagnostic fields', async () => {
+    mockGenerate.mockResolvedValue({
+      url: 'data:image/png;base64,abc123',
+      mimeType: 'image/png',
+      base64Data: 'abc123',
+    });
+
+    const response = await POST(makeRequest({ ending: mockEnding, world: mockWorld }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.imageUrl).toBe('data:image/png;base64,abc123');
+    expect(data.aiGenerated).toBe(true);
+    expect(data.placeholder).toBe(false);
+    expect(data.service).toBe('gemini-image-generation');
+    expect(data.tone).toBe('hopeful');
+    expect(data.description).toBe('A sunrise over rebuilt rooftops.');
+    expect(data.imageGenerationPrompt).toBe('A sunrise over rebuilt rooftops.');
+  });
+
+  it('falls back to a placeholder when the API key is missing', async () => {
+    delete process.env.GEMINI_API_KEY;
+
+    const response = await POST(makeRequest({ ending: mockEnding, world: mockWorld }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.aiGenerated).toBe(false);
+    expect(data.placeholder).toBe(true);
+    expect(data.service).toBe('fallback');
+    expect(data.imageUrl).toContain('picsum.photos');
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a placeholder when generation returns null', async () => {
+    mockGenerate.mockResolvedValue(null);
+
+    const response = await POST(makeRequest({ ending: mockEnding, world: mockWorld }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.aiGenerated).toBe(false);
+    expect(data.placeholder).toBe(true);
+    expect(data.imageUrl).toContain('picsum.photos');
+  });
+
+  it('falls back to a placeholder when generation throws', async () => {
+    mockGenerate.mockRejectedValue(new Error('rate limited'));
+
+    const response = await POST(makeRequest({ ending: mockEnding, world: mockWorld }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.aiGenerated).toBe(false);
+    expect(data.placeholder).toBe(true);
+    expect(data.imageUrl).toContain('picsum.photos');
+  });
+
+  it('returns prompts only, and no image, when promptOnly is set', async () => {
+    const response = await POST(
+      makeRequest({ ending: mockEnding, world: mockWorld, promptOnly: true })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.promptOnly).toBe(true);
+    expect(data.imageGenerationPrompt).toBe('A sunrise over rebuilt rooftops.');
+    expect(data.imageUrl).toBeUndefined();
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when request parsing fails', async () => {
+    const response = await POST(makeRequest('invalid json'));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe('Unable to load ending image. Please try again.');
+  });
+});

--- a/src/app/api/generate-ending-image/route.ts
+++ b/src/app/api/generate-ending-image/route.ts
@@ -5,7 +5,7 @@ import type { StoryEnding } from '@/types/narrative.types';
 import type { World } from '@/types/world.types';
 import type { Character } from '@/types/character.types';
 import Logger from '@/lib/utils/logger';
-import { generateImageWithGemini } from '@/lib/ai/geminiImageGenerator';
+import { resolveGeneratedImageUrl } from '@/lib/api/imageGenerationHelpers';
 import { getGenreStyleGuidance, getGenreFallbackImage } from '@/lib/utils/genrePromptGuide';
 
 const logger = new Logger('EndingImageAPI');
@@ -145,17 +145,8 @@ export async function POST(request: NextRequest) {
         });
       }
 
-      // Try to generate real AI image using Gemini's image generation model
-      let imageUrl = '';
-      let aiGenerated = false;
-      let placeholder = true;
-
-      // Use the key resolved above (player's BYO key -> env fallback).
-      if (apiKey) {
-        try {
-          logger.debug('generate-ending-image', 'Attempting Gemini image generation');
-          
-          const imagePromptForGemini = `Create a cinematic ending image for this story conclusion. ${imageDescription}
+      const { url: imageUrl, aiGenerated } = await resolveGeneratedImageUrl({
+        prompt: `Create a cinematic ending image for this story conclusion. ${imageDescription}
 
 Requirements:
 - Epic cinematic scene showing story conclusion
@@ -167,35 +158,18 @@ Requirements:
 - Focus on the end of the journey or its aftermath
 - No text, logos, or watermarks
 - Wide landscape orientation (3:1 aspect ratio, panoramic hero banner format)
-- Horizontal panoramic composition suitable for wide hero display`;
+- Horizontal panoramic composition suitable for wide hero display`,
+        apiKey,
+        fallbackUrl: generateFallbackImage(body.ending, body.world),
+        loggerContext: 'generate-ending-image',
+        onHardFailure: 'fallback',
+      });
 
-          const generatedImage = await generateImageWithGemini(imagePromptForGemini, apiKey);
-
-          if (generatedImage) {
-            imageUrl = generatedImage.url;
-            aiGenerated = true;
-            placeholder = false;
-
-            logger.debug('generate-ending-image', 'Gemini image generated successfully');
-          } else {
-            logger.warn('generate-ending-image', 'Image generation failed, using fallback');
-            imageUrl = generateFallbackImage(body.ending, body.world);
-          }
-
-        } catch (imageGenError) {
-          logger.error('generate-ending-image', 'Gemini image generation failed, using fallback:', imageGenError);
-          imageUrl = generateFallbackImage(body.ending, body.world);
-        }
-      } else {
-        logger.debug('generate-ending-image', 'No Gemini API key configured, using fallback');
-        imageUrl = generateFallbackImage(body.ending, body.world);
-      }
-      
-      return NextResponse.json({ 
+      return NextResponse.json({
         imageUrl,
         description: imageDescription,
         prompt: imagePrompt,
-        placeholder,
+        placeholder: !aiGenerated,
         aiGenerated,
         tone: body.ending.tone,
         // Include the prompt for future use

--- a/src/app/api/generate-journal-image/route.ts
+++ b/src/app/api/generate-journal-image/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import type { JournalEntry } from '@/types/journal.types';
 import type { World } from '@/types/world.types';
 import Logger from '@/lib/utils/logger';
-import { generateImageWithGemini } from '@/lib/ai/geminiImageGenerator';
+import { resolveGeneratedImageUrl } from '@/lib/api/imageGenerationHelpers';
 import { resolveApiKey } from '@/lib/ai/resolveApiKey';
 import { getGenreStyleGuidance, getGenreFallbackImage } from '@/lib/utils/genrePromptGuide';
 
@@ -61,41 +61,20 @@ export async function POST(request: NextRequest) {
     logger.debug('generate-journal-image', 'Starting image generation');
 
     const imagePrompt = customPrompt || generateImagePrompt(entry, world);
-    const apiKey = resolveApiKey(request);
 
-    if (!apiKey) {
-      logger.debug('generate-journal-image', 'No Gemini API key configured, using fallback');
-      return NextResponse.json({
-        imageUrl: generateFallbackImage(entry, world),
-        prompt: imagePrompt,
-        placeholder: true,
-        aiGenerated: false,
-      });
-    }
-
-    try {
-      const generatedImage = await generateImageWithGemini(imagePrompt, apiKey);
-
-      if (generatedImage) {
-        logger.debug('generate-journal-image', 'Gemini image generated successfully');
-        return NextResponse.json({
-          imageUrl: generatedImage.url,
-          prompt: imagePrompt,
-          placeholder: false,
-          aiGenerated: true,
-        });
-      }
-
-      logger.warn('generate-journal-image', 'Image generation failed, using fallback');
-    } catch (imageGenError) {
-      logger.error('generate-journal-image', 'Gemini image generation failed, using fallback:', imageGenError);
-    }
+    const { url: imageUrl, aiGenerated } = await resolveGeneratedImageUrl({
+      prompt: imagePrompt,
+      apiKey: resolveApiKey(request),
+      fallbackUrl: generateFallbackImage(entry, world),
+      loggerContext: 'generate-journal-image',
+      onHardFailure: 'fallback',
+    });
 
     return NextResponse.json({
-      imageUrl: generateFallbackImage(entry, world),
+      imageUrl,
       prompt: imagePrompt,
-      placeholder: true,
-      aiGenerated: false,
+      placeholder: !aiGenerated,
+      aiGenerated,
     });
   } catch (error) {
     logger.error('generate-journal-image', 'Journal image generation failed:', error);

--- a/src/app/api/generate-portrait/__tests__/route.test.ts
+++ b/src/app/api/generate-portrait/__tests__/route.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('@/lib/ai/geminiImageGenerator', () => ({
+  generateImageWithGemini: jest.fn(),
+}));
+jest.mock('@/lib/utils/logger', () => {
+  return jest.fn().mockImplementation(() => ({
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  }));
+});
+
+import { NextRequest } from 'next/server';
+import { POST } from '../route';
+import { generateImageWithGemini } from '@/lib/ai/geminiImageGenerator';
+
+const mockGenerate = generateImageWithGemini as jest.MockedFunction<typeof generateImageWithGemini>;
+
+// The direct-prompt input format skips the AI-assisted prompt builder, which
+// keeps these tests on the generate-and-fall-back path they're about.
+const makeRequest = (body: unknown) =>
+  new NextRequest('http://localhost:3000/api/generate-portrait', {
+    method: 'POST',
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+
+describe('/api/generate-portrait', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.GEMINI_API_KEY = 'test-api-key';
+  });
+
+  afterEach(() => {
+    delete process.env.GEMINI_API_KEY;
+  });
+
+  it('returns 400 when neither a prompt nor a character is provided', async () => {
+    const response = await POST(makeRequest({ world: { genre: 'fantasy' } }));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Either prompt string or character object is required');
+  });
+
+  it('returns the generated portrait when generation succeeds', async () => {
+    mockGenerate.mockResolvedValue({
+      url: 'data:image/png;base64,abc123',
+      mimeType: 'image/png',
+      base64Data: 'abc123',
+    });
+
+    const response = await POST(makeRequest({ prompt: 'a weathered knight' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.portrait.url).toBe('data:image/png;base64,abc123');
+    expect(data.portrait.type).toBe('ai-generated');
+    expect(data.portrait.prompt).toBe('a weathered knight');
+  });
+
+  it('falls back to a dicebear avatar when the API key is missing', async () => {
+    delete process.env.GEMINI_API_KEY;
+
+    const response = await POST(makeRequest({ prompt: 'a weathered knight' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.portrait.url).toContain('api.dicebear.com/7.x/avataaars/svg');
+    expect(data.portrait.type).toBe('ai-generated');
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a dicebear avatar when generation returns null', async () => {
+    mockGenerate.mockResolvedValue(null);
+
+    const response = await POST(makeRequest({ prompt: 'a weathered knight' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.portrait.url).toContain('api.dicebear.com/7.x/avataaars/svg');
+  });
+
+  it('still answers with a portrait when generation throws', async () => {
+    mockGenerate.mockRejectedValue(new Error('rate limited'));
+
+    const response = await POST(makeRequest({ prompt: 'a weathered knight' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.portrait.url).toContain('api.dicebear.com/7.x/avataaars/svg');
+    expect(data.portrait.prompt).toContain('rate limited');
+  });
+});

--- a/src/app/api/generate-portrait/route.ts
+++ b/src/app/api/generate-portrait/route.ts
@@ -5,7 +5,7 @@ import Logger from '@/lib/utils/logger';
 import { Character } from '@/types/character.types';
 import { World } from '@/types/world.types';
 import { truncate, getTimestamp } from '@/lib/utils';
-import { generateImageWithGemini } from '@/lib/ai/geminiImageGenerator';
+import { resolveGeneratedImageUrl } from '@/lib/api/imageGenerationHelpers';
 import { resolveApiKey } from '@/lib/ai/resolveApiKey';
 
 const logger = new Logger('API');
@@ -199,58 +199,24 @@ export async function POST(request: NextRequest) {
       truncate(prompt, 100)
     );
 
-    if (!apiKey) {
-      // Return a mock portrait for development
-      const mockPortrait = {
-        type: 'ai-generated' as const,
-        url: `https://api.dicebear.com/7.x/avataaars/svg?seed=${encodeURIComponent(character?.name || 'unknown')}`,
-        generatedAt: getTimestamp(),
-        prompt: prompt,
-      };
+    const { url } = await resolveGeneratedImageUrl({
+      prompt,
+      apiKey,
+      fallbackUrl: `https://api.dicebear.com/7.x/avataaars/svg?seed=${encodeURIComponent(character?.name || 'unknown')}`,
+      loggerContext: 'generate-portrait API',
+      onHardFailure: 'throw',
+    });
 
-      logger.debug(
-        'generate-portrait API',
-        'Using mock portrait for development'
-      );
-      return NextResponse.json({
-        portrait: mockPortrait,
-      });
-    }
-
-    // Call Google's Gemini API for image generation
-    const generatedImage = await generateImageWithGemini(prompt, apiKey);
-
-    if (!generatedImage) {
-      logger.warn(
-        'generate-portrait API',
-        'Image generation failed, using fallback'
-      );
-
-      // Return mock portrait as fallback
-      const fallbackPortrait = {
-        type: 'ai-generated' as const,
-        url: `https://api.dicebear.com/7.x/avataaars/svg?seed=${encodeURIComponent(character?.name || 'fallback')}`,
-        generatedAt: getTimestamp(),
-        prompt: prompt,
-      };
-
-      return NextResponse.json({
-        portrait: fallbackPortrait,
-      });
-    }
-
-    // Return the generated portrait
-    const portraitData = {
-      type: 'ai-generated' as const,
-      url: generatedImage.url,
-      generatedAt: getTimestamp(),
-      prompt: prompt,
-    };
-
-    logger.debug('generate-portrait API', 'Portrait generated successfully');
-
+    // Portraits are typed 'ai-generated' even when the URL is the dicebear
+    // placeholder: CharacterPortrait only renders a portrait whose type isn't
+    // 'placeholder', and the avatar is meant to show.
     return NextResponse.json({
-      portrait: portraitData,
+      portrait: {
+        type: 'ai-generated' as const,
+        url,
+        generatedAt: getTimestamp(),
+        prompt: prompt,
+      },
     });
   } catch (error) {
     logger.error('generate-portrait API', 'Portrait generation failed:', error);

--- a/src/app/api/generate-world-image/route.ts
+++ b/src/app/api/generate-world-image/route.ts
@@ -3,8 +3,7 @@ import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
 import { resolveApiKey } from '@/lib/ai/resolveApiKey';
 import type { World } from '@/types/world.types';
 import Logger from '@/lib/utils/logger';
-import { generateImageWithGemini } from '@/lib/ai/geminiImageGenerator';
-import { getAIConfig } from '@/lib/ai/config';
+import { resolveGeneratedImageUrl } from '@/lib/api/imageGenerationHelpers';
 import { getGenreStyleGuidance, getGenreFallbackImage } from '@/lib/utils/genrePromptGuide';
 
 const logger = new Logger('WorldImageAPI');
@@ -82,53 +81,32 @@ export async function POST(request: NextRequest) {
     logger.debug('generate-world-image', 'Starting image generation for world:', body.world.name);
 
     try {
-      // Use custom prompt if provided, otherwise generate one using AI
       const apiKey = resolveApiKey(request);
-      const client = createDefaultGeminiClient(apiKey);
-      let imagePrompt: string;
-      
-      if (body.customPrompt) {
-        // Use the custom prompt directly
-        imagePrompt = body.customPrompt;
-        logger.debug('generate-world-image', 'Using custom prompt:', imagePrompt);
-      } else {
-        // Generate image prompt using AI
-        imagePrompt = generateImagePrompt(body.world);
-        logger.debug('generate-world-image', 'Generated image prompt:', imagePrompt);
-      }
+      const imagePrompt = body.customPrompt || generateImagePrompt(body.world);
+      logger.debug('generate-world-image', 'Image prompt:', imagePrompt);
 
-      // Generate a detailed description that could be used with real AI image generation
+      // A custom prompt is already the visual description the player wants, so
+      // only a generated prompt gets elaborated by the model.
       let imageDescription: string;
-      
+
       if (body.customPrompt) {
-        // Use the custom prompt as the image description directly
         imageDescription = body.customPrompt;
-        logger.debug('generate-world-image', 'Using custom prompt as image description:', imageDescription);
       } else {
-        // Generate a detailed description using AI
+        const client = createDefaultGeminiClient(apiKey);
         const promptResponse = await client.generateContent(`
           Generate a detailed, artistic description for an image of this world that could be used as a prompt for an AI image generator like DALL-E or Midjourney. Be very specific about visual elements, atmosphere, lighting, and composition.
-          
+
           ${imagePrompt}
-          
+
           Respond with only the detailed visual description, no other text.
         `);
         imageDescription = promptResponse.content;
         logger.debug('generate-world-image', 'Generated image description:', imageDescription);
       }
 
-      // Try to generate real AI image using Gemini's image generation model
-      let imageUrl = '';
-      let aiGenerated = false;
-      let placeholder = true;
-
-      // Use the key resolved above (player's BYO key -> env fallback).
-      if (apiKey) {
-        try {
-          logger.debug('generate-world-image', `Attempting Gemini image generation with model: ${getAIConfig().imageModelName}`);
-
-          // Use the same approach as the portrait generation API
-          const imagePromptForGemini = `Create a detailed landscape image representing the world "${body.world.name}". ${imageDescription}
+      // Generated as a data URL so it persists in IndexedDB (no disk write)
+      const { url: imageUrl, aiGenerated } = await resolveGeneratedImageUrl({
+        prompt: `Create a detailed landscape image representing the world "${body.world.name}". ${imageDescription}
 
 Requirements:
 - Epic cinematic landscape
@@ -137,39 +115,18 @@ Requirements:
 - Rich atmospheric lighting and details
 - ${body.world.genre} genre elements
 - No text, logos, or watermarks
-- Landscape orientation suitable for world imagery`;
+- Landscape orientation suitable for world imagery`,
+        apiKey,
+        fallbackUrl: generateFallbackImage(body.world),
+        loggerContext: 'generate-world-image',
+        onHardFailure: 'fallback',
+      });
 
-          // Generate image as a data URL so it persists in IndexedDB (no disk write)
-          const generatedImage = await generateImageWithGemini(
-            imagePromptForGemini,
-            apiKey
-          );
-
-          if (generatedImage) {
-            imageUrl = generatedImage.url;
-            aiGenerated = true;
-            placeholder = false;
-
-            logger.debug('generate-world-image', `Gemini image generated successfully: ${generatedImage.url.slice(0, 50)}...`);
-          } else {
-            logger.warn('generate-world-image', 'Image generation failed, using fallback');
-            imageUrl = generateFallbackImage(body.world);
-          }
-
-        } catch (imageGenError) {
-          logger.error('generate-world-image', 'Gemini image generation failed, using fallback:', imageGenError);
-          imageUrl = generateFallbackImage(body.world);
-        }
-      } else {
-        logger.debug('generate-world-image', 'No Gemini API key configured, using fallback');
-        imageUrl = generateFallbackImage(body.world);
-      }
-      
-      return NextResponse.json({ 
+      return NextResponse.json({
         imageUrl,
         description: imageDescription,
         prompt: imagePrompt,
-        placeholder,
+        placeholder: !aiGenerated,
         aiGenerated,
         // Include the prompt for future use
         imageGenerationPrompt: imageDescription,

--- a/src/lib/api/__tests__/imageGenerationHelpers.test.ts
+++ b/src/lib/api/__tests__/imageGenerationHelpers.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('@/lib/ai/geminiImageGenerator', () => ({
+  generateImageWithGemini: jest.fn(),
+}));
+jest.mock('@/lib/utils/logger', () => {
+  return jest.fn().mockImplementation(() => ({
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  }));
+});
+
+import { generateImageWithGemini } from '@/lib/ai/geminiImageGenerator';
+import {
+  generateImageWithFallback,
+  resolveGeneratedImageUrl,
+} from '../imageGenerationHelpers';
+
+const mockGenerate = generateImageWithGemini as jest.MockedFunction<typeof generateImageWithGemini>;
+
+const request = (overrides: Partial<Parameters<typeof resolveGeneratedImageUrl>[0]> = {}) => ({
+  prompt: 'a lone lighthouse',
+  apiKey: 'test-api-key',
+  fallbackUrl: 'https://example.test/placeholder.svg',
+  loggerContext: 'test route',
+  onHardFailure: 'fallback' as const,
+  ...overrides,
+});
+
+describe('resolveGeneratedImageUrl', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the placeholder without calling the model when there is no key', async () => {
+    const result = await resolveGeneratedImageUrl(request({ apiKey: null }));
+
+    expect(result).toEqual({
+      url: 'https://example.test/placeholder.svg',
+      aiGenerated: false,
+    });
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it('returns the generated URL when generation succeeds', async () => {
+    mockGenerate.mockResolvedValue({
+      url: 'data:image/png;base64,abc123',
+      mimeType: 'image/png',
+      base64Data: 'abc123',
+    });
+
+    const result = await resolveGeneratedImageUrl(request());
+
+    expect(result).toEqual({ url: 'data:image/png;base64,abc123', aiGenerated: true });
+    expect(mockGenerate).toHaveBeenCalledWith('a lone lighthouse', 'test-api-key');
+  });
+
+  it('returns the placeholder on a soft failure', async () => {
+    mockGenerate.mockResolvedValue(null);
+
+    const result = await resolveGeneratedImageUrl(request());
+
+    expect(result).toEqual({
+      url: 'https://example.test/placeholder.svg',
+      aiGenerated: false,
+    });
+  });
+
+  it('returns the placeholder on a hard failure when the route asked for fallback', async () => {
+    mockGenerate.mockRejectedValue(new Error('rate limited'));
+
+    const result = await resolveGeneratedImageUrl(request({ onHardFailure: 'fallback' }));
+
+    expect(result).toEqual({
+      url: 'https://example.test/placeholder.svg',
+      aiGenerated: false,
+    });
+  });
+
+  it('rethrows a hard failure when the route asked to throw', async () => {
+    mockGenerate.mockRejectedValue(new Error('rate limited'));
+
+    await expect(
+      resolveGeneratedImageUrl(request({ onHardFailure: 'throw' }))
+    ).rejects.toThrow('rate limited');
+  });
+});
+
+describe('generateImageWithFallback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('answers with a placeholder-typed image when there is no key', async () => {
+    const response = await generateImageWithFallback({
+      prompt: 'a rusted sword',
+      apiKey: null,
+      fallback: { variant: 'shapes', seed: 'Rusted Sword', imageType: 'placeholder' },
+      loggerContext: 'test route',
+    });
+    const data = await response.json();
+
+    expect(data.image.type).toBe('placeholder');
+    expect(data.image.url).toContain('api.dicebear.com/7.x/shapes/svg');
+    expect(data.image.prompt).toBe('a rusted sword');
+  });
+
+  it('answers with the generated image when generation succeeds', async () => {
+    mockGenerate.mockResolvedValue({
+      url: 'data:image/png;base64,abc123',
+      mimeType: 'image/png',
+      base64Data: 'abc123',
+    });
+
+    const response = await generateImageWithFallback({
+      prompt: 'a rusted sword',
+      apiKey: 'test-api-key',
+      fallback: { variant: 'shapes', seed: 'Rusted Sword', imageType: 'placeholder' },
+      loggerContext: 'test route',
+    });
+    const data = await response.json();
+
+    expect(data.image.type).toBe('ai-generated');
+    expect(data.image.url).toBe('data:image/png;base64,abc123');
+  });
+});

--- a/src/lib/api/imageGenerationHelpers.ts
+++ b/src/lib/api/imageGenerationHelpers.ts
@@ -8,6 +8,35 @@ import Logger from '@/lib/utils/logger';
 const logger = new Logger('ImageGenerationHelpers');
 
 /**
+ * What a route wants done with a hard failure — auth rejection, rate limit,
+ * network error.
+ *
+ * 'throw' hands it to the route's own error handler, which is the only way a
+ * route can answer with something other than 200. 'fallback' serves the
+ * placeholder instead, so the player still gets an illustration when the
+ * provider is having a bad day.
+ */
+type HardFailurePolicy = 'throw' | 'fallback';
+
+interface ImageUrlRequest {
+  /** The prompt sent to the image model. */
+  prompt: string;
+  /** Resolved key for this request (player's BYO key); null means serve the placeholder. */
+  apiKey: string | null;
+  /** Placeholder served whenever real generation doesn't produce an image. */
+  fallbackUrl: string;
+  /** Logger context name (e.g. 'generate-portrait API'). */
+  loggerContext: string;
+  onHardFailure: HardFailurePolicy;
+}
+
+interface ResolvedImageUrl {
+  url: string;
+  /** False whenever the URL is the placeholder rather than a real generation. */
+  aiGenerated: boolean;
+}
+
+/**
  * Configuration for generating fallback images
  */
 interface FallbackImageConfig {
@@ -17,8 +46,6 @@ interface FallbackImageConfig {
   seed: string;
   /** Image type in response */
   imageType?: 'ai-generated' | 'placeholder';
-  /** Additional query parameters for dicebear */
-  params?: Record<string, string>;
 }
 
 /**
@@ -31,10 +58,8 @@ interface ImageGenerationConfig {
   fallback: FallbackImageConfig;
   /** Logger context name (e.g., 'generate-portrait API') */
   loggerContext: string;
-  /** Additional fields to include in response */
-  responseFields?: Record<string, unknown>;
-  /** Resolved key for this request (player's BYO key); falls back to env when omitted. */
-  apiKey?: string | null;
+  /** Resolved key for this request (player's BYO key). */
+  apiKey: string | null;
 }
 
 /**
@@ -42,44 +67,57 @@ interface ImageGenerationConfig {
  */
 function buildDicebearUrl(config: FallbackImageConfig): string {
   const baseUrl = `https://api.dicebear.com/7.x/${config.variant}/svg`;
-  const params = new URLSearchParams({
-    seed: config.seed,
-    ...config.params,
-  });
+  const params = new URLSearchParams({ seed: config.seed });
   return `${baseUrl}?${params.toString()}`;
 }
 
 /**
- * Create a fallback image object
- */
-function createFallbackImage(config: FallbackImageConfig, prompt: string) {
-  return {
-    type: config.imageType || 'placeholder',
-    url: buildDicebearUrl(config),
-    generatedAt: getTimestamp(),
-    prompt,
-  };
-}
-
-/**
- * Get the Gemini API key if available, null otherwise
- */
-function getGeminiApiKey(): string | null {
-  const apiKey = process.env.GEMINI_API_KEY;
-  return apiKey && apiKey !== 'MOCK_API_KEY' ? apiKey : null;
-}
-
-/**
- * Handle image generation with automatic fallback to mock/placeholder images.
- *
- * This centralizes the pattern of:
- * 1. Check for API key
- * 2. Return mock image if no key
+ * Run the image-generation sequence every image route shares:
+ * 1. Check for a key
+ * 2. Serve the placeholder if there isn't one
  * 3. Try real generation
- * 4. Return fallback if generation returns null (soft failure)
+ * 4. Serve the placeholder if generation returns null (soft failure)
  *
- * Note: Hard failures (auth errors, rate limits, network issues) are allowed
- * to throw so the route's error handler can return proper 500 status codes.
+ * Routes keep their own prompt building and response shape — this owns only
+ * the four steps and the logging around them.
+ *
+ * @throws When generation fails hard and the caller asked for 'throw'
+ */
+export async function resolveGeneratedImageUrl({
+  prompt,
+  apiKey,
+  fallbackUrl,
+  loggerContext,
+  onHardFailure,
+}: ImageUrlRequest): Promise<ResolvedImageUrl> {
+  if (!apiKey) {
+    logger.debug(loggerContext, 'No API key configured, using fallback');
+    return { url: fallbackUrl, aiGenerated: false };
+  }
+
+  try {
+    const generatedImage = await generateImageWithGemini(prompt, apiKey);
+
+    if (generatedImage) {
+      logger.debug(loggerContext, 'Image generated successfully');
+      return { url: generatedImage.url, aiGenerated: true };
+    }
+
+    logger.warn(loggerContext, 'Image generation failed, using fallback');
+  } catch (error) {
+    if (onHardFailure === 'throw') throw error;
+    logger.error(loggerContext, 'Image generation failed, using fallback:', error);
+  }
+
+  return { url: fallbackUrl, aiGenerated: false };
+}
+
+/**
+ * The dicebear-backed variant, for routes that answer with a GeneratedImage
+ * object under an `image` key.
+ *
+ * Hard failures are allowed to throw so the route's error handler can return a
+ * proper 500.
  *
  * @param config - Configuration for image generation
  * @returns NextResponse with image data
@@ -88,45 +126,20 @@ function getGeminiApiKey(): string | null {
 export async function generateImageWithFallback(
   config: ImageGenerationConfig
 ): Promise<NextResponse> {
-  const apiKey = config.apiKey ?? getGeminiApiKey();
-
-  // Mock mode - return placeholder immediately
-  if (!apiKey) {
-    const mockImage = createFallbackImage(config.fallback, config.prompt);
-    logger.debug(config.loggerContext, 'Using mock image for development');
-
-    return NextResponse.json({
-      image: mockImage,
-      ...config.responseFields,
-    });
-  }
-
-  // Try real image generation - let errors bubble to route handler
-  const generatedImage = await generateImageWithGemini(config.prompt, apiKey);
-
-  if (!generatedImage) {
-    // Soft failure - Gemini returned null but didn't throw
-    logger.warn(config.loggerContext, 'Image generation failed, using fallback');
-    const fallbackImage = createFallbackImage(config.fallback, config.prompt);
-
-    return NextResponse.json({
-      image: fallbackImage,
-      ...config.responseFields,
-    });
-  }
-
-  // Success - return generated image
-  const imageData = {
-    type: 'ai-generated' as const,
-    url: generatedImage.url,
-    generatedAt: getTimestamp(),
+  const { url, aiGenerated } = await resolveGeneratedImageUrl({
     prompt: config.prompt,
-  };
-
-  logger.debug(config.loggerContext, 'Image generated successfully');
+    apiKey: config.apiKey,
+    fallbackUrl: buildDicebearUrl(config.fallback),
+    loggerContext: config.loggerContext,
+    onHardFailure: 'throw',
+  });
 
   return NextResponse.json({
-    image: imageData,
-    ...config.responseFields,
+    image: {
+      type: aiGenerated ? 'ai-generated' : config.fallback.imageType ?? 'placeholder',
+      url,
+      generatedAt: getTimestamp(),
+      prompt: config.prompt,
+    },
   });
 }


### PR DESCRIPTION
## Description

Five image routes, one shared helper, and until now only `generate-item-image` used it. The other four hand-rolled the same four steps: check for a key, serve a placeholder if there isn't one, try real generation, serve a placeholder on a soft failure. This moves all four onto the helper.

The response shape was the thing blocking it, so that's what got solved first. The helper used to return a finished `NextResponse` shaped `{ image: {...} }`, which is what the item route wants and nothing else does. Splitting the helper in two fixes that without a second response shape or an options bag:

- `resolveGeneratedImageUrl` owns the four steps and returns a plain `{ url, aiGenerated }`. Each route keeps building its own response body from that, so `generate-world-image` still answers with `imageUrl`/`description`/`prompt`/`placeholder`/`aiGenerated`/`service` and `generate-portrait` still answers with `{ portrait }`.
- `generateImageWithFallback` stays as the thin dicebear-backed wrapper on top of it, unchanged for the item route.

The routes genuinely disagreed on what a hard failure (auth rejection, rate limit, network error) should do, so `onHardFailure` makes each one say. `generate-item-image` and `generate-portrait` throw, because their own catch blocks turn that into a 500 and a fallback avatar respectively. `generate-world-image`, `generate-ending-image` and `generate-journal-image` serve the placeholder, same as they did before.

Route-specific work stayed in the routes: prompt building, the AI elaboration step in the world and ending routes, the portrait prompt builder with its actor detection, and every error response.

Also fixes the low-severity finding from the issue: `generate-world-image` asked `if (body.customPrompt)` twice in a row to set two variables to the same value, each with its own near-identical debug log. Now it reads `const imagePrompt = body.customPrompt || generateImagePrompt(body.world)`, matching what the journal route already did.

| File | Before | After |
|---|---|---|
| `src/app/api/generate-portrait/route.ts` | 270 | 236 |
| `src/app/api/generate-ending-image/route.ts` | 228 | 202 |
| `src/app/api/generate-world-image/route.ts` | 201 | 158 |
| `src/app/api/generate-journal-image/route.ts` | 107 | 86 |
| `src/lib/api/imageGenerationHelpers.ts` | 132 | 145 |

## Related Issue

Closes #1753

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Not TDD in the strict sense - this is a behavior-preserving refactor, so the existing `generate-world-image` and `generate-journal-image` suites acted as the red/green harness while the routes moved. New tests went in for the surfaces that had none.

## User Stories Addressed

N/A - internal refactor, no player-visible change.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A - API routes only, no components touched.

## Implementation Notes

The shared code went into the existing `src/lib/api/imageGenerationHelpers.ts` rather than a new `src/app/api/_shared/` module like #1634's `similarityCheck.ts`. The helper this issue is about already lives in `lib/api` and is already imported by a route, so extending it beats standing up a second home for the same idea.

Every caller's field reads were checked before touching the response bodies, and none of them changed:

- `generate-world-image` - `worldApi.generateWorldImage` (`imageUrl`, `aiGenerated`, `prompt`) and `lib/ai/worldImageGenerator` (`aiGenerated`, `imageUrl`, `prompt`)
- `generate-ending-image` - `lib/api/endingImageApi` (`imageUrl`, `prompt`, `imageGenerationPrompt`, `description`, `tone`, `aiGenerated`, `placeholder`, `service`) and `EndingImageDebugSection`
- `generate-journal-image` - `lib/api/journalImageApi` (`aiGenerated`, `imageUrl`, `prompt`)
- `generate-portrait` - `lib/api/generatePortrait`, `usePortraitGeneration`, `npcPortraitService` (`portrait.url`), `PortraitDebugSection`
- `generate-item-image` - `itemImageService` (`data.image`), route file untouched

Three deliberate deviations, all outside the response contract:

1. `generate-portrait` used seed `unknown` for the no-key placeholder and seed `fallback` for the soft-failure placeholder - two arbitrary dicebear avatars for the same "no portrait available" case. It's one URL now, seeded `unknown`. Only reachable when the request carries no character (the direct-prompt input format); every real caller passes one, where both branches already produced the same URL.
2. Dropped the `getAIConfig().imageModelName` debug line from `generate-world-image`. The helper logs the attempt and its result with the route's own context, and the model name is a static config value.
3. Trimmed three options from the helper that no caller ever passed: `responseFields`, the dicebear `params` bag, and the `getGeminiApiKey()` env read that `resolveApiKey` already covers. `apiKey` is required now instead of optionally falling through to env.

Portraits still report `type: 'ai-generated'` even when the URL is a dicebear placeholder. That looks wrong next to the item route, but `CharacterPortrait` only renders a portrait whose type isn't `placeholder`, so the avatar would stop showing if it changed. Left alone with a comment saying why.

## Screenshots

N/A

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit wasn't run - no dependency changes in this PR.

```
npm test            2831 passed, 410 suites    exit 0
npm run type-check  exit 0
npm run lint        0 errors, 127 pre-existing warnings, none in changed files, exit 0
npm run deps:validate  no violations (1347 modules), exit 0
```

`lint:css` skipped - no CSS in scope. Visual and E2E suites not run.

## Testing Instructions

The behavior to check is that nothing changed, so the tests carry most of it:

1. `npm test src/lib/api/__tests__/imageGenerationHelpers.test.ts` covers the helper's four steps plus both hard-failure policies.
2. `npm test src/app/api/generate-portrait src/app/api/generate-ending-image src/app/api/generate-world-image src/app/api/generate-journal-image` covers all four migrated routes, each with its no-key, soft-failure and generation-throws path.
3. In the app with a Gemini key configured, generate a world image from the world wizard and a portrait from character creation, then confirm both still render. With the key cleared, the same two flows should fall back to a picsum placeholder and a dicebear avatar rather than erroring.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

No docs needed for this change. Worth flagging separately though: `src/app/api/generate-ending-image/README.md` documents a response of `{ prompt, altText, success, usingFallback }`, and the route hasn't returned those fields in a long time - it returns `{ imageUrl, description, prompt, placeholder, aiGenerated, tone, imageGenerationPrompt, service }`. That was already stale before this PR and fixing it is out of scope here, but it should get its own issue.
