### PR TITLE
Render typed actions as the player wrote them on the consequence card

### DIFF
--- a/src/components/Narrative/ChoiceOutcomeCallout.tsx
+++ b/src/components/Narrative/ChoiceOutcomeCallout.tsx
@@ -125,18 +125,21 @@ export const ChoiceOutcomeCallout: React.FC<ChoiceOutcomeCalloutProps> = ({
   const decision = useNarrativeStore((state) => state.decisions[decisionId]);
   const getNpcById = useNPCStore((state) => state.getById);
 
-  const displayDecisionText = buildOutcomeDecisionText(
-    decisionText,
-    decisionOutcome
+  const selectedOption = decision?.options?.find(
+    (option) => option.id === decision.selectedOptionId
   );
+
+  // A typed action is a first-person sentence; "You attempt to I walk over..."
+  // is the same person shift the stored text already avoids. The outcome label
+  // carries the failure signal on its own.
+  const displayDecisionText = selectedOption?.isCustomInput
+    ? decisionText
+    : buildOutcomeDecisionText(decisionText, decisionOutcome);
 
   const outcomeLabel = decisionOutcome
     ? outcomeLabels[decisionOutcome]
     : 'Decision Logged';
 
-  const selectedOption = decision?.options?.find(
-    (option) => option.id === decision.selectedOptionId
-  );
   const chips = buildConsequenceChips(
     selectedOption?.consequences ?? [],
     (id) => getNpcById(id)?.name

--- a/src/components/Narrative/ChoiceOutcomeCallout.tsx
+++ b/src/components/Narrative/ChoiceOutcomeCallout.tsx
@@ -6,6 +6,7 @@ import { clsx } from 'clsx';
 import { Consequence, DecisionOutcome } from '@/types/narrative.types';
 import { useNarrativeStore } from '@/state/narrativeStore';
 import { useNPCStore } from '@/state/npcStore';
+import { formatDecisionText } from '@/lib/narrative/formatDecisionText';
 
 interface ChoiceOutcomeCalloutProps {
   decisionId: EntityID;
@@ -129,11 +130,12 @@ export const ChoiceOutcomeCallout: React.FC<ChoiceOutcomeCalloutProps> = ({
     (option) => option.id === decision.selectedOptionId
   );
 
-  // A typed action is a first-person sentence; "You attempt to I walk over..."
-  // is the same person shift the stored text already avoids. The outcome label
-  // carries the failure signal on its own.
+  // A typed action is a first-person sentence, so it takes neither prefix -
+  // "You attempt to I walk over..." is the same person shift. Rendering it from
+  // the option rather than the stored text also repairs sessions saved before
+  // addSegment stopped mangling it. The outcome label carries the failure.
   const displayDecisionText = selectedOption?.isCustomInput
-    ? decisionText
+    ? formatDecisionText(selectedOption)
     : buildOutcomeDecisionText(decisionText, decisionOutcome);
 
   const outcomeLabel = decisionOutcome

--- a/src/components/Narrative/__tests__/ChoiceOutcomeCallout.test.tsx
+++ b/src/components/Narrative/__tests__/ChoiceOutcomeCallout.test.tsx
@@ -162,6 +162,39 @@ describe('ChoiceOutcomeCallout consequence chips', () => {
     expect(screen.getByText('Order +4')).toBeInTheDocument();
   });
 
+  it('leaves a typed action alone on a failed outcome', () => {
+    useNarrativeStore.setState({
+      decisions: {
+        'decision-4': {
+          id: 'decision-4',
+          prompt: 'What now?',
+          selectedOptionId: 'opt-custom',
+          options: [
+            {
+              id: 'opt-custom',
+              text: 'I walk over to the mill and ask who holds the debt',
+              isCustomInput: true,
+              customText: 'I walk over to the mill and ask who holds the debt',
+            },
+          ],
+        },
+      },
+    });
+
+    render(
+      <ChoiceOutcomeCallout
+        decisionId="decision-4"
+        decisionText="I walk over to the mill and ask who holds the debt"
+        decisionOutcome="failure"
+      />
+    );
+
+    expect(
+      screen.getByText('I walk over to the mill and ask who holds the debt')
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/You attempt to/)).not.toBeInTheDocument();
+  });
+
   it('surfaces the actual shift size rather than a fixed label', () => {
     useNarrativeStore.setState({
       decisions: {

--- a/src/components/Narrative/__tests__/ChoiceOutcomeCallout.test.tsx
+++ b/src/components/Narrative/__tests__/ChoiceOutcomeCallout.test.tsx
@@ -195,6 +195,37 @@ describe('ChoiceOutcomeCallout consequence chips', () => {
     expect(screen.queryByText(/You attempt to/)).not.toBeInTheDocument();
   });
 
+  it('repairs a typed action persisted in the old mangled form', () => {
+    useNarrativeStore.setState({
+      decisions: {
+        'decision-5': {
+          id: 'decision-5',
+          prompt: 'What now?',
+          selectedOptionId: 'opt-custom',
+          options: [
+            {
+              id: 'opt-custom',
+              text: 'i ask Martha Hendricks what they want',
+              isCustomInput: true,
+              customText: 'i ask Martha Hendricks what they want',
+            },
+          ],
+        },
+      },
+    });
+
+    render(
+      <ChoiceOutcomeCallout
+        decisionId="decision-5"
+        decisionText="You choose to i ask Martha Hendricks what they want"
+      />
+    );
+
+    expect(
+      screen.getByText('I ask Martha Hendricks what they want')
+    ).toBeInTheDocument();
+  });
+
   it('surfaces the actual shift size rather than a fixed label', () => {
     useNarrativeStore.setState({
       decisions: {

--- a/src/lib/narrative/formatDecisionText.ts
+++ b/src/lib/narrative/formatDecisionText.ts
@@ -1,0 +1,44 @@
+import { DecisionOption } from '@/types/narrative.types';
+import { safeTrim } from '@/lib/utils';
+
+/**
+ * An offered option is a verb phrase, so it reads as "You choose to <option>".
+ */
+const formatOfferedOption = (text: string): string => {
+  const trimmed = safeTrim(text);
+  if (!trimmed) return '';
+
+  const withoutYou = trimmed.replace(/^you\b\s*/i, '');
+  const withoutChoose = withoutYou.replace(/^(choose|decide|decided|chose)\s+to\s+/i, '');
+  const withoutTo = withoutChoose.replace(/^to\s+/i, '');
+  const firstChar = withoutTo.charAt(0);
+  const normalized = /[A-Z]/.test(firstChar)
+    ? `${firstChar.toLowerCase()}${withoutTo.slice(1)}`
+    : withoutTo;
+
+  return `You choose to ${normalized}`.trim();
+};
+
+/**
+ * A typed action is already a complete first-person sentence, and prefixing one
+ * shifts person as well as case ("You choose to i walk over to the mill"), so it
+ * renders as the player wrote it.
+ */
+const formatTypedAction = (option: DecisionOption): string => {
+  const typed = safeTrim(option.customText || option.text);
+  if (!typed) return '';
+
+  const firstChar = typed.charAt(0);
+  return /[a-z]/.test(firstChar)
+    ? `${firstChar.toUpperCase()}${typed.slice(1)}`
+    : typed;
+};
+
+/**
+ * Renders a selected decision option as the sentence shown on the consequence
+ * card. The display layer re-derives it from the option rather than trusting
+ * the persisted `causedByDecisionText`, so sessions saved before this existed
+ * render correctly too.
+ */
+export const formatDecisionText = (option: DecisionOption): string =>
+  option.isCustomInput ? formatTypedAction(option) : formatOfferedOption(option.text);

--- a/src/state/__tests__/narrativeStore.decisionConsequence.test.ts
+++ b/src/state/__tests__/narrativeStore.decisionConsequence.test.ts
@@ -219,6 +219,42 @@ describe('narrativeStore - Decision Consequence Tracking (Issue #971)', () => {
       expect(segment2.metadata.causedByDecisionText).toBe('You choose to buy supplies');
     });
 
+    it('should render a typed action as its own sentence', () => {
+      const store = useNarrativeStore.getState();
+      const sessionId = 'session-123';
+      const worldId = 'world-456';
+      const characterId = 'char-789';
+      const typed = 'i walk over to the mill and ask who holds the debt';
+
+      const decisionId = store.addDecision(sessionId, {
+        prompt: 'What do you do?',
+        options: [
+          {
+            id: 'custom-1',
+            text: typed,
+            isCustomInput: true,
+            customText: typed
+          }
+        ] as DecisionOption[]
+      });
+      store.selectDecisionOption(decisionId, 'custom-1', characterId);
+
+      const segmentId = store.addSegment(sessionId, {
+        worldId,
+        content: 'The foreman looks up.',
+        type: 'scene',
+        metadata: { tags: [] },
+        timestamp: new Date(),
+        updatedAt: getTimestamp()
+      });
+
+      const segment = useNarrativeStore.getState().segments[segmentId];
+
+      expect(segment.metadata.causedByDecisionText).toBe(
+        'I walk over to the mill and ask who holds the debt'
+      );
+    });
+
     it('should format decision text with "You choose to" prefix', () => {
       const store = useNarrativeStore.getState();
       const sessionId = 'session-123';

--- a/src/state/narrativeStore.segments.ts
+++ b/src/state/narrativeStore.segments.ts
@@ -1,49 +1,14 @@
-import { NarrativeSegment, NarrativeMetadata, DecisionOption } from '../types/narrative.types';
+import { NarrativeSegment, NarrativeMetadata } from '../types/narrative.types';
 import { EntityID } from '../types/common.types';
 import { generateUniqueId, getTimestamp, safeTrim } from '../lib/utils';
 import { logger } from '../lib/utils/logger';
 import { normalizeText, NORM_DESC } from '../lib/utils/textNormalization';
 import { applyWorldStateThreadUpdates } from '../lib/narrative/applyWorldStateThreadUpdates';
+import { formatDecisionText } from '../lib/narrative/formatDecisionText';
 import { useSessionStore } from './sessionStore';
 import { useGoalStore } from './goalStore';
 import { trackFunnelStep } from '@/lib/analytics/trackFunnelStep';
 import type { NarrativeStoreSet, NarrativeStoreGet } from './narrativeStore.types';
-
-const normalizeDecisionText = (text: string) => {
-  const trimmed = safeTrim(text);
-  if (!trimmed) return '';
-
-  const withoutYou = trimmed.replace(/^you\b\s*/i, '');
-  const withoutChoose = withoutYou.replace(/^(choose|decide|decided|chose)\s+to\s+/i, '');
-  const withoutTo = withoutChoose.replace(/^to\s+/i, '');
-  const firstChar = withoutTo.charAt(0);
-  const normalized =
-    firstChar && /[A-Z]/.test(firstChar)
-      ? `${firstChar.toLowerCase()}${withoutTo.slice(1)}`
-      : withoutTo;
-
-  return `You choose to ${normalized}`.trim();
-};
-
-/**
- * An offered option is a verb phrase, so it reads as "You choose to <option>".
- * A typed action is already a complete first-person sentence, and prefixing one
- * shifts person as well as case ("You choose to i walk over to the mill"), so it
- * renders as the player wrote it.
- */
-const formatDecisionText = (option: DecisionOption): string => {
-  if (!option.isCustomInput) {
-    return normalizeDecisionText(option.text);
-  }
-
-  const typed = safeTrim(option.customText || option.text);
-  if (!typed) return '';
-
-  const firstChar = typed.charAt(0);
-  return /[a-z]/.test(firstChar)
-    ? `${firstChar.toUpperCase()}${typed.slice(1)}`
-    : typed;
-};
 
 const normalizeLocationKey = (value: string): string =>
   safeTrim(value)

--- a/src/state/narrativeStore.segments.ts
+++ b/src/state/narrativeStore.segments.ts
@@ -1,4 +1,4 @@
-import { NarrativeSegment, NarrativeMetadata } from '../types/narrative.types';
+import { NarrativeSegment, NarrativeMetadata, DecisionOption } from '../types/narrative.types';
 import { EntityID } from '../types/common.types';
 import { generateUniqueId, getTimestamp, safeTrim } from '../lib/utils';
 import { logger } from '../lib/utils/logger';
@@ -23,6 +23,26 @@ const normalizeDecisionText = (text: string) => {
       : withoutTo;
 
   return `You choose to ${normalized}`.trim();
+};
+
+/**
+ * An offered option is a verb phrase, so it reads as "You choose to <option>".
+ * A typed action is already a complete first-person sentence, and prefixing one
+ * shifts person as well as case ("You choose to i walk over to the mill"), so it
+ * renders as the player wrote it.
+ */
+const formatDecisionText = (option: DecisionOption): string => {
+  if (!option.isCustomInput) {
+    return normalizeDecisionText(option.text);
+  }
+
+  const typed = safeTrim(option.customText || option.text);
+  if (!typed) return '';
+
+  const firstChar = typed.charAt(0);
+  return /[a-z]/.test(firstChar)
+    ? `${firstChar.toUpperCase()}${typed.slice(1)}`
+    : typed;
 };
 
 const normalizeLocationKey = (value: string): string =>
@@ -107,7 +127,7 @@ export const createNarrativeSegmentActions = (
 
       if (selectedOption?.text) {
         causedByDecisionId = latestDecisionId;
-        causedByDecisionText = normalizeDecisionText(selectedOption.text);
+        causedByDecisionText = formatDecisionText(selectedOption);
       }
     }
 


### PR DESCRIPTION
## Description

Typed actions now render as the player wrote them, with no "You choose to" in front. Every custom
turn of playtest round 4 came out broken on the consequence card, because typed input went through
the same normalizer as an offered option: "You choose to i walk over to The Daily Grind and ask
Sarah Jenkins straight out...".

Two layers had to change, and only the store one was in the issue. `normalizeDecisionText` in
`narrativeStore.segments.ts` lowercases the first character, which is right for a verb phrase and
wrong for a first-person sentence, so a new `formatDecisionText` branches on the option's
`isCustomInput` flag and leaves typed text alone apart from capitalising the first letter.

`ChoiceOutcomeCallout` then does the same thing again on any failed outcome, rewriting "You choose
to X" into "You attempt to X" and falling through to a bare prefix for anything that doesn't start
with "You". Fixing only the store would have moved the bug to failure turns and left it there, so
the callout now reads the selected option and passes typed text through untouched. The "Failure"
label still carries the outcome.

## Related Issue
Closes #1832

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The first box stays unchecked because the fix and its tests were written together rather than tests
first. Both new tests were then run against the stashed pre-fix code and both fail, so they do catch
the bug: `Tests: 2 failed, 18 passed`.

## User Stories Addressed

As a player typing my own action, I want the consequence card to quote what I actually wrote, so
the story doesn't open every custom turn with a broken sentence.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

No visual change beyond the text string itself. `ManuscriptSessionShell.stories.tsx` still carries
an offered-option example, which is the unchanged path.

## Implementation Notes

The typed-vs-offered signal already existed. `useActiveGameSessionActions.handleCustomSubmit` builds
the custom option with `isCustomInput: true` and `customText`, and stores it on the decision, so both
layers can read it without new metadata.

| File | Change |
|---|---|
| `src/state/narrativeStore.segments.ts` | `formatDecisionText` picks the typed or offered path |
| `src/components/Narrative/ChoiceOutcomeCallout.tsx` | Skip the "You attempt to" rewrite for typed input |

Grepped for other consumers of the prefix. `narrativeGenerator.continuity.ts` reads
`causedByDecisionText` as opaque text, so recent-decision context now carries the player's own
wording, which reads better going into the prompt anyway.

## Screenshots
N/A, text-only change on an existing card.

## Visual Baseline Changes
None.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

```bash
npm test                # 414 suites, 2860 tests, all green
npm run type-check
npm run lint
```

Live check, which needs a real session: start a game, type an action beginning with "I", and read
the consequence card on the next segment. It should quote the sentence back with a capital I and no
prefix, on a failed roll as well as a successful one.

Round 5 of the playtest loop scores this properly. F27 was on all 23 typed turns of round 4, so the
bar is zero mangled consequence lines.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
