### PR TITLE
Stop the play surface treating a taller page as the player scrolling away

### DIFF
--- a/src/components/Narrative/NarrativeHistory.tsx
+++ b/src/components/Narrative/NarrativeHistory.tsx
@@ -9,6 +9,7 @@ import {
   createFollowState,
   markAtLatestBeat,
   markLeftLatestBeat,
+  markMovedTowardLatestBeat,
   shouldFollowLatestBeat,
   type FollowState,
 } from '@/lib/narrative/autoFollowScroll';
@@ -155,6 +156,7 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
 
     const { scrollTop, scrollHeight, clientHeight } = scrollViewportRef.current;
     const scrollStep = clientHeight * 0.8; // Scroll 80% of viewport height
+    const measurement = { scrollTop, scrollHeight, clientHeight };
 
     switch (event.key) {
       case 'ArrowDown':
@@ -182,7 +184,10 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
             behavior: 'smooth'
           });
         }
-        followStateRef.current = markLeftLatestBeat(followStateRef.current);
+        followStateRef.current = markMovedTowardLatestBeat(
+          followStateRef.current,
+          measurement
+        );
         break;
       case 'ArrowUp':
         event.preventDefault();
@@ -217,7 +222,10 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
           top: Math.min(scrollTop + scrollStep, scrollHeight - clientHeight),
           behavior: 'smooth'
         });
-        followStateRef.current = markLeftLatestBeat(followStateRef.current);
+        followStateRef.current = markMovedTowardLatestBeat(
+          followStateRef.current,
+          measurement
+        );
         break;
       case 'PageUp':
         event.preventDefault();
@@ -238,12 +246,15 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
         break;
       case 'End':
         event.preventDefault();
-        // Scroll to the bottom to show the latest content
+        // Scroll to the bottom to show the latest content. End means "take me
+        // to the newest beat", so it re-engages following outright rather than
+        // waiting on a scroll event that a view already parked there never
+        // emits.
         scrollViewportRef.current.scrollTo({
           top: scrollViewportRef.current.scrollHeight,
           behavior: 'smooth'
         });
-        followStateRef.current = markLeftLatestBeat(followStateRef.current);
+        followStateRef.current = markAtLatestBeat(followStateRef.current);
         break;
       default:
         break;

--- a/src/components/Narrative/NarrativeHistory.tsx
+++ b/src/components/Narrative/NarrativeHistory.tsx
@@ -368,9 +368,10 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
         // notes and consequence callout are siblings of the narrative inside
         // the same scroller and change height every turn, so observing the
         // prose column alone let that growth push the turn's choices below the
-        // fold with nothing re-anchoring. The scroller's content wrapper is the
-        // one box whose height tracks all of it, with the prose column as a
-        // fallback when there's no wrapper.
+        // fold with nothing re-anchoring. The scroller's only child is the box
+        // whose height tracks all of it: `.manuscript-main-stage` on the play
+        // surface, and the Radix viewport's content wrapper everywhere else.
+        // The prose column is a null guard for a scroller with no children.
         const contentEl = scrollTarget.firstElementChild ?? scrollContentRef.current;
         let resizeObserver: ResizeObserver | null = null;
         if (contentEl) {

--- a/src/components/Narrative/NarrativeHistory.tsx
+++ b/src/components/Narrative/NarrativeHistory.tsx
@@ -4,6 +4,14 @@ import { NarrativeDisplay } from './NarrativeDisplay';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useBufferedNarrativeSegments } from './hooks/useBufferedNarrativeSegments';
 import { getSessionTimeDividerLabel } from '@/lib/narrative/sessionTimeDivider';
