### PR TITLE
Keep the continuity contract when all it carries is recent decisions

### DIFF
--- a/src/lib/ai/__tests__/narrativeGenerator.continuity.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.continuity.test.ts
@@ -319,4 +319,60 @@ describe('NarrativeGenerator - continuity guardrail', () => {
       { continuityTopics: ['mill debt'], playerCharacterName: 'Hero' }
     );
   });
+
+  it('keeps a decisions-only contract so the recent-decision lines reach the prompt', async () => {
+    // Fresh session: nothing in relationships or lore yet, one decision behind
+    // us. That is exactly the shape the emptiness check used to throw away.
+    (useWorldStore.getState as jest.Mock).mockImplementation(() => ({
+      worlds: { 'world-1': mockWorld },
+      worldStates: {},
+      currentWorldId: 'world-1',
+      error: null,
+      loading: false,
+      getWorldState: jest.fn(() => ({ npcRelationships: {} })),
+    }));
+    (useLoreStore.getState as jest.Mock).mockReturnValue({
+      getFacts: jest.fn().mockReturnValue([]),
+      getLoreContext: jest.fn().mockReturnValue({ factIds: [] }),
+      recordLoreMentions: jest.fn(),
+      recordLoreUsage: jest.fn(),
+      addStructuredLore: jest.fn(),
+    });
+
+    const client = createRoutedClient(CLEAN_PROSE, CORRECTED_PROSE);
+    const generator = new NarrativeGenerator(client);
+
+    const result = await generator.generateSegment({
+      ...request,
+      narrativeContext: {
+        worldId: 'world-1',
+        currentSceneId: 'scene-1',
+        characterIds: ['char-1'],
+        sessionId: 'session-1',
+        currentTags: [],
+        previousSegments: [
+          {
+            id: 'segment-1',
+            content: 'The mill door groans shut behind you.',
+            type: 'scene',
+            timestamp: new Date('2025-01-01T00:00:00.000Z'),
+            createdAt: '2025-01-01T00:00:00.000Z',
+            updatedAt: '2025-01-01T00:00:00.000Z',
+            metadata: {
+              tags: [],
+              causedByDecisionText: 'Bar the mill door from the inside',
+              decisionOutcome: 'success',
+            },
+          },
+        ],
+      },
+    });
+
+    const generationPrompt = client.generateContent.mock.calls[0][0] as string;
+    expect(generationPrompt).toContain('CONTINUITY REQUIREMENTS');
+    expect(generationPrompt).toContain(
+      'Recent decision: "Bar the mill door from the inside"'
+    );
+    expect(result.metadata.continuity).toEqual({ status: 'clean' });
+  });
 });

--- a/src/lib/ai/narrativeGenerator.continuity.ts
+++ b/src/lib/ai/narrativeGenerator.continuity.ts
@@ -86,9 +86,19 @@ export const collectContinuityTopicsFromStores = (
 };
 
 /**
+ * The guardrail's own emptiness test counts only what it can validate a
+ * segment against, and recent decisions are not that: they ride the contract
+ * purely to reach the prompt. Dropping a decisions-only contract strips the
+ * recent-decision lines through the opening turns of a fresh session, before
+ * any relationship or tagged fact exists.
+ */
+const carriesNothingForTheModel = (contract: ContinuityContract): boolean =>
+  isContinuityContractEmpty(contract) && contract.recentDecisions.length === 0;
+
+/**
  * Builds the continuity contract from live stores. Returns null when the
- * contract would be vacuous (nothing to validate against) or when any store
- * read fails — a null contract disables the guardrail for this request.
+ * contract carries nothing for the model, or when any store read fails. A
+ * null contract disables the guardrail for this request.
  */
 export const buildContinuityContractFromStores = (
   request: NarrativeGenerationRequest,
@@ -120,7 +130,7 @@ export const buildContinuityContractFromStores = (
       playerName: options?.playerName,
     });
 
-    if (isContinuityContractEmpty(contract)) {
+    if (carriesNothingForTheModel(contract)) {
       return null;
     }
     return contract;


### PR DESCRIPTION
## Description

The scene prompt was losing its "Recent decision:" lines for the first several turns of a fresh session. `buildContinuityContractFromStores` builds the contract with `recentDecisions` populated, then throws the whole thing away when `isContinuityContractEmpty` says it is empty - and that check counts relationships and tagged facts only. It never looks at `recentDecisions`. So in a new world, before any NPC relationship or tagged lore fact exists, a contract that carries the player's last choice reads as vacuous and comes back null. The recent-decision lines ride inside the contract, so they vanish with it. PR #1856's Run B caught this as a null contract at T1.

The issue floated two fixes: count `recentDecisions` in the emptiness check, or render the recent-decision lines outside the contract so they stop depending on it. This takes a third route that leaves both of those files untouched. The guardrail's `isContinuityContractEmpty` still means what it has always meant, which is "nothing here to validate a segment against", and that is genuinely true of a decisions-only contract. What changes is the call site: a small local predicate, `carriesNothingForTheModel`, keeps a contract when it has either something to validate or decisions to carry.

Worth noting why this is safe downstream. `detectContinuityIssues` iterates npcs, canon facts, assertions, commitments and scene changes, so a decisions-only contract yields zero issues, lands as `clean`, and never triggers the corrective AI call. The only behavioral change is that `formatContinuityExpectations` now gets a chance to emit its `- Recent decision: "..."` lines on the turns where it previously emitted nothing.

## Related Issue

Closes #1868

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The new test went in first and failed for the right reason: the generation prompt had no `CONTINUITY REQUIREMENTS` block at all, because the contract was null. Full failing output is in Testing Instructions below.

## User Stories Addressed

As a player starting a brand new story, the model should know what I just chose, so the next scene follows from my decision instead of ignoring it.

## Flow Diagrams

N/A

## Component Development

N/A - no UI in this change.

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes

| File | Change |
|---|---|
| `src/lib/ai/narrativeGenerator.continuity.ts` | Added `carriesNothingForTheModel`; the null-return guard now uses it instead of `isContinuityContractEmpty` directly |
| `src/lib/ai/__tests__/narrativeGenerator.continuity.test.ts` | Added the decisions-only contract case |

Deliberately not touched: `src/lib/lore/continuityGuardrail.ts` (the guardrail's own emptiness semantics stay intact), and `sceneTemplate.ts` / `context.ts`, which PR #1869 owns.

## Screenshots

N/A

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

Before the fix, the new test fails with the contract absent entirely:

```
● keeps a decisions-only contract so the recent-decision lines reach the prompt
  expect(received).toContain(expected)
  Expected substring: "CONTINUITY REQUIREMENTS"
```

After:

```
npx jest src/lib/ai/__tests__/narrativeGenerator.continuity.test.ts
EXIT=0
Tests: 5 passed, 5 total

npm run test:ci    EXIT=0    Test Suites: 420 passed    Tests: 2924 passed
npm run type-check EXIT=0
npm run lint       EXIT=0
```

To see it in real play: start a session in a fresh world, make one choice, generate the next scene, and check the scene prompt carries a `- Recent decision: "..."` line. Previously that line only showed up once at least one relationship or tagged fact existed, which could take several turns.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
