### PR TITLE
Stop the choice prompt teaching the lawful/neutral/chaotic order it forbids

### DIFF
--- a/src/lib/promptTemplates/templates/narrative/__tests__/choiceTemplates.alignmentSpread.test.ts
+++ b/src/lib/promptTemplates/templates/narrative/__tests__/choiceTemplates.alignmentSpread.test.ts
@@ -45,9 +45,14 @@ const tagOrderIn = (section: string): string[] => {
   return order;
 };
 
+/**
+ * Anchors on line starts. The glossary header itself mentions the section that
+ * follows it, so a bare indexOf for the end marker lands inside the header and
+ * yields an empty slice that makes every assertion pass for free.
+ */
 const sectionBetween = (prompt: string, start: string, end: string): string => {
-  const from = prompt.indexOf(start);
-  const to = prompt.indexOf(end, from);
+  const from = prompt.indexOf(`\n${start}`);
+  const to = prompt.indexOf(`\n${end}`, from + 1);
   return prompt.slice(from, to === -1 ? undefined : to);
 };
 
@@ -65,7 +70,26 @@ describe('aligned choice template: alignment spread instructions', () => {
     const prompt = alignedChoiceTemplate(baseContext);
     const glossary = sectionBetween(prompt, 'ALIGNMENT DEFINITIONS', 'CHOOSING THE MIX');
 
+    expect(tagOrderIn(glossary)).toHaveLength(3);
     expect(tagOrderIn(glossary)).not.toEqual(['LAWFUL', 'NEUTRAL', 'CHAOTIC']);
+  });
+
+  it('does not leave CHAOTIC sitting last in the glossary', () => {
+    // Last in an ordered glossary is the slot-3 tell the transcript exposed, so
+    // reordering that leaves CHAOTIC at the end just renames the pattern.
+    const prompt = alignedChoiceTemplate(baseContext);
+    const glossary = sectionBetween(prompt, 'ALIGNMENT DEFINITIONS', 'CHOOSING THE MIX');
+    const order = tagOrderIn(glossary);
+
+    expect(order).toHaveLength(3);
+    expect(order[order.length - 1]).not.toBe('CHAOTIC');
+  });
+
+  it('keeps the shared-tag guidance valid when more than three options are asked for', () => {
+    const prompt = alignedChoiceTemplate({ ...baseContext, optionCount: 5 });
+
+    expect(prompt).toContain('create 5 distinct action choices');
+    expect(prompt).not.toMatch(/all three may/i);
   });
 
   it('says the glossary order is not a running order', () => {
@@ -77,7 +101,7 @@ describe('aligned choice template: alignment spread instructions', () => {
   it('permits two or three options to share a tag', () => {
     const prompt = alignedChoiceTemplate(baseContext);
 
-    expect(prompt).toMatch(/two options may share a tag/i);
+    expect(prompt).toMatch(/two options may share a tag, and so may all of them/i);
   });
 
   it('forbids parking the disruptive option in the last slot', () => {

--- a/src/lib/promptTemplates/templates/narrative/__tests__/choiceTemplates.alignmentSpread.test.ts
+++ b/src/lib/promptTemplates/templates/narrative/__tests__/choiceTemplates.alignmentSpread.test.ts
@@ -1,0 +1,100 @@
+// Guards the parts of the aligned choice template that exist to stop the
+// alignment signature collapsing to one fixed tag order per turn. These are
+// template assertions: they prove the instructions and the output contract are
+// present, NOT that the model obeys them. Only an instrumented run can show
+// that.
+
+import { alignedChoiceTemplate } from '../choiceTypeTemplates';
+import type { NarrativeContext, NarrativeSegment } from '@/types/narrative.types';
+
+const segment: NarrativeSegment = {
+  id: 'segment-1',
+  worldId: 'world-1',
+  sessionId: 'session-1',
+  content: 'The dock plank creaks underfoot.',
+  type: 'scene',
+  metadata: { tags: [] },
+  timestamp: new Date('2026-01-01T00:00:00.000Z'),
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+const narrativeContext: NarrativeContext = {
+  worldId: 'world-1',
+  currentSceneId: 'scene-1',
+  characterIds: ['char-1'],
+  previousSegments: [segment],
+  recentSegments: [segment],
+  currentTags: [],
+  sessionId: 'session-1',
+  currentSituation: 'Facing the developer across the table',
+};
+
+const baseContext = {
+  worldName: 'Harrowgate Mills',
+  genre: 'small-town mystery',
+  narrativeContext,
+};
+
+/** Order the three tags appear in, first mention only, across a section. */
+const tagOrderIn = (section: string): string[] => {
+  const order: string[] = [];
+  for (const match of section.matchAll(/\b(LAWFUL|NEUTRAL|CHAOTIC)\b/g)) {
+    if (!order.includes(match[1])) order.push(match[1]);
+  }
+  return order;
+};
+
+const sectionBetween = (prompt: string, start: string, end: string): string => {
+  const from = prompt.indexOf(start);
+  const to = prompt.indexOf(end, from);
+  return prompt.slice(from, to === -1 ? undefined : to);
+};
+
+describe('aligned choice template: alignment spread instructions', () => {
+  it('makes the model commit to a mix before it writes any option', () => {
+    const prompt = alignedChoiceTemplate(baseContext);
+
+    expect(prompt).toContain('Alignment Mix:');
+    // The commitment has to come before the options scaffold to be a
+    // commitment at all rather than a description of what was already written.
+    expect(prompt.indexOf('Alignment Mix:')).toBeLessThan(prompt.indexOf('Options:'));
+  });
+
+  it('does not hand the model a canonical lawful-neutral-chaotic running order', () => {
+    const prompt = alignedChoiceTemplate(baseContext);
+    const glossary = sectionBetween(prompt, 'ALIGNMENT DEFINITIONS', 'CHOOSING THE MIX');
+
+    expect(tagOrderIn(glossary)).not.toEqual(['LAWFUL', 'NEUTRAL', 'CHAOTIC']);
+  });
+
+  it('says the glossary order is not a running order', () => {
+    const prompt = alignedChoiceTemplate(baseContext);
+
+    expect(prompt).toMatch(/not a running order/i);
+  });
+
+  it('permits two or three options to share a tag', () => {
+    const prompt = alignedChoiceTemplate(baseContext);
+
+    expect(prompt).toMatch(/two options may share a tag/i);
+  });
+
+  it('forbids parking the disruptive option in the last slot', () => {
+    const prompt = alignedChoiceTemplate(baseContext);
+
+    expect(prompt).toMatch(/last slot/i);
+  });
+
+  it('rules out the obviously-wrong reckless option that nobody picks', () => {
+    const prompt = alignedChoiceTemplate(baseContext);
+
+    expect(prompt).toMatch(/a bold player would actually consider/i);
+  });
+
+  it('keeps the no-quota rule that #1827 established', () => {
+    const prompt = alignedChoiceTemplate(baseContext);
+
+    expect(prompt).toMatch(/there is no quota/i);
+  });
+});

--- a/src/lib/promptTemplates/templates/narrative/__tests__/choiceTemplates.test.ts
+++ b/src/lib/promptTemplates/templates/narrative/__tests__/choiceTemplates.test.ts
@@ -63,6 +63,6 @@ describe('choice templates ask for as many options as the interface shows', () =
 
     expect(prompt).toContain('[LAWFUL]');
     expect(prompt).not.toContain('1 lawful, 2 neutral, 1 chaotic');
-    expect(prompt).toMatch(/do NOT repeat the same mix or the same tag order/i);
+    expect(prompt).toMatch(/do NOT repeat the same mix turn after turn/i);
   });
 });

--- a/src/lib/promptTemplates/templates/narrative/choiceTypeTemplates.ts
+++ b/src/lib/promptTemplates/templates/narrative/choiceTypeTemplates.ts
@@ -106,14 +106,14 @@ Based on the SPECIFIC narrative situation above, create ${choiceCount} distinct 
 
 ALIGNMENT DEFINITIONS (a glossary, not a running order - see CHOOSING THE MIX below):
 - NEUTRAL: Balanced approach, practical solutions, adapts to situation, moderate response
-- LAWFUL: Follows rules, respects authority, seeks order, honors agreements, protects others
 - CHAOTIC: WILDLY UNEXPECTED and DISRUPTIVE actions that completely change the situation. Dramatic, potentially dangerous, creative solutions that ignore social norms, defy expectations, and could lead to entirely different story outcomes. VARY THE KIND of chaos and do NOT default to making noise (yelling, shouting, singing). Draw from a wide range, fitted to the scene: sudden physical risk ("leap from the balcony onto the chandelier," "kick over the lantern to set the drapes alight"), trickery or deception ("impersonate the captain and bark orders," "bluff an outrageous lie with total confidence"), sabotage or destruction ("cut the rope bridge behind you," "smash the control panel," "throw open the cells and free the prisoners"), turning the tables ("start a brawl to scatter the room," "switch sides mid-negotiation"), or abandoning the obvious goal for something no one expects. The goal is options that dramatically shift the narrative in surprising ways.
+- LAWFUL: Follows rules, respects authority, seeks order, honors agreements, protects others
 
 CHOOSING THE MIX (IMPORTANT):
 - Always tag every choice [LAWFUL], [NEUTRAL], or [CHAOTIC].
 - Decide the mix from this scene BEFORE writing a single option, and report it on the Alignment Mix line. Pick what the scene actually supports. There is no quota: a tense standoff might offer two chaotic openings, a quiet interrogation none at all.
-- Two options may share a tag, and all three may. A mix of three different tags is one option among many, not the default.
-- The order the tags are listed above is not a running order. Do NOT tag the first option lawful, the second neutral and the third chaotic out of habit, and do NOT repeat the same mix turn after turn. A player who can predict which slot holds the reckless option has stopped reading the choices.
+- Two options may share a tag, and so may all of them. A mix of one tag per option is one possibility among many, not the default.
+- The order the tags are listed above is not a running order, and neither is any order you used last turn. Do NOT assign tags to slots by position out of habit, and do NOT repeat the same mix turn after turn. A player who can predict which slot holds the reckless option has stopped reading the choices.
 - Never park the most disruptive option in the last slot by default. When a chaotic option belongs in a scene it can just as easily be the first thing offered.
 - Only offer a chaotic option when a genuinely disruptive action fits the moment.
 - A chaotic option must be something a bold player would actually consider, with a real payoff if it works. An obvious mistake, a pointless stunt, or self-sabotage nobody would pick is wasted space: drop the chaotic tag and offer a different mix instead.

--- a/src/lib/promptTemplates/templates/narrative/choiceTypeTemplates.ts
+++ b/src/lib/promptTemplates/templates/narrative/choiceTypeTemplates.ts
@@ -21,9 +21,14 @@ interface PlayerChoiceTemplateContext {
 /**
  * Prompt template for generating alignment-tagged player choices.
  *
- * The mix of alignments is chosen per scene rather than mandated. A fixed
- * quota produced the same lawful/neutral/chaotic shape every turn, with the
- * chaotic option always last and almost never picked.
+ * The mix of alignments is chosen per scene rather than mandated. Removing the
+ * quota was not enough on its own: the model kept returning lawful, neutral,
+ * chaotic in that order because the prompt itself taught the pattern. The
+ * glossary listed the tags in exactly the order the numbered slots wanted
+ * them, and the chaotic entry dwarfed the other two, which marked it as the
+ * showy one that always turns up last. So the mix is now a decision the model
+ * has to state before it writes anything, the glossary no longer runs in slot
+ * order, and a chaotic option has to be one a player might really take.
  */
 export const alignedChoiceTemplate = (context: PlayerChoiceTemplateContext): string => {
   const { worldName, genre, narrativeContext, worldSkills, worldNpcs, optionCount } = context;
@@ -99,16 +104,19 @@ You MUST create choices that directly respond to the specific situation describe
 
 Based on the SPECIFIC narrative situation above, create ${choiceCount} distinct action choices, each tagged with the alignment it expresses:
 
-ALIGNMENT DEFINITIONS:
-- LAWFUL: Follows rules, respects authority, seeks order, honors agreements, protects others
+ALIGNMENT DEFINITIONS (a glossary, not a running order - see CHOOSING THE MIX below):
 - NEUTRAL: Balanced approach, practical solutions, adapts to situation, moderate response
+- LAWFUL: Follows rules, respects authority, seeks order, honors agreements, protects others
 - CHAOTIC: WILDLY UNEXPECTED and DISRUPTIVE actions that completely change the situation. Dramatic, potentially dangerous, creative solutions that ignore social norms, defy expectations, and could lead to entirely different story outcomes. VARY THE KIND of chaos and do NOT default to making noise (yelling, shouting, singing). Draw from a wide range, fitted to the scene: sudden physical risk ("leap from the balcony onto the chandelier," "kick over the lantern to set the drapes alight"), trickery or deception ("impersonate the captain and bark orders," "bluff an outrageous lie with total confidence"), sabotage or destruction ("cut the rope bridge behind you," "smash the control panel," "throw open the cells and free the prisoners"), turning the tables ("start a brawl to scatter the room," "switch sides mid-negotiation"), or abandoning the obvious goal for something no one expects. The goal is options that dramatically shift the narrative in surprising ways.
 
 CHOOSING THE MIX (IMPORTANT):
 - Always tag every choice [LAWFUL], [NEUTRAL], or [CHAOTIC].
-- Pick the mix the scene actually supports. There is no quota: a tense standoff might offer two chaotic openings, a quiet interrogation none at all.
-- Do NOT make every choice neutral, and do NOT repeat the same mix or the same tag order turn after turn. A player who can predict which slot holds the reckless option has stopped reading the choices.
-- Only offer a chaotic option when a genuinely disruptive action fits the moment. A reckless choice nobody would plausibly take is wasted space.
+- Decide the mix from this scene BEFORE writing a single option, and report it on the Alignment Mix line. Pick what the scene actually supports. There is no quota: a tense standoff might offer two chaotic openings, a quiet interrogation none at all.
+- Two options may share a tag, and all three may. A mix of three different tags is one option among many, not the default.
+- The order the tags are listed above is not a running order. Do NOT tag the first option lawful, the second neutral and the third chaotic out of habit, and do NOT repeat the same mix turn after turn. A player who can predict which slot holds the reckless option has stopped reading the choices.
+- Never park the most disruptive option in the last slot by default. When a chaotic option belongs in a scene it can just as easily be the first thing offered.
+- Only offer a chaotic option when a genuinely disruptive action fits the moment.
+- A chaotic option must be something a bold player would actually consider, with a real payoff if it works. An obvious mistake, a pointless stunt, or self-sabotage nobody would pick is wasted space: drop the chaotic tag and offer a different mix instead.
 
 PERSONALITY-INFORMED CHOICES (when character personality context is provided):
 - Create options that offer ways to express the character's traits
@@ -122,7 +130,7 @@ REQUIREMENTS:
 2. Offer meaningfully different paths forward in the story
 3. Are concise (under 15 words) and written as direct actions
 4. Consider both the immediate situation AND the broader story context
-5. Each choice must clearly fit its alignment category
+5. Each choice must clearly express the tag it carries - two choices sharing a tag should express it in visibly different ways
 6. DO NOT use generic terms like "guard" when the context specifies "dragon"
 
 Write choices as direct actions without "you" (e.g., "Investigate the noise" not "You investigate the noise").
@@ -144,7 +152,8 @@ Carefully evaluate the narrative situation and determine the significance of thi
 
 Consider the stakes, potential consequences, and story impact. MOST decisions are MINOR or MAJOR: MINOR for everyday beats, MAJOR for the interesting story moments. Reserve CRITICAL for the RARE, genuinely life-or-death turning points - deadly combat, final confrontations, or choices where failure would plausibly end the character's story. When unsure between MAJOR and CRITICAL, choose MAJOR.
 
-FORMAT (REQUIRED - include alignment tags, decision weight, and context summary):
+FORMAT (REQUIRED - include the alignment mix, alignment tags, decision weight, and context summary):
+Alignment Mix: [the tag for each option in the order you will write them, then a short clause naming what in THIS scene makes that mix right. Examples: "CHAOTIC, LAWFUL, CHAOTIC - the room is already burning, so restraint is the odd choice here" or "NEUTRAL, NEUTRAL, LAWFUL - a quiet archive with nothing to disrupt"]
 Decision Weight: [MINOR/MAJOR/CRITICAL]
 Context Summary: [Write a brief 1-sentence summary that captures WHY this decision matters - focus on the stakes, immediate tension, or key relationships at play. Do NOT retell the story. Examples: "Tension builds as you must choose how to respond to the merchant's accusation." "A critical moment where your response could determine if the alliance forms." "The stranger's offer seems too good to be true."]
 Decision: What will you do?
@@ -153,6 +162,6 @@ Options:
 ${Array.from({ length: choiceCount }, (_, i) => `${i + 1}. [ALIGNMENT] [Action choice]
    Requirements: [Optional - SkillName X+]${consequencesFormatLine}`).join('\n')}${consequencesInstructions}
 
-Keep your response EXACTLY in this format. Include the Decision Weight line, Context Summary line, then Decision and Options sections with alignment tags.`;
+Keep your response EXACTLY in this format. Include the Alignment Mix line, Decision Weight line, Context Summary line, then Decision and Options sections with alignment tags.`;
 };
 


### PR DESCRIPTION
## Description

**Read the unverified-criteria section before merging this.** The code change is here and the gate is green, but the acceptance criteria in #1829 call for an instrumented 30-turn run and that has not happened. My recommendation is at the bottom.

#1827 removed the alignment quota and the forced-spread eviction. The option-count half worked: all 31 decisions in the round-4 playtest offered exactly three options. The alignment shape did not move at all - `lawful/neutral/chaotic`, in that order, on 29 of 30 turns. The prompt already told the model not to do that, explicitly, under CHOOSING THE MIX. So adding another sentence saying the same thing was never going to be the fix. Something else in the prompt was teaching the pattern.

Two things were, and both are the kind of thing that only shows up when you stop reading the instructions and start reading the layout:

**The glossary ran in slot order.** `ALIGNMENT DEFINITIONS` listed LAWFUL, then NEUTRAL, then CHAOTIC, a few lines before the model began filling numbered slots 1, 2, 3. An ordered list sitting next to ordered output is an assignment, whatever the prose next to it says. That is the single best explanation for why the *order* was stable at 29 of 30 rather than just the *mix*.

**The chaotic entry dwarfed the other two.** One line for lawful, one for neutral, and a ~120-word paragraph for chaotic packed with vivid quoted examples. That asymmetry does two things: it marks chaotic as the special case that must appear every turn, and it hands over a house style for it. The blind judge independently described slot 3 as "a reckless public stunt that is obviously the wrong answer" and cited it at T1, T3, T8, T11, T17, T22, T26. That is the paragraph's fingerprint.

### What changed

| Change | The thing it attacks |
|---|---|
| Glossary reordered to NEUTRAL, CHAOTIC, LAWFUL, and labelled "a glossary, not a running order" | Breaks the coincidence between glossary order and slot order, and gets CHAOTIC out of the position the tell lived in |
| New `Alignment Mix:` output line, first in the format, naming the tags in write order plus what in the scene justifies them | Forces a per-turn decision instead of letting the model default down the glossary |
| "Two options may share a tag, and so may all of them. A mix of one tag per option is one possibility among many, not the default." | The implicit one-per-category read |
| "Never park the most disruptive option in the last slot by default." | The positional tell the judge found |
| A chaotic option must be one "a bold player would actually consider, with a real payoff if it works" | The obviously-wrong slot 3 that got picked once in 30 turns |
| Requirement 5 reworded from "must clearly fit its alignment category" to expressing the tag it carries | Also read as one-per-category |

The long chaotic paragraph is kept, deliberately. It exists to stop every chaotic option being "make noise", and gutting it to fix the asymmetry would risk regressing that. The asymmetry is addressed by the plausibility requirement instead, which is the half that was actually hurting.

## Related Issue

Closes #1829

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Tests first, six red. But see the honest reading of what they prove, below.

## User Stories Addressed

As a player, I want the third option to stop being the one I already know I'm not taking, so reading all three is worth the time.

## Flow Diagrams

N/A

## Component Development

N/A - prompt template, no UI.

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes

| File | Change |
|---|---|
| `src/lib/promptTemplates/templates/narrative/choiceTypeTemplates.ts` | `alignedChoiceTemplate` - glossary, CHOOSING THE MIX, requirement 5, format block, doc comment |
| `.../__tests__/choiceTemplates.alignmentSpread.test.ts` | New, 9 cases |

**Two review fixes, one of them on the central claim.** The first pass swapped LAWFUL and NEUTRAL but left CHAOTIC third, immediately before the numbered options. Under the exact mechanism this PR argues for, that keeps the slot-3 tell and just renames the pattern, which would have been an embarrassing way to ship a fix for a positional tell. The glossary now runs NEUTRAL, CHAOTIC, LAWFUL. Separately, "all three may" stops being true the moment a caller passes a different `optionCount`, and one already does, so it reads "and so may all of them".

**A test helper that was making its own assertions worthless.** `sectionBetween` sliced between two markers with plain `indexOf`, and the glossary header mentions the section that follows it, so the end marker matched inside the header and the slice came back empty. Any not-equal assertion passes for free against an empty array, which means the canonical-order check had never actually checked anything. It anchors on line starts now, and both order tests assert they found three tags before judging the order.
| `.../__tests__/choiceTemplates.test.ts` | One assertion retargeted, see below |

Confirmed `alignedChoiceTemplate` is the live path: registered as `narrative/alignedPlayerChoice` in `templates/narrative/index.ts`. `playerChoiceTemplate` was left alone.

**The new output line and the parser.** `parseChoiceResponse` is line-based - it regex-matches `Decision Weight:`, `Context Summary:`, `^Decision:`, and `^\d+\.` for options, and ignores everything else. An `Alignment Mix:` line is simply never read, so it cannot reach the player, and parse failures fall back to defaults rather than raw content. That mattered enough to check given #1859 was a stage-direction leak; `parseNarrativeResponse.ts` and the parser were both out of scope for this change anyway.

**One pre-existing assertion changed.** `choiceTemplates.test.ts` asserted the exact string "do NOT repeat the same mix or the same tag order". That sentence is the instruction the issue proved the model ignores, and it is now reworded, so the assertion was retargeted to the replacement wording rather than the old text. Same intent, and worth flagging because it is the one place this PR edits a test that was already passing.

## Screenshots

N/A

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

```
npx jest src/lib/promptTemplates
EXIT=0    Test Suites: 7 passed    Tests: 59 passed

npm run test:ci     EXIT=0    Test Suites: 421 passed    Tests: 2932 passed
npm run type-check  EXIT=0
npm run lint        EXIT=0
```

## Acceptance criteria: what is met and what is not

The issue is explicit that a template unit test is not the measurement, and it is right. Being straight about the split:

**Met**

- [x] The prompt no longer presents a canonical lawful/neutral/chaotic running order
- [x] The mix is a stated, scene-justified decision made before any option is written
- [x] Sharing a tag across options is explicitly permitted
- [x] The obviously-wrong reckless option is ruled out in as many words
- [x] Quality gate green, live template path confirmed, parser safety confirmed

**Not verified - this is the important list**

- [ ] Across a 30-turn run, the alignment signature varies (no single ordering on more than ~60% of turns)
- [ ] At least some turns offer no chaotic option, or two
- [ ] Slot position does not predict alignment
- [ ] Measured by instrumenting decisions over a real run

Nothing here measures model behavior. The seven new tests assert that instructions and the output contract are present in the string, which is exactly the evidence the issue says is insufficient. A 30-turn run needs a live browser session against real Gemini with a provider key and a dev server, and it did not happen in this session.

**How to close the gap.** Run `narraitor-playtest-loop` for 30 turns on Harrowgate Mills, instrumenting off `useNarrativeStore` decisions the same way the round-4 measurement did, and record the tag sequence per turn. Three things to look at: the ordering histogram (no single ordering above ~60%), how many turns come back with zero or two chaotic options, and whether slot index still predicts the tag. Worth also checking that the model actually emits the `Alignment Mix:` line, since nothing breaks if it silently omits it - the line is advisory to the model, and if it is being dropped then the pre-commitment lever is not doing anything.

**Merge or hold: I'd hold.** This is the second attempt at the same symptom, and #1827 is precisely the cautionary tale - it looked correct, it *was* correct, and it moved nothing. Merging another plausible-looking prompt change without a run risks a third round of the same. The change is low-risk and self-contained, so merging first and measuring after is defensible if you want it off the board. But #1829 exists because that is what happened last time.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