+import {
+  applyScrollEvent,
+  createFollowState,
+  markAtLatestBeat,
+  markLeftLatestBeat,
+  shouldFollowLatestBeat,
+  type FollowState,
+} from '@/lib/narrative/autoFollowScroll';
 
 /**
  * Session-relative time divider between two narrative segments — replaces
@@ -58,34 +66,29 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
   const scrollViewportRef = useRef<HTMLElement>(null);
   const scrollContentRef = useRef<HTMLDivElement>(null);
   const prevSegmentCountRef = useRef(segments.length);
-  const hasUserScrollInteractionRef = useRef(false);
-  const isNearBottomRef = useRef(true);
+  const followStateRef = useRef<FollowState>(createFollowState());
   const hasSettledInitialScrollRef = useRef(false);
   const [hasUnreadBelow, setHasUnreadBelow] = useState(false);
 
   const { renderedSegments } = useBufferedNarrativeSegments(segments, { isHydrating });
 
-  // Check if the viewport is near the bottom
-  const getIsNearBottom = useCallback(() => {
-    if (!scrollViewportRef.current) return false;
-    const { scrollTop, scrollHeight, clientHeight } = scrollViewportRef.current;
-    return scrollHeight - scrollTop - clientHeight < 100;
-  }, []);
-
-  // Detect manual scrolling
+  // Fold each scroll event into the follow decision. The rules, and why
+  // distance from the bottom can't decide this on its own, live in
+  // lib/narrative/autoFollowScroll.
   const handleScroll = useCallback(() => {
     if (!scrollViewportRef.current) return;
 
-    isNearBottomRef.current = getIsNearBottom();
+    const { scrollTop, scrollHeight, clientHeight } = scrollViewportRef.current;
+    followStateRef.current = applyScrollEvent(followStateRef.current, {
+      scrollTop,
+      scrollHeight,
+      clientHeight,
+    });
 
-    // If user scrolled up significantly, mark as manual scroll
-    if (!isNearBottomRef.current) {
-      hasUserScrollInteractionRef.current = true;
-    } else {
-      // Back at the latest beat under their own steam — nothing left to catch up on.
+    if (followStateRef.current.isNearBottom) {
       setHasUnreadBelow(false);
     }
-  }, [getIsNearBottom]);
+  }, []);
 
   // A new segment lands below whatever the player is reading. Follow it down
   // only if they were already at the bottom; if they'd scrolled up to re-read,
@@ -94,11 +97,8 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
   // this surface must not make.
   useEffect(() => {
     if (segments.length > prevSegmentCountRef.current && scrollViewportRef.current) {
-      const wasFollowing =
-        !hasUserScrollInteractionRef.current || isNearBottomRef.current;
-
-      if (wasFollowing) {
-        isNearBottomRef.current = true;
+      if (shouldFollowLatestBeat(followStateRef.current)) {
+        followStateRef.current = markAtLatestBeat(followStateRef.current);
         scrollViewportRef.current.scrollTo({
           top: scrollViewportRef.current.scrollHeight,
           behavior: 'auto'
@@ -112,8 +112,7 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
 
   const jumpToLatest = useCallback(() => {
     if (!scrollViewportRef.current) return;
-    hasUserScrollInteractionRef.current = false;
-    isNearBottomRef.current = true;
+    followStateRef.current = markAtLatestBeat(followStateRef.current);
     setHasUnreadBelow(false);
     scrollViewportRef.current.scrollTo({
       top: scrollViewportRef.current.scrollHeight,
@@ -136,7 +135,7 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
     // Use a small delay to ensure content is rendered
     const scrollTimer = setTimeout(() => {
       // Skip if they started reading somewhere else during the delay.
-      if (scrollViewportRef.current && !hasUserScrollInteractionRef.current) {
+      if (scrollViewportRef.current && !followStateRef.current.hasLeftLatestBeat) {
         scrollViewportRef.current.scrollTo({
           top: scrollViewportRef.current.scrollHeight,
           behavior: 'smooth'
@@ -183,7 +182,7 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
             behavior: 'smooth'
           });
         }
-        hasUserScrollInteractionRef.current = true;
+        followStateRef.current = markLeftLatestBeat(followStateRef.current);
         break;
       case 'ArrowUp':
         event.preventDefault();
@@ -210,7 +209,7 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
             behavior: 'smooth'
           });
         }
-        hasUserScrollInteractionRef.current = true;
+        followStateRef.current = markLeftLatestBeat(followStateRef.current);
         break;
       case 'PageDown':
         event.preventDefault();
@@ -218,7 +217,7 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
           top: Math.min(scrollTop + scrollStep, scrollHeight - clientHeight),
           behavior: 'smooth'
         });
-        hasUserScrollInteractionRef.current = true;
+        followStateRef.current = markLeftLatestBeat(followStateRef.current);
         break;
       case 'PageUp':
         event.preventDefault();
@@ -226,7 +225,7 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
           top: Math.max(scrollTop - scrollStep, 0),
           behavior: 'smooth'
         });
-        hasUserScrollInteractionRef.current = true;
+        followStateRef.current = markLeftLatestBeat(followStateRef.current);
         break;
       case 'Home':
         event.preventDefault();
@@ -235,7 +234,7 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
           behavior: 'smooth',
           block: 'center'
         });
-        hasUserScrollInteractionRef.current = true;
+        followStateRef.current = markLeftLatestBeat(followStateRef.current);
         break;
       case 'End':
         event.preventDefault();
@@ -244,7 +243,7 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
           top: scrollViewportRef.current.scrollHeight,
           behavior: 'smooth'
         });
-        hasUserScrollInteractionRef.current = true;
+        followStateRef.current = markLeftLatestBeat(followStateRef.current);
         break;
       default:
         break;
@@ -363,12 +362,20 @@ export const NarrativeHistory: React.FC<NarrativeHistoryProps> = ({
         // so mark it passive to avoid blocking scroll (issue #1358).
         scrollTarget.addEventListener('scroll', handleScroll, { passive: true });
 
-        // ResizeObserver: anchor scroll to bottom during content growth
-        const contentEl = scrollContentRef.current;
+        // ResizeObserver: anchor scroll to bottom during content growth.
+        //
+        // Watch everything the scroller scrolls. The decision block, story-beat
+        // notes and consequence callout are siblings of the narrative inside
+        // the same scroller and change height every turn, so observing the
+        // prose column alone let that growth push the turn's choices below the
+        // fold with nothing re-anchoring. The scroller's content wrapper is the
+        // one box whose height tracks all of it, with the prose column as a
+        // fallback when there's no wrapper.
+        const contentEl = scrollTarget.firstElementChild ?? scrollContentRef.current;
         let resizeObserver: ResizeObserver | null = null;
         if (contentEl) {
           resizeObserver = new ResizeObserver(() => {
-            if ((!hasUserScrollInteractionRef.current || isNearBottomRef.current) && scrollViewportRef.current) {
+            if (shouldFollowLatestBeat(followStateRef.current) && scrollViewportRef.current) {
               scrollViewportRef.current.scrollTo({
                 top: scrollViewportRef.current.scrollHeight,
                 behavior: 'auto'

--- a/src/components/Narrative/__tests__/NarrativeHistory.keyboard.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeHistory.keyboard.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { NarrativeHistory } from '../NarrativeHistory';
+import { isFeatureEnabled } from '@/lib/featureFlags';
+import {
+  createMockNarrativeSegment,
+  createMockNPCStore,
+  mockZustandStore,
+} from '@/lib/test-utils';
+import { useNPCStore } from '@/state/npcStore';
+
+jest.mock('@/lib/featureFlags');
+jest.mock('@/state/npcStore');
+
+/**
+ * jsdom reports every box as zero-sized, which makes the mounted viewport
+ * measure as parked at the newest beat. That is the boundary these cases care
+ * about: a key pressed there scrolls nowhere, so the browser emits no scroll
+ * event, and anything the handler assumed about position is never corrected.
+ * No geometry is stubbed to get here.
+ */
+describe('NarrativeHistory keyboard navigation at the newest beat', () => {
+  const mockIsFeatureEnabled = isFeatureEnabled as jest.MockedFunction<typeof isFeatureEnabled>;
+  let scrollToSpy: jest.Mock;
+
+  beforeEach(() => {
+    mockIsFeatureEnabled.mockReturnValue(false);
+    mockZustandStore(useNPCStore as jest.MockedFunction<typeof useNPCStore>, createMockNPCStore());
+    scrollToSpy = jest.fn();
+    Element.prototype.scrollTo = scrollToSpy as unknown as Element['scrollTo'];
+    Element.prototype.scrollBy = jest.fn() as unknown as Element['scrollBy'];
+    Element.prototype.scrollIntoView = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const firstSegment = createMockNarrativeSegment({ id: 'seg-1', content: 'The lake is still.' });
+  const secondSegment = createMockNarrativeSegment({ id: 'seg-2', content: 'A branch snaps.' });
+
+  const pressKeyThenAddSegment = (key: string) => {
+    const { container, rerender } = render(
+      <NarrativeHistory segments={[firstSegment]} disableInitialAutoScroll />
+    );
+
+    const history = container.querySelector('.narrative-history-container') as HTMLElement;
+    fireEvent.keyDown(history, { key });
+
+    scrollToSpy.mockClear();
+
+    act(() => {
+      rerender(
+        <NarrativeHistory segments={[firstSegment, secondSegment]} disableInitialAutoScroll />
+      );
+    });
+  };
+
+  it('keeps following after End, which means "take me to the latest"', () => {
+    pressKeyThenAddSegment('End');
+
+    expect(scrollToSpy).toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: /jump to latest/i })).not.toBeInTheDocument();
+  });
+
+  it('keeps following after a downward key that had nowhere to go', () => {
+    pressKeyThenAddSegment('PageDown');
+
+    expect(scrollToSpy).toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: /jump to latest/i })).not.toBeInTheDocument();
+  });
+
+  it('stops following after the reader pages back up to re-read', () => {
+    pressKeyThenAddSegment('PageUp');
+
+    expect(scrollToSpy).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /jump to latest/i })).toBeInTheDocument();
+  });
+});

