### PR TITLE
Roll skill checks on typed actions - the choice id went out before the option existed

### DIFF
--- a/src/components/GameSession/hooks/__tests__/useActiveGameSessionActions.test.ts
+++ b/src/components/GameSession/hooks/__tests__/useActiveGameSessionActions.test.ts
@@ -27,23 +27,30 @@ jest.mock('@/state/narrativeStore', () => ({
   ),
 }));
 
+const mockCharacter = { id: 'character-1', worldId: 'world-1', skills: [] };
+const mockWorld = { id: 'world-1', skills: [{ id: 'negotiation', name: 'Negotiation' }] };
+
 jest.mock('@/state/characterStore', () => ({
   useCharacterStore: Object.assign(
     jest.fn(),
-    { getState: jest.fn(() => ({ characters: {} })) }
+    { getState: jest.fn(() => ({ characters: { 'character-1': mockCharacter } })) }
   ),
 }));
 
 jest.mock('@/state/worldStore', () => ({
   useWorldStore: Object.assign(
     jest.fn(),
-    { getState: jest.fn(() => ({ worlds: {} })) }
+    { getState: jest.fn(() => ({ worlds: { 'world-1': mockWorld } })) }
   ),
 }));
 
 jest.mock('@/lib/ai/customActionSkillInference', () => ({
   inferCustomActionSkillChecks: jest.fn(async () => []),
 }));
+
+const { inferCustomActionSkillChecks } = jest.requireMock(
+  '@/lib/ai/customActionSkillInference'
+);
 
 const buildOptions = (overrides = {}) => ({
   sessionId: 'session-1',
@@ -144,6 +151,52 @@ describe('useActiveGameSessionActions', () => {
       // onChoiceSelected must be called with the same id that was registered
       expect(onChoiceSelected).toHaveBeenCalledTimes(1);
       expect(onChoiceSelected).toHaveBeenCalledWith(patch.selectedOptionId);
+    });
+  });
+
+  describe('handleCustomSubmit — inferred skill checks', () => {
+    const decision = {
+      id: 'decision-3',
+      prompt: 'What do you do?',
+      options: [{ id: 'opt-1', text: 'Walk away' }],
+    };
+
+    it('attaches inferred requirements to the registered option', async () => {
+      inferCustomActionSkillChecks.mockResolvedValueOnce([
+        { type: 'skill', targetId: 'negotiation', operator: 'gte', value: 3 },
+      ]);
+      const { result } = renderHook(() =>
+        useActiveGameSessionActions(buildOptions({ currentDecision: decision }))
+      );
+
+      await act(async () => {
+        await result.current.handleCustomSubmit('I ask Martha what she wants');
+      });
+
+      const [, patch] = mockNarrativeStoreState.updateDecision.mock.calls[0];
+      expect(patch.options[1].requirements).toEqual([
+        { type: 'skill', targetId: 'negotiation', operator: 'gte', value: 3 },
+      ]);
+    });
+
+    it('registers the option before handing its id to the generator', async () => {
+      const setLocalSelectedChoiceId = jest.fn();
+      const { result } = renderHook(() =>
+        useActiveGameSessionActions(
+          buildOptions({ currentDecision: decision, setLocalSelectedChoiceId })
+        )
+      );
+
+      await act(async () => {
+        await result.current.handleCustomSubmit('I ask who benefits from the deed');
+      });
+
+      // NarrativeController generates as soon as it sees a new choice id, and it
+      // reads requirements off the option in the store. Publishing the id first
+      // means the roll happens against an option that isn't there yet.
+      expect(setLocalSelectedChoiceId.mock.invocationCallOrder[0]).toBeGreaterThan(
+        mockNarrativeStoreState.updateDecision.mock.invocationCallOrder[0]
+      );
     });
   });
 });

