### PR TITLE
Reserve the player character's name against extracted lore

### DIFF
--- a/src/lib/ai/__tests__/narrativeGenerator.continuity.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.continuity.test.ts
@@ -316,7 +316,7 @@ describe('NarrativeGenerator - continuity guardrail', () => {
     expect(extractStructuredLore).toHaveBeenCalledWith(
       CLEAN_PROSE,
       expect.anything(),
-      { continuityTopics: ['mill debt'] }
+      { continuityTopics: ['mill debt'], playerCharacterName: 'Hero' }
     );
   });
 });

--- a/src/lib/ai/__tests__/structuredLoreExtractor.playerName.test.ts
+++ b/src/lib/ai/__tests__/structuredLoreExtractor.playerName.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The player character's name is reserved. A lore character entry carrying it is
+ * either a duplicate of the character sheet or a third party the model minted
+ * wearing the player's name, and either way it poisons later prompts.
+ */
+
+jest.mock('@/lib/ai/defaultGeminiClient');
+
+import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
+import { extractStructuredLore } from '../structuredLoreExtractor';
+
+const mockedCreateClient = createDefaultGeminiClient as jest.Mock;
+
+const respondWith = (json: unknown) => {
+  const generateContent = jest.fn().mockResolvedValue({
+    content: '```json\n' + JSON.stringify(json) + '\n```',
+  });
+  mockedCreateClient.mockReturnValue({ generateContent });
+  return generateContent;
+};
+
+const extraction = (characters: unknown[], events: unknown[] = []) => ({
+  characters,
+  locations: [],
+  rules: [],
+  events,
+});
+
+describe('extractStructuredLore reserves the player character name', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('drops a character entry named after the player', async () => {
+    respondWith(
+      extraction([
+        { name: 'Wren Calloway', description: 'Thomas\'s cousin at the county planning office' },
+        { name: 'Thomas', description: 'The mill foreman' },
+      ])
+    );
+
+    const result = await extractStructuredLore('prose', undefined, {
+      playerCharacterName: 'Wren Calloway',
+    });
+
+    expect(result.characters.map((c) => c.name)).toEqual(['Thomas']);
+  });
+
+  it('matches the player name regardless of case and surrounding whitespace', async () => {
+    respondWith(extraction([{ name: '  wren   calloway ' }]));
+
+    const result = await extractStructuredLore('prose', undefined, {
+      playerCharacterName: 'Wren Calloway',
+    });
+
+    expect(result.characters).toHaveLength(0);
+  });
+
+  it('drops a character that claims the player name as an alias', async () => {
+    respondWith(
+      extraction([{ name: 'The planning clerk', aliases: ['Wren Calloway'] }])
+    );
+
+    const result = await extractStructuredLore('prose', undefined, {
+      playerCharacterName: 'Wren Calloway',
+    });
+
+    expect(result.characters).toHaveLength(0);
+  });
+
+  it('keeps events naming the player, which usually record real player actions', async () => {
+    respondWith(
+      extraction(
+        [],
+        [{ description: 'Wren Calloway questions Councilman Davies about the mill debt.' }]
+      )
+    );
+
+    const result = await extractStructuredLore('prose', undefined, {
+      playerCharacterName: 'Wren Calloway',
+    });
+
+    expect(result.events).toHaveLength(1);
+  });
+
+  it('leaves characters alone when no player name is supplied', async () => {
+    respondWith(extraction([{ name: 'Wren Calloway' }]));
+
+    const result = await extractStructuredLore('prose');
+
+    expect(result.characters.map((c) => c.name)).toEqual(['Wren Calloway']);
+  });
+
+  it('tells the model the name is reserved', async () => {
+    const generateContent = respondWith(extraction([]));
+
+    await extractStructuredLore('prose', undefined, {
+      playerCharacterName: 'Wren Calloway',
+    });
+
+    expect(generateContent.mock.calls[0][0]).toContain(
+      '"Wren Calloway" is the PLAYER CHARACTER'
+    );
+  });
+});