--- a/src/lib/narrative/__tests__/autoFollowScroll.test.ts
+++ b/src/lib/narrative/__tests__/autoFollowScroll.test.ts
@@ -1,0 +1,66 @@
+import {
+  applyScrollEvent,
+  createFollowState,
+  markAtLatestBeat,
+  markLeftLatestBeat,
+  shouldFollowLatestBeat,
+} from '../autoFollowScroll';
+
+// A viewport parked at the bottom of a 1000px document.
+const PARKED_AT_BOTTOM = { scrollTop: 500, scrollHeight: 1000, clientHeight: 500 };
+
+describe('autoFollowScroll', () => {
+  it('keeps following when content grows below the reader without moving them', () => {
+    let state = applyScrollEvent(createFollowState(), PARKED_AT_BOTTOM);
+
+    // The turn's decision block renders under the prose: the document gets
+    // taller while the reader stays exactly where they were.
+    state = applyScrollEvent(state, { ...PARKED_AT_BOTTOM, scrollHeight: 1400 });
+
+    expect(state.hasLeftLatestBeat).toBe(false);
+    expect(shouldFollowLatestBeat(state)).toBe(true);
+  });
+
+  it('stops following once the reader scrolls back up to re-read', () => {
+    let state = applyScrollEvent(createFollowState(), PARKED_AT_BOTTOM);
+
+    state = applyScrollEvent(state, { ...PARKED_AT_BOTTOM, scrollTop: 100 });
+
+    expect(state.hasLeftLatestBeat).toBe(true);
+    expect(shouldFollowLatestBeat(state)).toBe(false);
+  });
+
+  it('resumes following when the reader returns to the bottom on their own', () => {
+    let state = applyScrollEvent(createFollowState(), PARKED_AT_BOTTOM);
+    state = applyScrollEvent(state, { ...PARKED_AT_BOTTOM, scrollTop: 100 });
+    expect(shouldFollowLatestBeat(state)).toBe(false);
+
+    state = applyScrollEvent(state, PARKED_AT_BOTTOM);
+
+    expect(state.hasLeftLatestBeat).toBe(false);
+    expect(shouldFollowLatestBeat(state)).toBe(true);
+  });
+
+  it('does not disengage while a following scroll catches up to a grown document', () => {
+    // The anchoring scroll runs after the document grew, so the scroll events
+    // it emits are measured against the taller scrollHeight on the way down.
+    let state = applyScrollEvent(createFollowState(), PARKED_AT_BOTTOM);
+
+    state = applyScrollEvent(state, { scrollTop: 600, scrollHeight: 1400, clientHeight: 500 });
+    state = applyScrollEvent(state, { scrollTop: 900, scrollHeight: 1400, clientHeight: 500 });
+
+    expect(state.hasLeftLatestBeat).toBe(false);
+    expect(shouldFollowLatestBeat(state)).toBe(true);
+  });
+
+  it('follows by default before any scroll has happened', () => {
+    expect(shouldFollowLatestBeat(createFollowState())).toBe(true);
+  });
+
+  it('treats keyboard navigation as leaving, and the pill as coming back', () => {
+    const left = markLeftLatestBeat(createFollowState());
+    expect(shouldFollowLatestBeat(left)).toBe(false);
+
+    expect(shouldFollowLatestBeat(markAtLatestBeat(left))).toBe(true);
+  });
+});

--- a/src/lib/narrative/__tests__/autoFollowScroll.test.ts
+++ b/src/lib/narrative/__tests__/autoFollowScroll.test.ts
@@ -3,6 +3,7 @@ import {
   createFollowState,
   markAtLatestBeat,
   markLeftLatestBeat,
+  markMovedTowardLatestBeat,
   shouldFollowLatestBeat,
 } from '../autoFollowScroll';
 
@@ -69,11 +70,28 @@ describe('autoFollowScroll', () => {
     expect(shouldFollowLatestBeat(markAtLatestBeat(left))).toBe(true);
   });
 
-  it('keeps following when a key moves nothing because the view is already at the bottom', () => {
-    // End and PageDown at the bottom scroll nowhere, so the browser fires no
-    // scroll event to correct a premature "they left" assumption.
-    const atBottom = applyScrollEvent(createFollowState(), PARKED_AT_BOTTOM);
+  // A key pressed at the newest beat scrolls nowhere, so the browser fires no
+  // scroll event, and anything asserted about position here is never corrected.
+  describe('keys that move nothing at the newest beat', () => {
+    const disengaged = { hasLeftLatestBeat: true, isNearBottom: false, lastScrollTop: 500 };
 
-    expect(shouldFollowLatestBeat(markLeftLatestBeat(atBottom))).toBe(true);
+    it('re-engages following on End, which means "take me to the latest"', () => {
+      expect(shouldFollowLatestBeat(markAtLatestBeat(disengaged))).toBe(true);
+    });
+
+    it('keeps following on downward keys, measuring instead of assuming', () => {
+      const state = markMovedTowardLatestBeat(disengaged, PARKED_AT_BOTTOM);
+
+      expect(shouldFollowLatestBeat(state)).toBe(true);
+    });
+  });
+
+  it('stops following when a downward key lands short of the newest beat', () => {
+    const state = markMovedTowardLatestBeat(createFollowState(), {
+      ...PARKED_AT_BOTTOM,
+      scrollTop: 100,
+    });
+
+    expect(shouldFollowLatestBeat(state)).toBe(false);
   });
 });

