### PR TITLE
Fix three ways the scene prompt read the wrong skill-check tags

### DIFF
--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -23,6 +23,7 @@ import {
   isFatalCriticalDecision,
 } from '@/lib/narrative/evaluateDecisionSkillChecks';
 import { computeTurnsSinceComplication } from '@/lib/narrative/turnsSinceComplication';
+import { mergeTurnTags } from '@/lib/narrative/turnTags';
 import { logger } from '@/lib/utils/logger';
 import { AI_GENERATION_TIMEOUT_MS } from '@/lib/constants/timeouts';
 import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
@@ -691,7 +692,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
       // Combine existing tags with skill check tags
       const existingTags =
         recentSegments[recentSegments.length - 1]?.metadata?.tags || [];
-      const currentTags = [...existingTags, ...skillCheckTags];
+      const currentTags = mergeTurnTags(existingTags, skillCheckTags);
 
       // Build skill check context for the AI
       let skillCheckContext = '';

--- a/src/lib/inventory/itemUsageService.ts
+++ b/src/lib/inventory/itemUsageService.ts
@@ -9,6 +9,7 @@ import { createItemUsageJournalEntry } from './itemUsageJournalIntegration';
 import { NarrativeGenerator } from '@/lib/ai/narrativeGenerator';
 import type { NarrativeGenerationResult } from '@/types/narrative.types';
 import { isSessionEndingSegment } from '@/lib/narrative/isSessionEndingSegment';
+import { mergeTurnTags } from '@/lib/narrative/turnTags';
 import { safeTrim } from '@/lib/utils';
 
 import Logger from '@/lib/utils/logger';
@@ -118,11 +119,10 @@ export async function generateItemUsageNarrative(
     const previousSegments = narrativeStore.getSessionSegments(sessionId);
     const recentSegments = previousSegments.slice(-5);
     const lastSegment = previousSegments[previousSegments.length - 1];
-    const currentTags = [
-      ...(lastSegment?.metadata?.tags || []),
+    const currentTags = mergeTurnTags(lastSegment?.metadata?.tags || [], [
       'item-usage',
       `item-${item.categoryId}`,
-    ];
+    ]);
 
     const generator = new NarrativeGenerator(createDefaultGeminiClient());
 

--- a/src/lib/narrative/__tests__/turnTags.test.ts
+++ b/src/lib/narrative/__tests__/turnTags.test.ts
@@ -1,0 +1,44 @@
+import { mergeTurnTags } from '../turnTags';
+import { sceneTemplate } from '@/lib/promptTemplates/templates/narrative/sceneTemplate';
+
+describe('mergeTurnTags', () => {
+  it('keeps scene and mood tags riding from the previous segment', () => {
+    expect(mergeTurnTags(['forest', 'tense'], ['skill-success:a'])).toEqual([
+      'forest',
+      'tense',
+      'skill-success:a',
+    ]);
+  });
+
+  it('drops the previous segment skill-check tags', () => {
+    expect(
+      mergeTurnTags(
+        ['forest', 'skill-failure:a', 'skill-roll:4'],
+        ['skill-success:a', 'skill-roll:19']
+      )
+    ).toEqual(['forest', 'skill-success:a', 'skill-roll:19']);
+  });
+});
+
+describe('scene prompt built from merged turn tags', () => {
+  it('gives a success turn success guidance even after a failed turn', () => {
+    const prompt = sceneTemplate({
+      worldName: 'Butler County Outskirts',
+      genre: 'zombie survival',
+      tone: 'tense',
+      playerCharacterName: 'Alex',
+      narrativeContext: {
+        recentSegments: [{ content: 'The lock does not give.' }],
+        currentSituation: 'Player chose: "Force the door"',
+        currentTags: mergeTurnTags(
+          ['skill-failure:lockpicking', 'skill-roll:3'],
+          ['skill-success:athletics', 'skill-roll:19']
+        ),
+      },
+    });
+
+    expect(prompt).toContain('The player SUCCEEDED at their action');
+    expect(prompt).not.toContain('FAILED ATTEMPT');
+    expect(prompt).not.toContain('MIXED OUTCOME:');
+  });
+});

--- a/src/lib/narrative/turnTags.ts
+++ b/src/lib/narrative/turnTags.ts
@@ -1,0 +1,17 @@
+const SKILL_CHECK_TAG_PREFIX = 'skill-';
+
+/**
+ * Builds the tag list a turn's prompt sees.
+ *
+ * The previous segment's tags carry forward so scene and mood context survives,
+ * but its skill-check tags are dropped first. The scene template reads those as
+ * "what the roll did this turn", so letting them ride means the turn after a
+ * failure gets narrated as another failure even when its own roll succeeded.
+ */
+export const mergeTurnTags = (
+  previousSegmentTags: string[],
+  currentTurnTags: string[]
+): string[] => [
+  ...previousSegmentTags.filter((tag) => !tag.startsWith(SKILL_CHECK_TAG_PREFIX)),
+  ...currentTurnTags,
+];

--- a/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts
+++ b/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts
@@ -83,12 +83,28 @@ describe('sceneTemplate skill result derivation', () => {
     expect(prompt).toContain('FAILED ATTEMPT — THE WORLD STILL MOVES:');
   });
 
-  it('keeps the critical bullet on a mixed turn that contains a critical roll', () => {
+  it('keeps the critical-failure bullet on a mixed turn that rolled a natural 1', () => {
     const prompt = sceneTemplate(
       makeContext(undefined, ['skill-critical-failure:a', 'skill-success:b'])
     );
     expect(prompt).toContain('MIXED OUTCOME:');
     expect(prompt).toContain('CRITICAL FAILURE:');
+  });
+
+  it('keeps the critical-success bullet on a mixed turn that rolled a natural 20', () => {
+    const prompt = sceneTemplate(
+      makeContext(undefined, ['skill-critical-success:a', 'skill-failure:b'])
+    );
+    expect(prompt).toContain('MIXED OUTCOME:');
+    expect(prompt).toContain('CRITICAL SUCCESS:');
+  });
+
+  it('still marks a critical-weight mixed failure as a critical one', () => {
+    const prompt = sceneTemplate(
+      makeContext(undefined, ['skill-critical-failure:a', 'skill-success:b'], 'critical')
+    );
+    expect(prompt).toContain('FATAL/INCAPACITATING OUTCOME:');
+    expect(prompt).toContain('it FAILED critically');
   });
 
   it('keeps a plain success free of the mixed and critical bullets', () => {

--- a/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts
+++ b/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts
@@ -83,6 +83,14 @@ describe('sceneTemplate skill result derivation', () => {
     expect(prompt).toContain('FAILED ATTEMPT — THE WORLD STILL MOVES:');
   });
 
+  it('keeps the critical bullet on a mixed turn that contains a critical roll', () => {
+    const prompt = sceneTemplate(
+      makeContext(undefined, ['skill-critical-failure:a', 'skill-success:b'])
+    );
+    expect(prompt).toContain('MIXED OUTCOME:');
+    expect(prompt).toContain('CRITICAL FAILURE:');
+  });
+
   it('keeps a plain success free of the mixed and critical bullets', () => {
     const prompt = sceneTemplate(makeContext(undefined, ['skill-success:skill-1']));
     expect(prompt).toContain(SUCCESS_BULLET);

--- a/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts
+++ b/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts
@@ -46,13 +46,6 @@ describe('sceneTemplate failed-attempt guidance', () => {
     expect(sceneTemplate(makeContext(undefined, []))).not.toContain('FAILED ATTEMPT');
   });
 
-  it('renders the block when a failure tag sits beside a success tag', () => {
-    const prompt = sceneTemplate(
-      makeContext(undefined, ['skill-success:a', 'skill-failure:b'])
-    );
-    expect(prompt).toContain(HEADER);
-  });
-
   it('co-renders with the fatal outcome block on a critical-weight failure', () => {
     const prompt = sceneTemplate(
       makeContext(undefined, ['skill-failure:skill-1'], 'critical')
@@ -65,6 +58,36 @@ describe('sceneTemplate failed-attempt guidance', () => {
     const prompt = sceneTemplate(makeContext(undefined, ['skill-failure:skill-1']));
     expect(prompt).toContain('see FAILED ATTEMPT rules below');
     expect(prompt).not.toContain('show realistic consequences and setbacks');
+  });
+});
+
+describe('sceneTemplate skill result derivation', () => {
+  const SUCCESS_BULLET = 'The player SUCCEEDED at their action';
+
+  it('gives a critical success the success guidance plus its own bullet', () => {
+    const prompt = sceneTemplate(
+      makeContext(undefined, ['skill-critical-success:skill-1'])
+    );
+    expect(prompt).toContain('SKILL CHECK RESULT GUIDANCE');
+    expect(prompt).toContain(SUCCESS_BULLET);
+    expect(prompt).toContain('CRITICAL SUCCESS:');
+    expect(prompt).not.toContain('FAILED ATTEMPT');
+  });
+
+  it('renders both halves when one check succeeds and another fails', () => {
+    const prompt = sceneTemplate(
+      makeContext(undefined, ['skill-success:a', 'skill-failure:b'])
+    );
+    expect(prompt).toContain(SUCCESS_BULLET);
+    expect(prompt).toContain('MIXED OUTCOME:');
+    expect(prompt).toContain('FAILED ATTEMPT — THE WORLD STILL MOVES:');
+  });
+
+  it('keeps a plain success free of the mixed and critical bullets', () => {
+    const prompt = sceneTemplate(makeContext(undefined, ['skill-success:skill-1']));
+    expect(prompt).toContain(SUCCESS_BULLET);
+    expect(prompt).not.toContain('MIXED OUTCOME:');
+    expect(prompt).not.toContain('CRITICAL SUCCESS:');
   });
 });
 

--- a/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
+++ b/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
@@ -127,9 +127,9 @@ ${narrativeContext?.currentSituation ? `PLAYER ACTION: ${narrativeContext.curren
 ${skillResult ? `
 SKILL CHECK RESULT GUIDANCE:
 ${showSuccessGuidance ? '- The player SUCCEEDED at their action - show the positive outcome naturally' : ''}
-${skillResult === 'critical-success' ? '- CRITICAL SUCCESS: make it count - something extra goes right, beyond what the player was reaching for' : ''}
+${hasCriticalSuccess ? '- CRITICAL SUCCESS: make it count - something extra goes right, beyond what the player was reaching for' : ''}
 ${showFailureGuidance ? '- The player FAILED at their action - the attempt still happens, goes wrong, and costs them (see FAILED ATTEMPT rules below)' : ''}
-${skillResult === 'critical-failure' ? '- CRITICAL FAILURE: consequences may be severe, irreversible, or lethal if the stakes justify it' : ''}
+${hasCriticalFailure ? '- CRITICAL FAILURE: consequences may be severe, irreversible, or lethal if the stakes justify it' : ''}
 ${skillResult === 'mixed' ? '- MIXED OUTCOME: part of this worked and part did not - show both in the same passage, and the failed part still costs' : ''}
 - DO NOT explicitly mention skill names, skill levels, or game mechanics
 - Show the outcome through what actually happens in the story

--- a/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
+++ b/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
@@ -71,19 +71,37 @@ export const sceneTemplate = (context: NarrativeTemplateContext) => {
   const hasCriticalFailure = currentTags.some((tag: string) =>
     tag.startsWith('skill-critical-failure:')
   );
-  const hasFailure = currentTags.some((tag: string) =>
-    tag.startsWith('skill-failure:')
+  const hasCriticalSuccess = currentTags.some((tag: string) =>
+    tag.startsWith('skill-critical-success:')
   );
-  const hasSuccess = currentTags.some((tag: string) =>
-    tag.startsWith('skill-success:')
-  );
-  const skillResult = hasCriticalFailure
-    ? 'critical-failure'
-    : hasFailure
-      ? 'failure'
-      : hasSuccess
-        ? 'success'
-        : null;
+  const failed =
+    hasCriticalFailure ||
+    currentTags.some((tag: string) => tag.startsWith('skill-failure:'));
+  const succeeded =
+    hasCriticalSuccess ||
+    currentTags.some((tag: string) => tag.startsWith('skill-success:'));
+  // A turn can roll several checks. When they split, neither tier alone
+  // describes the turn, so 'mixed' gets both halves of the guidance rather
+  // than letting failure silently win and erase the part that worked.
+  const skillResult = failed && succeeded
+    ? 'mixed'
+    : hasCriticalFailure
+      ? 'critical-failure'
+      : failed
+        ? 'failure'
+        : hasCriticalSuccess
+          ? 'critical-success'
+          : succeeded
+            ? 'success'
+            : null;
+  const showSuccessGuidance =
+    skillResult === 'success' ||
+    skillResult === 'critical-success' ||
+    skillResult === 'mixed';
+  const showFailureGuidance =
+    skillResult === 'failure' ||
+    skillResult === 'critical-failure' ||
+    skillResult === 'mixed';
   const turnsSinceComplication = narrativeContext?.turnsSinceComplication ?? 0;
   const isStale = turnsSinceComplication >= STALE_PACING_THRESHOLD;
 
@@ -108,15 +126,17 @@ ${narrativeContext?.currentSituation ? `PLAYER ACTION: ${narrativeContext.curren
 
 ${skillResult ? `
 SKILL CHECK RESULT GUIDANCE:
-${skillResult === 'success' ? '- The player SUCCEEDED at their action - show the positive outcome naturally' : ''}
-${skillResult === 'failure' || skillResult === 'critical-failure' ? '- The player FAILED at their action - the attempt still happens, goes wrong, and costs them (see FAILED ATTEMPT rules below)' : ''}
+${showSuccessGuidance ? '- The player SUCCEEDED at their action - show the positive outcome naturally' : ''}
+${skillResult === 'critical-success' ? '- CRITICAL SUCCESS: make it count - something extra goes right, beyond what the player was reaching for' : ''}
+${showFailureGuidance ? '- The player FAILED at their action - the attempt still happens, goes wrong, and costs them (see FAILED ATTEMPT rules below)' : ''}
 ${skillResult === 'critical-failure' ? '- CRITICAL FAILURE: consequences may be severe, irreversible, or lethal if the stakes justify it' : ''}
+${skillResult === 'mixed' ? '- MIXED OUTCOME: part of this worked and part did not - show both in the same passage, and the failed part still costs' : ''}
 - DO NOT explicitly mention skill names, skill levels, or game mechanics
 - Show the outcome through what actually happens in the story
 - Success = things work out, failure = the attempt goes wrong and leaves the scene worse than it found it
 ` : ''}
 
-${skillResult === 'failure' || skillResult === 'critical-failure' ? `
+${showFailureGuidance ? `
 FAILED ATTEMPT — THE WORLD STILL MOVES:
 - The failed attempt still HAPPENS: show the character doing it and the world answering badly — never render failure as the attempt simply not occurring.
 - The failure must COST something concrete: position or footing lost, a resource spent or broken, an NPC turned colder, noise or attention drawn, an option closed, time burned while the situation worsens.
@@ -133,9 +153,9 @@ PACING GUIDANCE — RISING TENSION:
 - Whatever complication you introduce here counts as a major event: record it in metadata.majorEvent (see the rules below) so this guidance doesn't fire again next turn for a problem you already resolved.
 ` : ''}
 
-${generationParameters?.decisionWeight === 'critical' && narrativeContext?.currentTags?.some((tag: string) => tag.startsWith('skill-failure:') || tag.startsWith('skill-critical-failure:')) ? `
+${generationParameters?.decisionWeight === 'critical' && failed ? `
 FATAL/INCAPACITATING OUTCOME:
-- This was a pivotal, life-or-death decision and it FAILED${narrativeContext?.currentTags?.some((tag: string) => tag.startsWith('skill-critical-failure:')) ? ' critically' : ''}.
+- This was a pivotal, life-or-death decision and it FAILED${hasCriticalFailure ? ' critically' : ''}.
 - The player character should be dead, unconscious, or otherwise unable to continue.
 - Describe the fatal consequence explicitly and dramatically - this is game over.
 - Keep it grounded in established world rules (no sudden miracles or lucky escapes).


### PR DESCRIPTION
## Description

The scene prompt derives its skill-check guidance from the tags on the turn, and three separate things were wrong with that derivation. They all live in the same handful of lines in `sceneTemplate.ts`, so they ship together.

**Natural 20 got no guidance at all (#1840).** Critical successes are tagged `skill-critical-success:<id>`, which doesn't start with `skill-success:`, so `skillResult` came out `null` and the entire SKILL CHECK RESULT GUIDANCE section was dropped — on the best roll in the game. It now matches as its own tier and gets a bullet telling the model to make it count, mirroring the critical-failure bullet that was already there.

**Skill-check tags carried over one turn (#1838).** The prompt's tag list merged the previous segment's stored tags with this turn's fresh ones. Segments persist their `skill-failure:` / `skill-critical-failure:` tags, so a failure survived exactly one extra turn: the next turn got failure guidance and the FAILED ATTEMPT block even when its own roll succeeded. Four of thirteen success turns in the #1821 playtest read wrong, and all four immediately follow a failed check. A new `mergeTurnTags` helper strips `skill-*` off the carried-over tags before merging. Scene and mood tags keep riding, which is what carrying them forward was for.

**Mixed outcomes rendered as pure failure (#1839).** Failure took precedence in the derivation, so a turn with `skill-success:a` and `skill-failure:b` was told the player failed, full stop, with no instruction to show the part that worked. There's a `'mixed'` branch now: both the success bullet and the failure bullet render, plus a short line saying part of this worked, part didn't, and the failed part still costs.

## Related Issue

Closes #1840
Closes #1838
Closes #1839

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Tests were written alongside the fixes rather than strictly first, so that box stays unchecked. Each of the three behaviors has a wiring test.

## User Stories Addressed

As a player, when I roll a natural 20 the story should show it going unusually well, not read like an ordinary success the model guessed at.

As a player, a turn where my roll succeeded should read as a success, even when the turn before it failed.

As a player, when one part of what I tried worked and another part didn't, the story should show both.

## Flow Diagrams

N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A — prompt text and tag derivation, no UI surface.

## Implementation Notes

**The #1821 wiring test is deliberately replaced.** `sceneTemplate.test.ts` had a test pinning failure-takes-precedence as intentional ("renders the block when a failure tag sits beside a success tag"). That was the right thing to pin until this got decided; #1839 decides it. The replacement test in the new `sceneTemplate skill result derivation` block asserts the mixed rendering instead. This is a deliberate behavior change, not a regression slipping past.

**`mergeTurnTags` lives in `src/lib/narrative/turnTags.ts`** so the merge is a testable unit rather than an inline spread buried in `NarrativeController`'s async handler. The test then exercises the real producer instead of a hand-rolled copy of it.

**`itemUsageService` got the same fix.** Its scene-generation path built `currentTags` the same way off the previous segment, feeding the same template, so an item used right after a failed check inherited the failure. The choice-generation path further down that file also carries previous-segment tags, but no choice template reads `skill-*` tags (verified by grep across `src/lib/promptTemplates/`), so it's untouched.

**Critical bullets key off the tags, not the tier.** Codex caught this on review: the first cut gated the CRITICAL SUCCESS and CRITICAL FAILURE bullets on `skillResult` matching those tiers exactly, so a mixed turn containing a natural 1 or a natural 20 dropped the severity bullet — the same erasure this PR exists to fix, one level down. Both bullets now read `hasCriticalSuccess` / `hasCriticalFailure` directly.

**The FATAL/INCAPACITATING gate now reads the derived booleans** instead of re-scanning `currentTags` with its own duplicate `.some()` calls. Same condition, so behavior is unchanged: a critical-weight turn with any failure tag still trips it, including a mixed one. Worth a reviewer's opinion — a mixed critical turn arguably shouldn't be fatal — but changing that is a separate decision and wasn't in any of the three issues. What #1838 does fix here is the carryover: the gate can no longer trip on a stale failure tag from the previous turn.

**Prompt template governance:** this is a derivation fix inside the registered `sceneTemplate`, not a new prompt or an inlined string, and no `NarrativeTemplateContext` field changed. Token cost drops slightly on the turn after a failure (the ~130-token FAILED ATTEMPT block no longer renders twice per failure) and rises by one bullet on critical-success and mixed turns. No live-play eval log: three of these are cases the model previously got wrong or blank guidance for, and mixed turns occurred 0/54 times in the #1821 run, so there's no meaningful before-side to compare against. Flagging that gap explicitly rather than claiming an eval that wasn't run.

## Screenshots

N/A

## Visual Baseline Changes

None — this PR doesn't touch `tests/visual/**-snapshots/**`.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit not run locally; CI's audit gate covers it. No dependency changes in this PR.

## Testing Instructions

```bash
npm test          # 2874 passed, 415 suites
npm run type-check
npm run lint      # 0 errors
npm run deps:validate
```

Targeted:

```bash
npx jest src/lib/narrative/__tests__/turnTags.test.ts src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts
```

In play: take a turn with a skill check that fails, then take a turn whose check succeeds. The second turn's prose should read as a success — before this, it read as another failure. Visual and E2E suites weren't run; nothing here renders.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

Docs: nothing to update — no doc describes the tag-to-guidance derivation. Accessibility: no UI surface touched.