--- a/src/lib/ai/narrativeGenerator.ts
+++ b/src/lib/ai/narrativeGenerator.ts
@@ -211,6 +211,7 @@ export class NarrativeGenerator {
         });
         void extractStructuredLore(result.content, existingLoreContext, {
           continuityTopics: collectContinuityTopicsFromStores(request),
+          playerCharacterName: context.playerCharacterName,
         })
           .then(async (structuredLore) => {
             const { useLoreStore } = await import('@/state/loreStore');
@@ -432,7 +433,9 @@ export class NarrativeGenerator {
         const existingLoreContext = getLoreContextForPrompt(worldId, sessionId, {
           recordUsage: false,
         });
-        void extractStructuredLore(response.content, existingLoreContext)
+        void extractStructuredLore(response.content, existingLoreContext, {
+          playerCharacterName: playerCharacter?.name,
+        })
           .then(async (structuredLore) => {
             const { useLoreStore } = await import('@/state/loreStore');
             const { addStructuredLore } = useLoreStore.getState();

--- a/src/lib/ai/structuredLoreExtractor.ts
+++ b/src/lib/ai/structuredLoreExtractor.ts
@@ -5,6 +5,7 @@
 
 import { createDefaultGeminiClient } from './defaultGeminiClient';
 import { extractFencedJson } from './parseJSON';
+import { normalizeText, NORM_NAME } from '@/lib/utils/textNormalization';
 import type {
   LoreContinuityAnnotation,
   LoreContinuityKind,
@@ -24,6 +25,11 @@ export interface ExtractStructuredLoreOptions {
    * the answers.
    */
   continuityTopics?: string[];
+  /**
+   * The player character's name. Reserved: the character store already owns the
+   * player, so nothing extracted under that name can be new information.
+   */
+  playerCharacterName?: string;
 }
 
 /**
@@ -39,7 +45,8 @@ export async function extractStructuredLore(
     const prompt = buildLoreExtractionPrompt(
       narrativeText,
       existingLoreContext,
-      options?.continuityTopics
+      options?.continuityTopics,
+      options?.playerCharacterName
     );
     const response = await geminiClient.generateContent(prompt);
     
@@ -58,7 +65,10 @@ export async function extractStructuredLore(
     }
 
     const extractedLore = JSON.parse(jsonStr) as StructuredLoreExtraction;
-    return validateAndCleanExtraction(extractedLore);
+    return reservePlayerCharacterName(
+      validateAndCleanExtraction(extractedLore),
+      options?.playerCharacterName
+    );
 
   } catch (error) {
     logger.warn('Failed to extract structured lore:', error);
@@ -72,9 +82,13 @@ export async function extractStructuredLore(
 function buildLoreExtractionPrompt(
   narrativeText: string,
   existingLoreContext?: string,
-  continuityTopics?: string[]
+  continuityTopics?: string[],
+  playerCharacterName?: string
 ): string {
   const existingContext = existingLoreContext ? `\n\nExisting Lore Context:\n${existingLoreContext}` : '';
+  const playerNameRule = playerCharacterName
+    ? `\n- "${playerCharacterName}" is the PLAYER CHARACTER, not an NPC. Never create a character entry for them. If the text names a separate person who happens to share that name, that is a mistake in the prose — do not record them as a character.`
+    : '';
   const topicHint =
     continuityTopics && continuityTopics.length > 0
       ? `\n- Continuity topics already in use (reuse the exact label when an event is about the same question, promise, or object): ${continuityTopics.join('; ')}`
@@ -107,7 +121,7 @@ CRITICAL QUALITY RULES:
 - Characters must be specific named individuals. Do NOT create character entries for unnamed or generic groups (e.g. "a guard", "unnamed warrior", "the villagers").
 - If a person is unnamed, keep it as part of an event description instead of a character entity.
 - Prefer stable locations ("Vaes Leisi", "Vaes Leisi marketplace") over micro-locations ("marketplace edge", "near a stall"). If you mention a micro-location, include it as an alias in the location entry.
-- Keep events concise and non-redundant: **extract EXACTLY 3 or fewer** high-signal events that add lasting story state. Never exceed this limit.
+- Keep events concise and non-redundant: **extract EXACTLY 3 or fewer** high-signal events that add lasting story state. Never exceed this limit.${playerNameRule}
 
 CONTINUITY TAGGING (within the 3-event limit, prefer events that carry one of these):
 - Add "continuity" to an event when it is one of:
@@ -265,6 +279,45 @@ function validateAndCleanExtraction(extraction: unknown): StructuredLoreExtracti
   }
 
   return cleaned;
+}
+
+const canonicalizeName = (name: string): string =>
+  normalizeText(name, NORM_NAME).trim().toLowerCase();
+
+/**
+ * Reserves the player character's name against the extracted lore.
+ *
+ * The character store already owns the player, so a lore character entry under
+ * their name is never new information — it is either a duplicate of the sheet
+ * or a third party the model minted wearing the player's name, which then reads
+ * back as world fact in later prompts. An entry that only claims the name as an
+ * alias goes too — entity resolution would otherwise merge it into the player.
+ *
+ * Events are left alone on purpose. Most events naming the player record real
+ * on-screen player actions, and no cheap signal separates those from an
+ * invented off-screen attribution, so filtering them would cost far more true
+ * facts than it saved false ones.
+ */
+function reservePlayerCharacterName(
+  extraction: StructuredLoreExtraction,
+  playerCharacterName?: string
+): StructuredLoreExtraction {
+  const reserved = playerCharacterName ? canonicalizeName(playerCharacterName) : '';
+  if (!reserved) return extraction;
+
+  const characters = extraction.characters.filter((character) => {
+    const claimsPlayerName =
+      canonicalizeName(character.name) === reserved ||
+      (character.aliases ?? []).some((alias) => canonicalizeName(alias) === reserved);
+    if (claimsPlayerName) {
+      logger.debug('Dropped extracted character claiming the player name', {
+        name: character.name,
+      });
+    }
+    return !claimsPlayerName;
+  });
+
+  return { ...extraction, characters };
 }
 
 const trimmedString = (value: unknown): string | undefined =>

--- a/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts
+++ b/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts
@@ -210,3 +210,26 @@ describe('sceneTemplate player character background', () => {
     expect(prompt).not.toContain('PLAYER ACTION:');
   });
 });
+
+describe('sceneTemplate reserved player name', () => {
+  const baseContext: NarrativeTemplateContext = {
+    worldName: 'Millbrook',
+    genre: 'small town drama',
+    tone: 'grounded',
+    playerCharacterName: 'Wren Calloway',
+    narrativeContext: {
+      recentSegments: [{ content: 'Thomas leans against the loading dock.' }],
+      currentTags: [],
+    },
+  };
+
+  it('tells the model the player name is reserved for the player', () => {
+    const prompt = sceneTemplate(baseContext);
+    expect(prompt).toContain('"Wren Calloway" is RESERVED for the player');
+  });
+
+  it('omits the rule when the world has no player character name', () => {
+    const prompt = sceneTemplate({ ...baseContext, playerCharacterName: undefined });
+    expect(prompt).not.toContain('is RESERVED for the player');
+  });
+});

--- a/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
+++ b/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
@@ -211,6 +211,7 @@ CRITICAL INSTRUCTIONS:
 2. The player IS ${playerCharacterName || 'the main character'} - NEVER use their name in narration
 3. Only use "${playerCharacterName}" when OTHER characters speak TO or ABOUT the player
 4. The player experiences everything through ${playerCharacterName || 'their character'}'s perspective
+${playerCharacterName ? `5. "${playerCharacterName}" is RESERVED for the player - never give a relative, contact, or any other character that name, and never describe a second person who carries it` : ''}
 
 Focus on varied sensory details and the character's reactions to bring the scene to life.
 - Use visual, auditory, and tactile descriptions primarily


### PR DESCRIPTION
## Description

An NPC in the round-4 measurement run introduced "my cousin, Wren Calloway, he works for the county planning office" — except Wren Calloway is the player. The post-segment lore extractor then recorded that person, and from the next turn on the Established World Facts block told the model the player had brokered the deal they were investigating.

Two layers here, and the honest split matters:

**The extractor guard (tested).** `extractStructuredLore` now takes the player character's name and drops any extracted character entry claiming it, by name or by alias. Nothing extracted under that name can be new information — the character store already owns the player, so the entry is either a duplicate of the sheet or a third party the model minted wearing the player's name. An alias match drops the whole entry too, since entity resolution would otherwise merge that entity into the player.

**The prompt line (unverified).** A reserved-name instruction now renders in the scene template's CRITICAL INSTRUCTIONS block and in the extraction prompt's quality rules, both gated on a player name being present. Per this repo's evidence bar, that half is not proven to do anything — there's no measurement run behind it, only unit tests that pin the line renders. Calling it a fix would be overclaiming. The extractor guard is the half with teeth.

### The deliberate tradeoff: events are left alone

The issue's minimum ask was character facts whose subject is the player, and this stops there on purpose. Reading `loreFacts` out of the round-4 artifact, 18 of the 78 stored facts name the player, and all but the two poisoned ones record real on-screen player actions:

```
KEPT   Wren Calloway questions Councilman Davies about who holds the mill's debt.
KEPT   Wren Calloway formally requests a written list of all required pre-vote disclosures.
KEPT   Aunt Carol expresses clear disapproval of Wren Calloway's actions.
BAD    Thomas reveals that his cousin, Wren Calloway, who works for the county planning office...
BAD    Wren Calloway put the developer in touch with Councilman Davies regarding the Rowan parcel.
```

Nothing cheap separates the two groups — both are third-person sentences with the player as grammatical subject. A blanket "drop events naming the player" filter would have destroyed 16 true facts to catch 2 false ones, and anything precise enough to tell them apart is the kind of clever the issue warns against. So the two poisoned event facts in the original report would still land today. What's fixed is the character-entity vector and, hopefully, the prose that produces it.

## Related Issue

Closes #1855

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Tests came right after the guard rather than before it, so the first box stays unchecked. They were verified the honest way instead: neutralizing the guard makes exactly the three enforcement tests fail (`drops a character entry named after the player`, the case/whitespace one, and the alias one) while the two negative-control tests keep passing.

## User Stories Addressed

As a player, the story shouldn't invent a second person carrying my character's name, and the world's memory shouldn't credit my character with things they never did.

## Flow Diagrams

N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A — no UI surface, this is generator and prompt logic.

## Implementation Notes

The guard lives in `src/lib/ai/structuredLoreExtractor.ts` as `reservePlayerCharacterName`, applied after `validateAndCleanExtraction`, so it catches everything the model returns regardless of shape. Name matching goes through the existing `normalizeText`/`NORM_NAME` helper the lore store already uses for name comparison, which handles case, whitespace, and smart-quote drift for free.

Both call sites in `narrativeGenerator.ts` pass the name — `generateSegment` from `context.playerCharacterName`, `generateInitialScene` from `playerCharacter?.name`. With no name supplied the extraction is returned untouched, so the dev lore-viewer route and any test harness behave exactly as before.

This sits upstream of the ledger-fed continuity contract that landed in #1856. That work assumes the ledger can hold poisoned facts; this narrows one of the ways they get in. `narrativeGenerator.continuity.ts` was read for context and deliberately not touched.

One existing assertion in `narrativeGenerator.continuity.test.ts` needed updating — it pinned the exact options object handed to the extractor, which now carries `playerCharacterName`. That's a real wiring change, so the assertion was extended rather than loosened.

## Screenshots

N/A

## Visual Baseline Changes

None — nothing under `tests/visual/**-snapshots/**` is touched.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit wasn't run locally; CI covers it. Lint reports 0 errors (127 pre-existing warnings, all in `tests/visual/**` files this PR doesn't touch).

## Testing Instructions

```
npm test          # 419 suites, 2911 tests, all passing
npm run type-check
npm run lint
npm run deps:validate
```

The behavior worth checking by hand is the negative case: start a session, play until an NPC mentions someone by name, and confirm the lore store still fills up normally. The guard only ever removes entries matching the player's name, so a session that never trips it should look identical to before.

## Checklist
- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed

Two touched files are over the 300-line guideline, both already were before this PR: `structuredLoreExtractor.ts` goes 310 to 352, and `narrativeGenerator.ts` sits at 799 and gained three lines. Splitting either one is its own change, not this one's job.

No docs needed — the prompt registry is the source of truth for prompt behavior, and no public doc describes lore extraction filtering. No accessibility surface.
