### PR TITLE
Record the two harness traps round 4 hit

### DIFF
--- a/.claude/skills/narraitor-playtest-loop/SKILL.md
+++ b/.claude/skills/narraitor-playtest-loop/SKILL.md
@@ -60,6 +60,19 @@ because React re-renders between them and the later clicks land on stale nodes. 
 them with `setTimeout(fn, 300 * i)` inside one call, then verify the result in the next
 call. Range inputs batch fine. Buttons do not.
 
+**Fire batches, do not await them.** The JavaScript bridge times out at 30 seconds and a
+turn costs 4 to 8, so any batch past three turns dies mid-run holding the tool call open.
+Kick the loop off without awaiting it, park progress on a `window` flag, and poll that flag
+from later calls. The work survives the timeout either way — round 4 lost a call to a 5-turn
+`await` and found the batch had completed in the background regardless — but polling is the
+difference between reading the result and guessing at it.
+
+**Dismiss the ending offer before every action.** Somewhere around turn 14 the session
+offers "Your story could end here" with View Ending and Continue Playing. It suppresses the
+choice list, so a runner that does not click Continue Playing stalls for the rest of its
+batch and reports a timeout that looks like a hung generation. Check for it at the top of
+each turn, not once at the start.
+
 **Capturing a turn:** one JavaScript call returning compact JSON from
 `window.useNarrativeStore.getState()` for `segments` and `decisions`, plus
 `useJournalStore` and `useInventoryStore`. All of them are exposed on `window` whenever

--- a/.claude/skills/narraitor-playtest-loop/SKILL.md
+++ b/.claude/skills/narraitor-playtest-loop/SKILL.md
@@ -67,11 +67,18 @@ from later calls. The work survives the timeout either way — round 4 lost a ca
 `await` and found the batch had completed in the background regardless — but polling is the
 difference between reading the result and guessing at it.
 
-**Dismiss the ending offer before every action.** Somewhere around turn 14 the session
-offers "Your story could end here" with View Ending and Continue Playing. It suppresses the
-choice list, so a runner that does not click Continue Playing stalls for the rest of its
-batch and reports a timeout that looks like a hung generation. Check for it at the top of
-each turn, not once at the start.
+**Handle the ending offer at the top of every action, and handle it per run.** Somewhere
+around turn 14 the session offers "Your story could end here" with View Ending and Continue
+Playing. It suppresses the choice list, so a runner that ignores it stalls for the rest of
+its batch and reports a timeout that looks like a hung generation. Check for it before each
+action rather than once at the start.
+
+What to click depends on the run. **Fixed-length runs click Continue Playing** — the offer
+fires well before turn 30 and accepting it ends the session early with the block scores
+unfinished. **Run 4 clicks View Ending**, because a naturally suggested ending is the thing
+that run exists to reach; dismissing it there leaves the run either circling forever or
+scoring a forced ending, which is a different question. A runner that hard-codes one branch
+breaks whichever run it did not consider.
 
 **Capturing a turn:** one JavaScript call returning compact JSON from
 `window.useNarrativeStore.getState()` for `segments` and `decisions`, plus


### PR DESCRIPTION
## Description

Round 4 of the playtest campaign (results in #1818) hit two mechanical traps that cost tool
calls and produced misleading failures. Neither was written down anywhere, so the next run
rediscovers both. This adds them to section 3, next to the one-click-per-tick note, which is
where the other gotchas about driving turns already live.

**Fire batches, do not await them.** The JavaScript bridge times out at 30 seconds and a turn
costs 4 to 8, so any batch past three turns dies mid-call. The work survives — round 4 lost a
call to a 5-turn `await` and found the batch had completed in the background anyway — but
without polling you cannot read the result, only guess at it.

**Dismiss the ending offer before every action.** Around turn 14 the session offers "Your
story could end here". It suppresses the choice list, so a runner that does not click Continue
Playing stalls for the rest of its batch and reports a timeout that reads like a hung
generation.

Documentation only. No source, no tests, no behaviour change.

## Related Issue
No issue - this is skill maintenance from the round 4 run recorded in #1818.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
N/A - documentation only, no code under test.

- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [ ] Test coverage maintained or improved

## User Stories Addressed
N/A - internal tooling documentation.

## Flow Diagrams
N/A

## Component Development
N/A - no UI changes.

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes

Both notes are stated as the trap and its symptom rather than as a recipe, matching how the
rest of section 3 is written. The timeout one is worth the extra sentence because the failure
is deceptive in a specific way: the tool call errors while the run keeps going, so the state
you find afterwards is further along than the error implies, and a runner that retries from
the error double-plays turns.

## Screenshots
N/A

## Visual Baseline Changes
None. This PR does not touch `tests/visual/**-snapshots/**`.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Lint and type-check are unaffected by a markdown-only change; no source file is touched.

## Testing Instructions

Read the diff. The claims are the two failures observed in round 4 and recorded in
`playtest-log.md` under "Harness notes"; the next run of `narraitor-playtest-loop` exercises
them for real.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed
