### PR TITLE
Make the skill-failure exemplar cost something

### DIFF
--- a/src/lib/promptTemplates/examples/exampleIntegration.test.ts
+++ b/src/lib/promptTemplates/examples/exampleIntegration.test.ts
@@ -77,6 +77,21 @@ describe('narrative templates embed their examples', () => {
   });
 });
 
+describe('the skill acknowledgment failure exemplar costs something', () => {
+  it('does not model failure as the world refusing to move', () => {
+    const costlessPhrasings = [
+      /remains? (stubbornly )?locked/i,
+      /refuses to budge/i,
+      /nothing (happens|changes)/i,
+      /no closer than before/i,
+    ];
+
+    costlessPhrasings.forEach((phrasing) => {
+      expect(SKILL_ACKNOWLEDGMENT_EXAMPLES).not.toMatch(phrasing);
+    });
+  });
+});
+
 describe('the context-length gate still drops examples', () => {
   it('scene omits examples once the context is long enough to stand on its own', () => {
     const result = sceneTemplate({

--- a/src/lib/promptTemplates/examples/index.ts
+++ b/src/lib/promptTemplates/examples/index.ts
@@ -83,13 +83,16 @@ Examples of CHAOTIC choices:
 /**
  * Skill acknowledgment examples. Both the success and failure cases ship, so
  * the model sees how to phrase either outcome regardless of which one happened.
+ * The failure example has to cost something concrete: it is the model answer for
+ * what a miss looks like, and a miss that leaves the world untouched is the
+ * failure shape the scene prompt spends a whole section ruling out.
  */
 export const SKILL_ACKNOWLEDGMENT_EXAMPLES = `
 
 EXAMPLES:
 Example 1: Failure Acknowledgment
 ---------------------------------
-Despite your efforts with the lockpicks, the mechanism remains stubbornly locked.
+Your pick binds, then snaps. Half of it stays in the keyway, the sound carries down the corridor behind you, and the lock is fouled for anyone who tries it next.
 
 Example 2: Success Acknowledgment
 ---------------------------------


### PR DESCRIPTION
## Description

The failure example in `SKILL_ACKNOWLEDGMENT_EXAMPLES` showed a lock that stayed locked ("the mechanism remains stubbornly locked"). That's failure rendered as the world not moving, which is the exact shape the scene template now spends a whole section ruling out - and it was shipping into every prompt that carries the skill-acknowledgment examples, presented as the model answer.

Two templates in the same request disagreeing about what a miss looks like gets settled by whichever one the model read last. So the exemplar had to change.

Before:

> Despite your efforts with the lockpicks, the mechanism remains stubbornly locked.

After:

> Your pick binds, then snaps. Half of it stays in the keyway, the sound carries down the corridor behind you, and the lock is fouled for anyone who tries it next.

Same mechanics-hiding style: no dice, no numbers, no skill names surfaced to the player. The attempt happens, and it costs a tool, some noise, and the option itself.

Prose edit only, no logic change. The sibling success exemplar was checked and left alone - it isn't a failure, so it doesn't have the costless shape.

## Related Issue

Closes #1841

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The guard test was written alongside the prose edit rather than before it - the change is one string, and a test asserting the old string is wrong before rewriting it doesn't buy anything a red-green cycle usually buys.

## User Stories Addressed

As a player, when my character's attempt fails, I want the story to show the attempt going wrong and costing something, not the world sitting exactly where it was.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A - no UI in this change.

## Implementation Notes

Both files touched live in `src/lib/promptTemplates/examples/`, which is a live few-shot library injected into prompts, not a regression corpus. Editing it changes generation behavior, which is the point here.

One thing a reviewer should weigh: the skill-acknowledgment template's own FAILURE ACKNOWLEDGMENT guidance still reads "meaningful but not overly punishing for MVP" and "focus on growth opportunities", which is softer than the scene template's cost rules. I left it alone on purpose - the issue scopes this to the exemplars, and one variable per prompt change. Worth a follow-up issue if that softness turns out to matter.

## Screenshots

N/A

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit wasn't run locally - CI covers it, and this change is two prose strings and a test.

## Testing Instructions

```
npm test                # 414 suites, 2869 tests, all green
npm run type-check      # clean
npm run lint            # 0 errors (127 pre-existing warnings, untouched)
```

Targeted: `npx jest src/lib/promptTemplates` covers the example-integration suite, including the new guard.

Live play verification wasn't done - this is an exemplar swap that ships into the prompt as text, and judging whether the generated prose improved needs the playtest loop, not a single session.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