--- a/src/components/GameSession/hooks/useActiveGameSessionActions.ts
+++ b/src/components/GameSession/hooks/useActiveGameSessionActions.ts
@@ -129,9 +129,11 @@ export const useActiveGameSessionActions = ({
     }
 
     // Disable input immediately; the inference + roll happen before generation.
+    // The choice id itself is published further down, once the option it names
+    // exists on the decision: NarrativeController starts a turn the moment it
+    // sees a new choice id, and reads that option's requirements to roll.
     setIsGenerating(true);
     setIsGeneratingChoices(true);
-    setLocalSelectedChoiceId(customChoiceId);
 
     // Phase 1 (Issue #918): infer skill checks for the typed action so custom
     // actions get the same d20 treatment as predefined choices. The resulting
@@ -186,6 +188,7 @@ export const useActiveGameSessionActions = ({
     setCurrentDecision(null);
 
     // Trigger narrative generation with the custom choice
+    setLocalSelectedChoiceId(customChoiceId);
     setShouldTriggerGeneration(true);
 
     maybeCompleteFirstPlay();


### PR DESCRIPTION
## Description

Typed actions never rolled a skill check because the generator was handed the choice id before the choice existed in the store.

`handleCustomSubmit` called `setLocalSelectedChoiceId(customChoiceId)` at the top, then awaited AI skill inference for a second or two, and only after that wrote the custom option (carrying the inferred `requirements`) onto the decision. NarrativeController watches that id and starts a turn the moment it changes, so it scanned the store's decisions, found no option matching the id, and ran `evaluateDecisionSkillChecks` with `selectedOption: null`. No requirements, no rolls, no `decisionOutcome`. Offered choices were unaffected because their options are already in the store when they're picked, which is exactly the 5-of-5 against 0-of-24 split measured in the playtest.

Git history pins the regression: before the inference work in #918, `setLocalSelectedChoiceId` sat below `updateDecision`. That commit hoisted it above the new `await` under a "disable input immediately" comment, which is what opened the gap.

The fix moves that one call back down next to `setShouldTriggerGeneration`, so the id only goes out once the option it names is on the decision. Input still disables the instant you submit, since that's driven by `isGenerating` and `isEvaluatingAction`, both of which are still set before the await.

The issue asked whether inference was failing, being filtered, or throwing silently. It's none of the three. Inference results were computed and attached correctly, then simply arrived after the turn had already been resolved without them, so nothing here changes `inferCustomActionSkillChecks` or adds the default-skill fallback the issue floated. That fallback is worth revisiting once there's real data on how often inference legitimately returns no check, which wasn't observable until now.

## Related Issue

Closes #1819

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The ordering test was written first and failed against the old code (`setLocalSelectedChoiceId` at invocation order 88, `updateDecision` at 97), then passed after the move.

## User Stories Addressed

As a player who types my own actions, I want my character's skills to matter, so the points I spent in the character wizard affect free-text play the same way they affect offered choices.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A - no UI surface changed, this is handler ordering inside a hook.

## Implementation Notes

Two things worth knowing for anyone reading this later.

The race is deterministic rather than flaky, which is why the playtest saw 0 of 24 and not a mix. React flushes the batched state updates from the synchronous part of the handler at the `await`, and passive effects run on a macrotask, so any real network round-trip in the inference call guarantees NarrativeController's effect fires first. A test that mocks inference as an instantly-resolved promise won't reproduce it, which is why the new test asserts call ordering instead of trying to race the microtask queue.

This also touches the same handler as #1820 (typed questions not being answered in the prose). Same root cause, different symptom: with no option in the store, `generateNextSegment` also falls back to using the raw choice id as the choice text, so the prompt got `custom-1755...` instead of what the player typed. This PR stays on the requirements and roll side and leaves the narrative prompt alone.

## Screenshots

N/A

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A - the failing path needs a live Gemini key and a multi-turn session, so verification here is the unit test plus the code trace above.

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit wasn't run; nothing in this diff touches dependencies, auth, or the API surface.

## Testing Instructions

```
npm test          # 412 suites, 2846 tests, all passing
npm run type-check
npm run lint      # 0 errors (127 pre-existing warnings in tests/visual)
```

For a manual check, start a session with a character who has real skill levels, type an action that plainly maps to one of those skills, and watch for the roll toast. Then confirm the segment carries an outcome:

```js
useNarrativeStore.getState().segments   // latest segment: metadata.decisionOutcome is set
```

Visual and E2E suites weren't run - macOS-only baselines, and nothing here renders differently.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
