### PR TITLE
Fix the pacing guard's broken reset signals so it can actually fire

### DIFF
--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -22,7 +22,7 @@ import {
   evaluateDecisionSkillChecks,
   isFatalCriticalDecision,
 } from '@/lib/narrative/evaluateDecisionSkillChecks';
-import { computeTurnsSinceComplication } from '@/lib/narrative/turnsSinceComplication';
+import { computeTurnsSinceComplication, isPacingStale } from '@/lib/narrative/turnsSinceComplication';
 import { mergeTurnTags } from '@/lib/narrative/turnTags';
 import { logger } from '@/lib/utils/logger';
 import { AI_GENERATION_TIMEOUT_MS } from '@/lib/constants/timeouts';
@@ -624,6 +624,11 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
       // Streak tracked over the whole session, not just the trimmed context
       // window above — a quiet stretch spans more than 3 segments.
       const turnsSinceComplication = computeTurnsSinceComplication(segments);
+      // The scene prompt only carries the rising-tension block above this
+      // threshold, and the complication it asks for arrives with no dice roll
+      // behind it. Stamping the ask onto the segment is what lets the streak
+      // reset; without it the guidance would repeat on every following turn.
+      const pacingEscalationRequested = isPacingStale(turnsSinceComplication);
 
       // Get the actual choice text from the narrative store
       const decisions = useNarrativeStore
@@ -775,6 +780,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
           // Merge skill check tags into metadata
           tags: [...(result.metadata.tags || []), ...skillCheckTags],
           decisionOutcome,
+          pacingEscalationRequested,
         },
         sessionId, // Explicitly set sessionId
         worldId, // Explicitly set worldId

