### PR TITLE
Override deepmerge-ts to 8.x so the audit gate stops failing on react-joyride's floater

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10003,9 +10003,19 @@
       }
     },
     "node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.1.tgz",
+      "integrity": "sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==",
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/deepmerge-ts"
+        }
+      ],
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"

--- a/package.json
+++ b/package.json
@@ -151,7 +151,8 @@
     "postcss": "$postcss",
     "uuid": "^11.1.1",
     "sharp": "^0.35.0",
-    "nanoid": "^3.3.18"
+    "nanoid": "^3.3.18",
+    "deepmerge-ts": "^8.0.1"
   },
   "description": "AI-powered storytelling app that runs narrative RPG experiences in any world — fictional or real — with mechanics and tone tailored to that world.",
   "directories": {


### PR DESCRIPTION
## Description

The Security Scan job went red on every branch this morning: GHSA-ggr8-5vv4-36mx (published 2026-08-17 13:32 UTC) flags `deepmerge-ts < 8.0.0`, which reaches the production tree through the pinned `react-joyride@3.0.0-7 -> react-floater@0.9.5-5`. Develop's last green run was before the advisory and the lockfile hadn't changed. First seen on #1844.

This adds `"deepmerge-ts": "^8.0.1"` to `overrides`, next to the existing `sharp` and `nanoid` entries. Bumping the dependents doesn't work: even `react-floater@0.10.1` still declares `^7.1.5`, and `npm audit fix --force` wants to unpin joyride to 3.2.0, which is what the pin (see #1251) exists to avoid. The only breaking change in deepmerge-ts 8.0.0 is that `deepmergeInto` no longer leak-mutates nested input containers; react-floater calls plain `deepmerge`, so this is behavior-neutral for it.

## Related Issue

Closes #1845 (merges to develop, so close by hand after merge).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

No code change; dependency override only. Existing tour/joyride tests (8 suites, 32 tests) pass on the new resolution.

## User Stories Addressed

N/A

## Flow Diagrams

N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A

## Implementation Notes

Lockfile diff is the single `deepmerge-ts` entry (7.1.5 to 8.0.1) plus the override. Verified locally after `npm ci`: `npm audit --omit=dev --audit-level=moderate` exits 0 (the exact CI invocation), `node_modules/deepmerge-ts` resolves to 8.0.1, type-check exits 0.

## Screenshots

N/A

## Visual Baseline Changes

None

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks (if applicable)
- [ ] Linting passed
- [x] Type checking passed
- [x] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

1. `npm ci`
2. `npm audit --omit=dev --audit-level=moderate; echo $?` should print 0
3. `npx jest tutorial joyride tour` for the tour surface that consumes react-floater

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed
