### PR TITLE
Stop the model's stage direction reaching the player

### DIFF
--- a/src/lib/ai/__tests__/narrativeGenerator.response.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.response.test.ts
@@ -46,6 +46,17 @@ describe('narrative response helpers', () => {
     );
   });
 
+  it('keeps the text on either side of a stripped tag apart', () => {
+    const normalized = normalizeNarrativeContent(
+      'The door swings shut.<br/>Rain starts against the <em>cracked</em> glass.',
+      {}
+    );
+
+    expect(normalized).toBe(
+      'The door swings shut.\nRain starts against the cracked glass.'
+    );
+  });
+
   it('keeps a bolded closing line that belongs to the scene', () => {
     const content = [
       'The lantern gutters out and the hall goes dark.',

--- a/src/lib/ai/__tests__/narrativeGenerator.response.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.response.test.ts
@@ -32,6 +32,31 @@ describe('narrative response helpers', () => {
     expect(normalized).toBe('Jordan nods.');
   });
 
+  it('drops a bare HTML tag and a trailing meta-commentary paragraph', () => {
+    const content = [
+      'Councilman Davies clears his throat and taps his pen on the table again.',
+      '<br/>',
+      '**The narrative will continue from this point, where the townspeople are reacting to the lack of a formal appraisal.**',
+    ].join('\n\n');
+
+    const normalized = normalizeNarrativeContent(content, {});
+
+    expect(normalized).toBe(
+      'Councilman Davies clears his throat and taps his pen on the table again.'
+    );
+  });
+
+  it('keeps a bolded closing line that belongs to the scene', () => {
+    const content = [
+      'The lantern gutters out and the hall goes dark.',
+      '**The mill bell rings once, and every head in the room turns.**',
+    ].join('\n\n');
+
+    const normalized = normalizeNarrativeContent(content, {});
+
+    expect(normalized).toBe(content);
+  });
+
   it('preserves itemsLost metadata when formatting response', async () => {
     const response = {
       content: `\n\n\`\`\`json\n{"content":"You drop the knife.","metadata":{"itemsLost":[{"name":"Rusted Knife","lossReason":"dropped","quantity":1}]}}\n\`\`\``,

--- a/src/lib/ai/narrativeGenerator.response.normalize.ts
+++ b/src/lib/ai/narrativeGenerator.response.normalize.ts
@@ -2,6 +2,29 @@ import { normalizeText, NORM_DESC } from '@/lib/utils/textNormalization';
 import { safeTrim } from '@/lib/utils';
 import type { NarrativeExtractedMetadata } from './narrativeGenerator.response.types';
 
+/**
+ * Bare HTML the model sometimes reaches for instead of markdown. The prose
+ * renderer only understands markdown, so the tag lands in front of the player
+ * as literal text.
+ */
+const HTML_TAG_PATTERN =
+  /<\/?(?:br|p|div|span|hr|em|strong|b|i|u|ul|ol|li|blockquote|pre|h[1-6])(?:\s[^<>]*)?\/?>/gi;
+
+/**
+ * A final paragraph that is bold end to end - the shape a stage direction takes
+ * when the model signs off about the story instead of staying inside it.
+ */
+const BOLD_CLOSING_PARAGRAPH_PATTERN = /(?:\n\s*)+\*\*([^*]+)\*\*\s*$/;
+
+/**
+ * Narrow on purpose: the narrative has to be the paragraph's own subject with the
+ * verb right behind it. Emphatic in-fiction closers survive, including ones that
+ * mention the story in passing ("the story of the mill will continue to haunt
+ * them"), where that verb belongs to a different subject.
+ */
+const META_COMMENTARY_PATTERN =
+  /^(?:the|this)\s+(?:narrative|story|scene|segment|chapter|passage)\s+(?:will\s+(?:continue|resume|proceed|pick\s+up)|continues|resumes|picks\s+up)\b/i;
+
 export const normalizeNarrativeContent = (
   content: string,
   extractedMetadata: NarrativeExtractedMetadata
@@ -126,7 +149,13 @@ export const normalizeNarrativeContent = (
       .replace(/[ \t]+([,;:.!?])/g, '$1')
       .replace(/[ \t]{2,}/g, ' ')
       .replace(/\s*\[[a-z0-9-]+\]/gi, '')
-      .replace(/\s*\[metadata\.[a-z]+:\s*[a-z0-9-]+\]/gi, '');
+      .replace(/\s*\[metadata\.[a-z]+:\s*[a-z0-9-]+\]/gi, '')
+      .replace(HTML_TAG_PATTERN, '')
+      .replace(/\n{3,}/g, '\n\n')
+      .replace(BOLD_CLOSING_PARAGRAPH_PATTERN, (match, statement: string) =>
+        META_COMMENTARY_PATTERN.test(statement.trim()) ? '' : match
+      )
+      .trim();
   }
 
   return normalizedContent;

--- a/src/lib/ai/narrativeGenerator.response.normalize.ts
+++ b/src/lib/ai/narrativeGenerator.response.normalize.ts
@@ -5,10 +5,15 @@ import type { NarrativeExtractedMetadata } from './narrativeGenerator.response.t
 /**
  * Bare HTML the model sometimes reaches for instead of markdown. The prose
  * renderer only understands markdown, so the tag lands in front of the player
- * as literal text.
+ * as literal text. Block tags become a line break rather than nothing, since
+ * they are the only thing separating the text on either side of them.
  */
-const HTML_TAG_PATTERN =
-  /<\/?(?:br|p|div|span|hr|em|strong|b|i|u|ul|ol|li|blockquote|pre|h[1-6])(?:\s[^<>]*)?\/?>/gi;
+const BLOCK_HTML_TAG_PATTERN =
+  /<\/?(?:br|p|div|hr|ul|ol|li|blockquote|pre|h[1-6])(?:\s[^<>]*)?\/?>/gi;
+
+/** Inline tags wrap a run of prose, so removing them has to leave it joined. */
+const INLINE_HTML_TAG_PATTERN =
+  /<\/?(?:span|em|strong|b|i|u|code|small|sub|sup)(?:\s[^<>]*)?\/?>/gi;
 
 /**
  * Narrow on purpose: the narrative has to be the paragraph's own subject with the
@@ -172,7 +177,9 @@ export const normalizeNarrativeContent = (
       .replace(/[ \t]{2,}/g, ' ')
       .replace(/\s*\[[a-z0-9-]+\]/gi, '')
       .replace(/\s*\[metadata\.[a-z]+:\s*[a-z0-9-]+\]/gi, '')
-      .replace(HTML_TAG_PATTERN, '')
+      .replace(BLOCK_HTML_TAG_PATTERN, '\n')
+      .replace(INLINE_HTML_TAG_PATTERN, '')
+      .replace(/[ \t]*\n[ \t]*/g, '\n')
       .replace(/\n{3,}/g, '\n\n')
       .trim();
 

--- a/src/lib/ai/narrativeGenerator.response.normalize.ts
+++ b/src/lib/ai/narrativeGenerator.response.normalize.ts
@@ -11,12 +11,6 @@ const HTML_TAG_PATTERN =
   /<\/?(?:br|p|div|span|hr|em|strong|b|i|u|ul|ol|li|blockquote|pre|h[1-6])(?:\s[^<>]*)?\/?>/gi;
 
 /**
- * A final paragraph that is bold end to end - the shape a stage direction takes
- * when the model signs off about the story instead of staying inside it.
- */
-const BOLD_CLOSING_PARAGRAPH_PATTERN = /(?:\n\s*)+\*\*([^*]+)\*\*\s*$/;
-
-/**
  * Narrow on purpose: the narrative has to be the paragraph's own subject with the
  * verb right behind it. Emphatic in-fiction closers survive, including ones that
  * mention the story in passing ("the story of the mill will continue to haunt
@@ -24,6 +18,34 @@ const BOLD_CLOSING_PARAGRAPH_PATTERN = /(?:\n\s*)+\*\*([^*]+)\*\*\s*$/;
  */
 const META_COMMENTARY_PATTERN =
   /^(?:the|this)\s+(?:narrative|story|scene|segment|chapter|passage)\s+(?:will\s+(?:continue|resume|proceed|pick\s+up)|continues|resumes|picks\s+up)\b/i;
+
+/**
+ * Drops the closing paragraph when it is bold end to end and reads as a note
+ * about the story rather than a beat of it - the shape a stage direction takes
+ * when the model signs off instead of staying inside the scene. Written as
+ * string slicing rather than an end-anchored regex, which the engine retries
+ * from every position in the passage before it can fail.
+ */
+const dropMetaCommentaryTrailer = (text: string): string => {
+  const breakIndex = text.lastIndexOf('\n\n');
+  if (breakIndex === -1) return text;
+
+  const closing = text.slice(breakIndex + 2).trim();
+  if (
+    closing.length <= 4 ||
+    !closing.startsWith('**') ||
+    !closing.endsWith('**')
+  ) {
+    return text;
+  }
+
+  const statement = closing.slice(2, -2).trim();
+  if (statement.includes('*') || !META_COMMENTARY_PATTERN.test(statement)) {
+    return text;
+  }
+
+  return text.slice(0, breakIndex).trimEnd();
+};
 
 export const normalizeNarrativeContent = (
   content: string,
@@ -152,10 +174,9 @@ export const normalizeNarrativeContent = (
       .replace(/\s*\[metadata\.[a-z]+:\s*[a-z0-9-]+\]/gi, '')
       .replace(HTML_TAG_PATTERN, '')
       .replace(/\n{3,}/g, '\n\n')
-      .replace(BOLD_CLOSING_PARAGRAPH_PATTERN, (match, statement: string) =>
-        META_COMMENTARY_PATTERN.test(statement.trim()) ? '' : match
-      )
       .trim();
+
+    normalizedContent = dropMetaCommentaryTrailer(normalizedContent);
   }
 
   return normalizedContent;

--- a/src/lib/promptTemplates/templates/narrative/initialSceneTemplate.ts
+++ b/src/lib/promptTemplates/templates/narrative/initialSceneTemplate.ts
@@ -64,6 +64,7 @@ CRITICAL INSTRUCTIONS:
 2. The player IS ${playerCharacterName || 'the main character'} - NEVER refer to them by name in narration
 3. Only use the player's name when OTHER characters speak TO or ABOUT them
 4. The player experiences the story through ${playerCharacterName || 'their character'}'s eyes
+5. Write only the scene itself - no HTML tags, and no closing note about what the narrative will do next
 
 Examples:
 ✓ CORRECT: "You adjust your pack and look at the trail ahead..."

--- a/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
+++ b/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
@@ -211,6 +211,7 @@ CRITICAL INSTRUCTIONS:
 2. The player IS ${playerCharacterName || 'the main character'} - NEVER use their name in narration
 3. Only use "${playerCharacterName}" when OTHER characters speak TO or ABOUT the player
 4. The player experiences everything through ${playerCharacterName || 'their character'}'s perspective
+5. Write only the scene itself - no HTML tags, and no closing note about what the narrative will do next
 
 Focus on varied sensory details and the character's reactions to bring the scene to life.
 - Use visual, auditory, and tactile descriptions primarily


### PR DESCRIPTION
## Description
Turn 31 of the guardrail measurement run ended with the model's own stage direction printed as scene text: a bare `<br/>` and then a bolded "The narrative will continue from this point, where the townspeople are reacting to the lack of a formal appraisal." `normalizeNarrativeContent` already strips bracket tokens and `[metadata.*]` tags, but it had no rule for markup or for the model narrating about the story, so both went through and then fed lore extraction and the journal summariser as if they were prose.

Two new rules land in the same cleanup chain the existing strips live in. The first drops recognised HTML tags, since the prose renderer only understands markdown and anything else reaches the player as literal text. Block tags collapse to a line break and inline tags vanish, so `One<br/>Two` doesn't come out as `OneTwo`. The second rule drops a final paragraph that is bold end to end when the narrative is its own grammatical subject with the verb right behind it.

That second rule is the one worth scrutiny, because legitimate prose can end on a bolded line. Requiring the subject-verb shape keeps emphatic in-fiction closers, and it also keeps prose that mentions the story in passing, like "the story of the mill will continue to haunt them", where the verb belongs to a different subject. Checked against all 36 segments of the measurement run: exactly one has a fully bolded final paragraph, and it's the offender.

Both scene prompts also pick up a line telling the model to write the scene and nothing else. That's the softer half. A prompt line can't be tested deterministically, so the normaliser is what actually closes the hole, and it covers every generation path since scene, initial scene, transition, and skill acknowledgment all funnel through `formatNarrativeResponse`.

## Related Issue
Closes #1854

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The first two tests went in before the implementation, and the fixture one failed on the exact `<br/>` plus trailer output. The third came out of the Codex review finding below.

## User Stories Addressed
As a player, I never see markup or the model talking about the story instead of telling it.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A, no UI in this change.

## Implementation Notes
Files touched:

```
src/lib/ai/narrativeGenerator.response.normalize.ts                 two tag patterns + a trailer helper
src/lib/ai/__tests__/narrativeGenerator.response.test.ts            T31 fixture + two guards
src/lib/promptTemplates/templates/narrative/sceneTemplate.ts        one instruction line
src/lib/promptTemplates/templates/narrative/initialSceneTemplate.ts one instruction line
```

The HTML rules match named tag lists rather than a generic angle-bracket pattern, on purpose. A generic pattern would eat angle-bracket constructs in dialogue; a named list can only ever remove something that really is an HTML tag.

Stripping a `<br/>` leaves a blank paragraph behind, so the chain collapses runs of three or more newlines and trims the result before returning.

The trailer check is string slicing off the last paragraph break, not a regex. The first pass used an end-anchored pattern and CodeQL was right to flag it: the engine retried it from every position in the passage, so a segment full of newlines cost quadratic time before the match could fail.

## Screenshots
N/A

## Visual Baseline Changes
None.

## Code Review Summary (if applicable)
Two automated findings came in on the first commit and both were real.

CodeQL flagged the closing-paragraph regex as a ReDoS risk. Fixed by finding the last paragraph break with `lastIndexOf` and checking that slice, which does the same job in one pass.

Codex flagged that replacing every tag with an empty string joins the text on either side of it. Fixed by splitting block from inline tags, with a test on `One<br/>Two`.

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit wasn't run locally; CI covers it.

## Testing Instructions
```
npm test -- src/lib/ai/__tests__/narrativeGenerator.response.test.ts
npm test
npm run type-check
npm run lint
```

Full local run: 418 suites, 2906 tests, all green. Type-check and lint both exit 0, with no new warnings.

Beyond the unit tests, the patterns were replayed against the preserved measurement-run artifact. Segment 31's real content comes out ending at "...his eyes scanning the faces in the room." with the tag and trailer gone, and no other segment in the run trips the rule.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
