### PR TITLE
Stop offering an ending while the threat is still outside the door

### DIFF
--- a/src/components/Narrative/__tests__/useEndingDetection.openThreats.test.ts
+++ b/src/components/Narrative/__tests__/useEndingDetection.openThreats.test.ts
@@ -1,0 +1,139 @@
+// src/components/Narrative/__tests__/useEndingDetection.openThreats.test.ts
+//
+// Covers the open-threat gate: a lull is not a resolution. When major events
+// are on record, the ending offer waits until the model reports them settled.
+
+import { renderHook } from '@testing-library/react';
+import { useEndingDetection } from '../useEndingDetection';
+import { getTimestamp } from '@/lib/utils/timestamp';
+import type { NarrativeSegment } from '@/types/narrative.types';
+
+const mockGenerateContent = jest.fn();
+jest.mock('@/lib/ai/defaultGeminiClient', () => ({
+  createDefaultGeminiClient: () => ({ generateContent: mockGenerateContent }),
+}));
+
+const segment = (
+  id: string,
+  metadata: Partial<NarrativeSegment['metadata']> = {}
+): NarrativeSegment => ({
+  id,
+  content: `Segment ${id} content.`,
+  type: 'scene',
+  timestamp: new Date(),
+  sessionId: 'test-session',
+  createdAt: getTimestamp(),
+  updatedAt: getTimestamp(),
+  metadata: { tags: [], ...metadata },
+});
+
+const renderDetection = (segments: NarrativeSegment[]) => {
+  const onEndingSuggested = jest.fn();
+  const { result } = renderHook(() =>
+    useEndingDetection({
+      sessionId: 'test-session',
+      worldId: 'test-world',
+      segments,
+      onEndingSuggested,
+    })
+  );
+  return { result, onEndingSuggested };
+};
+
+/** The turn-30 barricade case: calm room, threat still outside. */
+const barricadeStory = () => [
+  segment('1'),
+  segment('2', { majorEvent: 'A shape moves in the woods beyond the treeline' }),
+  segment('3', { majorEvent: 'A distress call from the other camp goes unanswered' }),
+  segment('4'),
+];
+
+const endingOffer = (extra: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    suggestEnding: true,
+    confidence: 'high',
+    endingType: 'story-complete',
+    reason:
+      'The immediate threat has been averted and the characters are secured in a safe location.',
+    ...extra,
+  });
+
+describe('useEndingDetection open-threat gate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('holds the offer back when the model reports an unresolved threat', async () => {
+    mockGenerateContent.mockResolvedValue({
+      content: endingOffer({
+        unresolvedThreats: ['The shape in the woods was never dealt with'],
+      }),
+    });
+    const { result, onEndingSuggested } = renderDetection(barricadeStory());
+
+    await result.current.checkForEndingIndicators(
+      segment('5', { majorEvent: 'The kitchen door is barred from the inside' })
+    );
+
+    expect(onEndingSuggested).not.toHaveBeenCalled();
+  });
+
+  it('holds the offer back when the model skips the threat census entirely', async () => {
+    // No census with major events on record means the calm went unweighed.
+    mockGenerateContent.mockResolvedValue({ content: endingOffer() });
+    const { result, onEndingSuggested } = renderDetection(barricadeStory());
+
+    await result.current.checkForEndingIndicators(
+      segment('5', { majorEvent: 'The kitchen door is barred from the inside' })
+    );
+
+    expect(onEndingSuggested).not.toHaveBeenCalled();
+  });
+
+  it('offers the ending once the model reports the threats settled', async () => {
+    mockGenerateContent.mockResolvedValue({
+      content: endingOffer({ unresolvedThreats: [] }),
+    });
+    const { result, onEndingSuggested } = renderDetection(barricadeStory());
+
+    await result.current.checkForEndingIndicators(
+      segment('5', { majorEvent: 'The thing in the woods is put down for good' })
+    );
+
+    expect(onEndingSuggested).toHaveBeenCalledWith(
+      expect.any(String),
+      'story-complete'
+    );
+  });
+
+  it('leaves stories with no major events on record alone', async () => {
+    // Nothing to weigh the calm against, so the gate must not block anything.
+    mockGenerateContent.mockResolvedValue({ content: endingOffer() });
+    const { result, onEndingSuggested } = renderDetection([
+      segment('1'),
+      segment('2'),
+    ]);
+
+    await result.current.checkForEndingIndicators(segment('3'));
+
+    expect(onEndingSuggested).toHaveBeenCalledWith(
+      expect.any(String),
+      'story-complete'
+    );
+  });
+
+  it('puts the open threads in the prompt so the model can weigh them', async () => {
+    mockGenerateContent.mockResolvedValue({
+      content: endingOffer({ unresolvedThreats: [] }),
+    });
+    const { result } = renderDetection(barricadeStory());
+
+    await result.current.checkForEndingIndicators(
+      segment('5', { majorEvent: 'The kitchen door is barred from the inside' })
+    );
+
+    const prompt = mockGenerateContent.mock.calls[0][0] as string;
+    expect(prompt).toContain('A shape moves in the woods beyond the treeline');
+    expect(prompt).toContain('unresolvedThreats');
+  });
+});

