### PR TITLE
Answer the accounts question with ADR-014, and give ADR-002 the trigger it lacked

### DIFF
--- a/public_docs/architecture/ADR-002-client-side-only-architecture.md
+++ b/public_docs/architecture/ADR-002-client-side-only-architecture.md
@@ -13,6 +13,12 @@ updated: 2026-05-22
 > Backfilled 2026-05-22. Retroactive record of an inception-era decision, reconstructed from the
 > codebase and git history.
 
+> **Note (2026-08-15):** Everything below still stands. What it was missing was a reopen condition,
+> since "an accepted trade-off for now" never said for how long.
+> [ADR-014](ADR-014-browser-local-until-named-trigger.md) names the three things that would reopen
+> this decision, and until one of them happens, accounts and server persistence stay off the
+> roadmap.
+
 ## The Situation
 
 Narraitor is a single-player tool built primarily for personal use. There's no multi-user

--- a/public_docs/architecture/ADR-014-browser-local-until-named-trigger.md
+++ b/public_docs/architecture/ADR-014-browser-local-until-named-trigger.md
@@ -27,7 +27,7 @@ Narraitor stays browser-local. ADR-002 is unchanged and still governs.
 Three conditions reopen it, and any one is enough:
 
 1. **Storage loss stops being hypothetical.** More than one recorded case of a lost world, character, or session from a cleared browser profile or from IndexedDB eviction. The ADR-002 downside actually biting is the strongest argument for sync there is, and it's observable rather than speculative.
-2. **A paying player asks to play on a second device.** This needs a paid product to exist first, so it depends on how #495 resolves.
+2. **A paying player asks for automatic cross-device sync.** Playing on a second device already works through the export and import controls in Settings, so what fires this trigger is the automatic version rather than the capability. It also needs a paid product to exist first, so it depends on how #495 resolves.
 3. **Shared worlds come back as a product goal.** One player hands a world to another to play in. That was #1370's territory, and closing it retired the goal, so reviving it has to be a deliberate act.
 
 Until one fires, accounts and server persistence are off the roadmap. No issue may assume them.
@@ -50,7 +50,7 @@ What's left is a cost comparison that isn't close. Staying browser-local costs n
 
 ### Upsides
 
-ADR-002's privacy story holds. Player data never reaches a server, the routes under `src/app/api/` stay stateless proxies, and the key stays out of server storage.
+ADR-002's privacy story holds. There is no server-side copy of a player's games and no server-side copy of the key. Both do travel through the routes under `src/app/api/`, since a turn's prompt carries world and character context and the key is what reaches the provider, but those routes stay stateless proxies and write nothing down. That is the claim worth making, and it's the one README already makes.
 
 Feature scoping gets a rule it can apply. If a proposal needs server state, the answer is a named trigger that hasn't fired yet. That check is quick, and it doesn't reopen the argument every time.
 
@@ -58,7 +58,7 @@ Feature scoping gets a rule it can apply. If a proposal needs server state, the 
 
 ### Downsides
 
-Cross-device play still doesn't exist. Starting a session on a laptop and continuing it on a phone isn't possible, and this decision doesn't move that any closer.
+Automatic cross-device sync still doesn't exist. Starting a session on a laptop and continuing it on a phone means exporting a JSON file from Settings and importing it on the other side, which works but is entirely manual, and this decision doesn't move it any closer.
 
 Losing the browser profile still loses the saves. The storage-resilience work lowers the odds without removing the failure mode, and trigger 1 exists precisely because that risk is accepted rather than solved.
 