--- a/src/lib/narrative/__tests__/autoFollowScroll.test.ts
+++ b/src/lib/narrative/__tests__/autoFollowScroll.test.ts
@@ -57,10 +57,23 @@ describe('autoFollowScroll', () => {
     expect(shouldFollowLatestBeat(createFollowState())).toBe(true);
   });
 
-  it('treats keyboard navigation as leaving, and the pill as coming back', () => {
-    const left = markLeftLatestBeat(createFollowState());
+  it('treats keyboard navigation away as leaving, and the pill as coming back', () => {
+    const scrolledUp = applyScrollEvent(
+      applyScrollEvent(createFollowState(), PARKED_AT_BOTTOM),
+      { ...PARKED_AT_BOTTOM, scrollTop: 100 }
+    );
+
+    const left = markLeftLatestBeat(scrolledUp);
     expect(shouldFollowLatestBeat(left)).toBe(false);
 
     expect(shouldFollowLatestBeat(markAtLatestBeat(left))).toBe(true);
+  });
+
+  it('keeps following when a key moves nothing because the view is already at the bottom', () => {
+    // End and PageDown at the bottom scroll nowhere, so the browser fires no
+    // scroll event to correct a premature "they left" assumption.
+    const atBottom = applyScrollEvent(createFollowState(), PARKED_AT_BOTTOM);
+
+    expect(shouldFollowLatestBeat(markLeftLatestBeat(atBottom))).toBe(true);
   });
 });

--- a/src/lib/narrative/autoFollowScroll.ts
+++ b/src/lib/narrative/autoFollowScroll.ts
@@ -12,7 +12,7 @@
  * Slack for "parked at the latest beat". A narrative beat renders far taller
  * than this, so it can't absorb one.
  */
