### PR TITLE
Generate three choices instead of four, and stop evicting one to force an alignment spread

### DIFF
--- a/src/components/shared/ChoiceSelector/ChoiceSelector.tsx
+++ b/src/components/shared/ChoiceSelector/ChoiceSelector.tsx
@@ -11,7 +11,6 @@ import { clsx } from 'clsx';
 import { safeTrim } from '@/lib/utils';
 import { useKeyboardShortcuts, KeyboardShortcut } from '@/hooks/useKeyboardShortcuts';
 import { normalizeDecisionOptions } from './optionNormalizer';
-import type { NormalizedOption } from './optionNormalizer';
 import {
   AlignmentBadge,
   SkillRequirementBadges,
@@ -99,16 +98,15 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
     },
   };
 
-  // Normalize the data into a common format
-  const normalizedOptions = normalizeDecisionOptions(
+  // Every generated option is shown. Trimming here used to evict a neutral
+  // choice to guarantee an alignment spread, which quietly threw away the
+  // option most likely to engage the scene. Variety is the generator's job.
+  const allOptions = normalizeDecisionOptions(
     decision,
     selectedOptionId,
     worldSkills,
     requirementEvaluationContext
   );
-
-  // Keep a compact set while preserving alignment variety when possible.
-  const allOptions = selectVisibleOptions(normalizedOptions, 3);
 
   // Determine the prompt text
   const displayPrompt = prompt || decision.prompt;
@@ -318,52 +316,3 @@ const ChoiceSelector: React.FC<ChoiceSelectorProps> = ({
 };
 
 export default ChoiceSelector;
-
-const selectVisibleOptions = (
-  options: NormalizedOption[],
-  maxVisible: number
-): NormalizedOption[] => {
-  if (options.length <= maxVisible) {
-    return options;
-  }
-
-  const base = options.slice(0, maxVisible);
-  const hasLawful = base.some((option) => option.alignment === 'lawful');
-  const hasChaotic = base.some((option) => option.alignment === 'chaotic');
-
-  if (hasLawful && hasChaotic) {
-    return base;
-  }
-
-  const desiredAlignments: Array<'lawful' | 'chaotic'> = [];
-  if (!hasLawful) desiredAlignments.push('lawful');
-  if (!hasChaotic) desiredAlignments.push('chaotic');
-
-  const existingIds = new Set(base.map((option) => option.id));
-  const result = [...base];
-
-  for (const alignment of desiredAlignments) {
-    const candidate = options.find(
-      (option) => option.alignment === alignment && !existingIds.has(option.id)
-    );
-    if (!candidate) continue;
-
-    // Prefer replacing the last neutral option so we keep lawful/chaotic variety.
-    let replaceIndex = -1;
-    for (let i = result.length - 1; i >= 0; i -= 1) {
-      if (result[i].alignment === 'neutral') {
-        replaceIndex = i;
-        break;
-      }
-    }
-    if (replaceIndex === -1) {
-      replaceIndex = result.length - 1;
-    }
-
-    existingIds.delete(result[replaceIndex].id);
-    result[replaceIndex] = candidate;
-    existingIds.add(candidate.id);
-  }
-
-  return result;
-};

--- a/src/components/shared/ChoiceSelector/__tests__/ChoiceSelector.test.tsx
+++ b/src/components/shared/ChoiceSelector/__tests__/ChoiceSelector.test.tsx
@@ -279,38 +279,22 @@ describe('ChoiceSelector', () => {
       expect(screen.getByText(/Intimidation.*DC 14/i)).toBeInTheDocument();
     });
 
-    it('limits the number of choices to 3', () => {
-      const decisionWithManyOptions: Decision = {
-        ...decision,
-        options: [
-          { id: '1', text: 'Option 1' },
-          { id: '2', text: 'Option 2' },
-          { id: '3', text: 'Option 3' },
-          { id: '4', text: 'Option 4' },
-        ]
-      };
-      renderChoiceSelector({decision: decisionWithManyOptions, onSelect: mockOnSelect});
-      expect(screen.queryByText('Option 4')).not.toBeInTheDocument();
-      expect(screen.getAllByRole('radio')).toHaveLength(3);
-    });
-
-    it('keeps a chaotic option visible when choices are capped to 3', () => {
+    it('renders every option the decision carries, without evicting one for alignment spread', () => {
       const alignedDecision: Decision = {
         id: 'decision-aligned',
         prompt: 'How do you respond?',
         options: [
           { id: 'lawful-opt', text: 'Follow protocol', alignment: 'lawful' },
           { id: 'neutral-opt-1', text: 'Assess risks', alignment: 'neutral' },
-          { id: 'neutral-opt-2', text: 'Observe quietly', alignment: 'neutral' },
+          { id: 'neutral-opt-2', text: 'Check the radio in the corner', alignment: 'neutral' },
           { id: 'chaotic-opt', text: 'Trigger a loud distraction', alignment: 'chaotic' },
         ],
       };
 
       renderChoiceSelector({ decision: alignedDecision, onSelect: mockOnSelect });
 
-      expect(screen.getByText('Follow protocol')).toBeInTheDocument();
-      expect(screen.getByText('Trigger a loud distraction')).toBeInTheDocument();
-      expect(screen.getAllByRole('radio')).toHaveLength(3);
+      expect(screen.getAllByRole('radio')).toHaveLength(4);
+      expect(screen.getByText('Check the radio in the corner')).toBeInTheDocument();
     });
 
     it('disables options when character lacks required skills', async () => {

--- a/src/lib/ai/__tests__/choiceAlignment.test.ts
+++ b/src/lib/ai/__tests__/choiceAlignment.test.ts
@@ -79,7 +79,10 @@ Options:
         worldId: 'test-world',
         narrativeContext: mockNarrativeContext,
         characterIds: ['char-1'],
-        useAlignedChoices: true
+        useAlignedChoices: true,
+        // Four options so every tag in the mock reaches the parser; play asks
+        // for three.
+        maxOptions: 4
       });
 
       expect(result.options).toHaveLength(4);
@@ -299,7 +302,9 @@ Options:
         worldId: 'test-world',
         narrativeContext: mockNarrativeContext,
         characterIds: ['char-1'],
-        useAlignedChoices: true
+        useAlignedChoices: true,
+        // Four options so the empty tag on the last one reaches the parser.
+        maxOptions: 4
       });
 
       expect(result.options).toHaveLength(4);

--- a/src/lib/ai/__tests__/choiceGenerator.personality.test.ts
+++ b/src/lib/ai/__tests__/choiceGenerator.personality.test.ts
@@ -142,7 +142,10 @@ describe('choiceGenerator.personality', () => {
 
       const result = formatPersonalityForChoices(character, false);
 
-      expect(result).toContain('within required alignment distribution');
+      expect(result).toContain(
+        'Personality guides HOW an alignment is expressed, not which alignments appear'
+      );
+      expect(result).not.toMatch(/required alignment distribution|the distribution/i);
       expect(result).not.toContain(
         'Lawful/neutral/chaotic alignment should consider personality:'
       );

--- a/src/lib/ai/__tests__/choiceGenerator.prompt.alignedAssembly.test.ts
+++ b/src/lib/ai/__tests__/choiceGenerator.prompt.alignedAssembly.test.ts
@@ -1,0 +1,107 @@
+import { buildChoicePrompt } from '../choiceGenerator.prompt';
+import type { NarrativeContext } from '@/types/narrative.types';
+import { createMockWorld } from '@/lib/test-utils/testDataFactory';
+import { useCharacterStore } from '@/state/characterStore';
+import type { Character as StoreCharacter } from '@/state/characterStore';
+
+// The template registry is deliberately NOT mocked here. Every other suite
+// stubs it out, which is why a contradiction between the aligned template and
+// the appended personality section could sit in the real prompt unnoticed.
+
+jest.mock('../loreContextHelper', () => ({
+  getLoreContextForPrompt: jest.fn(() => ''),
+}));
+
+jest.mock('@/state/inventoryStore', () => ({
+  useInventoryStore: {
+    getState: jest.fn().mockReturnValue({
+      getCharacterItems: jest.fn(() => []),
+    }),
+  },
+}));
+
+jest.mock('@/state/npcStore', () => ({
+  useNPCStore: {
+    getState: jest.fn().mockReturnValue({
+      getNPCsByWorld: jest.fn(() => []),
+    }),
+  },
+}));
+
+jest.mock('@/state/characterStore', () => ({
+  useCharacterStore: {
+    getState: jest.fn(),
+  },
+}));
+
+const playerCharacter: StoreCharacter = {
+  id: 'char-1',
+  name: 'Player One',
+  description: 'Test character',
+  worldId: 'world-1',
+  level: 1,
+  attributes: [],
+  skills: [],
+  derivedStats: [],
+  background: {
+    history: 'Former explorer',
+    personality: 'cautious, diplomatic, curious',
+    goals: ['Find the artifact'],
+    fears: ['Darkness'],
+    relationships: [],
+  },
+  isPlayer: true,
+  status: { health: 10, maxHealth: 10, conditions: [] },
+  inventory: {
+    characterId: 'char-1',
+    items: [],
+    capacity: 10,
+    categories: [],
+    itemOrder: [],
+  },
+  createdAt: '2023-01-01',
+  updatedAt: '2023-01-01',
+};
+
+const narrativeContext: NarrativeContext = {
+  worldId: 'world-1',
+  currentSceneId: 'scene-1',
+  characterIds: ['char-1'],
+  previousSegments: [],
+  currentTags: [],
+  sessionId: 'session-1',
+  currentLocation: 'Forest',
+  currentSituation: 'Exploring',
+};
+
+const buildAlignedPrompt = (): string =>
+  buildChoicePrompt({
+    world: createMockWorld({ id: 'world-1', name: 'Test World' }),
+    worldId: 'world-1',
+    narrativeContext,
+    characterIds: ['char-1'],
+    sessionId: 'session-1',
+    includeDecisionHistory: false,
+    useAlignedChoices: true,
+  });
+
+describe('assembled aligned choice prompt', () => {
+  beforeEach(() => {
+    (useCharacterStore.getState as jest.Mock).mockReturnValue({
+      characters: { 'char-1': playerCharacter },
+    });
+  });
+
+  it('asks for three options', () => {
+    expect(buildAlignedPrompt()).toContain('create 3 distinct action choices');
+  });
+
+  it('never mandates an alignment distribution, in the template or in anything appended to it', () => {
+    const prompt = buildAlignedPrompt();
+
+    expect(prompt).toContain('CHARACTER PERSONALITY CONTEXT:');
+    expect(prompt).not.toMatch(/required alignment distribution/i);
+    expect(prompt).not.toMatch(/NOT the distribution/i);
+    expect(prompt).not.toContain('1 lawful, 2 neutral, 1 chaotic');
+  });
+});

--- a/src/lib/ai/__tests__/choiceGenerator.prompt.personality.test.ts
+++ b/src/lib/ai/__tests__/choiceGenerator.prompt.personality.test.ts
@@ -168,7 +168,7 @@ describe('buildChoicePrompt personality integration', () => {
       useAlignedChoices: true,
     });
 
-    expect(prompt).toContain('within required alignment distribution');
+    expect(prompt).not.toMatch(/required alignment distribution|the distribution/i);
     expect(prompt).not.toContain(
       'Lawful/neutral/chaotic alignment should consider personality:'
     );

--- a/src/lib/ai/__tests__/choiceGenerator.test.ts
+++ b/src/lib/ai/__tests__/choiceGenerator.test.ts
@@ -112,9 +112,45 @@ describe('ChoiceGenerator', () => {
       expect(result.options[2].text).toBe('Draw your sword and prepare for combat');
     });
 
+    it('keeps three options by default when the model returns more', async () => {
+      mockAIClient.generateContent.mockResolvedValueOnce({
+        content: `Decision: What will you do in the forest?
+
+        Options:
+        1. Investigate the strange noise
+        2. Climb a tree to get a better view
+        3. Draw your sword and prepare for combat
+        4. Set the underbrush alight`,
+        finishReason: 'STOP',
+      });
+
+      const result = await generateChoices(mockAIClient, {
+        worldId: 'world-1',
+        narrativeContext: createMockNarrativeContext(),
+        characterIds: ['char-1'],
+      });
+
+      expect(result.options).toHaveLength(3);
+    });
+
+    it('falls back to exactly three options so nothing generated goes unshown', async () => {
+      mockAIClient.generateContent.mockResolvedValueOnce({
+        content: '',
+        finishReason: 'STOP',
+      });
+
+      const result = await generateChoices(mockAIClient, {
+        worldId: 'world-1',
+        narrativeContext: createMockNarrativeContext(),
+        characterIds: ['char-1'],
+      });
+
+      expect(result.options).toHaveLength(3);
+    });
+
     it('should handle AI errors and generate fallback choices', async () => {
       mockAIClient.generateContent.mockRejectedValueOnce(new Error('AI Service unavailable'));
-      
+
       const result = await generateChoices(mockAIClient, {
         worldId: 'world-1',
         narrativeContext: createMockNarrativeContext(),

--- a/src/lib/ai/__tests__/narrativeGenerator.choices.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.choices.test.ts
@@ -91,7 +91,7 @@ describe('NarrativeGenerator - Player Choices', () => {
         characterIds: ['character-1'],
         sessionId: 'session-1', // Now includes sessionId from narrativeContext
         minOptions: 3,
-        maxOptions: 4,
+        maxOptions: 3,
         useAlignedChoices: true
       });
     });

--- a/src/lib/ai/__tests__/narrativeGenerator.skillChoices.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.skillChoices.test.ts
@@ -90,7 +90,7 @@ describe('NarrativeGenerator - Skill-Based Choices', () => {
       characterIds: ['char-1'],
       sessionId: 'session-1', // Now includes sessionId from narrativeContext
       minOptions: 3,
-      maxOptions: 4,
+      maxOptions: 3,
       useAlignedChoices: true
     });
 

--- a/src/lib/ai/choiceGenerator.fallback.ts
+++ b/src/lib/ai/choiceGenerator.fallback.ts
@@ -12,14 +12,9 @@ export const generateFallbackChoices = (
   const options: DecisionOption[] = [];
   const genre = (world?.genre || 'fantasy').toLowerCase();
 
-  if (narrativeContext?.currentSituation) {
-    options.push({
-      id: generateUniqueId('option'),
-      text: 'Investigate further',
-      alignment: 'neutral',
-    });
-  }
-
+  // Each genre branch contributes exactly three options, matching what the
+  // generator asks the model for. A conditional fourth used to ride along here
+  // and get silently dropped downstream.
   switch (genre) {
     case 'fantasy':
       options.push(

--- a/src/lib/ai/choiceGenerator.personality.ts
+++ b/src/lib/ai/choiceGenerator.personality.ts
@@ -64,9 +64,7 @@ export const formatPersonalityForChoices = (
   }
 
   const guidanceLines = [
-    includeAlignmentHints
-      ? 'PERSONALITY-ALIGNED CHOICE GUIDANCE:'
-      : 'PERSONALITY-ALIGNED CHOICE GUIDANCE (within required alignment distribution):',
+    'PERSONALITY-ALIGNED CHOICE GUIDANCE:',
     "- Create options that reflect the character's personality traits",
     '- Reference active goals when choices can advance or challenge them',
     '- Consider fears when appropriate (avoidance or confrontation options)',
@@ -81,8 +79,12 @@ export const formatPersonalityForChoices = (
       "- Don't force personality alignment if it limits meaningful variety"
     );
   } else {
+    // The aligned template carries its own alignment guidance, so this branch
+    // only clarifies personality's role. It must not reassert a distribution:
+    // the template no longer mandates one, and this section is appended after
+    // it, so a contradiction here is the last thing the model reads.
     guidanceLines.push(
-      '- Personality guides HOW each required alignment is expressed, NOT the distribution'
+      '- Personality guides HOW an alignment is expressed, not which alignments appear'
     );
   }
 

--- a/src/lib/ai/choiceGenerator.ts
+++ b/src/lib/ai/choiceGenerator.ts
@@ -37,7 +37,7 @@ export async function generateChoices(
   params: ChoiceGenerationParams
 ): Promise<Decision> {
   try {
-    const { worldId, narrativeContext, characterIds, sessionId, maxOptions = 4, minOptions = 3, useAlignedChoices = false, includeDecisionHistory = true } = params;
+    const { worldId, narrativeContext, characterIds, sessionId, maxOptions = 3, minOptions = 3, useAlignedChoices = false, includeDecisionHistory = true } = params;
 
     const world = getWorld(worldId);
     const prompt = buildChoicePrompt({

--- a/src/lib/ai/narrativeGenerator.ts
+++ b/src/lib/ai/narrativeGenerator.ts
@@ -746,7 +746,7 @@ export class NarrativeGenerator {
         characterIds,
         sessionId: sessionId || narrativeContext.sessionId,
         minOptions: 3,
-        maxOptions: 4,
+        maxOptions: 3,
         useAlignedChoices: true,
       });
 

--- a/src/lib/promptTemplates/templates/narrative/__tests__/choiceTemplates.test.ts
+++ b/src/lib/promptTemplates/templates/narrative/__tests__/choiceTemplates.test.ts
@@ -1,0 +1,68 @@
+import { playerChoiceTemplate } from '../playerChoiceTemplate';
+import { alignedChoiceTemplate } from '../choiceTypeTemplates';
+import type { NarrativeContext, NarrativeSegment } from '@/types/narrative.types';
+
+const segment: NarrativeSegment = {
+  id: 'segment-1',
+  worldId: 'world-1',
+  sessionId: 'session-1',
+  content: 'The radio in the corner has been dead for days.',
+  type: 'scene',
+  metadata: { tags: [] },
+  timestamp: new Date('2026-01-01T00:00:00.000Z'),
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+const narrativeContext: NarrativeContext = {
+  worldId: 'world-1',
+  currentSceneId: 'scene-1',
+  characterIds: ['char-1'],
+  previousSegments: [segment],
+  recentSegments: [segment],
+  currentTags: [],
+  sessionId: 'session-1',
+  currentSituation: 'Deciding whether to move on',
+};
+
+const baseContext = {
+  worldName: 'Butler County Outskirts',
+  genre: 'zombie survival',
+  narrativeContext,
+};
+
+const countScaffoldedOptionLines = (prompt: string): number => {
+  const optionsSection = prompt.split('Options:')[1] ?? '';
+  return optionsSection.split('\n').filter((line) => /^\d+\.\s/.test(line)).length;
+};
+
+describe('choice templates ask for as many options as the interface shows', () => {
+  it('scaffolds three options by default in the plain choice template', () => {
+    const prompt = playerChoiceTemplate(baseContext);
+
+    expect(prompt).toContain('create 3 distinct action choices');
+    expect(countScaffoldedOptionLines(prompt)).toBe(3);
+  });
+
+  it('scaffolds three options by default in the aligned choice template', () => {
+    const prompt = alignedChoiceTemplate(baseContext);
+
+    expect(prompt).toContain('create 3 distinct action choices');
+    expect(countScaffoldedOptionLines(prompt)).toBe(3);
+  });
+
+  it('honors an explicit option count in the aligned choice template', () => {
+    const prompt = alignedChoiceTemplate({ ...baseContext, optionCount: 5 });
+
+    expect(prompt).toContain('create 5 distinct action choices');
+    expect(countScaffoldedOptionLines(prompt)).toBe(5);
+  });
+
+  it('leaves the alignment mix to the scene instead of pinning a tag to each slot', () => {
+    const prompt = alignedChoiceTemplate(baseContext);
+
+    expect(prompt).toContain('[LAWFUL]');
+    expect(prompt).not.toContain('1 lawful, 2 neutral, 1 chaotic');
+    expect(prompt).toMatch(/do NOT repeat the same mix or the same tag order/i);
+  });
+});

--- a/src/lib/promptTemplates/templates/narrative/choiceTypeTemplates.ts
+++ b/src/lib/promptTemplates/templates/narrative/choiceTypeTemplates.ts
@@ -6,6 +6,7 @@ interface PlayerChoiceTemplateContext {
   genre?: string;
   narrativeContext?: NarrativeContext;
   characterIds?: string[];
+  optionCount?: number;
   worldSkills?: Array<{
     id: string;
     name: string;
@@ -18,12 +19,19 @@ interface PlayerChoiceTemplateContext {
 }
 
 /**
- * Prompt template for generating player choices with lawful/chaotic alignment
- * Generates a decision prompt with 1 lawful, 2 neutral, and 1 chaotic option
+ * Prompt template for generating alignment-tagged player choices.
+ *
+ * The mix of alignments is chosen per scene rather than mandated. A fixed
+ * quota produced the same lawful/neutral/chaotic shape every turn, with the
+ * chaotic option always last and almost never picked.
  */
 export const alignedChoiceTemplate = (context: PlayerChoiceTemplateContext): string => {
-  const { worldName, genre, narrativeContext, worldSkills, worldNpcs } = context;
-  
+  const { worldName, genre, narrativeContext, worldSkills, worldNpcs, optionCount } = context;
+  const choiceCount =
+    typeof optionCount === 'number' && Number.isFinite(optionCount)
+      ? Math.max(1, Math.floor(optionCount))
+      : 3;
+
   // Extract recent narrative content to provide context
   const recentContent = narrativeContext?.recentSegments
     ?.slice(-1) // Use only the latest segment to reduce context size
@@ -89,19 +97,25 @@ ${shortContext}${skillsInfo}${npcInfo}
 === CRITICAL INSTRUCTIONS ===
 You MUST create choices that directly respond to the specific situation described above. Do NOT create generic choices. Reference the specific characters, objects, and events mentioned in the context.
 
-Based on the SPECIFIC narrative situation above, create 4 distinct action choices that follow these alignment categories:
+Based on the SPECIFIC narrative situation above, create ${choiceCount} distinct action choices, each tagged with the alignment it expresses:
 
 ALIGNMENT DEFINITIONS:
 - LAWFUL: Follows rules, respects authority, seeks order, honors agreements, protects others
 - NEUTRAL: Balanced approach, practical solutions, adapts to situation, moderate response
 - CHAOTIC: WILDLY UNEXPECTED and DISRUPTIVE actions that completely change the situation. Dramatic, potentially dangerous, creative solutions that ignore social norms, defy expectations, and could lead to entirely different story outcomes. VARY THE KIND of chaos and do NOT default to making noise (yelling, shouting, singing). Draw from a wide range, fitted to the scene: sudden physical risk ("leap from the balcony onto the chandelier," "kick over the lantern to set the drapes alight"), trickery or deception ("impersonate the captain and bark orders," "bluff an outrageous lie with total confidence"), sabotage or destruction ("cut the rope bridge behind you," "smash the control panel," "throw open the cells and free the prisoners"), turning the tables ("start a brawl to scatter the room," "switch sides mid-negotiation"), or abandoning the obvious goal for something no one expects. The goal is options that dramatically shift the narrative in surprising ways.
 
+CHOOSING THE MIX (IMPORTANT):
+- Always tag every choice [LAWFUL], [NEUTRAL], or [CHAOTIC].
+- Pick the mix the scene actually supports. There is no quota: a tense standoff might offer two chaotic openings, a quiet interrogation none at all.
+- Do NOT make every choice neutral, and do NOT repeat the same mix or the same tag order turn after turn. A player who can predict which slot holds the reckless option has stopped reading the choices.
+- Only offer a chaotic option when a genuinely disruptive action fits the moment. A reckless choice nobody would plausibly take is wasted space.
+
 PERSONALITY-INFORMED CHOICES (when character personality context is provided):
-- Within the REQUIRED alignment distribution (1 lawful, 2 neutral, 1 chaotic), create options that offer ways to express the character's traits
+- Create options that offer ways to express the character's traits
 - Reference active goals when choices can advance or challenge them
 - Consider fears when appropriate (avoidance or confrontation options)
 - Balance personality-consistent choices with growth opportunities
-- Personality context guides HOW each alignment is expressed, NOT the required distribution
+- Personality context guides HOW an alignment is expressed, not which alignments appear
 
 REQUIREMENTS:
 1. MANDATORY: Reference the SPECIFIC characters, objects, and events from the context (e.g., if there's a dragon, mention the dragon; if there's treasure, mention treasure)
@@ -136,14 +150,8 @@ Context Summary: [Write a brief 1-sentence summary that captures WHY this decisi
 Decision: What will you do?
 
 Options:
-1. [LAWFUL] [First choice - follows rules/authority/order]
-   Requirements: [Optional - SkillName X+]${consequencesFormatLine}
-2. [NEUTRAL] [Second choice - balanced/practical approach]
-   Requirements: [Optional - SkillName X+]${consequencesFormatLine}
-3. [NEUTRAL] [Third choice - different practical approach]
-   Requirements: [Optional - SkillName X+]${consequencesFormatLine}
-4. [CHAOTIC] [Fourth choice - WILDLY UNEXPECTED action that could completely change the situation - be creative and dramatic!]
-   Requirements: [Optional - SkillName X+]${consequencesFormatLine}${consequencesInstructions}
+${Array.from({ length: choiceCount }, (_, i) => `${i + 1}. [ALIGNMENT] [Action choice]
+   Requirements: [Optional - SkillName X+]${consequencesFormatLine}`).join('\n')}${consequencesInstructions}
 
 Keep your response EXACTLY in this format. Include the Decision Weight line, Context Summary line, then Decision and Options sections with alignment tags.`;
 };

--- a/src/lib/promptTemplates/templates/narrative/playerChoiceTemplate.ts
+++ b/src/lib/promptTemplates/templates/narrative/playerChoiceTemplate.ts
@@ -28,7 +28,7 @@ export const playerChoiceTemplate = (context: PlayerChoiceTemplateContext): stri
   const choiceCount =
     typeof optionCount === 'number' && Number.isFinite(optionCount)
       ? Math.max(1, Math.floor(optionCount))
-      : 4;
+      : 3;
   
   // Extract recent narrative content to provide context
   const recentContent = narrativeContext?.recentSegments


### PR DESCRIPTION
## Description

Four choices were generated every turn and three were shown. The fourth was paid for and dropped, and the drop wasn't a truncation: `selectVisibleOptions` took the first three, then replaced the last neutral option so a lawful and a chaotic always survived. The discarded choice was therefore always a neutral one, and the player saw the same lawful / neutral / chaotic shape every turn.

Digging into it turned up a second half the issue didn't name. The real play loop runs with `useAlignedChoices: true`, which selects `alignedChoiceTemplate`, and that template hardcoded four options in a fixed 1 lawful / 2 neutral / 1 chaotic order with chaotic always in slot 4. It also ignored the option count the generator passed it. That's the actual source of "the reckless option is slot 4 in all 29 turns" from the playtest campaign, and it means dropping the view-layer rule on its own would have made things worse: the template would still emit four in that order, the generator would slice to three, and the chaotic option would vanish entirely every turn.

So this took option 3 from the issue, generate 3 and drop the alignment forcing, and applied it at every layer that had an opinion:

- `playerChoiceTemplate` defaults `choiceCount` to 3 instead of 4.
- `alignedChoiceTemplate` now honors `optionCount` (default 3) and scaffolds that many `[ALIGNMENT]` lines, matching the pattern the plain template already uses. The mandated 1/2/1 distribution is replaced with guidance to pick the mix the scene supports, vary it turn to turn, and skip a chaotic option when nothing genuinely disruptive fits.
- `choiceGenerator` defaults to `maxOptions = 3`, and `narrativeGenerator.generatePlayerChoices` passes 3.
- `ChoiceSelector` renders every option it's given. `selectVisibleOptions` was deleted rather than narrowed, since it had exactly one caller and the eviction rule was its entire job.
- `generateFallbackChoices` lost the conditional "Investigate further" that made it emit four for some genres. Each genre branch now contributes exactly three, which also stops the fallback's chaotic option being the one sliced off downstream.

Then review caught a third place the quota lived. `formatPersonalityForChoices` has a branch that fires precisely when `useAlignedChoices` is true, and it was emitting "within required alignment distribution" and "Personality guides HOW each required alignment is expressed, NOT the distribution". That section is appended after the template, so for any player character carrying personality data, which is the normal case, the assembled prompt said the mix is the scene's call and then contradicted itself further down. Removing the quota from the template alone would have left the production prompt arguing with itself. Both lines now say the part that's still true, that personality shapes how an alignment is expressed rather than which alignments appear.

Option 2 (render four) was explicitly not taken. That walks back into the action rail's vertical footprint, which is still an open UX problem and out of scope here.

## Related Issue

Closes #1823

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Tests were written alongside rather than strictly before, since the first move was reading the three layers to confirm the issue's line references still held (they all did) and then finding the aligned-template half.

## User Stories Addressed

As a player, when the game offers me choices I want each one to be worth reading, rather than one predictable slot per alignment with the same reckless option sitting in the same place every turn.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [x] Components developed in isolation first
- [x] Visual consistency verified

The `ChoiceSelector` stories still carry four-option decisions, which is fine now that the component renders what it's handed. No story needed changing.

## Implementation Notes

The parser was checked before touching the prompt format. `choiceGenerator.parser.ts` reads the `[TAG]` prefix per option and is order- and count-independent, so nothing the parser relies on moved. What changed in the templates is the number of scaffolded lines and the alignment guidance, not the structure.

Worth being straight about the evidence boundary here. What's proven is the count contract: the prompt asks for three, the generator keeps three, the interface shows three, and the forced eviction is gone. What is not proven is the hypothesis underneath option 3, that per-scene alignment variety from the model beats a quota. That needs the multi-world, multi-turn eval matrix from `narraitor-ai-quality-discipline`, which needs a live provider key and a real play session, and it belongs in a playtest run rather than in this PR. If the mix comes back flat, the fix is prompt guidance, not a downstream rule.

`maxOptions` stays a parameter rather than becoming a constant, so a caller that genuinely wants a different count still can. Two alignment-parsing tests now pass `maxOptions: 4` explicitly, since they're testing tag parsing on four tagged options rather than the default count.

## Screenshots

N/A

## Visual Baseline Changes

None. Every decision the visual suite renders carries exactly three options (`tests/fixtures/narrative.fixture.ts` and the `/api/narrative/choices` mock in `tests/visual/utils/mockApi.ts`), and `selectVisibleOptions` returned its input unchanged at three or fewer. No snapshot in `tests/visual/**-snapshots/**` can move as a result of this change.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit wasn't run separately; CI covers it.

## Testing Instructions

Local run, all green:

- `npm run test:ci` - 414 suites, 2851 tests, exit 0
- `npm run type-check` - exit 0
- `npm run lint` - exit 0, no errors
- `npm run deps:validate` and `npm run deps:check` - exit 0, baseline holds at 17

No CSS changed, so `lint:css` wasn't needed. Visual and E2E suites weren't run locally, per the reasoning in the Visual Baseline Changes section.

To check it by hand: start a session, take a few turns, and count the buttons in the action rail. Three, matching what the prompt asked for, with the alignment mix varying rather than reading lawful / neutral / chaotic in that order every time.

New tests worth knowing about:

- `src/lib/promptTemplates/templates/narrative/__tests__/choiceTemplates.test.ts` pins both templates to three scaffolded options by default, checks `optionCount` is honored, and asserts the aligned template no longer pins a tag to each slot.
- `src/lib/ai/__tests__/choiceGenerator.test.ts` covers a model returning four options being kept at three, and the fallback path returning exactly three.
- `src/components/shared/ChoiceSelector/__tests__/ChoiceSelector.test.tsx` replaces the two cap tests with one asserting every option renders, using the real case from the issue (the radio in the corner) as the option that used to get evicted.
- `src/lib/ai/__tests__/choiceGenerator.prompt.alignedAssembly.test.ts` builds the aligned prompt against the real template registry, rather than the stub every other prompt suite uses, and asserts no required-distribution language survives anywhere in the assembled result. This is the test that would have caught the personality-section contradiction, and it was confirmed to fail against the pre-fix module.

## Checklist

- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

No docs needed updating. Accessibility is unchanged, the radiogroup just holds the options it was given instead of a filtered subset.

`ChoiceSelector.tsx` is 318 lines, still over the 300 limit, but this change took 51 lines out of it rather than adding any. Splitting it further isn't this PR's job.
