### PR TITLE
Give the per-turn prompt the character sheet it was missing

### DIFF
--- a/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts
+++ b/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts
@@ -44,8 +44,8 @@ describe('sceneTemplate pacing guidance', () => {
   });
 });
 
-describe('sceneTemplate player action handling', () => {
-  const typedAction = 'I ask who benefits if the deed goes through';
+describe('sceneTemplate player character background', () => {
+  const typedAction = 'I bring up my grandparents working the looms';
 
   function makeTypedContext(
     overrides: Partial<NarrativeTemplateContext> = {}
@@ -70,32 +70,8 @@ describe('sceneTemplate player action handling', () => {
     };
   }
 
-  it('carries the typed action into the prompt verbatim', () => {
+  it('still renders the player action line alongside the background section', () => {
     expect(sceneTemplate(makeTypedContext())).toContain(typedAction);
-  });
-
-  it('requires the passage to engage with what the player did or said', () => {
-    const prompt = sceneTemplate(makeTypedContext());
-    expect(prompt).toContain('PLAYER ACTION REQUIREMENTS');
-    expect(prompt).toMatch(/must visibly engage with the action above/i);
-  });
-
-  it('requires a direct question to be answered, dodged, or refused on the page', () => {
-    const prompt = sceneTemplate(makeTypedContext());
-    expect(prompt).toMatch(/asked a question/i);
-    expect(prompt).toMatch(/answers it, dodges it, or refuses it/i);
-  });
-
-  it('tells the model to invent an answer when nothing established supplies one', () => {
-    expect(sceneTemplate(makeTypedContext())).toMatch(
-      /invent one that fits the world/i
-    );
-  });
-
-  it("forbids reprinting an earlier passage as this turn's response", () => {
-    expect(sceneTemplate(makeTypedContext())).toMatch(
-      /do not reprint or paraphrase a passage from STORY SO FAR/i
-    );
   });
 
   it('gives the model the character background so raised backstory is answerable', () => {
@@ -122,7 +98,7 @@ describe('sceneTemplate player action handling', () => {
     expect(prompt).not.toContain('PLAYER CHARACTER BACKGROUND');
   });
 
-  it('omits the action requirements when there is no player action', () => {
+  it('renders the background even on a turn with no player action', () => {
     const prompt = sceneTemplate(
       makeTypedContext({
         narrativeContext: {
@@ -131,6 +107,7 @@ describe('sceneTemplate player action handling', () => {
         },
       })
     );
-    expect(prompt).not.toContain('PLAYER ACTION REQUIREMENTS');
+    expect(prompt).toContain('PLAYER CHARACTER BACKGROUND');
+    expect(prompt).not.toContain('PLAYER ACTION:');
   });
 });

--- a/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts
+++ b/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts
@@ -43,3 +43,94 @@ describe('sceneTemplate pacing guidance', () => {
     expect(prompt).toContain('9 turns in a row');
   });
 });
+
+describe('sceneTemplate player action handling', () => {
+  const typedAction = 'I ask who benefits if the deed goes through';
+
+  function makeTypedContext(
+    overrides: Partial<NarrativeTemplateContext> = {}
+  ): NarrativeTemplateContext {
+    return {
+      worldName: 'Millbrook',
+      genre: 'small town drama',
+      tone: 'grounded',
+      playerCharacterName: 'Alex',
+      playerCharacterBackground: {
+        history: 'Your grandparents worked the looms at the Hendricks mill.',
+        personality: 'Stubborn, slow to trust.',
+      },
+      narrativeContext: {
+        recentSegments: [
+          { content: 'Martha slides the ledger across the table.' },
+        ],
+        currentSituation: `Player chose: "${typedAction}"`,
+        currentTags: [],
+      },
+      ...overrides,
+    };
+  }
+
+  it('carries the typed action into the prompt verbatim', () => {
+    expect(sceneTemplate(makeTypedContext())).toContain(typedAction);
+  });
+
+  it('requires the passage to engage with what the player did or said', () => {
+    const prompt = sceneTemplate(makeTypedContext());
+    expect(prompt).toContain('PLAYER ACTION REQUIREMENTS');
+    expect(prompt).toMatch(/must visibly engage with the action above/i);
+  });
+
+  it('requires a direct question to be answered, dodged, or refused on the page', () => {
+    const prompt = sceneTemplate(makeTypedContext());
+    expect(prompt).toMatch(/asked a question/i);
+    expect(prompt).toMatch(/answers it, dodges it, or refuses it/i);
+  });
+
+  it('tells the model to invent an answer when nothing established supplies one', () => {
+    expect(sceneTemplate(makeTypedContext())).toMatch(
+      /invent one that fits the world/i
+    );
+  });
+
+  it("forbids reprinting an earlier passage as this turn's response", () => {
+    expect(sceneTemplate(makeTypedContext())).toMatch(
+      /do not reprint or paraphrase a passage from STORY SO FAR/i
+    );
+  });
+
+  it('gives the model the character background so raised backstory is answerable', () => {
+    const prompt = sceneTemplate(makeTypedContext());
+    expect(prompt).toContain('PLAYER CHARACTER BACKGROUND');
+    expect(prompt).toContain(
+      'Your grandparents worked the looms at the Hendricks mill.'
+    );
+    expect(prompt).toContain('Stubborn, slow to trust.');
+  });
+
+  it('accepts a plain string background', () => {
+    const prompt = sceneTemplate(
+      makeTypedContext({ playerCharacterBackground: 'Raised above the mill.' })
+    );
+    expect(prompt).toContain('PLAYER CHARACTER BACKGROUND');
+    expect(prompt).toContain('Raised above the mill.');
+  });
+
+  it('omits the background section when the character has no background', () => {
+    const prompt = sceneTemplate(
+      makeTypedContext({ playerCharacterBackground: undefined })
+    );
+    expect(prompt).not.toContain('PLAYER CHARACTER BACKGROUND');
+  });
+
+  it('omits the action requirements when there is no player action', () => {
+    const prompt = sceneTemplate(
+      makeTypedContext({
+        narrativeContext: {
+          recentSegments: [{ content: 'The mill sits quiet.' }],
+          currentTags: [],
+        },
+      })
+    );
+    expect(prompt).not.toContain('PLAYER ACTION REQUIREMENTS');
+  });
+});

--- a/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
+++ b/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
@@ -47,14 +47,6 @@ ${lines.join('\n')}
 `;
 };
 
-const PLAYER_ACTION_REQUIREMENTS = `
-PLAYER ACTION REQUIREMENTS:
-- This passage must visibly engage with the action above. A reader should be able to tell what the player just did or said from the prose alone.
-- If the player asked a question, someone answers it, dodges it, or refuses it out loud in this passage. Leaving it hanging is not an option.
-- If nothing established yet supplies the answer, invent one that fits the world and commit to it as canon from here on.
-- If the player raised something from their own background, name it in the fiction and let someone react to it.
-- Do not reprint or paraphrase a passage from STORY SO FAR as this turn's response.`;
-
 export const sceneTemplate = (context: NarrativeTemplateContext) => {
   const {
     worldName,
@@ -112,7 +104,7 @@ ${backgroundSection}
 STORY SO FAR:
 ${recentContent}
 
-${narrativeContext?.currentSituation ? `PLAYER ACTION: ${narrativeContext.currentSituation}\n${PLAYER_ACTION_REQUIREMENTS}` : ''}
+${narrativeContext?.currentSituation ? `PLAYER ACTION: ${narrativeContext.currentSituation}` : ''}
 
 ${skillResult ? `
 SKILL CHECK RESULT GUIDANCE:

--- a/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
+++ b/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
@@ -10,6 +10,51 @@ import type { NarrativeTemplateContext } from './context';
  */
 const STALE_PACING_THRESHOLD = 3;
 
+/**
+ * Puts the player's own sheet in front of the model. Without it the prompt
+ * carries only recent prose, so anything the player raises from their history
+ * has no source the passage could answer it from. Only the two free-text fields
+ * go in — goals and play style already arrive via the personalization section,
+ * and the rest of the sheet would grow every turn's context for no gain.
+ */
+const formatPlayerBackground = (background: unknown): string => {
+  const lines: string[] = [];
+
+  if (typeof background === 'string') {
+    if (background.trim()) {
+      lines.push(`- ${background.trim()}`);
+    }
+  } else if (background && typeof background === 'object') {
+    const { history, personality } = background as {
+      history?: unknown;
+      personality?: unknown;
+    };
+    if (typeof history === 'string' && history.trim()) {
+      lines.push(`- History: ${history.trim()}`);
+    }
+    if (typeof personality === 'string' && personality.trim()) {
+      lines.push(`- Personality: ${personality.trim()}`);
+    }
+  }
+
+  if (lines.length === 0) {
+    return '';
+  }
+
+  return `
+PLAYER CHARACTER BACKGROUND (established canon — true unless the story has already contradicted it):
+${lines.join('\n')}
+`;
+};
+
+const PLAYER_ACTION_REQUIREMENTS = `
+PLAYER ACTION REQUIREMENTS:
+- This passage must visibly engage with the action above. A reader should be able to tell what the player just did or said from the prose alone.
+- If the player asked a question, someone answers it, dodges it, or refuses it out loud in this passage. Leaving it hanging is not an option.
+- If nothing established yet supplies the answer, invent one that fits the world and commit to it as canon from here on.
+- If the player raised something from their own background, name it in the fiction and let someone react to it.
+- Do not reprint or paraphrase a passage from STORY SO FAR as this turn's response.`;
+
 export const sceneTemplate = (context: NarrativeTemplateContext) => {
   const {
     worldName,
@@ -18,6 +63,7 @@ export const sceneTemplate = (context: NarrativeTemplateContext) => {
     narrativeContext,
     generationParameters,
     playerCharacterName,
+    playerCharacterBackground,
     characterSkillContext,
     enhancedCharacterContext,
     npcRoster = []
@@ -56,15 +102,17 @@ ${npcRoster.map((npc: { id: string; name: string; description?: string }) => `- 
 `
     : '';
 
+  const backgroundSection = formatPlayerBackground(playerCharacterBackground);
+
   const baseContent = `Continue the ${genre} narrative for "${worldName}" with a new ${segmentType} segment.
 
 World: ${worldName}
 Tone: ${tone}${characterSkillContext ? characterSkillContext : ''}${enhancedCharacterContext ? enhancedCharacterContext : ''}
-
+${backgroundSection}
 STORY SO FAR:
 ${recentContent}
 
-${narrativeContext?.currentSituation ? `PLAYER ACTION: ${narrativeContext.currentSituation}` : ''}
+${narrativeContext?.currentSituation ? `PLAYER ACTION: ${narrativeContext.currentSituation}\n${PLAYER_ACTION_REQUIREMENTS}` : ''}
 
 ${skillResult ? `
 SKILL CHECK RESULT GUIDANCE:


### PR DESCRIPTION
## Description

The per-turn narrative prompt never carried the player's character sheet, so any fact a player raised from their own history was unanswerable. This renders it.

**Correction to an earlier version of this PR.** The first draft of this description claimed the typed text already reached the prompt and that the bug was purely missing template guidance. That was wrong, and it's worth stating plainly rather than quietly editing out, because a wrong root cause in a merged PR body outlives the PR.

The real cause is the one the issue listed first: the typed text genuinely never reached the narrative prompt. At `src/components/Narrative/NarrativeController.tsx:631`, `choiceText` starts as the raw triggering id and is only overwritten when the loop below finds a matching option on a decision in the store. Line 740 then builds `currentSituation` as `Player chose: "${choiceText}"`. And no matching option was there at generation time: `handleCustomSubmit` called `setLocalSelectedChoiceId(customChoiceId)` *before* awaiting `inferCustomActionSkillChecks` (a real `generateContent` network call) and only wrote the option onto the decision *after*. Since `choiceId={localSelectedChoiceId || selectedChoiceId}` and `triggerGeneration` is already true throughout an active session, publishing the id starts the turn immediately. The model received `PLAYER ACTION: Player chose: "custom-1755..."`. Regression came in with 38769491 (#918).

That also explains the near-verbatim reprints on turns 7, 22, 23 and 30. Handed an opaque id, the model has no action to advance and no question to answer, so it re-renders prior state. **#1825 fixes the ordering**, and it's the fix for the reported symptom.

Why my own test didn't catch it: `carries the typed action into the prompt verbatim` built a context with `currentSituation` already populated and asserted the template rendered it. The template was always fine. The defect is one layer up, in who populates `currentSituation`, and I tested below it and read the pass as proof the plumbing was sound.

**What's left in this PR, and why it still earns its place.** `initialSceneTemplate.ts:24` renders `playerCharacterBackground`; `sceneTemplate.ts` destructured the context bag and dropped it. So the character sheet reached the opening scene and then vanished for every turn after. `buildNarrativeContext` was already populating the field (`narrativeGenerator.prompt.ts:76`, and `narrativeGenerator.ts:365` for the initial scene), so this was live data stopping one line short of the prompt. `sceneTemplate` now renders History and Personality from it.

That's an independent gap and #1825 doesn't touch it. It's also the issue's sharpest case: "I bring up my grandparents working the looms" was unanswerable on its own terms, because the model had never been shown the History field it referred to. Fixing the id gets the sentence into the prompt; this gets the fact the sentence points at into the prompt too.

**What I removed after the correction.** An earlier commit added a `PLAYER ACTION REQUIREMENTS` block telling the model to engage with the action, resolve questions, and not reprint earlier passages. Its entire justification was a symptom with a different cause, so it's gone. Shipping five bullets of unevaluated instruction into every turn's prompt on a false premise is the exact trap `narraitor-ai-quality-discipline` warns about, and I have no eval matrix to back it. If typed questions still go unanswered once #1825 lands and the real text reaches the prompt, that's a prompt change with an evaluation behind it, filed separately.

This also moots the Codex P2 finding on that block (the unconditional "out loud" requirement would have forced a speaker for a self-directed question). The block no longer exists.

## Related Issue

Contributes to #1820

Deliberately not `Closes`. #1825 fixes the mechanical cause of the reported symptom and should own the close. This PR fixes a real but distinct half — the character sheet never reaching the per-turn prompt — which #1825 doesn't address. Whether #1820 is fully satisfied is a question for a playtest run after both land, not something either PR should assert on its own.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Tests went in first and the background cases failed against the unmodified template. Caveat worth carrying: writing tests first didn't save me from testing at the wrong layer, which is what produced the wrong root cause in the first place.

## User Stories Addressed

As a player, when I raise something from my own character's history I want the story to know what I'm talking about.

## Flow Diagrams

N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A — prompt template change, no UI surface.

## Implementation Notes

One registry template, `src/lib/promptTemplates/templates/narrative/sceneTemplate.ts`. No prompt strings went into a generator or a route.

Against the template-governance gates:

- **G1 input contract** — no context-type change needed. `playerCharacterBackground?: unknown` was already on `NarrativeTemplateContext` because `initialSceneTemplate` uses it. `formatPlayerBackground` narrows defensively (object with `history`/`personality`, or a plain string) since the field is typed `unknown` and legacy characters can carry a string.
- **G2 leakage** — nothing new enters the prompt except the player's own character sheet, which is the player's data by definition.
- **G3 determinism** — no change to the response format, the JSON shape, or any heading a parser reads. Nothing in `src/lib/ai/*parse*` or `*normalize*` is affected.
- **G6 cost** — two short free-text fields per turn. Goals and play style already arrive via the personalization section and the rest of the sheet was left out deliberately.

Only History and Personality go in. The rest of `CharacterBackground` (goals, fears, relationships) either duplicates the personalization section or would grow every turn's context for no narrative gain.

No G4/G5 live evaluation matrix here. The claim this PR makes is narrow and deterministic: the character's history is present in the constructed prompt where it previously wasn't. Whether prose measurably improves is a separate claim needing the 2x2x3 matrix through the real play loop, and I'm not making it.

Interaction with #1825 was verified without stacking, per the repo's rule. Merging `origin/feature/issue-1819-typed-action-skill-check` into a throwaway local branch merged cleanly (the two diffs touch disjoint files) and the combined `src/lib/promptTemplates` and `useActiveGameSessionActions` suites passed, 38 tests, exit 0. The throwaway branch was deleted; this branch stays based on `develop`.

## Screenshots

N/A

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

Codex left one P2 on the `PLAYER ACTION REQUIREMENTS` block. That block has since been removed for the reasons above, so the finding no longer applies to the diff.

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

`npm test` 2849 passed / 412 suites, exit 0. `npm run type-check` exit 0. `npm run lint` exit 0 (pre-existing warnings only, none from this diff). No CSS touched, so `lint:css` wasn't run. Visual and E2E skipped locally on purpose — macOS-pinned baselines, no rendered surface in this change; CI runs them.

## Testing Instructions

`npx jest src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts`. To see the failure this addresses, stash the change to `sceneTemplate.ts` and re-run — the background cases go red.

By hand, and this needs #1825 merged to be meaningful: create a character whose History says something concrete, start a session, and type something that references it. The fact should be available to the passage rather than invisible to it. Treat that as a signal, not proof.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