-export const NEAR_BOTTOM_THRESHOLD_PX = 100;
+const NEAR_BOTTOM_THRESHOLD_PX = 100;
 
 export interface ScrollMeasurement {
   scrollTop: number;
@@ -31,7 +31,7 @@ export function createFollowState(): FollowState {
   return { hasLeftLatestBeat: false, isNearBottom: true, lastScrollTop: 0 };
 }
 
-export function isNearBottom({
+function measureIsNearBottom({
   scrollTop,
   scrollHeight,
   clientHeight,
@@ -57,7 +57,7 @@ export function applyScrollEvent(
   state: FollowState,
   measurement: ScrollMeasurement
 ): FollowState {
-  const nearBottom = isNearBottom(measurement);
+  const nearBottom = measureIsNearBottom(measurement);
   const didScrollUp = measurement.scrollTop < state.lastScrollTop;
 
   return {
@@ -69,9 +69,17 @@ export function applyScrollEvent(
   };
 }
 
-/** The reader took the view somewhere themselves (keyboard navigation). */
+/**
+ * The reader took the view somewhere themselves (keyboard navigation).
+ *
+ * Deliberately leaves isNearBottom alone. Keys that travel towards the newest
+ * beat (End, PageDown) move nothing when the view is already parked there, so
+ * the browser fires no scroll event to correct an assumption made here. Let
+ * the position speak for itself and following survives those keys, as it did
+ * before this state moved out of the component.
+ */
 export function markLeftLatestBeat(state: FollowState): FollowState {
-  return { ...state, hasLeftLatestBeat: true, isNearBottom: false };
+  return { ...state, hasLeftLatestBeat: true };
 }
 
 /** Snapped back to the newest beat, by the pill or by a following scroll. */

--- a/src/lib/narrative/autoFollowScroll.ts
+++ b/src/lib/narrative/autoFollowScroll.ts
@@ -70,21 +70,41 @@ export function applyScrollEvent(
 }
 
 /**
- * The reader took the view somewhere themselves (keyboard navigation).
+ * The reader moved away from the newest beat (ArrowUp, PageUp, Home).
  *
- * Deliberately leaves isNearBottom alone. Keys that travel towards the newest
- * beat (End, PageDown) move nothing when the view is already parked there, so
- * the browser fires no scroll event to correct an assumption made here. Let
- * the position speak for itself and following survives those keys, as it did
- * before this state moved out of the component.
+ * Safe to assert without measuring, including when the key moves nothing
+ * because the view already sits at the top: somewhere near the top is not the
+ * newest beat either way.
  */
 export function markLeftLatestBeat(state: FollowState): FollowState {
-  return { ...state, hasLeftLatestBeat: true };
+  return { ...state, hasLeftLatestBeat: true, isNearBottom: false };
 }
 
-/** Snapped back to the newest beat, by the pill or by a following scroll. */
+/** Snapped back to the newest beat, by the pill, End, or a following scroll. */
 export function markAtLatestBeat(state: FollowState): FollowState {
   return { ...state, hasLeftLatestBeat: false, isNearBottom: true };
+}
+
+/**
+ * The reader moved down through the history (ArrowDown, PageDown).
+ *
+ * Measured rather than assumed, because these keys move nothing when the view
+ * already sits at the newest beat, and a scroll that never happens fires no
+ * event to correct state asserted here. Where the keys do move, the scroll
+ * events they emit refine this on the way.
+ */
+export function markMovedTowardLatestBeat(
+  state: FollowState,
+  measurement: ScrollMeasurement
+): FollowState {
+  const nearBottom = measureIsNearBottom(measurement);
+
+  return {
+    ...state,
+    lastScrollTop: measurement.scrollTop,
+    isNearBottom: nearBottom,
+    hasLeftLatestBeat: !nearBottom,
+  };
 }
 
 /** Whether a newly arrived beat should pull the view down to it. */

--- a/src/lib/narrative/autoFollowScroll.ts
+++ b/src/lib/narrative/autoFollowScroll.ts
@@ -1,0 +1,85 @@
+/**
+ * Whether the play surface should keep following new narrative beats.
+ *
+ * This lives outside the component on purpose. jsdom has no layout engine, so
+ * a unit test can't measure a scroller, but the decision itself is arithmetic
+ * over measurements and that part can be tested for real. The measuring stays
+ * in NarrativeHistory and is checked against the surface's actual scroller in
+ * tests/visual/narrative-reading-position.spec.ts.
+ */
+
+/**
+ * Slack for "parked at the latest beat". A narrative beat renders far taller
+ * than this, so it can't absorb one.
+ */
+export const NEAR_BOTTOM_THRESHOLD_PX = 100;
+
+export interface ScrollMeasurement {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+}
+
+export interface FollowState {
+  /** The reader deliberately moved off the latest beat. */
+  hasLeftLatestBeat: boolean;
+  isNearBottom: boolean;
+  lastScrollTop: number;
+}
+
+export function createFollowState(): FollowState {
+  return { hasLeftLatestBeat: false, isNearBottom: true, lastScrollTop: 0 };
+}
+
+export function isNearBottom({
+  scrollTop,
+  scrollHeight,
+  clientHeight,
+}: ScrollMeasurement): boolean {
+  return scrollHeight - scrollTop - clientHeight < NEAR_BOTTOM_THRESHOLD_PX;
+}
+
+/**
+ * Fold one scroll event into the follow state.
+ *
+ * Distance from the bottom can't decide this alone. The scroller holds the
+ * whole turn (prose, decision block, consequence callout), so content landing
+ * below the reader grows scrollHeight and pushes the bottom away without them
+ * moving a pixel. Treating that as "they scrolled off" strands the surface on
+ * an old beat for the rest of the session, because nothing but the
+ * jump-to-latest pill ever cleared the flag.
+ *
+ * A backwards scrollTop is the signal that carries real intent: growth never
+ * moves a reader up, and every way to leave (wheel, trackpad, scrollbar drag,
+ * keys) does.
+ */
+export function applyScrollEvent(
+  state: FollowState,
+  measurement: ScrollMeasurement
+): FollowState {
+  const nearBottom = isNearBottom(measurement);
+  const didScrollUp = measurement.scrollTop < state.lastScrollTop;
+
+  return {
+    lastScrollTop: measurement.scrollTop,
+    isNearBottom: nearBottom,
+    // Getting back to the latest beat clears the flag, so following resumes
+    // under the reader's own steam instead of only via the pill.
+    hasLeftLatestBeat: nearBottom ? false : state.hasLeftLatestBeat || didScrollUp,
+  };
+}
+
+/** The reader took the view somewhere themselves (keyboard navigation). */
+export function markLeftLatestBeat(state: FollowState): FollowState {
+  return { ...state, hasLeftLatestBeat: true, isNearBottom: false };
+}
+
+/** Snapped back to the newest beat, by the pill or by a following scroll. */
+export function markAtLatestBeat(state: FollowState): FollowState {
+  return { ...state, hasLeftLatestBeat: false, isNearBottom: true };
+}
+
+/** Whether a newly arrived beat should pull the view down to it. */
+export function shouldFollowLatestBeat(state: FollowState): boolean {
+  return !state.hasLeftLatestBeat || state.isNearBottom;
+}


### PR DESCRIPTION
## Description

The play surface stopped following new segments mid-session because a page that got taller was being read as the player scrolling away.

`handleScroll` decided "the reader left the latest beat" from one number: `scrollHeight - scrollTop - clientHeight > 100`. That distance grows when the reader scrolls up, but it grows just as well when content lands *below* them, and the play surface does that every single turn. The scroller is `.manuscript-overlay-main`, which holds the prose, the decision block, the story-beat notes and the consequence callout. So any scroll event measured after the turn's content rendered could read as "scrolled away" without the player touching anything.

That alone would have been self-correcting, except the flag was a one-way latch. `hasUserScrollInteractionRef` was set by that check and cleared by exactly one thing: clicking "Jump to latest". Once it flipped with `isNearBottomRef` false, `wasFollowing` stayed false forever, and nothing scrolled again, so no later scroll event could ever set it back. That is the three-turns-parked-until-you-click-the-pill behaviour from the report, exactly.

The fix changes what counts as intent. A backwards `scrollTop` is the signal, since content growth never moves a reader up while wheel, trackpad, scrollbar drag and keys all do. Returning to the bottom now clears the flag too, so following resumes under the player's own steam instead of only via the pill.

There's a second defect in the same area, which is what produced the `firstChoiceOffscreen` flag in the capture. The ResizeObserver that re-anchors during growth was watching `.narrative-history-segments`, the prose column only. Since PR #1764 moved the choices out of a docked rail and into the story flow, the decision block is a sibling of the prose inside the same scroller, so its growth never triggered the observer and never re-anchored. It now watches the scroller's content wrapper, which is the one box whose height tracks the whole scrolled document.

The decision logic moved to `src/lib/narrative/autoFollowScroll.ts`. That was not gold-plating: the repo's ESLint config makes stubbing `scrollTop`/`scrollHeight`/`clientHeight` in jsdom a hard error, on the grounds that a test feeding an element its own geometry isn't observing layout. Pulling the arithmetic out means it can be tested honestly, while the measuring stays in the component where Playwright checks it against the real scroller.

## Related Issue

Closes #1842

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Worth being precise about the order here. The first thing written was a jsdom component test that reproduced both defects, and it failed for the right reasons: auto-follow disengaged after nothing but a `scrollHeight` increase, and the ResizeObserver was observing only the prose column. Two sibling cases covering the behaviour that had to survive (a genuine scroll up still disengages, returning to the bottom still re-engages) passed against the unfixed code, which is what made the two failures meaningful rather than a broken harness.

That reproduction had to be rewritten, because it stubbed layout geometry and the repo bans that. The shipped tests assert the same four behaviours against the extracted pure logic instead.

## User Stories Addressed

As a player mid-session, I want the story to keep showing me the newest beat and its choices without having to notice a small pill, so a working game doesn't look like it hung.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A. No new component and no visual change. The bug is in scroll behaviour, which Storybook can't show since it doesn't mount the play surface's scroller.

## Implementation Notes

The follow decision is now a small state machine in `src/lib/narrative/autoFollowScroll.ts`:

| Export | What it does |
|---|---|
| `applyScrollEvent` | Folds one scroll event into the follow state |
| `shouldFollowLatestBeat` | Whether a new beat should pull the view down |
| `markLeftLatestBeat` / `markAtLatestBeat` | Keyboard navigation and the pill |

`NarrativeHistory` keeps one `followStateRef` where it had two separate refs.

The keyboard handlers took two follow-up commits to get right, and the second one came out of a Codex review on this PR. Every case used to mark the reader as having left the newest beat, including the keys that head straight for it. `End` at the bottom scrolls nowhere, so no scroll event arrives to correct that, and following stayed off until the pill was clicked. Same trap as the headline bug, reached through the keyboard.

There are three intents now rather than one:

| Keys | Intent |
|---|---|
| ArrowUp, PageUp, Home | `markLeftLatestBeat`, which holds even when they no-op at the top |
| End | `markAtLatestBeat`, re-engaging following outright |
| ArrowDown, PageDown | `markMovedTowardLatestBeat`, measured at the keypress rather than assumed |

`src/components/Narrative/__tests__/NarrativeHistory.keyboard.test.tsx` covers the boundary directly. It needs no stubbed geometry: jsdom reports every box as zero-sized, which measures as parked at the newest beat, so it is the boundary case for free. Both cases were checked against the regressions they guard, and each goes red when its key is routed back to `markLeftLatestBeat`.

The ResizeObserver target is `scrollTarget.firstElementChild`, falling back to the prose column. On the play surface that resolves to `.manuscript-main-stage`, a grid with `align-items: start` and no height cap, so its height tracks content. In the Radix fallback path (no play surface in the tree) it resolves to the viewport's content div. Checked both.

Two things deliberately left alone. The ResizeObserver still fires once on `observe` with the initial size, and that initial fire scrolls to the bottom on mount, which is what a resumed session wants anyway. And `NarrativeHistory.tsx` is 423 lines, over the template's 300-line guideline, but it was 416 before this change and splitting it isn't this PR's job.

## Screenshots

N/A, no visual change.

## Visual Baseline Changes

None. This PR doesn't touch `tests/visual/**-snapshots/**`.

## Code Review Summary

N/A

## Chrome DevTools MCP Verification Summary

Not done, and worth being straight about it. Reproducing the original failure live needs a real provider key and a session run out past turn 18, since the trigger depends on a growth spurt landing in the window between an anchoring scroll and the scroll event it emits. That wasn't practical here, so the evidence for this fix is the failing-then-passing test plus the code path being traceable end to end, not a browser session.

`tests/visual/narrative-reading-position.spec.ts` already measures the reading-position rules against `.manuscript-overlay-main` and exercises the changed code, but it wasn't run locally: the Playwright baselines in this repo are macOS-specific and out of scope for this run. CI covers it.

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit not run, nothing in this change touches dependencies or input handling.

```
npm test               416 suites, 2880 tests, exit 0
npm run type-check     exit 0
npm run lint           exit 0 (127 pre-existing warnings, 0 errors)
npm run deps:validate  clean, 17 known violations ignored
```

`npm run lint:css` skipped, no `.css` file touched.

## Testing Instructions

Unit level: `npx jest src/lib/narrative/__tests__/autoFollowScroll.test.ts`. The case that matters is "keeps following when content grows below the reader without moving them", which is the regression guard.

To see it fail the old way, revert `applyScrollEvent` to set `hasLeftLatestBeat` whenever the measurement isn't near the bottom, and that test goes red while the two scroll-up cases stay green.

In a real session, play past the point where a turn renders a tall consequence card or decision-logged callout and confirm the view keeps landing on the newest beat with its choices on screen. Scrolling up to re-read should still hold position and still offer "Jump to latest", and scrolling back down to the bottom yourself should resume following without clicking it.

## Checklist

- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

File size: `NarrativeHistory.tsx` is 423 lines, already over before this change, noted above. Documentation: nothing to update, the behaviour is described where it lives. Accessibility: the keyboard navigation paths were carried over unchanged, and the fix means a keyboard user who presses End stops needing the pill to resume following.
