### PR TITLE
Add the playtest-loop skill, the taste instrument the library was missing

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -7,6 +7,9 @@ A distilled, evidence-disciplined skill library that lets future sessions (weake
 **Pre-existing skills (kept, referenced as siblings — not part of this pass):**
 `narraitor-architecture` (authoring conventions) · `narraitor-pattern-alignment-skill` (post-edit check) · `review` (PR review) · `style-port` (inline-style porting).
 
+**Added after the distillation pass:**
+`narraitor-playtest-loop` (live multi-turn play sessions scored for story quality) — the taste instrument the distilled library had no answer for. Ships its own `rubric.md` and reusable world specs under `worlds/`.
+
 **The distilled library (16 skills):**
 
 | Skill | One line | Invoke when |
@@ -37,7 +40,8 @@ change-control  <- the spine; every skill's status claims route through it
   ├─ validation-and-qa ──── which tier proves what
   │    └─ storybook-app-parity ── the "integrated" bar
   ├─ ai-quality-discipline ── the AI evidence bar
-  │    └─ prompt-template-governance ── consumes the matrix as gate G4
+  │    ├─ prompt-template-governance ── consumes the matrix as gate G4
+  │    └─ playtest-loop ── one way to meet the bar for story quality specifically
   ├─ feature-experiment-lifecycle ── wraps delivery; emits ship/hold memos
   └─ docs-and-writing ── how verdicts get written down
 
@@ -60,7 +64,7 @@ hardest-problem-campaign ── composes: ai-quality-discipline + diagnostics + 
 
 **Safe for automatic model invocation** (procedural, read-mostly, self-limiting): repo-orientation, build-test-env, debugging-playbook, architecture-contract, change-control, ai-quality-discipline, prompt-template-governance, storybook-app-parity, validation-and-qa, failure-archaeology, domain-reference, diagnostics-and-tooling, docs-and-writing.
 
-**Prefer deliberate/manual invocation** (long-running, owner-decision-heavy, or spends money/tokens): `hardest-problem-campaign` (hours of work + owner sign-offs + live generation costs), `feature-experiment-lifecycle` P9 decisions, `product-frontier` (scoping conversations). Auto-triggering their *advice* is fine; executing their protocols is a deliberate act.
+**Prefer deliberate/manual invocation** (long-running, owner-decision-heavy, or spends money/tokens): `hardest-problem-campaign` (hours of work + owner sign-offs + live generation costs), `playtest-loop` (hundreds of live Gemini calls per campaign, owner check-in between every run), `feature-experiment-lifecycle` P9 decisions, `product-frontier` (scoping conversations). Auto-triggering their *advice* is fine; executing their protocols is a deliberate act.
 
 ## Honesty contract
 

--- a/.claude/skills/narraitor-playtest-loop/SKILL.md
+++ b/.claude/skills/narraitor-playtest-loop/SKILL.md
@@ -63,9 +63,10 @@ call. Range inputs batch fine. Buttons do not.
 **Capturing a turn:** one JavaScript call returning compact JSON from
 `window.useNarrativeStore.getState()` for `segments` and `decisions`, plus
 `useJournalStore` and `useInventoryStore`. All of them are exposed on `window` whenever
-`NODE_ENV` is not production, per `src/lib/utils/shouldExposeStoreOnWindow.ts`. Every
-segment carries `metadata.debugInfo.tokenUsage` in dev, courtesy of
-`src/lib/ai/debugInfoBuilder.ts`, so prompt and completion tokens come free.
+`NODE_ENV` is not production, per `src/lib/utils/shouldExposeStoreOnWindow.ts`. Note that
+`segments` and `decisions` are both keyed records rather than arrays, so read turns in
+order through `getSessionSegments(sessionId)` and not by index. Token counts are not
+available on this path; see section 4.
 
 **Pair a segment to its decision through `metadata.causedByDecisionId`, never by zipping
 the two arrays on index.** They do not line up, and the failure is silent: the first
@@ -102,14 +103,28 @@ line fails, fix the harness first.
 
 1. `window.__PLAYWRIGHT__` is undefined and the user agent has no "Playwright" in it
 2. The network shows real POSTs to `/api/narrative/generate` and `/api/narrative/choices`
-3. `useNarrativeStore.getState().segments.length` is 3, with distinct prose in each
-4. `segments[2].metadata.debugInfo.tokenUsage.promptTokens` is above zero
-5. A journal entry exists. `/api/narrative/summarize` is suppressed under the Playwright
-   gate, so its output proves the gate is off.
+3. `useNarrativeStore.getState().getSessionSegments(sessionId)` returns 3 segments with
+   distinct prose in each
+4. A journal entry exists. `/api/narrative/summarize` is suppressed under the Playwright
+   gate, so its output proves the gate is off. This is the strongest single signal in the
+   list, because it is the one thing a mocked run cannot fake.
+
+**`segments` is a `Record<EntityID, NarrativeSegment>`, not an array.** `.length` is
+`undefined` on it and `segments[2]` is an id lookup rather than the third turn. Order comes
+from `sessionSegments[sessionId]`, which `getSessionSegments` already resolves and filters.
+Any check written against `segments` as an array fails in a way that looks like a mocked
+harness, which is the most expensive false alarm this checkpoint can raise.
+
+**Do not assert on `debugInfo.tokenUsage`.** The first campaign tried, and the check failed
+at turn 3 on a run that was demonstrably live. `debugInfo` is attached in
+`src/lib/ai/narrativeGenerator.ts` under a condition the browser path does not meet, so
+token counts are absent no matter how real the generation is. Four independent proofs of
+live generation stood while that one criterion said otherwise. Cost per run is better read
+from the provider console than from the store.
 
 ## 5. The campaign
 
-Five runs. Vary one thing at a time so a bad score points somewhere.
+Five scored runs plus an A/B pair. Vary one thing at a time so a bad score points somewhere.
 
 | Run | World | Character | Persona | Turns |
 |---|---|---|---|---|
@@ -117,10 +132,20 @@ Five runs. Vary one thing at a time so a bad score points somewhere.
 | 2 | Camp Crystal Lake | fresh | Reckless | 30 |
 | 3 | Contrast world | fresh | Custom-text-heavy | 30 |
 | 4 | Contrast world | established | Contrarian | to a real ending |
+| 5 | Camp Crystal Lake | established | Cautious | 30 |
 | A/B | Camp Crystal Lake, branched at turn 8 | fresh | opposite choices | 10 per arm |
 
+**The five runs are what close the evaluation matrix, and the matrix is binding.**
+`narraitor-ai-quality-discipline` is the single home of those minimums: two contrasting
+worlds crossed with one fresh and one established character, three or more generations per
+cell. Runs 1 through 5 cover all four cells at 30 generations each. Run 5 exists only to
+close the Camp Crystal Lake and established cell, which the first campaign left open, so
+that campaign's results are a story-quality read and cannot be cited as a matrix. The A/B
+pair sits outside the matrix and answers a different question.
+
 Cautious goes first. That playstyle produced #1680, where the story never escalated because
-the player never forced it to.
+the player never forced it to. Run 5 repeats it on an established character so the only
+thing that changed is the character's history.
 
 Run 1 includes world creation and character creation through the real wizards. The first
 three turns decide whether anyone keeps playing, and a returning player never walks that

--- a/.claude/skills/narraitor-playtest-loop/SKILL.md
+++ b/.claude/skills/narraitor-playtest-loop/SKILL.md
@@ -18,7 +18,9 @@ somewhere around turn twenty.
 ## 2. When to reach for this instead of a sibling skill
 
 `narraitor-qa-walkthrough` finds defects before a release. It walks every surface and asks
-whether things work. Its Phases 4 through 6 delegate the live story loop to this skill.
+whether things work. Its Phases 4 through 6 delegate the live story loop to this skill. Do
+not copy its curl-chaining workaround for live generation: browser automation reaches the
+real path on its own, per section 3. That skill has not been corrected yet.
 
 `narraitor-ai-quality-discipline` sets the evidence bar. It says one good generation is a
 signal, not evidence, and it owns the eval matrix for prompt changes. This skill is one
@@ -46,7 +48,17 @@ or the whole loop silently no-ops.
 
 **Driving a turn:** click `[data-testid^="choice-option-"]`, or type into
 `[aria-label="Custom response input"]` and press `[aria-label="Send"]`. Both live in
-`src/components/shared/ChoiceSelector/ChoiceSelector.tsx`.
+`src/components/shared/ChoiceSelector/ChoiceSelector.tsx`. The custom input is an `INPUT`,
+not a `TEXTAREA`, so the native value setter has to come off the right prototype or the
+call throws "Illegal invocation".
+
+**Driving the wizards:** their selects key off `id`, not `name`. `#content-rating`,
+`#narrative-style`, `#language-complexity`.
+
+**One click per tick.** Clicking five toggles in a single JavaScript call registers one,
+because React re-renders between them and the later clicks land on stale nodes. Stagger
+them with `setTimeout(fn, 300 * i)` inside one call, then verify the result in the next
+call. Range inputs batch fine. Buttons do not.
 
 **Capturing a turn:** one JavaScript call returning compact JSON from
 `window.useNarrativeStore.getState()` for `segments` and `decisions`, plus
@@ -54,6 +66,16 @@ or the whole loop silently no-ops.
 `NODE_ENV` is not production, per `src/lib/utils/shouldExposeStoreOnWindow.ts`. Every
 segment carries `metadata.debugInfo.tokenUsage` in dev, courtesy of
 `src/lib/ai/debugInfoBuilder.ts`, so prompt and completion tokens come free.
+
+**Pair a segment to its decision through `metadata.causedByDecisionId`, never by zipping
+the two arrays on index.** They do not line up, and the failure is silent: the first
+campaign's index-zipped transcript showed turn 1 offering options about a pry bar that did
+not exist until later. A misaligned transcript produces a confidently wrong verdict, which
+is worse than no verdict.
+
+**Turn latency is 4 to 6 seconds in steady state.** The 20 to 24 seconds on the first few
+turns is Next compiling the route, not the model. Do not log it as a performance finding,
+and do not measure latency at all until the routes are warm.
 
 **Assert usability every turn, not just when something looks wrong.** A state dump will
 happily report a healthy store while the player is staring at a modal that covers the
@@ -118,10 +140,16 @@ or narrative logic gets fixed mid-campaign under any circumstances.
 
 ## 6. Judging
 
-Dump each transcript to a file, then hand it plus `rubric.md` to a fresh subagent. The judge
-gets no world spec, no character sheet, and no idea what the campaign expects to find.
-Scoring generations you just watched being produced is the exact bias
+Hand `rubric.md` to a fresh subagent and let it pull the transcript itself. The judge gets
+no world spec, no character sheet, and no idea what the campaign expects to find. Scoring
+generations you just watched being produced is the exact bias
 `narraitor-ai-quality-discipline` exists to prevent.
+
+**Let the judge fetch the transcript, do not carry it.** Stash the assembled turns on
+`window.__tx` and tell the judge to read it in slices against the session's tab. The
+transcript never passes through the orchestrator's context, which is worth roughly 8k
+tokens a run and is the difference between a five-run campaign fitting in one session or
+not.
 
 Seven dimensions, scored 1 to 5, separately per ten-turn block so the trajectory shows.
 The A/B pair goes to a different judge under the discrimination protocol at the bottom of

--- a/.claude/skills/narraitor-playtest-loop/SKILL.md
+++ b/.claude/skills/narraitor-playtest-loop/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: narraitor-playtest-loop
+description: Drive real multi-turn game sessions in a browser against live Gemini and score whether the story is actually engaging. Use when asking "is this fun to play", "does the narrative hold up over 30 turns", "why does the story get boring", when planning a release playtest, or when a change to prompts or narrative logic needs a before-and-after read on story quality. This is the taste instrument; narraitor-qa-walkthrough is the release defect gate and narraitor-ai-quality-discipline is the evidence bar both of them answer to.
+---
+
+# Playtest loop
+
+## 1. Purpose
+
+Every automated tier in this repo can be green while the game is boring. Unit tests prove
+functions return, visual specs prove pixels match, and neither reads a single sentence of
+prose. This skill closes that gap by playing the actual game through the actual UI against
+live Gemini, capturing the transcript, and handing it to a judge who has never seen the app.
+
+It answers one question: does the story hold up over a real session, or does it fall apart
+somewhere around turn twenty.
+
+## 2. When to reach for this instead of a sibling skill
+
+`narraitor-qa-walkthrough` finds defects before a release. It walks every surface and asks
+whether things work. Its Phases 4 through 6 delegate the live story loop to this skill.
+
+`narraitor-ai-quality-discipline` sets the evidence bar. It says one good generation is a
+signal, not evidence, and it owns the eval matrix for prompt changes. This skill is one
+concrete way to meet that bar for story quality specifically.
+
+`visual-crawl` and `design-loop` cover pixels. Neither reads the story.
+
+## 3. The harness
+
+**Real AI runs fine under browser automation.** `isPlaywrightEnv()` in
+`src/lib/utils/isPlaywrightEnv.ts` trips only when the user agent contains "Playwright" or
+`window.__PLAYWRIGHT__` is set, and the second only happens inside
+`tests/visual/utils/seedTestData.ts`. A browser session that avoids both runs the real
+generation path end to end. Do not call `seedTestData` and do not call `mockApiEndpoints`,
+or the whole loop silently no-ops.
+
+**Setup, in order:**
+
+1. Reset the worktree onto `refs/remotes/origin/develop` so the build under test is current
+2. Copy `.env.local` from the main checkout, which already carries `GEMINI_API_KEY`. Never
+   type a key into the BYOK wizard.
+3. Set `.claude/launch.json`'s Next.js port to this worktree's port from
+   `node scripts/worktree-port.js`, then start the server through the preview tooling
+4. Confirm the startup log says `Environments: .env.local`
+
+**Driving a turn:** click `[data-testid^="choice-option-"]`, or type into
+`[aria-label="Custom response input"]` and press `[aria-label="Send"]`. Both live in
+`src/components/shared/ChoiceSelector/ChoiceSelector.tsx`.
+
+**Capturing a turn:** one JavaScript call returning compact JSON from
+`window.useNarrativeStore.getState()` for `segments` and `decisions`, plus
+`useJournalStore` and `useInventoryStore`. All of them are exposed on `window` whenever
+`NODE_ENV` is not production, per `src/lib/utils/shouldExposeStoreOnWindow.ts`. Every
+segment carries `metadata.debugInfo.tokenUsage` in dev, courtesy of
+`src/lib/ai/debugInfoBuilder.ts`, so prompt and completion tokens come free.
+
+**Assert usability every turn, not just when something looks wrong.** A state dump will
+happily report a healthy store while the player is staring at a modal that covers the
+choices. Every capture checks, and reports as warnings: a mounted Joyride tooltip, the
+first choice button outside the viewport, `body` scroll-locked, the choice button not being
+the topmost element at its own center, a visible "Jump to latest" affordance, and a
+non-null `generationError`. These cost nothing and catch the whole class.
+
+**Screenshot at turn 1 and every fifth turn after, and read them.** The first run of this
+skill set screenshots to anomaly-only and played two turns underneath a full-screen tour
+overlay without noticing. The state dump looked perfect. One screenshot at turn 1 would
+have shown the tooltip sitting on top of the prose it was telling the player to read. A
+screenshot also catches what no assertion thinks to check, like an NPC present in the prose
+but missing from the character chips.
+
+**Walk the tutorial tours on at least one run.** Skipping them every time leaves the entire
+first-run path untested, and the tours are modal, so they are part of whether the opening
+is playable at all.
+
+## 4. Harness checkpoint
+
+Run this at turn 3 of the first session, before spending the rest of the budget. If any
+line fails, fix the harness first.
+
+1. `window.__PLAYWRIGHT__` is undefined and the user agent has no "Playwright" in it
+2. The network shows real POSTs to `/api/narrative/generate` and `/api/narrative/choices`
+3. `useNarrativeStore.getState().segments.length` is 3, with distinct prose in each
+4. `segments[2].metadata.debugInfo.tokenUsage.promptTokens` is above zero
+5. A journal entry exists. `/api/narrative/summarize` is suppressed under the Playwright
+   gate, so its output proves the gate is off.
+
+## 5. The campaign
+
+Five runs. Vary one thing at a time so a bad score points somewhere.
+
+| Run | World | Character | Persona | Turns |
+|---|---|---|---|---|
+| 1 | Camp Crystal Lake, cold start through both wizards | fresh | Cautious | 30 |
+| 2 | Camp Crystal Lake | fresh | Reckless | 30 |
+| 3 | Contrast world | fresh | Custom-text-heavy | 30 |
+| 4 | Contrast world | established | Contrarian | to a real ending |
+| A/B | Camp Crystal Lake, branched at turn 8 | fresh | opposite choices | 10 per arm |
+
+Cautious goes first. That playstyle produced #1680, where the story never escalated because
+the player never forced it to.
+
+Run 1 includes world creation and character creation through the real wizards. The first
+three turns decide whether anyone keeps playing, and a returning player never walks that
+path again, so it only gets tested here.
+
+World specs live in `worlds/`. The contrast world exists to remove the crutch: Camp Crystal
+Lake has something hunting you, so the narrative can borrow momentum. A world where nothing
+is chasing the player has to manufacture it.
+
+**Observe and file only.** Fixing mid-campaign means run 3 plays a different build than run
+1 and the scores stop comparing. The one exception is a hard blocker, meaning a crash,
+unrecoverable state, or a route returning 500. Fix that, record in the log that the build
+changed between runs, and caveat every score across the boundary. Nothing touching prompts
+or narrative logic gets fixed mid-campaign under any circumstances.
+
+**Check in with the owner after every run** before picking the next persona and world.
+
+## 6. Judging
+
+Dump each transcript to a file, then hand it plus `rubric.md` to a fresh subagent. The judge
+gets no world spec, no character sheet, and no idea what the campaign expects to find.
+Scoring generations you just watched being produced is the exact bias
+`narraitor-ai-quality-discipline` exists to prevent.
+
+Seven dimensions, scored 1 to 5, separately per ten-turn block so the trajectory shows.
+The A/B pair goes to a different judge under the discrimination protocol at the bottom of
+`rubric.md`.
+
+Alongside the transcript, log what a transcript cannot show: per-turn wait time, whether the
+prose wall got tiring, dead-end UI, and any moment the game state was unclear.
+
+## 7. Findings
+
+Two tracks, because filing "the story circles at turn 18" as a bug produces a ticket nobody
+can close.
+
+**Defects** score Critical, Major, or Minor and file as `bug`. Same tiers the v1.0
+walkthrough used in #1417, so severity language stays consistent between rounds.
+
+**Design gaps** score Blocks-fun, Erodes-over-time, or Papercut and file as `enhancement`
+against epic #435, the surviving narrative-depth epic.
+
+Everything gets a number in `playtest-log.md` at the repo root, which is gitignored and
+accumulates across rounds. File one umbrella tracking issue holding every finding, then
+batch-file Major and Blocks-fun as individual issues linked back to it. Round 2 of playtest
+triage skipped the umbrella, and two round-1 fixes regressed with nobody noticing until
+#1574 caught it months later.

--- a/.claude/skills/narraitor-playtest-loop/rubric.md
+++ b/.claude/skills/narraitor-playtest-loop/rubric.md
@@ -1,0 +1,100 @@
+# Blind judging rubric
+
+Hand this file, plus a transcript, to a subagent that has seen nothing else. No world spec,
+no character sheet, no knowledge of the app or what the campaign expects to find. If the
+prose fails to convey the setting, that is itself the finding, and a judge who was handed
+the setting separately cannot see it.
+
+## Judge instructions
+
+You are reading a transcript of a text adventure someone played. You have never seen this
+game and know nothing about how it was built. Read the whole transcript before scoring
+anything.
+
+The transcript gives you, per turn: the turn number, the prose the game returned, the
+options it offered, and which option the player took.
+
+Score seven dimensions from 1 to 5. Score them **separately for each block of ten turns**
+(1-10, 11-20, 21-30). Do not average across blocks. The question this campaign is asking is
+whether the story gets worse as it goes, and that is a slope, not a number.
+
+**Every score cites at least one turn number.** A score with no citation is not usable.
+
+## The dimensions
+
+### Agency - do the player's choices visibly change what happens
+
+- **1** The passage after a choice would read the same whichever option had been taken. The
+  choice is announced, then ignored.
+- **3** The chosen action shows up in the next passage, but its effects stop there. Nothing
+  carries forward.
+- **5** Choices leave marks that surface turns later. A door left open, a person alienated,
+  a resource spent, and the story remembers.
+
+### Momentum - does each turn move, or does it circle
+
+- **1** Turns restate the situation in new words. A reader could skip five of them and lose
+  nothing.
+- **3** Events occur but pressure stays flat. The scene changes without anything getting
+  harder.
+- **5** Each turn narrows the options or raises the cost. Something is more difficult now
+  than it was ten turns ago.
+
+### Memory - are earlier facts still true
+
+- **1** The narrative contradicts something it established earlier. A name changes, a dead
+  character speaks, geography rearranges, an item the player never had appears in hand.
+- **3** No contradictions, but nothing from the first ten turns is ever mentioned again.
+  The early story might as well not have happened.
+- **5** Specific earlier details recur, correctly, and pay off.
+
+### Voice - is the prose worth reading
+
+- **1** The same sentence shapes and stock phrases turn after turn. The template is visible.
+- **3** Competent and generic. Nothing wrong with it, nothing memorable in it.
+- **5** A distinct register that fits the setting, with images that do not repeat.
+
+### Stakes - can anything actually be lost
+
+- **1** Nothing is at risk. Every attempt resolves without cost.
+- **3** Threats get described but never land. The story menaces and then relents.
+- **5** Something is genuinely lost or foreclosed, and the loss registers.
+
+### Surprise - does anything land that the reader did not see coming
+
+- **1** Every outcome is the obvious one. The story is fully predictable from the setup.
+- **3** New details appear, but no reversals. Nothing recontextualizes what came before.
+- **5** At least one real turn the reader did not predict, which still fits everything
+  established.
+
+### Choice quality - are the options meaningfully different
+
+- **1** The options are one action in different words, or one option is obviously correct
+  and the rest are filler.
+- **3** Options differ in flavor but converge on the same outcome.
+- **5** Options represent different strategies with different costs, and picking wrong
+  costs something.
+
+## Output format
+
+For each block, report the seven scores with a cited turn number each, then two or three
+sentences on what changed since the previous block. Close with the sharpest single problem
+you saw across the whole transcript, stated as something a designer could act on.
+
+## A/B discrimination protocol
+
+Used only for the branch pair, and run by a different judge than the one who scored the
+sessions.
+
+You get two transcripts, unlabeled, that share an identical opening of eight turns and then
+diverge. At the divergence point, one player took choice A and the other took choice B. You
+are told what A and B were, but not which transcript followed which.
+
+Answer three things:
+
+1. Which transcript followed which choice, and how confident are you from 1 to 5
+2. What in the text made you say that, cited by turn number
+3. At what turn do the two transcripts stop being distinguishable, if they do
+
+A judge who cannot tell them apart is the finding. Report that plainly rather than guessing
+confidently.

--- a/.claude/skills/narraitor-playtest-loop/worlds/camp-crystal-lake.md
+++ b/.claude/skills/narraitor-playtest-loop/worlds/camp-crystal-lake.md
@@ -1,0 +1,78 @@
+# Test world: Camp Crystal Lake
+
+The control world. A 1980s summer-camp slasher in the Friday the 13th vein, first used for
+the v1.0 QA walkthrough (issue #1417). Re-running the same world each release keeps rubric
+scores comparable across rounds, which is the whole reason it stays fixed. Do not improve
+it between rounds.
+
+This world has a built-in threat engine: something is hunting you, so the narrative can
+borrow momentum instead of manufacturing it. Pair it with `harrowgate-council.md`, which
+takes that crutch away.
+
+## World, manual create path
+
+Wizard fields, in order:
+
+- Template step: pick "Start from scratch" and skip the templates
+- **World Name**: `Camp Crystal Lake`
+- **Genre**: `Horror`
+- **World Type**: `Inspired By`, with **Existing Setting** `Friday the 13th`
+- **Tone Settings** on the Basic Info step:
+  - Content rating: `R`
+  - Narrative style: `Mysterious`
+  - Language complexity: `Moderate`
+  - Custom instructions: `tense, dread-soaked 1980s slasher; sudden violence, earned not gratuitous`
+- **Full Description**:
+
+  > Summer, 1984. Camp Crystal Lake reopens despite the stories - the drownings, the
+  > disappearances, the name locals won't say after dark. You're among the counselors who
+  > came up early to ready the cabins before the kids arrive. The woods are too quiet, the
+  > radio's dead, the nearest town is forty minutes of dirt road away, and something out
+  > there is watching the firelight. Survive the night. Get whoever's left out alive.
+
+- **Attributes** and **Skills** steps: the wizard suggests these from the description.
+  Verify they land near the targets below and edit toward them.
+
+**Attribute targets:** Vigor, Agility, Awareness, Nerve, Cunning
+
+**Skill targets:** Athletics, Stealth, First Aid, Improvised Weapons, Survival/Woodcraft,
+Perception, Persuasion
+
+## World, AI generate path
+
+The `/worlds` Generate flow uses a different field set:
+
+- **World Type**: `Inspired By`
+- **Existing Setting**: `Friday the 13th`
+- **Additional Details**: `1980s summer camp on a cursed lake; a masked killer stalking the counselors at night`
+- Name, if the flow shows one: `Camp Crystal Lake`
+
+## Character: Jamie Holt
+
+Custom character wizard:
+
+- **Name**: `Jamie Holt`
+- **Character description**: `A returning camp counselor who grew up nearby and knows the grounds cold.`
+- **Physical description**: `Nineteen, wiry and quick; worn camp hoodie, flashlight clipped to her belt.`
+- **Attributes**: most points into Agility and Awareness, a survivor build, spend the full pool
+- **Skills**: top points into Stealth, Athletics, First Aid
+- **History**: `Nineteen, second summer on staff. Grew up forty minutes down the road, so the camp's ghost stories were bedtime stories. Knows the trails, the boathouse, which cabin doors don't lock.`
+- **Personality**: `Level-headed, protective, hates being the one who panics.`
+- **Motivation**: `Get everyone out of the camp alive before dawn.`
+- **Goals**: `Get every camper and counselor out alive` and `Make it to morning`
+- **Portrait**: skip, it costs a generation and nothing in the rubric scores it
+
+## Facts to plant and check later
+
+The Memory dimension needs specific early facts to test recall against. These come out of
+the world description and the character sheet, so they should be established by turn 5
+without any prompting:
+
+1. The nearest town is forty minutes away by dirt road
+2. The radio is dead
+3. Jamie grew up locally and knows which cabin doors don't lock
+4. The kids have not arrived yet, only counselors are on site
+5. It is summer 1984
+
+At turn 30, check whether the narrative still holds these, contradicts them, or has quietly
+forgotten them. A contradiction scores Memory at 1. Silence scores 3.

--- a/.claude/skills/narraitor-playtest-loop/worlds/harrowgate-mills.md
+++ b/.claude/skills/narraitor-playtest-loop/worlds/harrowgate-mills.md
@@ -1,0 +1,74 @@
+# Contrast world: Harrowgate Mills
+
+The control against `camp-crystal-lake.md`. That world has something hunting you, so the
+narrative can borrow momentum from the monster. This one has no threat engine at all: nobody
+can die, nothing is chasing anyone, and every stake is social. If the engine can only advance
+a story when the player shoves it, this is where that shows up naked.
+
+Keep it fixed between rounds for the same reason Camp Crystal Lake is fixed.
+
+Field values below are the real wizard options, verified against the running app.
+
+## World, manual create path
+
+- Template step: "Start from scratch"
+- **World Name**: `Harrowgate Mills`
+- **Genre**: `Modern`
+- **World Type**: `Original World`
+- **Tone Settings**:
+  - Content rating: `PG-13`
+  - Narrative style: `Dramatic`
+  - Language complexity: `Moderate`
+  - Custom instructions: `small-town civic drama; tension comes from money, memory and who owes whom, never from violence; nobody is a villain`
+- **Full Description**:
+
+  > Harrowgate, population 4,100, has been arguing about the mill for eleven years. Rowan
+  > Textiles shut in 2014 and took a third of the town's jobs with it; the building has been
+  > sitting on the river ever since, too expensive to fix and too loved to knock down. Now a
+  > developer from out of state has offered 4.2 million for the parcel, and the council votes
+  > in six weeks. You were appointed last month to finish out a seat nobody wanted, which
+  > means you owe your chair to people who expect something for it. Everyone in town has a
+  > position, most of them have a reason, and several of them are related to you.
+
+- **Attributes** and **Skills**: the wizard suggests these. Verify they land near the targets
+  below and edit toward them.
+
+**Attribute targets:** Composure, Insight, Diligence, Presence, Resolve, Integrity
+
+**Skill targets:** Negotiation, Public Speaking, Research, Bookkeeping, Local History,
+Listening, Coalition Building, Media Handling
+
+## Character: Wren Calloway
+
+- **Name**: `Wren Calloway`
+- **Character description**: `A newly appointed council member finishing out someone else's term.`
+- **Physical description**: `Late thirties, plain coat, always carrying a folder they never quite open.`
+- **Attributes**: most points into Insight and Composure, then Diligence
+- **Skills**: top points into Listening, Research, Negotiation
+- **History**: `Grew up four streets from the mill; both grandparents worked the looms until 2014. Left for a decade, came back when their mother got sick, and got appointed to the council in a room of eleven people because nobody else raised a hand.`
+- **Personality**: `Careful, slow to commit, uncomfortable being owed favours.`
+- **Motivation**: `Get a decision the town can live with, and keep being able to shop in it afterwards.`
+- **Goals**: `Reach the vote without having lied to anyone` and `Find out what the mill is actually worth`
+- **Portrait**: skip
+
+## Facts to plant and check at turn 30
+
+The Memory dimension needs specific early facts to test recall against. All five come out of
+the world description and character sheet and should be established by turn 5 unprompted:
+
+1. The council vote is in six weeks
+2. The mill closed in 2014, eleven years empty
+3. The player was appointed, not elected, to a seat nobody wanted
+4. The developer's offer is 4.2 million
+5. The player's grandparents worked the looms
+
+## Why this world is the harder test
+
+Camp Crystal Lake can always fall back on the killer: a quiet stretch can be broken by a
+noise in the woods, and the world description pre-authorises that. Harrowgate has no such
+escape hatch. Advancing this story requires the engine to move something the player is not
+touching, on its own initiative, with no monster to reach for: a neighbour changes their
+vote, the developer adds a deadline, a document surfaces, someone talks to a reporter.
+
+If a run here reduces to the player interviewing one NPC in one room for thirty turns, that
+is F20 with no confound left. There was nothing else the engine could have blamed.

--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,6 @@ characters-debug.png
 
 # design-loop skill's per-worktree session log — local paper trail, not repo docs
 design-loop-log.md
+
+# narraitor-playtest-loop's running findings log — same deal, findings graduate to issues
+playtest-log.md


### PR DESCRIPTION
## Description

Adds `narraitor-playtest-loop`, a skill that plays the actual game through the actual UI against live Gemini for 30-plus turns and hands the transcript to a subagent that has never seen the app.

Every automated tier here can be green while the game is boring. Unit tests prove functions return, visual specs prove pixels match, and neither reads a sentence of prose. The 16-skill library had no answer for "is this fun to play". This is that answer.

Four runs across two worlds and four playstyles produced 32 findings, an umbrella issue and six filed bugs, and one durable result: the game holds up for about ten turns and degrades from there regardless of world or persona, which is structural rather than a writing-quality problem.

Ships four files:

- `SKILL.md` (148 lines) - the harness, the turn-3 checkpoint, the campaign shape, the judging protocol, the two finding tracks
- `rubric.md` (100 lines) - seven dimensions scored per ten-turn block, plus the A/B discrimination protocol
- `worlds/camp-crystal-lake.md` - control world, something is hunting the player
- `worlds/harrowgate-mills.md` - contrast world, deliberately nothing chasing anyone

Plus the `.claude/skills/README.md` inventory entry and dep-map placement, and a gitignore line for `playtest-log.md` on the same arrangement `design-loop-log.md` already has: the log is the local paper trail, findings graduate to issues.

## Related Issue

Related: #1818 (the campaign's umbrella tracking issue). No issue closed by this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [ ] Test addition or improvement

Markdown only. No `src/` changes, no runtime code.

## TDD Compliance

N/A. No executable code in this PR.

- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally (unaffected, nothing under `src/` changed)
- [x] Test coverage maintained or improved (unchanged)

## User Stories Addressed

None directly. This is process tooling. It exists so the question "does the story hold up over a real session" has a repeatable answer instead of a hunch.

## Flow Diagrams

N/A.

## Component Development

N/A. No components.

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes

Three things the skill encodes that are non-obvious and cost real time to learn:

**Real AI runs fine under browser automation.** `isPlaywrightEnv()` trips only on a "Playwright" user agent or `window.__PLAYWRIGHT__`, and only `tests/visual/utils/seedTestData.ts` sets the latter. A browser session that avoids both runs the real generation path end to end. The skill says explicitly not to call `seedTestData` or `mockApiEndpoints`, because either one silently no-ops the whole loop.

**A state dump will report a healthy store while the player cannot see the choices.** The first campaign run set screenshots to anomaly-only and played two turns underneath a full-screen tour overlay without noticing. The skill now asserts six usability invariants every turn (mounted Joyride tooltip, first choice outside the viewport, `body` scroll-locked, choice button not topmost at its own center, visible jump-to-latest, non-null `generationError`) and screenshots turn 1 and every fifth turn after.

**Observe and file only.** Fixing mid-campaign means run 3 plays a different build than run 1 and the scores stop comparing. The single exception is a hard blocker. Nothing touching prompts or narrative logic gets fixed mid-campaign at all.

The second commit writes down five gotchas the campaign paid for and the first draft omitted, including one step the campaign had already disproved. Section 6 originally said to dump each transcript to a file; stashing it on `window.__tx` and letting the judge pull it in slices keeps roughly 8k tokens a run out of the orchestrator's context. The other four: pair a segment to its decision through `metadata.causedByDecisionId` rather than zipping arrays on index, because they do not line up and the failure is silent; stagger batched clicks through React's re-render or only the first one registers; the custom response field is an `INPUT`, not a `TEXTAREA`, and the wizard selects key off `id`, not `name`; and warm turn latency is 4 to 6 seconds, so the 20-plus seconds on the opening turns is Next compiling the route and not a performance finding.

Known follow-up, not in this PR: `narraitor-qa-walkthrough` still carries a curl-chaining workaround for live generation that browser automation makes unnecessary. This skill flags it in section 2 so nobody copies it; that skill has not been corrected.

## Screenshots

N/A.

## Visual Baseline Changes

None. This PR does not touch `tests/visual/**-snapshots/**`.

## Code Review Summary

N/A.

## Chrome DevTools MCP Verification Summary

N/A.

## Quality Checks

- [x] Linting passed (no lintable files changed; ESLint and Stylelint globs do not cover `.claude/skills/**`)
- [x] Type checking passed (no TypeScript changed)
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

There is nothing to run. To review it, read `SKILL.md` and `rubric.md` and judge whether a session with no context could follow them and produce a comparable result.

The evidence that the harness works is #1818 and the six issues filed off it (#1819, #1820, #1821, #1822, #1823, and the reopened #1680), all found by following this procedure.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file; largest here is 148)
- [x] Self-review of code performed
- [x] Comments added for complex logic (N/A, prose only)
- [x] Documentation updated (the skills README inventory, dep map and manual-invocation list)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed (N/A, no UI)