--- a/public_docs/architecture/ADR-014-browser-local-until-named-trigger.md
+++ b/public_docs/architecture/ADR-014-browser-local-until-named-trigger.md
@@ -1,0 +1,81 @@
+---
+title: "ADR-014: Narraitor stays browser-local until a named trigger fires"
+tags: [architecture, decision, adr, persistence, accounts, roadmap]
+created: 2026-08-15
+updated: 2026-08-15
+---
+
+# ADR-014: Narraitor stays browser-local until a named trigger fires
+
+**Status**: Accepted
+**Date**: 2026-08-15
+
+Extends [ADR-002](ADR-002-client-side-only-architecture.md) rather than superseding it. ADR-002's decision stands exactly as written: no user accounts, no application database, all player data in the browser. What this adds is the reopen condition ADR-002 left blank.
+
+## The Situation
+
+ADR-002 accepted a real trade-off back in 2025-04-28. Data lives in one browser profile, so there's no cross-device sync and no cloud backup. It called that "an accepted trade-off for now," and said anything genuinely multi-user "would require revisiting this from the ground up." Both are fair. Neither says what would cause the revisit.
+
+That blank turned into drift. Two epics parked themselves behind a prerequisite with no scope, no issue, and no owner. #1370 (multiplayer and shared worlds) sat from the 2026-06-04 backlog reorg until it was closed on 2026-08-10. #495 (commercialization) still assumes a hosted service with subscription billing. Neither was ever scheduled and neither was ever ruled out, so both kept their place in the backlog on the strength of a question nobody had answered.
+
+#1744 was filed to force that answer, on the argument that any answer beats the limbo. It's right about the limbo and wrong on one detail: it says nobody ever made the decision, but ADR-002 made it. The decision just had no expiry condition attached, which is why it kept feeling open.
+
+## What We Decided
+
+Narraitor stays browser-local. ADR-002 is unchanged and still governs.
+
+Three conditions reopen it, and any one is enough:
+
+1. **Storage loss stops being hypothetical.** More than one recorded case of a lost world, character, or session from a cleared browser profile or from IndexedDB eviction. The ADR-002 downside actually biting is the strongest argument for sync there is, and it's observable rather than speculative.
+2. **A paying player asks to play on a second device.** This needs a paid product to exist first, so it depends on how #495 resolves.
+3. **Shared worlds come back as a product goal.** One player hands a world to another to play in. That was #1370's territory, and closing it retired the goal, so reviving it has to be a deliberate act.
+
+Until one fires, accounts and server persistence are off the roadmap. No issue may assume them.
+
+## Why This Made Sense
+
+The usual reason to build accounts is billing, and bring-your-own-key removes it. The player configures a provider and supplies the key, so the provider bills the player direct. Narraitor pays nothing per turn. There's no per-user cost to recover and no usage worth metering, which is the exact pressure that pushes most apps toward accounts whether they want them or not.
+
+The multiplayer reason is gone too. #1370 closed on 2026-08-10, and with it the one goal in the backlog that genuinely could not work without shared server state.
+
+What's left is a cost comparison that isn't close. Staying browser-local costs nothing new. Building accounts costs an auth surface, a data model, a migration path off IndexedDB, conflict resolution, and a retention policy, each carrying permanent operational and privacy weight, for a product where one person owns the data and sits at one browser.
+
+### What Else We Considered
+
+- **Build accounts and server persistence now.** Rejected: no driver survives inspection. The epic that needed shared state is closed, and BYOK means there's nothing to bill for.
+- **Say never, and close the question permanently.** Tempting, and cheaper to reason about than a conditional. Rejected because the ADR-002 downside is real: browser profiles do get cleared and IndexedDB does get evicted. A permanent no would have to be walked back in public the first time that cost somebody their saves, and the stronger claim buys nothing over a conditional one.
+- **Leave ADR-002 alone and close #1744 as already answered.** Rejected. "For now" with no condition attached is what produced the drift, and closing the issue without filling that gap would just produce it again.
+
+## What This Means Going Forward
+
+### Upsides
+
+ADR-002's privacy story holds. Player data never reaches a server, the routes under `src/app/api/` stay stateless proxies, and the key stays out of server storage.
+
+Feature scoping gets a rule it can apply. If a proposal needs server state, the answer is a named trigger that hasn't fired yet. That check is quick, and it doesn't reopen the argument every time.
+
+#495 can be scoped against the product that exists rather than a foundation that isn't coming.
+
+### Downsides
+
+Cross-device play still doesn't exist. Starting a session on a laptop and continuing it on a phone isn't possible, and this decision doesn't move that any closer.
+
+Losing the browser profile still loses the saves. The storage-resilience work lowers the odds without removing the failure mode, and trigger 1 exists precisely because that risk is accepted rather than solved.
+
+## Implementation Notes
+
+No code changes. This is a scoping decision.
+
+Backlog follow-through:
+
+- **#1370** - closed 2026-08-10. Nothing to do.
+- **#495** - needs rescoping, and that rescope is its own call. Its checklist assumes a hosted subscription: choose a payment provider, implement a payment flow, manage subscriptions, track conversion. A browser-local BYOK app has no per-user cost to recover, so a recurring subscription is a hard sell. The launch-prep half of that epic applies either way, since a landing page, user documentation, terms of service, a privacy policy, and a feedback route are all things a browser-local product still needs.
+- **#1744** - closes once #495 has been updated to match.
+
+For whoever reopens this later: reopening means a new ADR that supersedes ADR-002, not an edit to ADR-002 in place. Name which trigger fired and what it was observed as.
+
+## Related Decisions
+
+- [ADR-002: Client-side-only architecture](ADR-002-client-side-only-architecture.md) - the decision this extends.
+- [ADR-004: IndexedDB persistence](ADR-004-indexeddb-persistence.md) - the storage layer, and where the per-browser-profile trade-off is documented.
+- [ADR-006: Gemini behind server-side API routes](ADR-006-gemini-server-side-api.md) - why a thin server exists at all.