--- a/src/components/Narrative/__tests__/useEndingDetection.openThreats.test.ts
+++ b/src/components/Narrative/__tests__/useEndingDetection.openThreats.test.ts
@@ -122,6 +122,47 @@ describe('useEndingDetection open-threat gate', () => {
     );
   });
 
+  it('keeps protecting a threat that has scrolled out of the recent window', async () => {
+    // The only major event sits at segment 1, eight turns back and well outside
+    // RECENT_SEGMENT_WINDOW. Nothing in the recent window carries one, so a
+    // windowed collection would find no threads and switch the guard off for
+    // exactly the threat that has been ignored longest. 9 segments total keeps
+    // the routine check on its interval without a major event to force it.
+    mockGenerateContent.mockResolvedValue({
+      content: endingOffer({
+        unresolvedThreats: ['The pursuer was never shaken off'],
+      }),
+    });
+    const { result, onEndingSuggested } = renderDetection([
+      segment('1', { majorEvent: 'A pursuer picks up the trail out of town' }),
+      segment('2'),
+      segment('3'),
+      segment('4'),
+      segment('5'),
+      segment('6'),
+      segment('7'),
+      segment('8'),
+    ]);
+
+    await result.current.checkForEndingIndicators(segment('9'));
+
+    expect(mockGenerateContent).toHaveBeenCalled();
+    expect(onEndingSuggested).not.toHaveBeenCalled();
+  });
+
+  it('treats a malformed census as unanswered rather than all clear', async () => {
+    mockGenerateContent.mockResolvedValue({
+      content: endingOffer({ unresolvedThreats: [{ threat: 'the pursuer' }] }),
+    });
+    const { result, onEndingSuggested } = renderDetection(barricadeStory());
+
+    await result.current.checkForEndingIndicators(
+      segment('5', { majorEvent: 'The kitchen door is barred from the inside' })
+    );
+
+    expect(onEndingSuggested).not.toHaveBeenCalled();
+  });
+
   it('puts the open threads in the prompt so the model can weigh them', async () => {
     mockGenerateContent.mockResolvedValue({
       content: endingOffer({ unresolvedThreats: [] }),

--- a/src/components/Narrative/useEndingDetection.ts
+++ b/src/components/Narrative/useEndingDetection.ts
@@ -4,12 +4,15 @@
 // focused on orchestrating narrative generation. Sends
 // recent narrative context to Gemini and asks whether the story has reached
 // a natural conclusion. Only fires onEndingSuggested for medium/high
-// confidence responses; silent on any AI/parse/network failure (no fallback).
+// confidence responses, and holds the offer back while the story's major
+// events are still unsettled; silent on any AI/parse/network failure (no
+// fallback).
 
 import { useCallback, useEffect, useRef } from 'react';
 import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
 import { truncate } from '@/lib/utils';
 import { safeParseNarrativeAnalysis } from '@/lib/ai/parseNarrativeResponse';
+import { stripMarkdownFences } from '@/lib/ai/parseJSON';
 import type {
   EndingType,
   NarrativeSegment,
@@ -32,6 +35,41 @@ const ACCEPTED_ENDING_TYPES = new Set<EndingType>([
   'character-retirement',
   'session-limit',
 ]);
+const MAX_OPEN_THREADS = 6;
+
+/**
+ * Major events are the story's only durable record that something significant
+ * is in play, and they never reached this prompt before: the model saw prose
+ * only. Listing them gives it something to weigh the current calm against,
+ * which is the difference between a resolution and a lull.
+ */
+function collectOpenThreads(segments: NarrativeSegment[]): string[] {
+  const threads: string[] = [];
+  for (const segment of segments) {
+    const event = segment.metadata?.majorEvent;
+    if (event) threads.push(event);
+  }
+  return threads.slice(-MAX_OPEN_THREADS);
+}
+
+/**
+ * The shared parser narrows to a fixed shape, so the threat census is read
+ * straight off the payload here. Null means the model never answered, which
+ * the caller treats as "the calm went unweighed" rather than "all clear".
+ */
+function readUnresolvedThreats(raw: string): string[] | null {
+  try {
+    const parsed: unknown = JSON.parse(stripMarkdownFences(raw));
+    if (!parsed || typeof parsed !== 'object') return null;
+    const value = (parsed as Record<string, unknown>).unresolvedThreats;
+    if (!Array.isArray(value)) return null;
+    return value.filter(
+      (entry): entry is string => typeof entry === 'string' && entry.trim().length > 0
+    );
+  } catch {
+    return null;
+  }
+}
 
 interface UseEndingDetectionOptions {
   sessionId: string;
@@ -118,9 +156,17 @@ export function useEndingDetection({
               )}\n\n`
             : '';
 
+        const openThreads = collectOpenThreads(recentSegments);
+        const openThreadsContext =
+          openThreads.length > 0
+            ? `Threads this story put in play (each one is unfinished business unless the recent narrative settled it on the page):\n${openThreads
+                .map((thread) => `- ${thread}`)
+                .join('\n')}\n\n`
+            : '';
+
         const analysisPrompt = `You are a narrative expert analyzing a story in progress. Determine if this story has reached a natural conclusion point where the player would feel satisfied ending.
 
-${fullStoryContext}Recent narrative developments:
+${fullStoryContext}${openThreadsContext}Recent narrative developments:
 ${narrativeContext}
 
 Analyze this story for natural ending points. Consider:
@@ -130,6 +176,11 @@ STORY STRUCTURE:
 - Are character arcs showing completion or fulfillment?
 - Is there a sense of narrative closure or resolution?
 - Does the story feel like it has reached a satisfying conclusion?
+
+OPEN THREATS:
+- Is any danger, pursuer, or unanswered call still active and unaddressed?
+- Reaching safety is not the same as resolving what made it unsafe. A locked
+  door with the threat still outside is a pause, not an ending.
 
 EMOTIONAL SATISFACTION:
 - Would ending here feel fulfilling to the reader?
@@ -144,6 +195,7 @@ DO NOT:
 
 Respond with JSON format:
 {
+  "unresolvedThreats": ["each threat or open question still active, or [] if none remain"],
   "suggestEnding": true/false,
   "confidence": "high" | "medium" | "low",
   "endingType": "story-complete" | "character-retirement" | "session-limit" | "none",
@@ -159,6 +211,22 @@ Respond with JSON format:
           analysis.suggestEnding &&
           ACCEPTED_CONFIDENCES.has(analysis.confidence)
         ) {
+          // A story with threads in play only gets an offer once the model
+          // accounts for them. No census means the calm went unweighed, and
+          // suppressing is recoverable where a premature offer is not: the
+          // check runs again on later segments.
+          const unresolvedThreats = readUnresolvedThreats(response.content);
+          if (
+            openThreads.length > 0 &&
+            (unresolvedThreats === null || unresolvedThreats.length > 0)
+          ) {
+            logger.debug('Holding the ending offer back, threads still open', {
+              openThreads,
+              unresolvedThreats,
+            });
+            return;
+          }
+
           const endingType: EndingType = ACCEPTED_ENDING_TYPES.has(analysis.endingType)
             ? analysis.endingType
             : 'story-complete';

--- a/src/components/Narrative/useEndingDetection.ts
+++ b/src/components/Narrative/useEndingDetection.ts
@@ -42,6 +42,10 @@ const MAX_OPEN_THREADS = 6;
  * is in play, and they never reached this prompt before: the model saw prose
  * only. Listing them gives it something to weigh the current calm against,
  * which is the difference between a resolution and a lull.
+ *
+ * Drawn from the whole session rather than the recent window. A threat that
+ * has been ignored for six turns is more unresolved than one raised last turn,
+ * not less, and windowing would quietly switch the guard off for exactly those.
  */
 function collectOpenThreads(segments: NarrativeSegment[]): string[] {
   const threads: string[] = [];
@@ -56,6 +60,10 @@ function collectOpenThreads(segments: NarrativeSegment[]): string[] {
  * The shared parser narrows to a fixed shape, so the threat census is read
  * straight off the payload here. Null means the model never answered, which
  * the caller treats as "the calm went unweighed" rather than "all clear".
+ *
+ * A census carrying anything that is not a string is malformed rather than
+ * empty. Filtering those out would turn a garbled answer into an all-clear,
+ * which is the one reading that lets a premature ending through.
  */
 function readUnresolvedThreats(raw: string): string[] | null {
   try {
@@ -63,9 +71,8 @@ function readUnresolvedThreats(raw: string): string[] | null {
     if (!parsed || typeof parsed !== 'object') return null;
     const value = (parsed as Record<string, unknown>).unresolvedThreats;
     if (!Array.isArray(value)) return null;
-    return value.filter(
-      (entry): entry is string => typeof entry === 'string' && entry.trim().length > 0
-    );
+    if (!value.every((entry) => typeof entry === 'string')) return null;
+    return (value as string[]).filter((entry) => entry.trim().length > 0);
   } catch {
     return null;
   }
@@ -156,7 +163,7 @@ export function useEndingDetection({
               )}\n\n`
             : '';
 
-        const openThreads = collectOpenThreads(recentSegments);
+        const openThreads = collectOpenThreads(allSegments);
         const openThreadsContext =
           openThreads.length > 0
             ? `Threads this story put in play (each one is unfinished business unless the recent narrative settled it on the page):\n${openThreads


### PR DESCRIPTION
## Description

At turn 30 of the #1821 playtest run the engine offered an ending because "the immediate threat of the unseen presence has been averted, and the characters are now secured in a safe location". Two turns earlier a skillet had clanged off a doorframe and a crack came from the woods much closer than expected. Nothing outside was ever dealt with. The group locking a kitchen door read to the detector as narrative closure, which is the same failure #1680 and #1818 describe in a louder form: the engine treats a lull as a resolution.

The root cause turned out to be an information gap rather than a scoring problem. The detector only ever saw segment prose. Major events live in segment metadata, and they never reached the analysis prompt at all, so the model had nothing to weigh the current calm against. A barricaded room genuinely does look like closure if the shape in the woods was never mentioned to you.

Three changes, all inside the hook:

1. The recent window's major events now go into the prompt as threads in play, framed as unfinished business unless the narrative settled them on the page.
2. A new OPEN THREATS criterion names the trap directly, because reaching safety is not the same as resolving what made it unsafe.
3. The JSON contract gains an `unresolvedThreats` census, and the offer is gated on it: when threads are on record, the ending only goes out once that census comes back empty.

## Related Issue

Closes #1843

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The tests went in first and split exactly the way they should have: the three new-behavior cases failed, and the two "this must keep working" cases passed before any implementation existed. That second half matters here, because it proves the guard is what changes behavior rather than the fixture.

## User Stories Addressed

As a player who has just barricaded a room with something still hunting me, I don't want the game telling me my story could end here, because it plainly could not.

## Flow Diagrams

N/A

## Component Development

N/A - this is a hook, no rendered surface.

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes

| File | Change |
|---|---|
| `src/components/Narrative/useEndingDetection.ts` | `collectOpenThreads`, `readUnresolvedThreats`, the prompt additions, and the gate |
| `src/components/Narrative/__tests__/useEndingDetection.openThreats.test.ts` | New: 7 cases covering both directions |

**Two defects the first pass shipped, both caught in review and both fixed here.** Worth stating plainly rather than folding into the description, because the first one was serious. Threads were collected from the recent five-segment window, so a threat ignored for six turns fell out of the list and the gate switched itself off for precisely the threats that had gone unaddressed longest - the opposite of the intent. They now come from the whole session, still capped. Separately, the census filter turned a malformed answer into an empty array, which read as "nothing unresolved" and let the offer through; anything that is not a string now nulls the whole field onto the unanswered path.

Both fixes carry a regression test that was run against the unfixed code first. That mattered: my first windowing test passed without the fix, because the new segment's own major event kept the list non-empty and the gate fired for the wrong reason. The version here isolates the windowing properly.

**The tradeoff worth arguing about.** A missing `unresolvedThreats` census counts as "unweighed", not "all clear", so an offer is suppressed when the model skips the field. That is deliberate, and it rests on suppression being recoverable where a premature offer is not: `endingSuggestedRef` only latches on success, so the check runs again on later segments and a held offer can still arrive once the story settles. A premature offer cannot be taken back.

The risk that buys is real, though. If Gemini turns out to omit the field reliably, stories carrying major events would stop getting AI-suggested endings, and the deterministic tests here cannot detect that. Two things bound it: stories with no major events on record are untouched, and the fatal-tag and other short-circuit branches still end runs. A live check that the field comes back populated is the thing I'd want before trusting this in a long session, and it is not in this PR.

Why the census is parsed separately: `safeParseNarrativeAnalysis` narrows to a fixed four-field shape and drops anything else, and `parseNarrativeResponse.ts` was out of scope for this change, so the hook reads the extra field off the payload itself.

Deliberately not touched: `sceneTemplate.ts` and `context.ts`, which PR #1869 owns.

## Screenshots

N/A

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

```
npx jest src/components/Narrative/__tests__/useEndingDetection
EXIT=0    Tests: 12 passed, 12 total

npm run test:ci     EXIT=0    Test Suites: 421 passed    Tests: 2930 passed
npm run type-check  EXIT=0
npm run lint        EXIT=0
```

The five new cases, and what each one pins down:

| Case | Proves |
|---|---|
| Model reports an unresolved threat | The barricade offer is held back |
| Model skips the census | Missing means unweighed, not all clear |
| Model reports threats settled | The offer still fires, so the gate is not a wall |
| No major events on record | Quiet stories are untouched |
| Prompt contents | The threads and the census field actually reach the model |
| Threat outside the recent window | Windowing cannot switch the guard off (review fix) |
| Malformed census | A garbled answer is not an all-clear (review fix) |

Acceptance criteria, taken from the issue's prose since it carries no checkbox list:

- [x] An unresolved recent threat suppresses the ending offer
- [x] A genuinely resolved arc still gets one
- [x] The guard cannot permanently block endings (inert with no major events; releases once the census is empty)
- [ ] Confirmed in live play that the model populates `unresolvedThreats` - not verified here, see the tradeoff note above

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
