### PR TITLE
Make a failed skill check cost something instead of quietly not happening

### DIFF
--- a/.claude/skills/narraitor-prompt-template-governance/eval-logs/1821-failed-attempts-cost.md
+++ b/.claude/skills/narraitor-prompt-template-governance/eval-logs/1821-failed-attempts-cost.md
@@ -1,0 +1,54 @@
+# Prompt/template eval log - #1821 failed attempts must cost something
+
+- Change: one variable - the failure-outcome guidance in `sceneTemplate.ts`. A new `FAILED ATTEMPT — THE WORLD STILL MOVES` block renders only when `skillResult` is `failure` or `critical-failure` (same derivation from `skill-*:` tags the SKILL CHECK RESULT block already uses); the old failure bullet ("show realistic consequences and setbacks") and the tail line ("failure = things go wrong or backfire") were rewritten so the weaker rule can't compete with the new one. Nothing else in the template moved.
+- Diff: `src/lib/promptTemplates/templates/narrative/sceneTemplate.ts`, `.../__tests__/sceneTemplate.test.ts`, this log. Branch `claude/failed-turns-world-state-7f1422`.
+- Date / evaluator: 2026-08-17, implementation session with a live Gemini key available for the matched run.
+
+## Why this shape
+
+Run 1 of the round-3 playtest (Camp Crystal Lake, cautious persona, 30 turns, live Gemini, two blind judges) resolved 18 turns as failed skill checks and rendered 13 of them as the player's action simply not occurring - world state at turn end identical to turn start. The one-bullet failure guidance is satisfiable by a reaction shot, and Gemini took the cheap satisfaction every time.
+
+The block copies the shape of the PACING and FATAL blocks, which demonstrably fire: a checkable condition (only failure turns), an ALL-CAPS header, one-sentence imperative bullets, and one bullet that is a predicate the model can test its own draft against ("if every person, object, and advantage would stand exactly where it started, the outcome is wrong"). The choice-mix instruction that Gemini ignored had the opposite shape - always-on, policy-toned, nothing to check.
+
+Deliberately absent: any quoted no-op imagery in the ban (no "words dying in throats", no "clumsy", no "no purchase"). Quoting the attractor feeds it at temperature 0.7, and that lexicon is the judges' no-op tell - putting it in the prompt would break the scoring instrument. Also absent: crit-scaling language (line 113 owns that) and any survival/"story continues" language, so the block co-renders cleanly with FATAL on critical-weight failures.
+
+## Gates
+
+- G1 (input contract): reads only the existing `narrativeContext.currentTags`; `NarrativeTemplateContext` is unchanged.
+- G2 (context leakage): no new state is fed to the model; tone settings, roster, background untouched.
+- G3 (parser safety): no structural change to the parsed output - the response format block is untouched. The only code that reads prompt text back is `parseContentRating` (`src/lib/ai/safety/contentRatingGuidance.ts`), regex `/((?:PG-13|NC-17|[A-Z]{1,5}))(?:-RATED)? CONTENT GUIDELINES/i`; the new block never contains the phrase "CONTENT GUIDELINES" (grep-verified). Response parsers read model JSON, not the prompt.
+- G6 (regression anchors): the run-1 no-op excerpts quoted in #1821 are the "before"; `1681-phrase-variety.md` is the format precedent for an honest partial log.
+
+## Coverage matrix
+
+| World (genre/tone) | Character (fresh/established) | Runs | Verdict | Representative excerpt (1-3 lines) |
+|---|---|---|---|---|
+| Camp Crystal Lake (1984 slasher / tense) | Jamie Holt, fresh | 1 x 30 turns | pending - filled after the matched run below | |
+| Camp Crystal Lake | established | 0 | not run - milestone round 5 (#1834) | |
+| Harrowgate | fresh | 0 | not run - milestone round 5 (#1834) | |
+| Harrowgate | established | 0 | not run - milestone round 5 (#1834) | |
+
+Scope decision: one matched cell, honestly filled. This closes #1821's acceptance criterion (a matched 30-turn re-run with the no-op count materially below 13/18); it does not close the eval matrix, which round 5 owns.
+
+Cross-build caveat: run 1 predates #1825 (typed actions now roll checks, so the population of failure turns changed), #1826, #1827, and #1836. The re-run against run 1 is a matched-method comparison, not a controlled A/B on a single variable.
+
+## Arc check (>= 3 consecutive turns, one cell)
+- Pending the matched run: 30 consecutive turns; five planted facts checked at turn 30 (dirt road 40 min, dead radio, Jamie knows which doors don't lock, kids not arrived, summer 1984).
+- Contradictions found: pending.
+
+## Failure drill
+- Malformed/empty response path: unaffected - this change alters outbound prompt text only. Template renders with absent and empty `currentTags` (unit tests: no block on `[]`, no block on success-only tags).
+- Slow-response/timeout behavior: unaffected - no new AI round trip.
+- Missing/invalid key behavior: unaffected - template assembly runs before the client is touched.
+- Discovered while reading, filed as follow-ups, not fixed here: `NarrativeController.tsx` merges the previous segment's `metadata.tags` into this turn's `currentTags`, so a failure tag survives one extra turn and the failure guidance (and the FATAL gate) re-fires on the turn after a failure. Scoring below uses `segment.metadata.decisionOutcome`, not tags, so the stale carryover can't contaminate the failure-turn set.
+
+## Regression vs prior good outputs
+- Compared against: the run-1 transcript excerpts in #1821 (the no-op turns) and the run-1 success/no-check turns (the contamination guard - success prose must not start imposing costs).
+- Old strengths preserved? Pending the run. The success bullet, the mechanics-hiding bullet, and the crit-severity bullet are byte-identical.
+
+## Cost/latency
+- Token delta: roughly +125-140 tokens on failure turns only, zero on success and no-check turns. While the stale-tag carryover stands, the block also fires on the turn after each failure, so per-session cost is about twice the failure count. No new AI round-trip; no latency change.
+
+## Verdict
+- Pending the matched run. No behavioral claim is made from the wiring tests - they prove the block assembles on the right turns and only those, nothing about what Gemini does with it.
+- Ship/hold decision recorded at: PR for #1821 (to be linked).

--- a/.claude/skills/narraitor-prompt-template-governance/eval-logs/1821-failed-attempts-cost.md
+++ b/.claude/skills/narraitor-prompt-template-governance/eval-logs/1821-failed-attempts-cost.md
@@ -23,18 +23,42 @@ Deliberately absent: any quoted no-op imagery in the ban (no "words dying in thr
 
 | World (genre/tone) | Character (fresh/established) | Runs | Verdict | Representative excerpt (1-3 lines) |
 |---|---|---|---|---|
-| Camp Crystal Lake (1984 slasher / tense) | Jamie Holt, fresh | 1 x 30 turns | pending - filled after the matched run below | |
+| Camp Crystal Lake (1984 slasher / tense) | Jamie Holt, fresh | 1 x 54 turns (matched 30 + 24 extension) | improved on this cell: no-op 1-2/6 in the matched 30, 4/11 over the full session, vs 13/18 in run 1 | Turn 19 (failure): "Your boot slides on something greasy ... You catch yourself on the edge of the stainless steel, the impact echoing sharply through the quiet kitchen. The glint ... now vanishes into the deeper shadows." Turn 55 (critical failure): "The blade snags on a particularly tough root, wrenching your wrist ... scraping your palm on rough bark and twisting your ankle." (pocketknife lost) |
 | Camp Crystal Lake | established | 0 | not run - milestone round 5 (#1834) | |
 | Harrowgate | fresh | 0 | not run - milestone round 5 (#1834) | |
 | Harrowgate | established | 0 | not run - milestone round 5 (#1834) | |
 
 Scope decision: one matched cell, honestly filled. This closes #1821's acceptance criterion (a matched 30-turn re-run with the no-op count materially below 13/18); it does not close the eval matrix, which round 5 owns.
 
-Cross-build caveat: run 1 predates #1825 (typed actions now roll checks, so the population of failure turns changed), #1826, #1827, and #1836. The re-run against run 1 is a matched-method comparison, not a controlled A/B on a single variable.
+Cross-build caveat: run 1 predates #1825 (typed actions now roll checks, so the population of failure turns changed), #1826, #1827, and #1836. The re-run against run 1 is a matched-method comparison, not a controlled A/B on a single variable. The same-build A/B was not run.
+
+### The matched run (2026-08-17, build 3760b3b3, live Gemini, cautious persona)
+
+Setup and harness: worktree on the branch, `.env.local` synced from the main checkout (startup log `Environments: .env.local`), dev server on this worktree's port 3302, world and character built through the real wizards to the fixture in `narraitor-playtest-loop/worlds/camp-crystal-lake.md` (attributes renamed to the targets, skills trimmed to the seven targets, Jamie Holt with Stealth/Athletics/First Aid at 5). Harness checkpoint at turn 3 passed: no `__PLAYWRIGHT__`, no Playwright UA, real POSTs to `/api/narrative/generate`, `/choices` and `/summarize`, 4 distinct segments, journal entries present. Turn latency 4.8-8.8 s throughout.
+
+Failure-turn population: the matched 30 player turns produced only 6 failed checks (run 1 produced 18). Jamie's build clears most DCs, and typed actions get model-inferred difficulties of 1-5 (DC 2-10), so a roll of 2 still passes on a Stealth 5 action. Because 6 is a thin denominator, the session was extended past the ending prompt to 54 player turns and 11 failed checks (segments 4, 9, 11, 19, 26, 27, 32, 45, 49, 54, 55; two critical). Both strata are reported. The failure set was taken from `segment.metadata.decisionOutcome`; the tag-derived set matched it exactly, and no `mixed` outcomes occurred.
+
+Scoring: two independent blind judges (fresh subagents, different models, no world spec, no knowledge of the change, inputs = attempted action + resulting prose only) answered per failure turn: does the attempt occur, name the cost as a state delta (feelings and atmosphere excluded), lexicon check, verdict no-op vs world-moved.
+
+| Stratum | Failure turns | Judge A no-op | Judge B no-op | Unanimous no-op | Judge agreement |
+|---|---|---|---|---|---|
+| Matched first 30 turns | 6 | 2/6 (turns 4, 11) | 1/6 (turn 11) | 1/6 | 5/6 |
+| Full 54-turn session | 11 | 4/11 (4, 11, 32, 54) | 4/11 (11, 32, 45, 54) | 3/11 | 9/11 |
+| Run 1 baseline (for reference) | 18 | 13/18 | | | |
+
+The attempt was rendered as not happening on 1/11 failure turns (turn 11, "the words catch in your throat", both judges), against 13/18 in run 1. Run-1 canned lexicon recurred twice: turn 11's throat line, and "clumsy" twice on turn 27. The surviving no-ops (11, 32, 54) are the same shape: a listening or reading action where the world answers with silence and "the stillness intensifies" - atmosphere standing in for cost.
+
+Mechanical store tally, kept separate from the blind call: 8/11 failure turns set `majorEvent`; itemsLost fired on 2 (turn 54's map, turn 55's pocketknife); no location changes on failure turns except 55. Store stasis on the others is consistent with the judges' costs being positional, social, or noise, which touch no store.
+
+Contamination check (over-firing guard): a third blind judge read 13 success or no-check turns and rated 9 as reading like success with no imposed cost. The other 4 (turns 10, 33, 46 neutral; turn 50 read as failure - "the deadbolt gouges the frame" on a roll of 19) are exactly the four turns that immediately follow a failure turn. Every non-adjacent success turn read clean. This is the stale-tag carryover defect (below) showing a real cost now that the failure block is stronger.
+
+Interaction with the PACING signal: 8/11 failure turns set `majorEvent`, so costly failures do count as complications for the escalation guard. That is #1680's problem and it stays untouched here.
+
+Observations for follow-up (not fixed here): the play surface stopped auto-following at around segment 18 and showed "Jump to latest" for three turns until clicked; the ending prompt fired at turn 30 ("secured in a safe location") while a threat was still outside; the story loops in a room once the group is secured (repeated "check the windows/exits" offers).
 
 ## Arc check (>= 3 consecutive turns, one cell)
-- Pending the matched run: 30 consecutive turns; five planted facts checked at turn 30 (dirt road 40 min, dead radio, Jamie knows which doors don't lock, kids not arrived, summer 1984).
-- Contradictions found: pending.
+- 54 consecutive turns, one session, no reload. Planted facts at the end: dead radio held (Chad's handheld stays dead; the walkie-talkie found at turn 34 is a separate object); Jamie knowing which doors don't lock was used at turn 13 and the narrative ran with it (staff cabins have unreliable latches, mess hall has a deadbolt); summer 1984 held (beige landline "relic", walkie-talkie, no anachronisms); dirt road / forty minutes never resurfaced (silence, not contradiction); kids not arrived never contradicted at Crystal Lake (turn 40's "the kids are terrified" is Counselor Davies at a different camp).
+- Contradictions found: none hard. Soft: turn 24 has fluorescent lights humming in a mess hall the group had entered dark; turn 55 has Jamie clearing brush outside alone from an office that was barricaded two turns earlier.
 
 ## Failure drill
 - Malformed/empty response path: unaffected - this change alters outbound prompt text only. Template renders with absent and empty `currentTags` (unit tests: no block on `[]`, no block on success-only tags).
@@ -44,11 +68,12 @@ Cross-build caveat: run 1 predates #1825 (typed actions now roll checks, so the 
 
 ## Regression vs prior good outputs
 - Compared against: the run-1 transcript excerpts in #1821 (the no-op turns) and the run-1 success/no-check turns (the contamination guard - success prose must not start imposing costs).
-- Old strengths preserved? Pending the run. The success bullet, the mechanics-hiding bullet, and the crit-severity bullet are byte-identical.
+- Old strengths preserved? Yes on the turns the block doesn't touch: 9/9 non-adjacent success turns read as success with no imposed cost. The success bullet, the mechanics-hiding bullet, and the crit-severity bullet are byte-identical. Weakened: the turn after a failure, via the pre-existing tag carryover (see contamination check).
 
 ## Cost/latency
 - Token delta: roughly +125-140 tokens on failure turns only, zero on success and no-check turns. While the stale-tag carryover stands, the block also fires on the turn after each failure, so per-session cost is about twice the failure count. No new AI round-trip; no latency change.
 
 ## Verdict
-- Pending the matched run. No behavioral claim is made from the wiring tests - they prove the block assembles on the right turns and only those, nothing about what Gemini does with it.
-- Ship/hold decision recorded at: PR for #1821 (to be linked).
+- Improved on the evaluated matrix (single cell: Camp Crystal Lake x fresh). No-op failures went from 13/18 in run 1 to 1-2/6 in the matched 30 turns and 4/11 across the full 54-turn session, with the attempt itself rendered as not happening on 1/11 instead of 13/18. Both judges independently landed on 4/11 with 9/11 per-turn agreement. That is materially below the baseline; it is not "reliable", and it is not the milestone's 80% bar under the strict unanimous count (6/11 unanimous world-moved, 8/11 by either judge). Sample is thin (11 failure turns) and the comparison is matched-method, not same-build A/B.
+- Hold points, not blockers: the residual no-op shape is the "listen and hear nothing" turn (atmosphere as cost), and the turn after a failure inherits the block through the tag carryover and sometimes reads as a second failure. Both are filed as follow-ups.
+- Ship/hold decision recorded at: PR for #1821 (linked from the PR body).

--- a/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts
+++ b/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts
@@ -1,7 +1,11 @@
 import { sceneTemplate } from '../sceneTemplate';
 import type { NarrativeTemplateContext } from '../context';
 
-function makeContext(turnsSinceComplication?: number): NarrativeTemplateContext {
+function makeContext(
+  turnsSinceComplication?: number,
+  currentTags: string[] = [],
+  decisionWeight?: 'minor' | 'major' | 'critical'
+): NarrativeTemplateContext {
   return {
     worldName: 'Butler County Outskirts',
     genre: 'zombie survival',
@@ -10,11 +14,59 @@ function makeContext(turnsSinceComplication?: number): NarrativeTemplateContext 
     narrativeContext: {
       recentSegments: [{ content: 'You crouch by the fence, watching the road.' }],
       currentSituation: 'Player chose: "Follow the trail cautiously"',
-      currentTags: [],
+      currentTags,
       turnsSinceComplication,
     },
+    ...(decisionWeight ? { generationParameters: { decisionWeight } } : {}),
   };
 }
+
+describe('sceneTemplate failed-attempt guidance', () => {
+  const HEADER = 'FAILED ATTEMPT — THE WORLD STILL MOVES:';
+
+  it('renders the failed-attempt block on a failed skill check', () => {
+    const prompt = sceneTemplate(makeContext(undefined, ['skill-failure:skill-1']));
+    expect(prompt).toContain(HEADER);
+    expect(prompt).toContain('never render failure as the attempt simply not occurring');
+  });
+
+  it('co-renders the block with the critical-failure severity bullet', () => {
+    const prompt = sceneTemplate(makeContext(undefined, ['skill-critical-failure:skill-1']));
+    expect(prompt).toContain(HEADER);
+    expect(prompt).toContain('CRITICAL FAILURE:');
+  });
+
+  it('omits the block on a successful check', () => {
+    const prompt = sceneTemplate(makeContext(undefined, ['skill-success:skill-1']));
+    expect(prompt).not.toContain('FAILED ATTEMPT');
+    expect(prompt).toContain('The player SUCCEEDED at their action');
+  });
+
+  it('omits the block when no check was rolled', () => {
+    expect(sceneTemplate(makeContext(undefined, []))).not.toContain('FAILED ATTEMPT');
+  });
+
+  it('renders the block when a failure tag sits beside a success tag', () => {
+    const prompt = sceneTemplate(
+      makeContext(undefined, ['skill-success:a', 'skill-failure:b'])
+    );
+    expect(prompt).toContain(HEADER);
+  });
+
+  it('co-renders with the fatal outcome block on a critical-weight failure', () => {
+    const prompt = sceneTemplate(
+      makeContext(undefined, ['skill-failure:skill-1'], 'critical')
+    );
+    expect(prompt).toContain(HEADER);
+    expect(prompt).toContain('FATAL/INCAPACITATING OUTCOME:');
+  });
+
+  it('replaces the old consequences-and-setbacks bullet so it cannot compete', () => {
+    const prompt = sceneTemplate(makeContext(undefined, ['skill-failure:skill-1']));
+    expect(prompt).toContain('see FAILED ATTEMPT rules below');
+    expect(prompt).not.toContain('show realistic consequences and setbacks');
+  });
+});
 
 describe('sceneTemplate pacing guidance', () => {
   it('omits pacing guidance when the streak is below the threshold', () => {

--- a/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
+++ b/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
@@ -109,11 +109,19 @@ ${narrativeContext?.currentSituation ? `PLAYER ACTION: ${narrativeContext.curren
 ${skillResult ? `
 SKILL CHECK RESULT GUIDANCE:
 ${skillResult === 'success' ? '- The player SUCCEEDED at their action - show the positive outcome naturally' : ''}
-${skillResult === 'failure' || skillResult === 'critical-failure' ? '- The player FAILED at their action - show realistic consequences and setbacks' : ''}
+${skillResult === 'failure' || skillResult === 'critical-failure' ? '- The player FAILED at their action - the attempt still happens, goes wrong, and costs them (see FAILED ATTEMPT rules below)' : ''}
 ${skillResult === 'critical-failure' ? '- CRITICAL FAILURE: consequences may be severe, irreversible, or lethal if the stakes justify it' : ''}
 - DO NOT explicitly mention skill names, skill levels, or game mechanics
 - Show the outcome through what actually happens in the story
-- Success = things work out, failure = things go wrong or backfire
+- Success = things work out, failure = the attempt goes wrong and leaves the scene worse than it found it
+` : ''}
+
+${skillResult === 'failure' || skillResult === 'critical-failure' ? `
+FAILED ATTEMPT — THE WORLD STILL MOVES:
+- The failed attempt still HAPPENS: show the character doing it and the world answering badly — never render failure as the attempt simply not occurring.
+- The failure must COST something concrete: position or footing lost, a resource spent or broken, an NPC turned colder, noise or attention drawn, an option closed, time burned while the situation worsens.
+- End the segment concretely changed from how it began — if every person, object, and advantage would stand exactly where it started, the outcome is wrong: pick a cost above and show it happening.
+- The cost must appear in the prose as something that happened, not as a feeling or an omen.
 ` : ''}
 
 ${isStale ? `


### PR DESCRIPTION
## Description

Failed skill checks now have to cost something. Round-3 playtest run 1 (Camp Crystal Lake, cautious, 30 turns, live Gemini, two blind judges) resolved 18 turns as failed checks and rendered 13 of them as the player's action simply not occurring: world state at the end of the turn identical to the start, so the player retried into the same nothing and turns 8-21 looped one scene. The failure guidance in `sceneTemplate.ts` was one bullet ("show realistic consequences and setbacks"), which the model satisfies with a reaction shot.

This adds a `FAILED ATTEMPT - THE WORLD STILL MOVES` block that renders only on `failure` and `critical-failure` turns, in the same conditional, imperative shape as the PACING and FATAL blocks that already fire. It says the attempt still happens, names concrete cost categories (position, a resource, an NPC's disposition, noise, a closed option, time), and gives the model a predicate to check its own draft against: if every person, object, and advantage would stand exactly where it started, the outcome is wrong. The old failure bullet and the tail line were rewritten so the weaker rule can't compete. Everything else in the template is byte-identical.

Measured on a matched re-run (same world, character, persona, method; 54 turns on this build; two independent blind judges, different models):

| Stratum | Failure turns | Judge A no-op | Judge B no-op | Unanimous no-op | Agreement |
|---|---|---|---|---|---|
| Matched first 30 turns | 6 | 2/6 | 1/6 | 1/6 | 5/6 |
| Full 54-turn session | 11 | 4/11 | 4/11 | 3/11 | 9/11 |
| Run 1 baseline | 18 | 13/18 | | | |

The attempt itself was rendered as not happening on 1/11 failure turns (turn 11, "the words catch in your throat", both judges) against 13/18 in run 1. Where run 1 gave "your words die in your throat, and the moment passes", this run gives "Your boot slides on something greasy ... You catch yourself on the edge of the stainless steel, the impact echoing sharply through the quiet kitchen. The glint ... now vanishes into the deeper shadows" (turn 19) and "The blade snags on a particularly tough root, wrenching your wrist ... scraping your palm on rough bark and twisting your ankle" with the pocketknife lost (turn 55). The residual no-ops are all one shape: a listen-or-read action where the world answers with silence and "the stillness intensifies".

## Related Issue

Closes #1821 (merges to develop, so this needs closing by hand after merge). Item 2 in the #1834 build order; sequenced ahead of #1680, which is untouched here.

Follow-ups filed from this work, none fixed here: #1838 (skill tags carry over one turn), #1839 (mixed outcomes render as failure), #1840 (natural 20 gets no guidance), #1841 (acknowledgment template's costless-failure exemplar), #1842 (play surface stops auto-following), #1843 (ending offered on a barricaded room).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Seven wiring tests in `sceneTemplate.test.ts`: block present on failure and critical-failure tags, absent on success and on no tags, present when a failure tag sits beside a success tag (pinning today's precedence, see #1839), co-renders with the CRITICAL FAILURE bullet and with the FATAL block on a critical-weight failure, and the old bullet is gone. They pin assembly, not prose. They are a wiring guard and not the acceptance test; the acceptance test is the matched run above, recorded in the eval log. Same lesson as #1826: template tests can be green while play doesn't change, so the behavioral claim rests on the run.

## User Stories Addressed

As a player, when my action fails I want the world to change anyway (something lost, something noticed, someone turned colder) so a failed turn is a story beat and not a retry prompt.

## Flow Diagrams

N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A, no UI change.

## Implementation Notes

Governance gates, all in the eval log at `.claude/skills/narraitor-prompt-template-governance/eval-logs/1821-failed-attempts-cost.md`:

- G1: reads only the existing `narrativeContext.currentTags`; `NarrativeTemplateContext` unchanged.
- G2: no new state fed to the model.
- G3: response format untouched; the only code that reads prompt text back is `parseContentRating`, and the block never contains "CONTENT GUIDELINES" (grep-verified).
- Cost: roughly +130 tokens on failure turns only, zero elsewhere; effectively twice per failure while #1838 stands.

Why the wording is shaped like this: it copies the PACING and FATAL blocks, which demonstrably fire (conditional gate, ALL-CAPS header, one-sentence imperatives, one checkable predicate). The always-on, policy-toned choice-mix instruction is the one the model ignored. The run-1 no-op imagery is deliberately not quoted in the ban: quoting the attractor feeds it at temperature 0.7, and that lexicon is the judges' no-op tell, so putting it in the prompt would break the instrument. No crit-scaling language (the existing CRITICAL FAILURE bullet owns that) and no survival language (so it co-renders cleanly with FATAL).

What is and isn't claimed: improved on one matrix cell (Camp Crystal Lake x fresh character), materially below 13/18. Not "reliable", and not yet the #1834 milestone bar of 80% of failure turns changing something (6/11 unanimous world-moved, 8/11 by either judge). Sample is thin (11 failure turns; the build clears most DCs, and typed actions get inferred DCs of 2-10) and the comparison is matched-method, not same-build A/B, because run 1 predates #1825/#1826/#1827/#1836. The other three matrix cells are declared not run and belong to milestone round 5.

Contamination check (over-firing guard): a third blind judge read 13 success or no-check turns; 9 read as clean success. The 4 that didn't are exactly the 4 turns that immediately follow a failure, which is #1838 (tag carryover) leaking the block into the next turn. Every non-adjacent success turn read clean.

## Screenshots

N/A

## Visual Baseline Changes

None

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

Playtest harness checkpoint at turn 3: no `__PLAYWRIGHT__`, no Playwright UA, real POSTs to `/api/narrative/generate`, `/choices`, `/summarize`; journal entries present (the summarize route is Playwright-gated, so its output is the unfakeable live signal). Turn latency 4.8-8.8 s across 54 turns. Screenshots at turns 1, 10, 20, 30 read; the turn-20 one caught #1842.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

`npm test` 414 suites / 2868 tests, `npm run type-check`, `npm run lint` all exit 0. No CSS touched.

## Testing Instructions

1. `npx jest src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts` for the wiring guard.
2. For the behavioral check, follow `narraitor-playtest-loop`: worktree on this branch, `.env.local` synced from the main checkout, dev server, world and character from `worlds/camp-crystal-lake.md` through the real wizards, cautious persona, 30 turns.
3. Take the failure set from `segment.metadata.decisionOutcome in {failure, critical-failure}` (not tags, see #1838). Hand two fresh subagents the attempted action and resulting prose only, no world spec, and ask per turn: does the attempt occur, name the cost as a state delta (feelings and atmosphere excluded), verdict no-op vs world-moved. Compare against 13/18.
4. Spot check ~5 success turns that don't follow a failure: they should still read as success with no imposed cost.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
