### PR TITLE
Stop a bare { shipping as the whole passage

### DIFF
--- a/src/lib/ai/__tests__/narrativeGenerator.response.parse.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.response.parse.test.ts
@@ -1,0 +1,29 @@
+import { parseNarrativeResponse } from '../narrativeGenerator.response.parse';
+
+describe('parseNarrativeResponse debris guard', () => {
+  it('throws when the response is a bare opening brace', () => {
+    expect(() => parseNarrativeResponse({ content: '{' }, 'scene')).toThrow(
+      'Service error: malformed API response'
+    );
+  });
+
+  it('throws when the response is truncated mid-content', () => {
+    expect(() =>
+      parseNarrativeResponse({ content: '{"content": "The door' }, 'scene')
+    ).toThrow('Service error: malformed API response');
+  });
+
+  it('still returns prose from a well-formed JSON response', () => {
+    const parsed = parseNarrativeResponse(
+      {
+        content:
+          '{"content":"The door groans open on a room that has not been aired in years.","type":"scene"}',
+      },
+      'scene'
+    );
+
+    expect(parsed.actualContent).toBe(
+      'The door groans open on a room that has not been aired in years.'
+    );
+  });
+});

--- a/src/lib/ai/__tests__/narrativeGenerator.response.parse.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.response.parse.test.ts
@@ -26,4 +26,22 @@ describe('parseNarrativeResponse debris guard', () => {
       'The door groans open on a room that has not been aired in years.'
     );
   });
+  it('keeps a short closed content field when the rest of the JSON is malformed', () => {
+    const parsed = parseNarrativeResponse(
+      { content: '{"content":"You flee.","type": scene}' },
+      'scene'
+    );
+
+    expect(parsed.actualContent).toBe('You flee.');
+  });
+
+  it('keeps a short closed content field when the object itself is cut off', () => {
+    const parsed = parseNarrativeResponse(
+      { content: '{"content":"You flee.","type":"sce' },
+      'scene'
+    );
+
+    expect(parsed.actualContent).toBe('You flee.');
+  });
+
 });

--- a/src/lib/ai/narrativeGenerator.response.parse.ts
+++ b/src/lib/ai/narrativeGenerator.response.parse.ts
@@ -6,12 +6,35 @@ import type { ParsedNarrativeResponse, NarrativeExtractedMetadata } from './narr
 import { validateMood, validateLossReason } from './narrativeGenerator.response.helpers';
 import { stripMarkdownFences, extractJsonObject } from './parseJSON';
 
+/**
+ * A recovered passage is at minimum a full sentence, so anything shorter is a
+ * fragment the response was cut off mid-way through rather than prose.
+ */
+const MIN_RECOVERED_PASSAGE_LENGTH = 20;
+
+/**
+ * Recognises what's left when a response never carried a usable content field -
+ * a bare brace, an unclosed object, a fragment cut off mid-sentence. Only
+ * applied to text the recovery paths produced; a content field the model
+ * actually closed is taken at its word however short it is.
+ */
+const isJsonDebris = (text: string): boolean => {
+  const trimmed = text.trim();
+  return (
+    trimmed.startsWith('{') ||
+    trimmed.startsWith('[') ||
+    !/\w/.test(trimmed) ||
+    trimmed.length < MIN_RECOVERED_PASSAGE_LENGTH
+  );
+};
+
 export const parseNarrativeResponse = (
   response: { content?: string },
   segmentType: string
 ): ParsedNarrativeResponse => {
   let actualContent = response.content || '';
   let extractedMetadata: NarrativeExtractedMetadata = {};
+  let contentFromParsedField = false;
 
   if (
     actualContent.includes('```json') ||
@@ -44,6 +67,7 @@ export const parseNarrativeResponse = (
         const parsed = JSON.parse(jsonStr);
         if (parsed.content) {
           actualContent = parsed.content;
+          contentFromParsedField = true;
         }
         if (
           parsed.type &&
@@ -205,6 +229,13 @@ export const parseNarrativeResponse = (
       } catch {
         // Fallback extraction failed - use default content
       }
+    }
+
+    // Every recovery path above can leave the raw text in place. Failing here
+    // hands the turn to the existing retry and fallback-segment handling
+    // instead of shipping a one-character passage.
+    if (!contentFromParsedField && isJsonDebris(actualContent)) {
+      throw new Error('Service error: malformed API response');
     }
   }
 

--- a/src/lib/ai/narrativeGenerator.response.parse.ts
+++ b/src/lib/ai/narrativeGenerator.response.parse.ts
@@ -7,16 +7,16 @@ import { validateMood, validateLossReason } from './narrativeGenerator.response.
 import { stripMarkdownFences, extractJsonObject } from './parseJSON';
 
 /**
- * A recovered passage is at minimum a full sentence, so anything shorter is a
- * fragment the response was cut off mid-way through rather than prose.
+ * A passage salvaged from a cut-off response is at minimum a full sentence, so
+ * anything shorter is the fragment the response stopped in the middle of.
  */
 const MIN_RECOVERED_PASSAGE_LENGTH = 20;
 
 /**
  * Recognises what's left when a response never carried a usable content field -
  * a bare brace, an unclosed object, a fragment cut off mid-sentence. Only
- * applied to text the recovery paths produced; a content field the model
- * actually closed is taken at its word however short it is.
+ * applied to text recovered without a closing quote to stop at; a field the
+ * model actually finished is taken at its word however short it is.
  */
 const isJsonDebris = (text: string): boolean => {
   const trimmed = text.trim();
@@ -34,7 +34,7 @@ export const parseNarrativeResponse = (
 ): ParsedNarrativeResponse => {
   let actualContent = response.content || '';
   let extractedMetadata: NarrativeExtractedMetadata = {};
-  let contentFromParsedField = false;
+  let contentFromClosedField = false;
 
   if (
     actualContent.includes('```json') ||
@@ -57,6 +57,9 @@ export const parseNarrativeResponse = (
             actualContent = contentMatch[1]
               .replace(/\\"/g, '"')
               .replace(/\\n/g, '\n');
+            // Same regex serves both endings, so the terminator is what says
+            // whether the field closed or the response simply ran out.
+            contentFromClosedField = contentMatch[0].endsWith('",');
           } else {
             throw new Error('Incomplete JSON without extractable content');
           }
@@ -67,7 +70,7 @@ export const parseNarrativeResponse = (
         const parsed = JSON.parse(jsonStr);
         if (parsed.content) {
           actualContent = parsed.content;
-          contentFromParsedField = true;
+          contentFromClosedField = true;
         }
         if (
           parsed.type &&
@@ -190,18 +193,21 @@ export const parseNarrativeResponse = (
             .replace(/\\"/g, '"')
             .replace(/\\n/g, '\n')
             .replace(/\\\\/g, '\\');
+          contentFromClosedField = true;
         } else {
           const altContentMatch = actualContent.match(
             /"content"\s*:\s*"([^"]*(?:"[^"]*"[^"]*)*)"/
           );
           if (altContentMatch && altContentMatch[1]) {
             actualContent = altContentMatch[1];
+            contentFromClosedField = true;
           } else {
             const finalContentMatch = actualContent.match(
               /"content"\s*:\s*"(.+?)"\s*,\s*"(?:type|metadata)/
             );
             if (finalContentMatch && finalContentMatch[1]) {
               actualContent = finalContentMatch[1];
+              contentFromClosedField = true;
             }
           }
         }
@@ -231,10 +237,10 @@ export const parseNarrativeResponse = (
       }
     }
 
-    // Every recovery path above can leave the raw text in place. Failing here
-    // hands the turn to the existing retry and fallback-segment handling
-    // instead of shipping a one-character passage.
-    if (!contentFromParsedField && isJsonDebris(actualContent)) {
+    // When no path found a closed content field the raw text is still sitting
+    // there. Failing here hands the turn to the existing retry and
+    // fallback-segment handling instead of shipping a one-character passage.
+    if (!contentFromClosedField && isJsonDebris(actualContent)) {
       throw new Error('Service error: malformed API response');
     }
   }


### PR DESCRIPTION
## Description

A response that never carried a usable `content` field could ship its raw text to the player as the whole passage. `parseNarrativeResponse` tries `JSON.parse`, then falls back to regex-extracting `"content": "..."`, and when none of those match it just leaves `actualContent` as whatever came back. Turn 29 of a 30-turn playtest put a single `{` in front of the player that way, with `location` falling through to the genre default.

The parser now validates what the recovery paths produced before returning it. Text that starts with `{` or `[`, has no word characters, or is under a 20-character floor gets thrown as `Service error: malformed API response` - the same message the provider layer already uses for a 200 with no usable content, so the existing retry and fallback-segment handling in `NarrativeController` picks it up unchanged.

One thing worth calling out: the guard deliberately skips content that came from a `content` field the model actually closed. Short-but-valid passages like `"You drop the knife."` are taken at their word, and the length floor only applies to text recovered with no closing quote to stop at. Without that split the floor would reject well-formed responses, which two existing fixtures caught immediately.

## Related Issue

Closes #1870

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Both guard tests were written and run before the fix existed, and both failed with "Received function did not throw". The third test in the file pins the happy path so the floor can't quietly start rejecting real prose.

## User Stories Addressed

As a player, when the provider returns a truncated or empty object, the story falls back or retries instead of printing JSON debris as a passage.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A - no UI changes, this is parser logic.

## Implementation Notes

The 20-character floor is the one judgment call here. It exists because the truncated payload from the issue (`{"content": "The door`) does get partially recovered by the existing regex, which hands back `The door` - technically prose, but a fragment cut off mid-sentence rather than a passage. A floor above that fragment length is the only thing that catches it, and 20 characters is roughly four short words, which nothing that reaches the player as a story beat should ever be.

Scoping the guard to the JSON-ish branch keeps it off plain-prose responses entirely, so a response that never looked like JSON behaves exactly as before.

Review follow-up: the first version keyed the exception off a successful `JSON.parse`, which was too narrow. A payload like `{"content":"You flee.","type": scene}` fails to parse on the unquoted value, yet the catch path still recovers a properly closed content field from it - and the floor then threw the prose away. The flag now tracks whether the content came from a field that closed, which all three catch-path regexes guarantee since each needs a closing quote to match. The truncated-object branch decides per match, because its regex can end on either the closing quote or the end of the response.

## Screenshots

N/A

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit wasn't run - no dependency or auth surface changed here.

| Gate | Command | Exit |
|---|---|---|
| Targeted | `npx jest src/lib/ai/__tests__` | 0 (72 suites, 469 tests) |
| Full suite | `npm test` | 0 (429 suites, 2983 tests) |
| Types | `npm run type-check` | 0 |
| Lint | `npm run lint` | 0 errors, 127 pre-existing warnings |

## Testing Instructions

```bash
npx jest src/lib/ai/__tests__/narrativeGenerator.response.parse.test.ts
```

To see the failure the fix removes, revert the guard block at the bottom of the `if` in `narrativeGenerator.response.parse.ts` and re-run - the two throw assertions go red.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

