### PR TITLE
Add comment and test audit scripts, reap worldStore's restating comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "lint:css": "stylelint \"**/*.css\"",
     "lint:css:fix": "stylelint \"**/*.css\" --fix",
     "audit:css": "node scripts/audit-css.mjs",
+    "audit:comments": "node scripts/audit-comments.mjs",
+    "audit:tests": "node scripts/audit-tests.mjs",
     "docs:check-links": "node scripts/check-docs-links.js",
     "docs:check-symbols": "node scripts/check-docs-symbols.mjs",
     "validate:routes": "node scripts/validate-routes.js",

--- a/scripts/audit-comments.mjs
+++ b/scripts/audit-comments.mjs
@@ -116,7 +116,11 @@ const PATTERNS = {
   // Past-state phrasing only. Bare "used to" is usually present tense
   // ("the salt used to encrypt"), so it is matched with a past-state verb.
   archaeological:
-    /\b(extracted (?:out )?from|moved (?:out )?from|refactored out|refactored from|formerly|previously|renamed from|split out (?:of|from)|used to (?:be|live|call|gate|have|exist|return|do|get|point|sit)|(?:was|were|had) (?:previously|originally)|once (?:was|lived|called)|as of \d)\b/i,
+    /\b((?:was|were|been) extracted (?:out )?from|extracted out from|moved (?:out )?from|refactored out|refactored from|formerly|previously|renamed from|split out (?:of|from)|used to (?:be|live|call|gate|have|exist|return|do|get|point|sit)|(?:was|were|had) (?:previously|originally)|once (?:was|lived|called)|as of \d)\b/i,
+  // "a previously selected skill", "any previously encrypted data": here
+  // "previously" is an adjective describing current data, not a note about how
+  // the code used to be written. An article in front is the tell.
+  adjectivalPrevious: /\b(a|an|any|the|some|each|every|all) previously\b/i,
   // Only line comments draw banners. Block-comment continuation lines are
   // excluded because markdown inside JSDoc ("* - **Bold**:", "* ### Heading")
   // trips any charset loose enough to catch a real divider.
@@ -200,7 +204,10 @@ function scanFile(file) {
       else findings.issueCitation.push(entry);
     }
 
-    if (PATTERNS.archaeological.test(line)) {
+    if (
+      PATTERNS.archaeological.test(line) &&
+      !PATTERNS.adjectivalPrevious.test(line)
+    ) {
       findings.archaeological.push({ at, text: trimmed });
     }
 
@@ -252,6 +259,12 @@ function scanFile(file) {
     // the next line already spells out. "// Add attribute" over "addAttribute:"
     // is the shape this is looking for.
     if (overlapRatio(trimmed, next.line, 4) >= 0.8) {
+      // A comment that matches the line after next as well is heading a GROUP --
+      // a run of sibling constants or literals, like "// Sci-fi" over four
+      // scifi-* preset entries. That labels the run and has to survive; only a
+      // comment that restates one single line is noise.
+      const after = nextCodeLine(lines, next.index + 1);
+      if (after && overlapRatio(trimmed, after.line, 4) >= 0.8) return;
       findings.restating.push({
         at,
         text: trimmed,

--- a/scripts/audit-comments.mjs
+++ b/scripts/audit-comments.mjs
@@ -1,0 +1,357 @@
+/**
+ * Comment audit.
+ *
+ * Lists code comments that the repo's comment hygiene rules say shouldn't exist:
+ * ones that restate the line below them, cite an issue number, narrate refactor
+ * history, or draw a section banner. It is an AUDIT, not a fix: it writes
+ * nothing, deletes nothing, and never fails CI (exit 0 on findings).
+ *
+ * Why this approach (chosen over alternatives):
+ *  - A line-oriented scan with a tiny comment-state machine is enough here. The
+ *    patterns we care about are lexical (a token in a comment, a phrase, an
+ *    overlap between a comment and the next line), so a full TS AST parse buys
+ *    accuracy we don't need and a dependency we'd have to keep current.
+ *  - ESLint rules were considered and rejected: these findings are advisory and
+ *    subjective, and wiring them into the lint gate would either block commits
+ *    on style opinions or get blanket-disabled within a week.
+ *  - The restating-the-code check is a word-overlap heuristic, not a parser. It
+ *    is deliberately tuned to under-report: a missed noise comment costs
+ *    nothing, a false positive costs trust in the whole list.
+ *
+ * Findings are grouped into three tiers, matching the comment-reaper skill:
+ *   Tier 1  mechanical, safe to strip without reading context
+ *   Tier 2  needs a human call, presented as a batch
+ *   Context density stats, to pick where to sweep next
+ *
+ * Tier 3 (never touch) is deliberately absent. Regression anchors, type-field
+ * docblocks, and SECURITY notes are judgment the script shouldn't pretend to
+ * make; the skill applies that filter when reading this output.
+ *
+ * How to read the output: every line is a CANDIDATE for human review -- DO NOT
+ * auto-delete. Comments citing an issue number inside a test file are called out
+ * separately because those are usually regression anchors, where the number is
+ * the point.
+ *
+ * Run: npm run audit:comments [-- --json] [-- --root <dir>] [-- --dir src/state]
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const argv = process.argv.slice(2);
+const argValue = (flag, fallback) => {
+  const i = argv.indexOf(flag);
+  return i !== -1 && argv[i + 1] ? argv[i + 1] : fallback;
+};
+const asJson = argv.includes('--json');
+const rootDir = path.resolve(argValue('--root', path.join(__dirname, '..')));
+const scopeDir = argValue('--dir', 'src');
+
+const SKIP_DIRS = new Set([
+  'node_modules',
+  '.next',
+  '.git',
+  'coverage',
+  'dist',
+  'build',
+  '__snapshots__',
+]);
+const EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs']);
+
+function walk(dir, out = []) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) walk(full, out);
+    } else if (EXTENSIONS.has(path.extname(entry.name))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const isTestFile = (file) => /\.(test|spec)\.[jt]sx?$/.test(file);
+
+// A comment line is a whole-line //, a block opener, or a block continuation.
+const COMMENT_LINE = /^\s*(\/\/|\/\*|\*)/;
+
+// Words that carry no signal when comparing a comment against the code below it.
+const STOPWORDS = new Set([
+  'a', 'an', 'and', 'the', 'to', 'of', 'for', 'in', 'on', 'at', 'by', 'is',
+  'are', 'be', 'it', 'its', 'this', 'that', 'these', 'those', 'we', 'if',
+  'then', 'else', 'so', 'as', 'or', 'not', 'no', 'with', 'from', 'into',
+  'each', 'all', 'any', 'new', 'via', 'per', 'up', 'out', 'do', 'does',
+]);
+
+// Split identifiers into their component words: camelCase, PascalCase,
+// snake_case, kebab-case, SCREAMING_CASE.
+function identifierWords(text) {
+  return text
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+    .split(/[^A-Za-z0-9]+/)
+    .map((w) => w.toLowerCase())
+    .filter((w) => w.length > 1 && !STOPWORDS.has(w));
+}
+
+function commentWords(text) {
+  return identifierWords(text.replace(/^\s*\/\/+/, '').replace(/[*/]/g, ' '));
+}
+
+// Singular/plural and verb-form collapse, so "Add attribute" matches
+// "addAttributes" and "Updates the world" matches "updateWorld".
+const stem = (w) => w.replace(/(ies)$/, 'y').replace(/(es|s|ed|ing)$/, '');
+const stemSet = (words) => new Set(words.map(stem));
+
+const PATTERNS = {
+  issueCitation: /#\d{3,4}\b/,
+  // Past-state phrasing only. Bare "used to" is usually present tense
+  // ("the salt used to encrypt"), so it is matched with a past-state verb.
+  archaeological:
+    /\b(extracted (?:out )?from|moved (?:out )?from|refactored out|refactored from|formerly|previously|renamed from|split out (?:of|from)|used to (?:be|live|call|gate|have|exist|return|do|get|point|sit)|(?:was|were|had) (?:previously|originally)|once (?:was|lived|called)|as of \d)\b/i,
+  // Only line comments draw banners. Block-comment continuation lines are
+  // excluded because markdown inside JSDoc ("* - **Bold**:", "* ### Heading")
+  // trips any charset loose enough to catch a real divider.
+  banner:
+    /^\s*\/\/\s*(?:[-=_~]{3,}|[-=_~]{2,}[^\n]*?[-=_~]{2,})\s*$/,
+  malformedJsdoc: /\*\/\s*\*\//,
+  // A docblock whose entire content is one line, in either form:
+  //   /** Get the thing */
+  //   /**
+  //    * Get the thing
+  //    */
+  oneLineJsdoc: /^\s*\/\*\*\s*([^*].*?)\s*\*\/\s*$/,
+  jsdocOpen: /^\s*\/\*\*\s*$/,
+  jsdocBody: /^\s*\*\s*([^*@\s].*?)\s*$/,
+  jsdocClose: /^\s*\*\/\s*$/,
+  declaration:
+    /^\s*(?:export\s+)?(?:async\s+)?(?:function|const|let|class)\s+([A-Za-z0-9_$]+)|^\s*([A-Za-z0-9_$]+)\s*[:(]/,
+  // A type or interface field: `name: Type;` with no call or arrow. Docblocks
+  // on these are the closest thing the repo has to a data-model spec and are
+  // never proposed for removal, so they are counted apart from function docs.
+  typeField: /^\s*(?:readonly\s+)?[A-Za-z0-9_$]+\??:\s*[^=(]*;\s*$/,
+};
+
+const findings = {
+  issueCitation: [],
+  issueCitationInTest: [],
+  restating: [],
+  banner: [],
+  malformedJsdoc: [],
+  redundantJsdoc: [],
+  typeFieldJsdoc: [],
+  archaeological: [],
+};
+
+const density = [];
+
+function nextCodeLine(lines, from) {
+  for (let i = from; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+    if (COMMENT_LINE.test(line)) continue;
+    return { line, index: i };
+  }
+  return null;
+}
+
+// Ratio of the comment's meaningful words that also appear in the code line.
+// maxWords caps how long a comment can be and still be judged a restatement:
+// past a handful of words a comment is usually saying something extra.
+function overlapRatio(comment, code, maxWords = 6) {
+  const cWords = commentWords(comment);
+  if (cWords.length === 0 || cWords.length > maxWords) return 0;
+  const codeWords = stemSet(identifierWords(code));
+  const hits = cWords.filter((w) => codeWords.has(stem(w))).length;
+  return hits / cWords.length;
+}
+
+function scanFile(file) {
+  const rel = path.relative(rootDir, file);
+  const source = fs.readFileSync(file, 'utf8');
+  const lines = source.split('\n');
+  const test = isTestFile(file);
+  let commentLines = 0;
+
+  lines.forEach((line, i) => {
+    const lineNo = i + 1;
+    const at = `${rel}:${lineNo}`;
+    const trimmed = line.trim();
+    const isComment = COMMENT_LINE.test(line);
+    if (isComment) commentLines += 1;
+
+    if (PATTERNS.malformedJsdoc.test(line)) {
+      findings.malformedJsdoc.push({ at, text: trimmed });
+    }
+
+    if (!isComment) return;
+
+    if (PATTERNS.issueCitation.test(line)) {
+      const entry = { at, text: trimmed };
+      if (test) findings.issueCitationInTest.push(entry);
+      else findings.issueCitation.push(entry);
+    }
+
+    if (PATTERNS.archaeological.test(line)) {
+      findings.archaeological.push({ at, text: trimmed });
+    }
+
+    if (PATTERNS.banner.test(line)) {
+      findings.banner.push({ at, text: trimmed });
+    }
+
+    // Redundant JSDoc: a docblock whose whole content is one sentence that the
+    // declaration name below it already says. Matches both the inline form and
+    // the three-line block form, which is the common one in practice.
+    let docText = null;
+    let docEnd = i;
+    const inline = line.match(PATTERNS.oneLineJsdoc);
+    if (inline) {
+      docText = inline[1];
+    } else if (PATTERNS.jsdocOpen.test(line)) {
+      const body = lines[i + 1]?.match(PATTERNS.jsdocBody);
+      if (body && PATTERNS.jsdocClose.test(lines[i + 2] ?? '')) {
+        docText = body[1];
+        docEnd = i + 2;
+      }
+    }
+    if (docText) {
+      const next = nextCodeLine(lines, docEnd + 1);
+      if (next && next.index <= docEnd + 1) {
+        const decl = next.line.match(PATTERNS.declaration);
+        const name = decl ? decl[1] || decl[2] : null;
+        if (name && overlapRatio(docText, name, 8) >= 0.6) {
+          const bucket = PATTERNS.typeField.test(next.line)
+            ? findings.typeFieldJsdoc
+            : findings.redundantJsdoc;
+          bucket.push({
+            at,
+            text: docText,
+            code: next.line.trim().slice(0, 80),
+          });
+        }
+      }
+      return;
+    }
+
+    // Restating-the-code: a short // comment whose words are all already in the
+    // identifiers on the next line of code.
+    if (!trimmed.startsWith('//')) return;
+    if (PATTERNS.issueCitation.test(line) || PATTERNS.banner.test(line)) return;
+    const next = nextCodeLine(lines, i + 1);
+    if (!next || next.index > i + 1) return;
+    // Tuned to under-report: at most four meaningful words, nearly all of which
+    // the next line already spells out. "// Add attribute" over "addAttribute:"
+    // is the shape this is looking for.
+    if (overlapRatio(trimmed, next.line, 4) >= 0.8) {
+      findings.restating.push({
+        at,
+        text: trimmed,
+        code: next.line.trim().slice(0, 80),
+      });
+    }
+  });
+
+  if (lines.length > 40) {
+    density.push({
+      file: rel,
+      commentLines,
+      total: lines.length,
+      pct: Math.round((commentLines / lines.length) * 100),
+    });
+  }
+  return commentLines;
+}
+
+function main() {
+  const scanRoot = path.join(rootDir, scopeDir);
+  if (!fs.existsSync(scanRoot)) {
+    console.error(`No such directory: ${scanRoot}`);
+    return;
+  }
+  const files = walk(scanRoot);
+  let totalComments = 0;
+  let totalLines = 0;
+  for (const file of files) {
+    totalComments += scanFile(file);
+    totalLines += fs.readFileSync(file, 'utf8').split('\n').length;
+  }
+
+  const tier1 =
+    findings.issueCitation.length +
+    findings.restating.length +
+    findings.banner.length +
+    findings.malformedJsdoc.length;
+  const tier2 =
+    findings.redundantJsdoc.length + findings.archaeological.length;
+
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        {
+          scope: scopeDir,
+          files: files.length,
+          totalLines,
+          commentLines: totalComments,
+          tier1,
+          tier2,
+          findings,
+          density: density.sort((a, b) => b.pct - a.pct).slice(0, 20),
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  const section = (title, items, render) => {
+    console.log(`\n## ${title} (${items.length})`);
+    if (items.length === 0) {
+      console.log('  none');
+      return;
+    }
+    for (const item of items.slice(0, 40)) console.log(`  ${render(item)}`);
+    if (items.length > 40) console.log(`  ... and ${items.length - 40} more`);
+  };
+
+  console.log(`Comment audit: ${scopeDir} (${files.length} files, ${totalLines} lines)`);
+  console.log(`Comment lines: ${totalComments} (${Math.round((totalComments / totalLines) * 100)}%)`);
+
+  console.log('\n==== TIER 1: mechanical, safe to strip ====');
+  section('Issue/PR citations in production code', findings.issueCitation, (f) => `${f.at}  ${f.text}`);
+  section('Restating the code', findings.restating, (f) => `${f.at}  ${f.text}\n      -> ${f.code}`);
+  section('Section-divider banners', findings.banner, (f) => `${f.at}  ${f.text}`);
+  section('Malformed comment syntax', findings.malformedJsdoc, (f) => `${f.at}  ${f.text}`);
+
+  console.log('\n==== TIER 2: needs a human call ====');
+  section('Redundant one-line JSDoc', findings.redundantJsdoc, (f) => `${f.at}  ${f.text}\n      -> ${f.code}`);
+  section('Archaeological comments', findings.archaeological, (f) => `${f.at}  ${f.text}`);
+
+  console.log('\n==== TIER 3: reported for context, do not reap ====');
+  console.log('Citations inside tests are usually regression anchors, where the number IS the');
+  console.log('information. Docblocks on type fields are the data-model spec and feed IDE hover.');
+  section('Issue/PR citations in tests', findings.issueCitationInTest, (f) => `${f.at}  ${f.text}`);
+  section('Docblocks on type fields', findings.typeFieldJsdoc, (f) => `${f.at}  ${f.text}`);
+
+  console.log('\n==== Densest files (comment % of total lines) ====');
+  for (const d of density.sort((a, b) => b.pct - a.pct).slice(0, 15)) {
+    console.log(`  ${String(d.pct).padStart(3)}%  ${String(`${d.commentLines}/${d.total}`).padStart(10)}  ${d.file}`);
+  }
+
+  console.log(`\n==== TOTAL: ${tier1} tier-1, ${tier2} tier-2, ${findings.issueCitationInTest.length} test citations ====`);
+  console.log(
+    'NOTE: every line above is a CANDIDATE. Review manually; keep any comment ' +
+      'carrying a WHY the code cannot show. DO NOT auto-delete.',
+  );
+}
+
+main();

--- a/scripts/audit-tests.mjs
+++ b/scripts/audit-tests.mjs
@@ -42,7 +42,13 @@ const argValue = (flag, fallback) => {
 };
 const asJson = argv.includes('--json');
 const rootDir = path.resolve(argValue('--root', path.join(__dirname, '..')));
-const scopeDir = argValue('--dir', 'src');
+// Every root jest.config.cjs matches, not just src. Auditing only src silently
+// skipped the seven suites under __tests__/ and scripts/, and a suite the audit
+// cannot see is one it can never report a defect in.
+const DEFAULT_SCOPE = ['src', '__tests__', 'scripts'];
+const scopeArg = argValue('--dir', null);
+const scopeDirs = scopeArg ? scopeArg.split(',') : DEFAULT_SCOPE;
+const scopeLabel = scopeDirs.join(', ');
 
 const SKIP_DIRS = new Set(['node_modules', '.next', '.git', 'coverage', 'dist', 'build']);
 const TEST_FILE = /\.(test|spec)\.[jt]sx?$/;
@@ -67,6 +73,11 @@ function walk(dir, out = []) {
 
 const CASE_OPEN =
   /^\s*(?:(x)|f)?(it|test)(\.(?:each|only|skip|todo|concurrent))?\s*(?:\([^)]*\))?\s*\(\s*(['"`])(.*?)\4/;
+// `it.each([` with the table spread over following lines puts the case name on
+// the `])(` line instead. Without this the whole parameterized case is invisible
+// to the audit, which is worse than miscounting it.
+const CASE_EACH_OPEN = /^\s*(?:(x)|f)?(it|test)(\.each)\s*\(\s*[[({]\s*$/;
+const CASE_EACH_NAME = /^\s*[\])}]+\s*\)?\s*\(\s*(['"`])(.*?)\1/;
 const DESCRIBE_OPEN = /^(\s*)(?:x|f)?describe(?:\.\w+)?\s*\(\s*(['"`])(.*?)\2/;
 const DESCRIBE_SKIP = /^\s*(?:x)?describe\s*\.\s*(skip|todo)\s*\(/;
 const ONLY = /^\s*(?:it|test|describe)\s*\.\s*only\s*\(/;
@@ -74,7 +85,15 @@ const ONLY = /^\s*(?:it|test|describe)\s*\.\s*only\s*\(/;
 // Assertion shapes.
 const EXPECT = /\bexpect\s*\(/;
 const MOCK_MATCHER = /\.(toHaveBeenCalled|toHaveBeenCalledWith|toHaveBeenCalledTimes|toHaveBeenLastCalledWith|toHaveBeenNthCalledWith)\b/;
-const MOCK_SUBJECT = /\bexpect\s*\(\s*[^)]*\b(mock[A-Za-z0-9_$]*|[A-Za-z0-9_$]*Mock|jest\.fn|\w+\.mock)\b/i;
+// A case counts as mock-only on the MATCHER alone. An earlier version also
+// required the subject to look mock-named, which made detection depend on what
+// a variable was called: `expect(notFound).toHaveBeenCalled()` slipped through
+// purely because the spy wasn't named mockSomething. A jest call matcher only
+// works on a mock or spy, so the matcher already proves the subject.
+// Any case whose every assertion is a call-check that can fail when the wiring
+// changes and never when the behavior does.
+const ASSERTION_SHAPED =
+  /\bexpect\s*\(|\bassert[A-Za-z0-9_$]*\s*\(|\b(toThrow|rejects|resolves)\b/;
 const SNAPSHOT = /\.(toMatchSnapshot|toMatchInlineSnapshot)\b/;
 const IN_DOCUMENT = /\.(toBeInTheDocument|toBeVisible)\b/;
 const DEFINED_ONLY = /expect\s*\([^)]*\)\s*\.\s*(toBeDefined|toBeTruthy)\s*\(\s*\)/;
@@ -163,10 +182,31 @@ function scanFile(file) {
     if (DESCRIBE_SKIP.test(line)) findings.skipped.push({ at, text: line.trim().slice(0, 90) });
     if (ONLY.test(line)) findings.only.push({ at, text: line.trim().slice(0, 90) });
 
-    const open = line.match(CASE_OPEN);
-    if (!open) return;
-    const modifier = open[3] || '';
-    const name = open[5];
+    let open = line.match(CASE_OPEN);
+    let bodyStart = i;
+    let name;
+    let modifier;
+    if (open) {
+      modifier = open[3] || '';
+      name = open[5];
+    } else {
+      // Multiline `it.each([`: find the `])('name'` line that closes the table.
+      const each = line.match(CASE_EACH_OPEN);
+      if (!each) return;
+      let nameLine = null;
+      for (let k = i + 1; k < lines.length && k < i + 200; k += 1) {
+        const m = lines[k].match(CASE_EACH_NAME);
+        if (m) {
+          nameLine = { index: k, name: m[2] };
+          break;
+        }
+      }
+      if (!nameLine) return;
+      open = each;
+      modifier = each[3];
+      name = nameLine.name;
+      bodyStart = nameLine.index;
+    }
     cases += 1;
     totalCases += 1;
 
@@ -185,7 +225,7 @@ function scanFile(file) {
       seenNames.set(key, at);
     }
 
-    const body = caseBody(lines, i);
+    const body = caseBody(lines, bodyStart);
     const text = body.join('\n');
     const expects = body.filter((l) => EXPECT.test(l));
     const statements = body.filter((l) => l.trim() && !l.trim().startsWith('//')).length;
@@ -193,7 +233,10 @@ function scanFile(file) {
     if (expects.length === 0) {
       // A case with no expect() at all still counts if it awaits an assertion
       // helper, so only flag when nothing assertion-shaped appears anywhere.
-      if (!/\b(expect|assert|toThrow|rejects|resolves)\b/.test(text)) {
+      // `assert\w*\(` rather than a bare `assert` token: this repo delegates to
+      // named helpers like assertChoicesVisible(), which its jest lint config
+      // already recognizes as assertions.
+      if (!ASSERTION_SHAPED.test(text)) {
         findings.noAssertion.push({ at, name, statements });
       }
       return;
@@ -211,9 +254,7 @@ function scanFile(file) {
     // Mock-only: every assertion is a call-check, or targets a mock and checks
     // nothing but call-ness. These can fail when wiring changes, never when
     // behavior does.
-    const allMockMatchers = expects.every((l) => MOCK_MATCHER.test(l));
-    const allMockSubjects = expects.every((l) => MOCK_SUBJECT.test(l));
-    if (allMockMatchers && allMockSubjects) {
+    if (expects.every((l) => MOCK_MATCHER.test(l))) {
       const entry = { at, name, assertions: expects.length };
       findings.mockOnly.push(entry);
       if (PROMISE_WORDS.test(name) || PROMISE_WORDS.test(rel)) {
@@ -234,12 +275,19 @@ function scanFile(file) {
 }
 
 function main() {
-  const scanRoot = path.join(rootDir, scopeDir);
-  if (!fs.existsSync(scanRoot)) {
-    console.error(`No such directory: ${scanRoot}`);
-    return;
+  const roots = scopeDirs
+    .map((d) => path.join(rootDir, d))
+    .filter((full) => {
+      // A missing root is only an error when the user named it explicitly; the
+      // defaults are the union of jest's roots and not every repo has all three.
+      if (fs.existsSync(full)) return true;
+      if (scopeArg) console.error(`No such directory: ${full}`);
+      return false;
+    });
+  if (roots.length === 0) return;
+  for (const root of roots) {
+    for (const file of walk(root)) scanFile(file);
   }
-  for (const file of walk(scanRoot)) scanFile(file);
 
   const mocks = globalMocks();
 
@@ -261,7 +309,7 @@ function main() {
   if (asJson) {
     console.log(
       JSON.stringify(
-        { scope: scopeDir, totalFiles, totalCases, globalMocks: mocks, findings, renderHeavy },
+        { scope: scopeLabel, totalFiles, totalCases, globalMocks: mocks, findings, renderHeavy },
         null,
         2,
       ),
@@ -279,7 +327,7 @@ function main() {
     if (items.length > 30) console.log(`  ... and ${items.length - 30} more`);
   };
 
-  console.log(`Test audit: ${scopeDir} (${totalFiles} files, ${totalCases} cases)`);
+  console.log(`Test audit: ${scopeLabel} (${totalFiles} files, ${totalCases} cases)`);
   if (mocks.length) {
     console.log(`\nGLOBAL MOCKS in jest.setup - suites touching these may have no`);
     console.log(`non-mock observation available. Judge their tests accordingly:`);

--- a/scripts/audit-tests.mjs
+++ b/scripts/audit-tests.mjs
@@ -1,0 +1,318 @@
+/**
+ * Test audit.
+ *
+ * Lists tests that pass no matter what the code does: duplicates, cases whose
+ * every assertion is a mock call-check, single-assertion render checks, and
+ * suites whose name promises behavior the body never observes. It is an AUDIT,
+ * not a fix: it writes nothing, deletes nothing, and never fails CI (exit 0).
+ *
+ * Why this approach (chosen over alternatives):
+ *  - Coverage tooling answers "was this line executed", which is the wrong
+ *    question. A mock-only test executes plenty of lines and asserts nothing
+ *    about them. This scans assertion SHAPE instead, which is what decides
+ *    whether a test can fail for a real reason.
+ *  - Mutation testing (stryker, already configured here for a few directories)
+ *    answers the question properly but takes far too long to run as a sweep.
+ *    Treat this audit as the cheap filter that says where to point it.
+ *  - A brace-counting block scanner is used rather than a TS AST parse. Test
+ *    files are formatted regularly enough that it holds, and it keeps the
+ *    script dependency-free.
+ *
+ * IMPORTANT CAVEAT the output repeats: a global jest.mock() in the setup file
+ * means whole suites run against auto-mocks, and a mock assertion may be the
+ * only observation available to them. Check the setup file before judging any
+ * case this flags. The script reports which modules are globally mocked.
+ *
+ * How to read the output: every case listed is a CANDIDATE for human review --
+ * DO NOT auto-delete. Mock-only cases especially: they usually mark a coverage
+ * gap that wants a rewrite, not a deletion.
+ *
+ * Run: npm run audit:tests [-- --json] [-- --root <dir>] [-- --dir src/state]
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const argv = process.argv.slice(2);
+const argValue = (flag, fallback) => {
+  const i = argv.indexOf(flag);
+  return i !== -1 && argv[i + 1] ? argv[i + 1] : fallback;
+};
+const asJson = argv.includes('--json');
+const rootDir = path.resolve(argValue('--root', path.join(__dirname, '..')));
+const scopeDir = argValue('--dir', 'src');
+
+const SKIP_DIRS = new Set(['node_modules', '.next', '.git', 'coverage', 'dist', 'build']);
+const TEST_FILE = /\.(test|spec)\.[jt]sx?$/;
+
+function walk(dir, out = []) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) walk(full, out);
+    } else if (TEST_FILE.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const CASE_OPEN =
+  /^\s*(?:(x)|f)?(it|test)(\.(?:each|only|skip|todo|concurrent))?\s*(?:\([^)]*\))?\s*\(\s*(['"`])(.*?)\4/;
+const DESCRIBE_OPEN = /^(\s*)(?:x|f)?describe(?:\.\w+)?\s*\(\s*(['"`])(.*?)\2/;
+const DESCRIBE_SKIP = /^\s*(?:x)?describe\s*\.\s*(skip|todo)\s*\(/;
+const ONLY = /^\s*(?:it|test|describe)\s*\.\s*only\s*\(/;
+
+// Assertion shapes.
+const EXPECT = /\bexpect\s*\(/;
+const MOCK_MATCHER = /\.(toHaveBeenCalled|toHaveBeenCalledWith|toHaveBeenCalledTimes|toHaveBeenLastCalledWith|toHaveBeenNthCalledWith)\b/;
+const MOCK_SUBJECT = /\bexpect\s*\(\s*[^)]*\b(mock[A-Za-z0-9_$]*|[A-Za-z0-9_$]*Mock|jest\.fn|\w+\.mock)\b/i;
+const SNAPSHOT = /\.(toMatchSnapshot|toMatchInlineSnapshot)\b/;
+const IN_DOCUMENT = /\.(toBeInTheDocument|toBeVisible)\b/;
+const DEFINED_ONLY = /expect\s*\([^)]*\)\s*\.\s*(toBeDefined|toBeTruthy)\s*\(\s*\)/;
+const RENDER = /\brender\s*\(/;
+
+// Names that promise more than a mock assertion can deliver.
+const PROMISE_WORDS =
+  /\b(persist|persists|persisted|persistence|save|saves|saved|store[sd]?|restore[sd]?|load[sd]?|integrat|sync|write[sn]?|read[sn]?|hydrat)/i;
+
+const findings = {
+  duplicateNames: [],
+  skipped: [],
+  only: [],
+  snapshotOnly: [],
+  definedOnly: [],
+  mockOnly: [],
+  mockOnlyNameMismatch: [],
+  singleRenderAssertion: [],
+  noAssertion: [],
+};
+
+let totalCases = 0;
+let totalFiles = 0;
+const fileStats = [];
+
+// Walk forward from a case's opening line, tracking brace depth, and return
+// every line in its body. Brace counting ignores braces inside strings, which
+// is the only place it would otherwise drift.
+function caseBody(lines, start) {
+  let depth = 0;
+  let started = false;
+  const body = [];
+  for (let i = start; i < lines.length && i < start + 400; i += 1) {
+    const line = lines[i];
+    const stripped = line
+      .replace(/\\./g, '')
+      .replace(/'[^']*'/g, "''")
+      .replace(/"[^"]*"/g, '""')
+      .replace(/`[^`]*`/g, '``');
+    for (const ch of stripped) {
+      if (ch === '{') {
+        depth += 1;
+        started = true;
+      } else if (ch === '}') depth -= 1;
+    }
+    if (i > start) body.push(line);
+    if (started && depth <= 0) break;
+  }
+  return body;
+}
+
+function globalMocks() {
+  const out = [];
+  for (const candidate of ['jest.setup.ts', 'jest.setup.js', 'jest.setup.tsx']) {
+    const full = path.join(rootDir, candidate);
+    if (!fs.existsSync(full)) continue;
+    const text = fs.readFileSync(full, 'utf8');
+    for (const m of text.matchAll(/jest\.mock\(\s*['"`]([^'"`]+)/g)) out.push(m[1]);
+  }
+  return out;
+}
+
+function scanFile(file) {
+  const rel = path.relative(rootDir, file);
+  const lines = fs.readFileSync(file, 'utf8').split('\n');
+  const seenNames = new Map();
+  let cases = 0;
+  // Duplicate names only matter within one describe block: jest's reported name
+  // is the full describe > it path, so the same `it` text under two different
+  // describes is unique and usually deliberate.
+  const describeStack = [];
+
+  lines.forEach((line, i) => {
+    const lineNo = i + 1;
+    const at = `${rel}:${lineNo}`;
+
+    const describe = line.match(DESCRIBE_OPEN);
+    if (describe) {
+      const indent = describe[1].length;
+      while (describeStack.length && describeStack[describeStack.length - 1].indent >= indent) {
+        describeStack.pop();
+      }
+      describeStack.push({ indent, name: describe[3] });
+    }
+
+    if (DESCRIBE_SKIP.test(line)) findings.skipped.push({ at, text: line.trim().slice(0, 90) });
+    if (ONLY.test(line)) findings.only.push({ at, text: line.trim().slice(0, 90) });
+
+    const open = line.match(CASE_OPEN);
+    if (!open) return;
+    const modifier = open[3] || '';
+    const name = open[5];
+    cases += 1;
+    totalCases += 1;
+
+    if (open[1] || /skip|todo/.test(modifier)) {
+      findings.skipped.push({ at, name });
+      return;
+    }
+    if (/only/.test(modifier)) findings.only.push({ at, name });
+
+    // Duplicate names inside a single describe block.
+    const scope = describeStack.map((d) => d.name).join(' > ');
+    const key = `${scope} > ${name}`;
+    if (seenNames.has(key)) {
+      findings.duplicateNames.push({ at, name, scope, first: seenNames.get(key) });
+    } else {
+      seenNames.set(key, at);
+    }
+
+    const body = caseBody(lines, i);
+    const text = body.join('\n');
+    const expects = body.filter((l) => EXPECT.test(l));
+    const statements = body.filter((l) => l.trim() && !l.trim().startsWith('//')).length;
+
+    if (expects.length === 0) {
+      // A case with no expect() at all still counts if it awaits an assertion
+      // helper, so only flag when nothing assertion-shaped appears anywhere.
+      if (!/\b(expect|assert|toThrow|rejects|resolves)\b/.test(text)) {
+        findings.noAssertion.push({ at, name, statements });
+      }
+      return;
+    }
+
+    if (expects.every((l) => SNAPSHOT.test(l))) {
+      findings.snapshotOnly.push({ at, name });
+      return;
+    }
+    if (expects.every((l) => DEFINED_ONLY.test(l))) {
+      findings.definedOnly.push({ at, name });
+      return;
+    }
+
+    // Mock-only: every assertion is a call-check, or targets a mock and checks
+    // nothing but call-ness. These can fail when wiring changes, never when
+    // behavior does.
+    const allMockMatchers = expects.every((l) => MOCK_MATCHER.test(l));
+    const allMockSubjects = expects.every((l) => MOCK_SUBJECT.test(l));
+    if (allMockMatchers && allMockSubjects) {
+      const entry = { at, name, assertions: expects.length };
+      findings.mockOnly.push(entry);
+      if (PROMISE_WORDS.test(name) || PROMISE_WORDS.test(rel)) {
+        findings.mockOnlyNameMismatch.push(entry);
+      }
+      return;
+    }
+
+    // A render plus one presence assertion. Fine alone, a smell in bulk, so the
+    // per-file rollup below is what actually matters.
+    if (expects.length === 1 && IN_DOCUMENT.test(expects[0]) && RENDER.test(text) && statements <= 4) {
+      findings.singleRenderAssertion.push({ at, name });
+    }
+  });
+
+  totalFiles += 1;
+  fileStats.push({ file: rel, cases });
+}
+
+function main() {
+  const scanRoot = path.join(rootDir, scopeDir);
+  if (!fs.existsSync(scanRoot)) {
+    console.error(`No such directory: ${scanRoot}`);
+    return;
+  }
+  for (const file of walk(scanRoot)) scanFile(file);
+
+  const mocks = globalMocks();
+
+  // Roll single-assertion render checks up per file: one is fine, a file made
+  // of them is the finding.
+  const renderByFile = {};
+  for (const f of findings.singleRenderAssertion) {
+    const file = f.at.split(':')[0];
+    renderByFile[file] = (renderByFile[file] || 0) + 1;
+  }
+  const renderHeavy = Object.entries(renderByFile)
+    .map(([file, count]) => {
+      const stat = fileStats.find((s) => s.file === file);
+      return { file, count, cases: stat ? stat.cases : count };
+    })
+    .filter((f) => f.count >= 3 && f.count / f.cases >= 0.5)
+    .sort((a, b) => b.count - a.count);
+
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        { scope: scopeDir, totalFiles, totalCases, globalMocks: mocks, findings, renderHeavy },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  const section = (title, items, render) => {
+    console.log(`\n## ${title} (${items.length})`);
+    if (items.length === 0) {
+      console.log('  none');
+      return;
+    }
+    for (const item of items.slice(0, 30)) console.log(`  ${render(item)}`);
+    if (items.length > 30) console.log(`  ... and ${items.length - 30} more`);
+  };
+
+  console.log(`Test audit: ${scopeDir} (${totalFiles} files, ${totalCases} cases)`);
+  if (mocks.length) {
+    console.log(`\nGLOBAL MOCKS in jest.setup - suites touching these may have no`);
+    console.log(`non-mock observation available. Judge their tests accordingly:`);
+    for (const m of mocks) console.log(`  ${m}`);
+  }
+
+  console.log('\n==== TIER 1: mechanical ====');
+  section("Duplicate test names in one describe block", findings.duplicateNames, (f) => `${f.at}  "${f.name}"  in [${f.scope}]  (first at ${f.first})`);
+  section('Leaked .only - silently skips the rest of the file', findings.only, (f) => `${f.at}  ${f.name || f.text}`);
+  section('Skipped / todo cases', findings.skipped, (f) => `${f.at}  ${f.name || f.text}`);
+  section('Snapshot-only cases', findings.snapshotOnly, (f) => `${f.at}  "${f.name}"`);
+  section('Existence-only cases (toBeDefined / toBeTruthy)', findings.definedOnly, (f) => `${f.at}  "${f.name}"`);
+  section('Cases with no assertion at all', findings.noAssertion, (f) => `${f.at}  "${f.name}"`);
+
+  console.log('\n==== TIER 2: needs a human call - rewrite or delete ====');
+  console.log('Name promises behavior the body never observes. Strongest signal here:');
+  section('Mock-only, and the name claims real behavior', findings.mockOnlyNameMismatch, (f) => `${f.at}  "${f.name}"  (${f.assertions} assertions, all call-checks)`);
+  section('Mock-only cases (all assertions are call-checks)', findings.mockOnly, (f) => `${f.at}  "${f.name}"  (${f.assertions})`);
+  section('Files that are mostly single-assertion render checks', renderHeavy, (f) => `${f.file}  ${f.count}/${f.cases} cases`);
+
+  const tier1 =
+    findings.duplicateNames.length +
+    findings.only.length +
+    findings.skipped.length +
+    findings.snapshotOnly.length +
+    findings.definedOnly.length +
+    findings.noAssertion.length;
+
+  console.log(`\n==== TOTAL: ${tier1} tier-1, ${findings.mockOnly.length} mock-only (${findings.mockOnlyNameMismatch.length} with a mismatched name), ${findings.singleRenderAssertion.length} single-assertion render checks ====`);
+  console.log(
+    'NOTE: every case above is a CANDIDATE. Mock-only cases usually mark a ' +
+      'coverage gap that wants a REWRITE, not a deletion. DO NOT auto-delete.',
+  );
+}
+
+main();

--- a/src/state/worldStore.ts
+++ b/src/state/worldStore.ts
@@ -266,7 +266,6 @@ export const useWorldStore = create<WorldStore>()(
         deleteWorld: (id) => get().delete(id),
         setCurrentWorld: (id) => get().setCurrent(id),
 
-        // Add attribute
         addAttribute: (worldId, attributeData) => {
           const world = get().worlds[worldId];
           if (!world) {
@@ -294,7 +293,6 @@ export const useWorldStore = create<WorldStore>()(
           });
         },
 
-        // Update attribute
         updateAttribute: (worldId, attributeId, updates) => {
           const world = get().worlds[worldId];
           if (!world) {
@@ -312,7 +310,6 @@ export const useWorldStore = create<WorldStore>()(
           });
         },
 
-        // Remove attribute
         removeAttribute: (worldId, attributeId) => {
           const world = get().worlds[worldId];
           if (!world) {
@@ -330,7 +327,6 @@ export const useWorldStore = create<WorldStore>()(
           });
         },
 
-        // Add skill
         addSkill: (worldId, skillData) => {
           const world = get().worlds[worldId];
           if (!world) {
@@ -358,7 +354,6 @@ export const useWorldStore = create<WorldStore>()(
           });
         },
 
-        // Update skill
         updateSkill: (worldId, skillId, updates) => {
           const world = get().worlds[worldId];
           if (!world) {
@@ -376,7 +371,6 @@ export const useWorldStore = create<WorldStore>()(
           });
         },
 
-        // Remove skill
         removeSkill: (worldId, skillId) => {
           const world = get().worlds[worldId];
           if (!world) {
@@ -394,7 +388,6 @@ export const useWorldStore = create<WorldStore>()(
           });
         },
 
-        // Update settings
         updateSettings: (worldId, settings) => {
           const world = get().worlds[worldId];
           if (!world) {
@@ -411,7 +404,6 @@ export const useWorldStore = create<WorldStore>()(
           });
         },
 
-        // Update tone settings
         updateToneSettings: (worldId, toneSettings) => {
           const world = get().worlds[worldId];
           if (!world) {


### PR DESCRIPTION
## Description

Adds `npm run audit:comments` and `npm run audit:tests`, the detection half of the new `comment-reaper` and `test-reaper` skills, plus the first reap as a dogfood.

The reason these exist rather than an extension to `dead-code-cleanup` or `doc-rot`: those skills key off markers this repo has already cleared. Run their criteria against `src/` and you get zero snapshot tests, zero `.skip`, zero orphaned test files, zero commented-out code, and one untracked TODO. The sweep finds nothing and stops.

What is actually here is a different kind of debt. Comments that are accurate and still worthless, and tests that pass no matter what the code does:

| Finding | Count |
|---|---|
| Issue/PR-number citations in comments | 214 (139 prod, 75 test) |
| Comments restating the line below them | 198 |
| Redundant one-line docblocks | 112 |
| Archaeological comments | 16 |
| Section-divider banners | 14 |
| Tests whose every assertion is a mock call-check | 274 (31 with a name promising more) |
| Files that are mostly single-assertion render checks | 44 |
| Cases asserting only `toBeDefined`/`toBeTruthy` | 2 |
| Duplicate test names within one describe block | 0 |

Both scripts follow `audit-css.mjs`: no new dependencies, write nothing, delete nothing, always exit 0. Output is grouped into the tiers the skills act on, so tier 1 can be applied mechanically and the rest gets read first.

Neither script is a parser, deliberately. The restating check compares a comment's words against the identifiers on the next line. The mock-only check looks at assertion shape rather than coverage, because "was this line executed" is the wrong question: a mock-only test executes plenty and asserts nothing about any of it. Both are tuned to under-report. A missed noise comment costs nothing; a false positive costs trust in the whole list.

## Related Issue

None. This came out of a request to build the two routines rather than from a filed issue.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Not TDD, and marking that honestly. These are advisory audit scripts whose correctness question is "does this finding hold up when you read the source", which is answered by sampling real output, not by unit tests. That sampling is in the Testing Instructions below and it did find three defects. The `worldStore` change is comment deletion with no behavior to test.

## User Stories Addressed

None directly. This serves the comment hygiene rules in `CLAUDE.md`, which flag issue-number citations as the most-violated item and had nothing looking for them.

## Flow Diagrams

N/A.

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A, no UI in this PR.

## Implementation Notes

Findings sort into three tiers, and tier 3 (never touch) is the load-bearing one:

- A regression test's `#1206` is the reason the test looks strange. Strip the number and the next person deletes the test. Citations inside test files are reported in their own section for exactly this reason.
- The field-level docblocks in `src/types/*.types.ts` are the closest thing the repo has to a data-model spec, and IDE hover reads them. `typeFieldJsdoc` buckets separately from `redundantJsdoc` so a sweep cannot mix them up.
- Mock-only tests are flagged "rewrite or delete, you pick" and never auto-deleted. They mark a coverage gap, and deleting one hides the gap instead of closing it.

One repo-specific trap the test skill calls out: `jest.setup.ts` applies a global `jest.mock('@/state/worldStore')`. Any store test runs against an auto-mock suite-wide, so a mock assertion is sometimes the only observation available. Do not judge one without accounting for that.

Calibration was done by sampling, and it moved real numbers. Three shapes were misfiring, all the same mistake of reading a present-tense phrase as history:

- Group headers. `// Sci-fi` over four `scifi-*` preset entries labels the run rather than restating one line. A comment that also matches the line after next is now treated as a group header. Restating went 229 to 198.
- Adjectival "previously". In "any previously encrypted data", previously describes the data, not the code's history. An article in front is the tell.
- Bare "extracted from". "JSON is extracted from the response" describes what the code does. Now requires was/were/been in front, which still catches "Persistence was extracted from the provider".

Redundant JSDoc stayed at 112. Fourteen spread across the list were checked and every one was genuine.

Codex review found four blind spots in `audit-tests.mjs`, all verified against the source before fixing and all real (`6e0dad9b`). Two were coverage holes: the audit only scanned `src`, missing the seven suites under `__tests__/` and `scripts/` that `jest.config.cjs` also matches, and multiline `it.each([` declarations were invisible because the case name sits on the `])(` line. Two were detection defects: a bare `assert` token did not match named helpers like `assertChoicesVisible()`, and mock-only detection required the subject to *look* mock-named, so `expect(notFound).toHaveBeenCalled()` slipped through purely on naming. A jest call matcher only works on a mock or spy, so the matcher already proves the subject.

Net effect: case count 2482 to 2580, mock-only 173 to 274, and `noAssertion` 3 to 0 because all three were false positives. Duplicate names are 0 and always were; the earlier "3" in this description was the tier-1 total, which those three false positives made up. Duplicates are scoped per describe block on purpose, since jest reports the full `describe > it` path and the same `it` text under two different describes is unique.

The two scripts are 370 and 318 lines, over the checklist's 300-line limit, so that box is unchecked. `scripts/` already holds four larger files (`github.js` at 572, `generate-homepage-showcase.mjs` at 561), so the limit does not appear to apply to this directory in practice. Splitting either script would separate the pattern definitions from the single pass that uses them for no real gain.

Companion skills live in the marketplace repo (`jerseycheese/agent-skills`, commit `e36a0ed`), along with two report-only weekly sweeps under `~/.claude/scheduled-tasks/`. Nothing in this PR depends on them; the scripts stand alone.

## Screenshots

N/A.

## Visual Baseline Changes

None. This PR does not touch `tests/visual/**-snapshots/**`.

## Code Review Summary (if applicable)

N/A.

## Chrome DevTools MCP Verification Summary (if applicable)

N/A.

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit not run; no dependencies were added or changed. The scripts use `console.log` as their entire output mechanism, which is what `audit-css.mjs` does and why `scripts/**` carries its own eslint config.

## Testing Instructions

Three stages.

1. The scripts run clean and report zero for the markers this repo has genuinely cleared:

```bash
npm run audit:comments
npm run audit:tests
```

Expect exit 0 from both. `audit:tests` should report 0 snapshot tests, 0 skipped, 0 `.only`, and 0 orphans. Those zeroes are the regression guard: if a future edit makes the taxonomy drift back to generic advice, they stop being zero.

2. Spot-check that the findings hold up. Pick any entry from the restating section and read the source. `src/state/worldStore.ts` is the worked example: eight comments that named the function directly below them (`// Add attribute` over `addAttribute`) and are removed in this PR.

3. Full gate:

```bash
npm test && npm run type-check && npm run lint
```

Last run: 393 suites and 2681 tests passed, `tsc` exit 0, lint 0 errors with 143 pre-existing `any` warnings.

## Checklist

- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

File size limits: see Implementation Notes. Accessibility is N/A here, no UI.