--- a/src/lib/narrative/__tests__/turnsSinceComplication.test.ts
+++ b/src/lib/narrative/__tests__/turnsSinceComplication.test.ts
@@ -1,4 +1,4 @@
-import { computeTurnsSinceComplication } from '../turnsSinceComplication';
+import { computeTurnsSinceComplication, isPacingStale } from '../turnsSinceComplication';
 import type { NarrativeSegment } from '@/types/narrative.types';
 
 function makeSegment(overrides: Partial<NarrativeSegment['metadata']> = {}): NarrativeSegment {
@@ -57,11 +57,68 @@ describe('computeTurnsSinceComplication', () => {
     expect(computeTurnsSinceComplication(segments)).toBe(2);
   });
 
-  it('resets on a segment with a majorEvent even without a skill check', () => {
+  it('keeps counting through majorEvent segments, which mark plot movement rather than setbacks', () => {
     const segments = [
       makeSegment({ majorEvent: 'Discovered they are wanted by the authorities' }),
+      makeSegment({ majorEvent: 'Reached the far side of the ridge' }),
+      makeSegment({ majorEvent: 'Struck a bargain with the ferryman' }),
+      makeSegment({ decisionOutcome: 'success' }),
+    ];
+    expect(computeTurnsSinceComplication(segments)).toBe(4);
+  });
+
+  it('counts a cautious run of successes and majorEvents that used to read 0', () => {
+    const segments = [
+      makeSegment({ decisionOutcome: 'success', majorEvent: 'Found leaves pressed flat' }),
+      makeSegment({ decisionOutcome: 'success', majorEvent: 'Followed the furrow uphill' }),
+      makeSegment({ decisionOutcome: 'critical-success', majorEvent: 'Found an abandoned stretcher' }),
+      makeSegment({ decisionOutcome: 'success', majorEvent: 'Picked up a locket in the grass' }),
+    ];
+    expect(computeTurnsSinceComplication(segments)).toBe(4);
+  });
+
+  it('resets when the pacing guard asked this segment to escalate', () => {
+    const segments = [
+      makeSegment({ pacingEscalationRequested: true }),
+      makeSegment(),
       makeSegment(),
     ];
-    expect(computeTurnsSinceComplication(segments)).toBe(1);
+    expect(computeTurnsSinceComplication(segments)).toBe(2);
+  });
+
+  it('lets the streak climb back to the threshold after an escalation', () => {
+    const segments = [
+      makeSegment(),
+      makeSegment(),
+      makeSegment({ pacingEscalationRequested: true }),
+      makeSegment(),
+      makeSegment(),
+      makeSegment(),
+    ];
+    expect(computeTurnsSinceComplication(segments)).toBe(3);
+  });
+
+  it('does not reset on a segment the guard left alone', () => {
+    const segments = [
+      makeSegment({ pacingEscalationRequested: false }),
+      makeSegment(),
+    ];
+    expect(computeTurnsSinceComplication(segments)).toBe(2);
+  });
+});
+
+describe('isPacingStale', () => {
+  it('is quiet below three uneventful turns', () => {
+    expect(isPacingStale(0)).toBe(false);
+    expect(isPacingStale(2)).toBe(false);
+  });
+
+  it('fires at three and stays fired above it', () => {
+    expect(isPacingStale(3)).toBe(true);
+    expect(isPacingStale(9)).toBe(true);
+  });
+
+  it('treats an untracked streak as quiet', () => {
+    expect(isPacingStale(undefined)).toBe(false);
   });
 });

--- a/src/lib/narrative/turnsSinceComplication.ts
+++ b/src/lib/narrative/turnsSinceComplication.ts
@@ -1,31 +1,62 @@
-import type { NarrativeSegment } from '@/types/narrative.types';
+import type { DecisionOutcome, NarrativeSegment } from '@/types/narrative.types';
 
 /**
  * Outcomes that count as a real complication for pacing purposes. A pure
- * success (or no skill check at all, e.g. a cautious no-requirement choice)
- * doesn't reset the streak — only a segment where something actually went
- * wrong does.
+ * success, or no skill check at all (a cautious no-requirement choice),
+ * doesn't reset the streak. Only a segment where the dice went against the
+ * player does, and the scene prompt now requires a failed attempt to cost
+ * something concrete, so it earns the reset.
  */
-const COMPLICATION_OUTCOMES = new Set(['failure', 'critical-failure', 'mixed']);
+const COMPLICATION_OUTCOMES: ReadonlySet<DecisionOutcome> = new Set<DecisionOutcome>([
+  'failure',
+  'critical-failure',
+  'mixed',
+]);
 
 /**
- * Counts how many segments in a row have passed since the last complication
- * (a failed or mixed skill-check outcome), walking backward from the most
- * recent segment. A cautious playstyle that never triggers a skill check, or
- * always succeeds, never resets this count — it just keeps climbing, giving
- * the narrative prompt a signal to escalate when a session has gone quiet
- * for too long.
+ * Consecutive uneventful segments before the scene prompt starts pushing the
+ * model to break the calm. Below this, a quiet stretch reads as normal pacing;
+ * at or above it, cautious play stops being a free pass.
+ */
+const STALE_PACING_THRESHOLD = 3;
+
+/**
+ * Single source of truth for "the scene has gone quiet". The scene template
+ * reads it to decide whether to render the rising-tension block, and the
+ * controller reads it to stamp the segment that block produced. Keeping the
+ * threshold in one place is what stops those two halves drifting apart.
+ */
+export function isPacingStale(turnsSinceComplication: number | undefined): boolean {
+  return (turnsSinceComplication ?? 0) >= STALE_PACING_THRESHOLD;
+}
+
+/**
+ * Counts how many segments in a row have passed since the last complication,
+ * walking backward from the most recent segment. A cautious playstyle that
+ * never triggers a skill check, or always succeeds, never resets this count.
+ * It just keeps climbing, giving the narrative prompt a signal to escalate
+ * when a session has gone quiet for too long.
  *
- * A segment's own majorEvent also resets the streak: a story-changing beat
- * (arrival, revelation, injury) is a complication in its own right even
- * without a dice roll behind it.
+ * Two things reset the streak: a skill check that went against the player, and
+ * a segment the pacing guard itself asked to escalate. The second is what lets
+ * the guard stand down. A complication the model invented on request carries no
+ * dice roll, so without a marker of its own the guidance would fire on every
+ * subsequent turn forever.
+ *
+ * `majorEvent` deliberately does NOT reset it. That field marks plot movement
+ * of any kind, and its own rules qualify revelations, alliances, arrivals and
+ * milestones, which are the story going well. Measured live it came back set on
+ * the large majority of segments. A signal that fires on most turns cannot mark
+ * the exception.
  */
 export function computeTurnsSinceComplication(segments: NarrativeSegment[]): number {
   let count = 0;
   for (let i = segments.length - 1; i >= 0; i--) {
     const metadata = segments[i]?.metadata;
     const outcome = metadata?.decisionOutcome;
-    const hadComplication = (outcome && COMPLICATION_OUTCOMES.has(outcome)) || Boolean(metadata?.majorEvent);
+    const hadComplication =
+      (outcome !== undefined && COMPLICATION_OUTCOMES.has(outcome)) ||
+      Boolean(metadata?.pacingEscalationRequested);
     if (hadComplication) {
       break;
     }

--- a/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts
+++ b/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.test.ts
@@ -131,10 +131,10 @@ describe('sceneTemplate pacing guidance', () => {
     expect(prompt).toContain('3 turns in a row');
   });
 
-  it('tells the model to record the forced complication as a majorEvent so the streak actually resets', () => {
+  it('stops leaning on majorEvent to reset the streak', () => {
     const prompt = sceneTemplate(makeContext(3));
-    expect(prompt).toContain('counts as a major event');
-    expect(prompt).toContain('metadata.majorEvent');
+    expect(prompt).not.toContain('counts as a major event');
+    expect(prompt).toContain('this guidance stands down on its own');
   });
 
   it('keeps escalating the guidance for longer streaks', () => {

--- a/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
+++ b/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
@@ -2,13 +2,7 @@ import { PERSPECTIVE_EXAMPLES, shouldIncludeExamples } from '../../examples';
 import { majorEventGuidelines } from './majorEventGuidelines';
 import { describeNarrativeLength } from './narrativeLength';
 import type { NarrativeTemplateContext } from './context';
-
-/**
- * Number of consecutive uneventful segments before the prompt starts pushing
- * the model to break the calm. Below this, a quiet stretch just reads as
- * normal pacing; at or above it, cautious play stops being a free pass.
- */
-const STALE_PACING_THRESHOLD = 3;
+import { isPacingStale } from '@/lib/narrative/turnsSinceComplication';
 
 /**
  * Puts the player's own sheet in front of the model. Without it the prompt
@@ -103,7 +97,7 @@ export const sceneTemplate = (context: NarrativeTemplateContext) => {
     skillResult === 'critical-failure' ||
     skillResult === 'mixed';
   const turnsSinceComplication = narrativeContext?.turnsSinceComplication ?? 0;
-  const isStale = turnsSinceComplication >= STALE_PACING_THRESHOLD;
+  const isStale = isPacingStale(turnsSinceComplication);
 
   const formattedRoster = Array.isArray(npcRoster) && npcRoster.length > 0
     ? `
@@ -150,7 +144,7 @@ PACING GUIDANCE — RISING TENSION:
 - This segment MUST introduce a complication: an interruption, a new threat, an unexpected cost, or a setback tied to the current situation.
 - The complication does not need a skill check behind it — it can simply happen (an NPC arrives, a resource runs out, the trail leads somewhere worse than expected, time runs short).
 - Do not extend the current chain with another same-shape discovery (another clue, another trace) with nothing else changing.
-- Whatever complication you introduce here counts as a major event: record it in metadata.majorEvent (see the rules below) so this guidance doesn't fire again next turn for a problem you already resolved.
+- Judge the majorEvent field on its own rules below — this guidance stands down on its own and does not need one.
 ` : ''}
 
 ${generationParameters?.decisionWeight === 'critical' && failed ? `

--- a/src/state/__tests__/narrativeStore.segments.pacing.test.ts
+++ b/src/state/__tests__/narrativeStore.segments.pacing.test.ts
@@ -1,0 +1,77 @@
+/**
+ * addSegment persists the pacing-escalation marker on segment metadata — the
+ * finalMetadata whitelist drops anything it doesn't list, and the streak is
+ * recomputed from stored segments after a reload.
+ */
+
+import { useNarrativeStore } from '../narrativeStore';
+import { useWorldStore } from '../worldStore';
+import { useSessionStore } from '../sessionStore';
+import { computeTurnsSinceComplication } from '@/lib/narrative/turnsSinceComplication';
+
+describe('addSegment pacing metadata', () => {
+  let worldId: string;
+  const sessionId = 'session-pacing-test';
+
+  beforeEach(() => {
+    jest.useRealTimers();
+    useWorldStore.getState().reset();
+    useNarrativeStore.getState().reset();
+    global.fetch = jest.fn();
+
+    worldId = useWorldStore.getState().createWorld({
+      name: 'Test World',
+      description: 'A test world',
+      genre: 'fantasy',
+      attributes: [],
+      skills: [],
+      settings: {
+        maxAttributes: 5,
+        maxSkills: 5,
+        attributePointPool: 10,
+        skillPointPool: 10,
+      },
+    });
+    useSessionStore.getState().upsertSessionLifecycle({
+      id: sessionId,
+      worldId,
+      characterId: 'char-test',
+      status: 'active',
+      lastActivity: new Date().toISOString(),
+    });
+  });
+
+  afterEach(() => {
+    useNarrativeStore.getState().reset();
+    useWorldStore.getState().reset();
+    jest.restoreAllMocks();
+  });
+
+  function addSegment(pacingEscalationRequested?: boolean): string {
+    return useNarrativeStore.getState().addSegment(sessionId, {
+      worldId,
+      content: 'The trail bends toward the treeline.',
+      type: 'scene',
+      metadata: { tags: [], pacingEscalationRequested },
+      timestamp: new Date(),
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  it('persists the marker so the streak survives a reload', () => {
+    const segmentId = addSegment(true);
+    expect(
+      useNarrativeStore.getState().segments[segmentId].metadata
+        .pacingEscalationRequested
+    ).toBe(true);
+  });
+
+  it('reads back as a complication when recomputing the streak from the store', () => {
+    addSegment(true);
+    addSegment();
+    addSegment();
+
+    const stored = useNarrativeStore.getState().getSessionSegments(sessionId);
+    expect(computeTurnsSinceComplication(stored)).toBe(2);
+  });
+});

--- a/src/state/narrativeStore.segments.ts
+++ b/src/state/narrativeStore.segments.ts
@@ -112,6 +112,7 @@ export const createNarrativeSegmentActions = (
       causedByDecisionId,
       causedByDecisionText,
       decisionOutcome: metadata?.decisionOutcome,
+      pacingEscalationRequested: metadata?.pacingEscalationRequested,
       continuity: metadata?.continuity,
       debugInfo: metadata?.debugInfo, // Preserve debug info from AI generation
     };

--- a/src/types/narrative.types.ts
+++ b/src/types/narrative.types.ts
@@ -270,6 +270,12 @@ export interface NarrativeMetadata {
   causedByDecisionId?: EntityID;
   causedByDecisionText?: string;
   decisionOutcome?: DecisionOutcome;
+  /**
+   * Set by the engine, not the model: this segment was generated while the
+   * pacing guard was asking for a complication. Asking is what spends the
+   * quiet streak, so the guard paces itself instead of firing every turn.
+   */
+  pacingEscalationRequested?: boolean;
   // Continuity guardrail outcome (#409/#412)
   continuity?: ContinuitySegmentNote;
   // Debug information (dev mode only)


### PR DESCRIPTION
## Description

The pacing guard could never fire. `computeTurnsSinceComplication` needs three quiet turns before the scene prompt asks for a complication, and measured live it read 0, 0 and 1 across three runs, and 0 again at turn 45. The cause was `majorEvent`: it reset the streak, and it comes back set on most segments, so the counter was pinned near zero and the rising-tension block essentially never rendered.

`majorEvent` no longer resets the streak. Its own rules in `majorEventGuidelines.ts` qualify revelations, alliances, arrivals and milestones, which is the story going well, so it was flagging good news as a setback. In its place the controller stamps `pacingEscalationRequested` on any segment generated while the rising-tension block was in the prompt. The engine sets that flag, not the model, and the ask is what spends the streak. Without something like it, removing `majorEvent` would swing the guard the other way: a complication the model invents on request carries no dice roll, so the guidance would fire again on every following turn forever.

The failure-outcome reset stays as it was. See the diagnostic notes below for why.

## Related Issue

Closes #1680

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## The milestone's two diagnostic claims, checked against the code

Both reproduce as code facts. They do not both survive as defects.

| Claim | Reproduces? | Verdict |
|---|---|---|
| `'failure'` counts as a complication and resets the streak | Yes. `COMPLICATION_OUTCOMES` held `failure`, `critical-failure`, `mixed`, and `decisionOutcome` is honest dice from `evaluateDecisionSkillChecks` | Left alone. #1821 fixed this upstream by changing what a failure renders as |
| `majorEvent` also resets the streak | Yes, the old line ORed in `Boolean(metadata?.majorEvent)` | Removed. This is the actual bug |

On the failure signal: the milestone's own wording is that `'failure'` was broken *because* #1821's non-events read as setbacks, which is why #1821 was sequenced first. #1821 has shipped, and the scene prompt now requires a failed attempt to cost something concrete: position, a resource, an NPC's disposition, noise drawn. A turn that costs the player something is not a quiet turn, so it should reset the streak. Narrowing it further would need a way to grade how much a failure cost, and nothing in the engine can see that. Fixing it would have been fixing a phantom.

The `majorEvent` claim is the real one, and it holds for a reason visible in the code rather than only in the measurement. The signal's own spec makes plot advancement qualify. A signal whose definition includes the story going well cannot mark the exception.

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The new cases in `turnsSinceComplication.test.ts` cover sequences that read 0 under the old logic and now accumulate, including a rebuild of the issue's own nine-turn clue chain (successes with a `majorEvent` on every turn). The existing test proving a failed skill check resets to 0 is untouched.

## User Stories Addressed

A cautious player should not get an indefinitely quiet story. This is the mechanism half of that: the counter that feeds the escalation prompt can now reach its threshold.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A, no UI change.

## Implementation Notes

`STALE_PACING_THRESHOLD` moved out of `sceneTemplate.ts` into `turnsSinceComplication.ts` behind an `isPacingStale()` predicate. Both halves need the same answer now, and a threshold duplicated in a template and a controller is the kind of thing that drifts silently.

`pacingEscalationRequested` had to be added to the `finalMetadata` whitelist in `narrativeStore.segments.ts`. Anything not listed there gets dropped, and the streak is recomputed from stored segments after a reload, so a missing line would have looked like the fix working in memory and failing on refresh. There's a store test pinning that.

The prompt change is one bullet. The old PACING GUIDANCE block told the model to record its forced complication in `metadata.majorEvent` so the guidance wouldn't repeat, which was the piggyback this PR removes. That bullet now points the model back at the majorEvent rules and says the guidance stands down on its own.

Two things deliberately left out, both separate milestone items: the choice generator still offers three variants of the same tactical approach (#1830), and there's no world clock (#1822). The issue's Additional Context lists both as options worth weighing. Neither is a signal repair, and success-with-a-cost would change what a *successful* turn means, which is a bigger swing than this issue is scoped for.

## Screenshots

N/A

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

Ran `narraitor-architecture` before the change and `narraitor-pattern-alignment-skill` after, plus `narraitor-prompt-template-governance` for the template edit. Gate G1 is unaffected: no new `NarrativeTemplateContext` field, the template still reads `turnsSinceComplication` only. G3 is unaffected too, since the change removes a bullet and touches nothing the response parsers key on.

Where this PR falls short of the governance gates, plainly: G4 and G5 want an eval run, and there isn't one. See Testing Instructions.

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks (if applicable)

- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

**This is proven at the unit level and unverified in live play.** Per `narraitor-ai-quality-discipline`, unit tests over synthetic segment sequences show the counter can now reach its threshold on a quiet run. They say nothing about whether the model obeys the rising-tension block when it finally arrives, or whether the resulting complications make the story better. The pacing problem in #1680 is not solved by this PR. It is unblocked.

The milestone's round-5 playtest is where this gets scored, against the choice-quality and momentum rows of the success bar. One tradeoff worth watching there: the guard now stands down when it *asks* for a complication, not when the model delivers one. If the model ignores the ask, the streak still resets and the story stays quiet for another three turns. The alternative is firing the directive on every single turn, which #1829 is direct evidence against.

Local gate, all from the worktree root, exit codes captured separately:

```
npm test               # exit 1: 2909 passed, 3 failed. All three are one
                       # pre-existing SkillEditor flake under parallel load
                       # (userEvent character interleaving). That suite passes
                       # on its own at exit 0 and this diff does not touch it
npm run type-check     # exit 0
npm run lint           # exit 0, 0 errors
npm run deps:validate  # exit 0, baseline holds at 17
npm run deps:check     # exit 0
npm run knip           # exit 0
npm run skott:check    # exit 0, 6 cycles against a baseline of 6
```

Targeted: `npx jest src/lib/narrative src/lib/promptTemplates src/state/__tests__/narrativeStore.segments.pacing.test.ts`, exit 0, 156 passed.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

No docs to update. Nothing in `public_docs/` describes the pacing guard.