--- a/public_docs/architecture/architecture-decisions.md
+++ b/public_docs/architecture/architecture-decisions.md
@@ -29,6 +29,7 @@ codebase and git history); 009 onward were written as the decisions were made.
 - [ADR-011: Three design systems (DS1/DS2/DS3)](ADR-011-three-design-systems.md) — structural differentiation across themes (**superseded by ADR-013**)
 - [ADR-012: Storybook as the single canon surface](ADR-012-storybook-single-canon-surface.md) — retires the `/dev/design-system*` showcase routes
 - [ADR-013: Collapse to a single design system (DS3)](ADR-013-collapse-to-single-design-system-ds3.md) — greenfield collapse back to one system
+- [ADR-014: Browser-local until a named trigger](ADR-014-browser-local-until-named-trigger.md) — extends ADR-002 with the conditions that would reopen it
 
 ## Frontend Architecture
 


### PR DESCRIPTION
## Description

#1744 asked for a decision on whether Narraitor ever gets user accounts and server-side storage, on the grounds that two epics were parked behind a question nobody had answered. The question turned out to be half-answered already: [ADR-002](../public_docs/architecture/ADR-002-client-side-only-architecture.md) decided client-side-only back in 2025-04-28 and is still Accepted.

What ADR-002 was actually missing is a reopen condition. It calls the no-sync trade-off "an accepted trade-off for now" and says multi-user work "would require revisiting this from the ground up," without ever saying what would cause the revisit. That blank is what produced the drift, so ADR-014 fills it rather than re-deciding anything.

The decision: Narraitor stays browser-local, ADR-002 unchanged, and three named conditions reopen it. Recorded storage loss happening more than once, a paying player asking to play on a second device, or shared worlds returning as a product goal. Until one fires, accounts and server persistence are off the roadmap.

Two things made this straightforward. Bring-your-own-key removes the usual driver, since the provider bills the player direct and there is no per-user cost to recover or usage worth metering. And #1370 closed on 2026-08-10, which took the multiplayer driver with it.

"Never, permanently" was on the table and lost to the conditional. Browser profiles do get cleared and IndexedDB does get evicted, so a permanent no would have to be walked back in public the first time that cost somebody their saves, and the stronger claim buys nothing.

## Related Issue

Closes #1744

Note that the base branch here is `develop`, not the repo default, so GitHub will not fire the keyword automatically. #1744 needs a manual close after merge.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

N/A. No code changes, so there is nothing to test. The three files are markdown under `public_docs/architecture/`.

- [ ] Tests written before implementation
- [ ] All new code is tested
- [ ] All tests pass locally
- [ ] Test coverage maintained or improved

## User Stories Addressed

From #1744:

- Write the decision as an ADR, picking one of three: build accounts and server persistence; stay browser-local permanently; or defer until a specific named trigger fires. Picked the third.
- Update #495 to match the outcome, or close it. See Implementation Notes.
- Update #1370 to match the outcome, or close it. Already closed 2026-08-10, no action needed.
- If the answer is "build it", break the foundation into real stories. Not applicable, the answer was not "build it".

## Flow Diagrams

N/A.

## Component Development

N/A, no UI.

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes

Three files:

| File | Change |
|---|---|
| `public_docs/architecture/ADR-014-browser-local-until-named-trigger.md` | New. The decision, its three triggers, and the rejected alternatives. |
| `public_docs/architecture/ADR-002-client-side-only-architecture.md` | Dated note pointing at ADR-014, following the same pattern ADR-011 uses for its notes. Nothing else in the document changes. |
| `public_docs/architecture/architecture-decisions.md` | Index entry. |

ADR-014 extends ADR-002 rather than superseding it, which is why ADR-002 gets a note instead of a superseded banner. The index entry uses an em dash to match its thirteen siblings in that list, not house prose style.

#495 still needs rescoping and that is deliberately not in this PR. Its checklist assumes a hosted subscription (choose a payment provider, implement a payment flow, manage subscriptions, track conversion) and none of that survives a browser-local BYOK product. The launch-prep half applies either way, since a landing page, user documentation, terms of service, a privacy policy, and a feedback route are all things a browser-local product still needs. ADR-014 records that reasoning; acting on it is a separate change.

## Screenshots

N/A.

## Visual Baseline Changes

None. This PR does not touch `tests/visual/**-snapshots/**`.

## Code Review Summary (if applicable)

N/A.

## Chrome DevTools MCP Verification Summary (if applicable)

N/A.

## Quality Checks

Markdown only, so the quality gate does not apply to these files. Nothing under `src/` changed.

- [ ] Linting passed
- [ ] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

Read [ADR-014](public_docs/architecture/ADR-014-browser-local-until-named-trigger.md) and check the three triggers are the right three, since that is the only invented part. Everything else is derived from ADR-002, #1744, and the closed state of #1370.

Confirm the relative links resolve: ADR-014 links to ADR-002, ADR-004 and ADR-006, and ADR-002 links back to ADR-014.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed
