### PR TITLE
Record a cost before the extraction closes the thread that imposed it

### DIFF
--- a/src/lib/narrative/__tests__/applyWorldClockUpdates.test.ts
+++ b/src/lib/narrative/__tests__/applyWorldClockUpdates.test.ts
@@ -228,6 +228,41 @@ describe('applyWorldClockUpdates', () => {
       expect(useCharacterStore.getState().characters['char-1'].status.conditions).toEqual(['shaken', 'discredited before the room']);
     });
 
+    it('records a cost against the thread the same extraction resolved', async () => {
+      mockIsFeatureEnabled.mockReturnValue(true);
+      useWorldThreadStore.getState().applyExtraction(
+        'session-1',
+        worldId,
+        { opened: [{ kind: 'actor', summary: 'The thing in the shed' }], advanced: [], resolved: [] },
+        1
+      );
+      const threadId = useWorldThreadStore.getState().getOpenThreadsBySession('session-1')[0].id;
+      processSpy.mockResolvedValue({
+        newGoalsCreated: 0,
+        goalsUpdated: 0,
+        goalsCompleted: 0,
+        worldThreads: {
+          opened: [],
+          advanced: [],
+          resolved: [{ id: threadId, outcome: 'resolved', resolution: 'It got through and struck' }],
+        },
+        worldCost: { imposed: [{ kind: 'condition', detail: 'gashed left forearm', threadId }], cleared: [] },
+      });
+
+      const note = await applyWorldClockUpdates({
+        segment: segment(worldId),
+        sessionId: 'session-1',
+        playerCharacterId: 'char-1',
+        currentTurn: 4,
+      });
+
+      expect(useWorldThreadStore.getState().threads[threadId].costs).toEqual(['gashed left forearm']);
+      expect(note?.worldCost?.imposed).toEqual([
+        { kind: 'condition', detail: 'gashed left forearm', thread: 'The thing in the shed' },
+      ]);
+      expect(note?.worldClock?.resolved).toEqual(['The thing in the shed']);
+    });
+
     it('with the flag off, the extractor gets no cost input and nothing is stamped or written', async () => {
       mockIsFeatureEnabled.mockImplementation(clockOnly as typeof isFeatureEnabled);
       processSpy.mockResolvedValue({

--- a/src/lib/narrative/applyWorldClockUpdates.ts
+++ b/src/lib/narrative/applyWorldClockUpdates.ts
@@ -95,6 +95,16 @@ async function reconcileSegment({
     const result = await goalStore.processSegmentForGoals(segment, sessionId, characterId, worldThreads, worldCost);
     const notes: ReconciledSegmentNotes = {};
 
+    // Cost before ledger. A cost is attributed to a thread that was open while
+    // the segment was being written, and recordThreadCost takes only an open
+    // thread, so applying the extraction first drops the cost on exactly the
+    // turn this channel exists to catch: the one where a thread lands and takes
+    // something. The extractor can only cite ids it was handed, so nothing it
+    // attributes can belong to a thread opened by this same result.
+    if (result.worldCost && playerCharacterId) {
+      notes.worldCost = applyWorldCost({ sessionId, characterId: playerCharacterId, result: result.worldCost });
+    }
+
     if (result.worldThreads && worldId) {
       const applied = useWorldThreadStore
         .getState()
@@ -104,10 +114,6 @@ async function reconcileSegment({
         .getAll()
         .filter((thread) => thread.sessionId === sessionId);
       notes.worldClock = summarizeLedgerForSegment(sessionThreads, currentTurn, applied);
-    }
-
-    if (result.worldCost && playerCharacterId) {
-      notes.worldCost = applyWorldCost({ sessionId, characterId: playerCharacterId, result: result.worldCost });
     }
 
     return notes.worldClock || notes.worldCost ? notes : undefined;


### PR DESCRIPTION
## Description

Codex left two findings on PR #1883 and only one of them was fixed before it merged. This is the other one.

One extraction response can both **resolve** a landed thread and **attribute an imposed cost to it**. `reconcileSegment` applied the ledger first, so `applyExtraction` closed the thread before `applyWorldCost` ran, and `worldThreadStore.recordThreadCost` accepts only a thread with `status === 'open'`. The cost was dropped from the thread and its summary went missing from `metadata.worldCost` — silently, with the character-level condition still landing, so nothing looked wrong. That is exactly the turn the cost channel exists to catch: a thread lands and takes something.

The fix is one reorder in `applyWorldClockUpdates.ts` — apply the cost, then the ledger. A cost is attributed to a thread that was open while the segment was being written, so the open ledger is the right state to record it against; the resolution is what is true *afterwards*. The extractor can only cite ids it was handed as `openThreads`, so nothing it attributes can belong to a thread opened by the same result, and reordering cannot strand a newly opened thread.

Codex's other suggestion — let `recordThreadCost` accept a thread resolved by the same pass — would have meant loosening a store invariant to work around a call order. Reordering keeps the invariant.

**The sibling P1 is already in.** "Pass the player ID into cost reconciliation" was fixed on the #1883 branch as `f829f5d6` (`playerCharacterId` resolved from the session store at `narrativeStore.segments.ts:174`, not `metadata.characterIds[0]`), and it rode the squash into `develop`. Its review thread reads unresolved only because GitHub marked it outdated when the line moved. Verified on `develop` at `6902e895`; covered by the existing test "keys the cost channel on the player character, not on the first NPC the scene listed".

Dark behind `WORLD_COST`, which stays off. No player-visible change.

## Related Issue

Closes #1890

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

One test, written first and confirmed red for the right reason:

```
● applyWorldClockUpdates › WORLD_COST › records a cost against the thread the same extraction resolved
    Expected: ["gashed left forearm"]
    Received: undefined
```

Green after the reorder. It seeds an open thread, has the extraction resolve that thread and impose a cost citing its id in the same response, then asserts all three things the bug broke: the cost is on `thread.costs`, the note's imposed entry carries the thread summary, and the clock note still shows the thread resolved.

## User Stories Addressed

None directly — this is instrument repair. It keeps a future measurement round on this channel from under-counting the landing-and-cost turns it is meant to read.

## Flow Diagrams

N/A. Same one extraction call; only the order of the two reconciliation steps changes:

`processSegmentForGoals` -> **`applyWorldCost`** (thread still open, cost recorded) -> `applyExtraction` (thread resolved) -> stamp both notes.

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A. No UI.

## Implementation Notes

`notes.worldClock` is still summarized after `applyExtraction`, so open/overdue counts and the opened/advanced/resolved lists are unchanged. The two notes are independent; only `recordThreadCost`'s open-status check couples them, which is what the order now respects.

## Screenshots

N/A.

## Visual Baseline Changes

None. This PR does not touch `tests/visual/**-snapshots/**`.

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

```bash
npx jest src/lib/narrative/__tests__/applyWorldClockUpdates.test.ts
```

To see the bug rather than the fix, move the `result.worldCost` block back below the `result.worldThreads` block in `src/lib/narrative/applyWorldClockUpdates.ts` and re-run — the new test fails with `costs: undefined`.

Full local gate on this branch:

- `npm run test:ci` — 435 suites, 3022 tests, exit 0
- `npm run type-check` — exit 0
- `npm run lint` — exit 0, 0 errors (127 pre-existing warnings, none in touched files)

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) — N/A
- [x] No new warnings generated
- [x] Accessibility considerations addressed — N/A, no UI
