### PR TITLE
Reap comments that restate the code or cite an issue number

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,8 +5,9 @@ import { DashboardHome } from '@/components/Dashboard';
 import { SSRClientOnly } from '@/components/shared/SSRClientOnly';
 
 /**
- * App home (#1528). Moved from / so the public Landing page can own the root
- * route; first-time users still get GuidedFirstTimeExperience via DashboardHome.
+ * App home. Lives here rather than at / so the public Landing page can own the
+ * root route; first-time users still get GuidedFirstTimeExperience via
+ * DashboardHome.
  */
 export default function DashboardPage() {
   return (

--- a/src/components/CharacterCreationWizard/components/CharacterSuggestions.tsx
+++ b/src/components/CharacterCreationWizard/components/CharacterSuggestions.tsx
@@ -80,8 +80,6 @@ export const CharacterSuggestions: React.FC<CharacterSuggestionsProps> = ({
     if (editingCard === key) setEditingCard(null);
   };
 
-  // --- Adopt handlers -------------------------------------------------------
-
   const adoptDescription = (value: string) => {
     onAdopt({ description: value });
     dismiss('description');
@@ -128,8 +126,6 @@ export const CharacterSuggestions: React.FC<CharacterSuggestionsProps> = ({
     dismiss('skills');
   };
 
-  // --- Derived suggestion views --------------------------------------------
-
   const attributeSuggestions = suggestion
     ? suggestion.attributes
         .map((a) => {
@@ -166,8 +162,6 @@ export const CharacterSuggestions: React.FC<CharacterSuggestionsProps> = ({
         })
         .filter((s): s is NonNullable<typeof s> => s !== null)
     : [];
-
-  // --- Edit-mode initializers ----------------------------------------------
 
   const startEdit = (key: CardKey) => {
     if (!suggestion) return;

--- a/src/components/Faq/Faq.tsx
+++ b/src/components/Faq/Faq.tsx
@@ -3,9 +3,9 @@ import Link from 'next/link';
 import { FAQ_GROUPS } from './faqContent';
 
 /**
- * Faq — the answers to the questions a new player asks before they've played,
- * gathered from copy that was previously scattered across the README, /about,
- * /privacy, and the provider wizard.
+ * Faq — the answers to the questions a new player asks before they've played.
+ * The same ground is covered in the README, /about, /privacy, and the provider
+ * wizard, so changes here usually want a matching edit there.
  *
  * Server component, deliberately: every answer ships open, with a jump list of
  * questions on top. Nothing collapses, so in-page find works and there's no

--- a/src/components/GameSession/ActiveGameSession.tsx
+++ b/src/components/GameSession/ActiveGameSession.tsx
@@ -75,7 +75,7 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
   selectedChoiceId,
 }) => {
   const [isGenerating, setIsGenerating] = React.useState(true);
-  // Live preview of the segment currently generating (issue #1476), fed by
+  // Live preview of the segment currently generating, fed by
   // the hidden NarrativeController via onStreamingPreviewChange. Cleared
   // whenever a turn stops generating, for whatever reason (completion,
   // error, retry) — isGenerating already tracks all of those.
@@ -144,12 +144,12 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
 
   // Live story-generation failure for the current turn (timeout, network,
   // provider 429/5xx, bad key). Captured in the store by NarrativeController so
-  // the choices column can surface inline error + Retry — see issue #1478.
+  // the choices column can surface inline error + Retry.
   const generationError = useNarrativeStore((state) => state.generationError);
 
   // A failure must drop the "Continuing your story..." spinner/skeleton —
-  // otherwise the turn hangs on the loading state forever (the original #1478
-  // bug). Clearing both generation flags lets the error surface take over.
+  // otherwise the turn hangs on the loading state forever. Clearing both
+  // generation flags lets the error surface take over.
   React.useEffect(() => {
     if (generationError) {
       setIsGenerating(false);
@@ -288,14 +288,14 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
   // - must not fire while one of these is open: the underlying content stays
   // mounted behind the overlay, so without this gate a player reading the
   // shortcuts dialog could press "1" and silently advance the turn behind it
-  // (#276 review follow-up). The character summary panel is deliberately
-  // excluded - it's non-modal and doesn't trap focus.
+  // behind it. The character summary panel is deliberately excluded - it's
+  // non-modal and doesn't trap focus.
   const isModalOpen = isShortcutsHelpOpen || activeDrawer !== null || showEndConfirmation;
 
-  // Game-session keyboard shortcuts (#276): number keys for choices live in
+  // Game-session keyboard shortcuts: number keys for choices live in
   // ChoiceSelector itself since that's where the option list is. These cover
-  // the remaining common actions the issue calls out - journal, character
-  // sheet, and a discoverable reference for all of it. Only active once the
+  // the remaining common actions - journal, character sheet, and a
+  // discoverable reference for all of it. Only active once the
   // session has rendered its real HUD (isGameReady) and no modal is already
   // covering it.
   const gameSessionShortcuts = React.useMemo(
@@ -358,7 +358,7 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
     createJournalEntryFromSegment,
   });
 
-  // One modal decision at a time (#1536): the End Story confirmation renders
+  // One modal decision at a time: the End Story confirmation renders
   // without a focus trap, so the HUD Close/Reset controls stay reachable while
   // it is open. Those controls hand off to page-level confirmation dialogs, so
   // close the End Story confirmation first or both dialogs mount at once.
@@ -571,7 +571,7 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
                           subtitle={
                             // Session-scoped drawers show the world name as
                             // readable context — never the raw persistence ID,
-                            // which truncated to "Session session-" (#1534).
+                            // which truncated to "Session session-".
                             // No world name means no subtitle at all.
                             activeDrawer === 'character'
                               ? character?.name

--- a/src/components/GameSession/GameSession.tsx
+++ b/src/components/GameSession/GameSession.tsx
@@ -370,9 +370,9 @@ const GameSession: React.FC<GameSessionProps> = ({
   // Treat 'loading' as an active session to allow the
   // ActiveGameSession to show its coordinated skeleton and
   // continue initialization even if the store is still 'loading'
-  // (fresh sessions should not be blocked by this gate).
-  // Previously this returned <GameSessionLoading /> and could get stuck.
-  
+  // (fresh sessions should not be blocked by this gate). Returning
+  // <GameSessionLoading /> here instead gets stuck.
+
   if (error || sessionState.error) {
     return (
       <div className="manuscript-play-entry">

--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -62,7 +62,7 @@ interface NarrativeControllerProps {
   retryToken?: number;
   /**
    * Fires with the growing narrative preview as the active generation
-   * streams in, and with '' once a turn finishes (issue #1476). A composer
+   * streams in, and with '' once a turn finishes. A composer
    * that renders its own visible history from the store instead of this
    * controller's own (often hidden, see hideHistory) NarrativeHistory — the
    * live play surface does this via NarrativeHistoryManager — uses this to
@@ -92,8 +92,8 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
   const [error, setError] = useState<string | null>(null);
   const toast = useToast();
 
-  // Live-updating preview of the segment currently generating (issue #1476:
-  // real API streaming). streamingPreviewRef is the source of truth so
+  // Live-updating preview of the segment currently generating as the real API
+  // streams. streamingPreviewRef is the source of truth so
   // handleStreamChunk stays a stable callback and the post-await read in
   // generate*() below never sees a stale closure; streamingPreview mirrors it
   // into state purely to trigger the re-render NarrativeHistory needs to show
@@ -705,7 +705,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
       // Read characters/worlds at call time via getState() rather than
       // subscribing — they're only needed here inside this async handler, so a
       // store subscription would re-render the controller on every character/
-      // world write for no benefit (issue #1358).
+      // world write for no benefit.
       const character = characterId
         ? useCharacterStore.getState().characters[characterId]
         : undefined;
@@ -723,7 +723,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
       // critical-failure roll (natural 1). An ordinary missed roll is a
       // survivable setback the AI narrates (and can still escalate via the
       // fatal-outcome tag the extraction stamps), so one unlucky-but-ordinary
-      // roll no longer ends the story (issue #1426).
+      // roll does not end the story.
       const isFatalCriticalFailure = isFatalCriticalDecision(
         decisionWeight,
         rollResults

--- a/src/components/ui/toast/index.ts
+++ b/src/components/ui/toast/index.ts
@@ -1,60 +1,7 @@
 /**
- * Toast Notification System
- * 
- * A toast notification system for Narraitor with support for multiple variants,
- * auto-dismissal, manual dismissal, and accessibility features.
- * 
- * @example
- * ```tsx
- * // 1. Set up the toast system in your app root
- * function App() {
- *   return (
- *     <ToastProvider>
- *       <YourAppContent />
- *       <Toaster position="bottom-right" maxToasts={5} />
- *     </ToastProvider>
- *   )
- * }
- * 
- * // 2. Use toasts in your components
- * function MyComponent() {
- *   const toast = useToast()
- * 
- *   const handleSave = async () => {
- *     try {
- *       await saveData()
- *       toast.success('Saved successfully', 'Your changes have been saved.')
- *     } catch (error) {
- *       toast.error('Save failed', 'Please try again later.')
- *     }
- *   }
- * 
- *   return <button onClick={handleSave}>Save</button>
- * }
- * ```
- * 
- * @integration
- * Integration with AutoSave Service:
- * - Success toasts for manual saves
- * - Error toasts for save failures
- * - Automatic cleanup and dismissal
- * 
- * @accessibility
- * - Screen reader announcements
- * - Keyboard navigation support
- * - ARIA labels and roles
- * - Focus management
- * 
- * @mobile
- * - Responsive positioning
- * - Touch-friendly dismiss buttons
- * - Proper viewport handling
- * 
- * @module Toast
+ * useToast throws unless the tree is wrapped in ToastProvider, and toasts stay
+ * invisible unless a Toaster is rendered inside that provider. Both are needed.
  */
 
-// Core components
 export { Toast } from './toast'
 export { Toaster, ToastProvider, useToast } from './toaster'
-
-// Type definitions

--- a/src/lib/ai/debugInfoBuilder.ts
+++ b/src/lib/ai/debugInfoBuilder.ts
@@ -85,9 +85,6 @@ export function buildPromptDebugInfo(context: DebugInfoContext): PromptDebugInfo
   };
 }
 
-/**
- * Extract lore entries from lore context string
- */
 function extractLoreEntries(loreContext: string): Array<{
   loreId: EntityID;
   title: string;
@@ -119,9 +116,6 @@ function extractLoreEntries(loreContext: string): Array<{
   return entries;
 }
 
-/**
- * Extract active goals from full prompt string
- */
 function extractActiveGoalsFromPrompt(fullPrompt: string): string[] {
   const goals: string[] = [];
 
@@ -164,9 +158,6 @@ function buildCharacterContext(
   }));
 }
 
-/**
- * Extract inventory items from full prompt string
- */
 function extractInventoryItemsFromPrompt(fullPrompt: string): Array<{
   itemName: string;
   isEquipped?: boolean;
@@ -220,9 +211,6 @@ function truncateText(text: string, maxLength: number): string {
   return text.substring(0, maxLength) + '...';
 }
 
-/**
- * Check if debug info capture is enabled
- */
 export function isDebugInfoEnabled(): boolean {
   // Check if we're in a browser environment
   if (typeof window !== 'undefined') {

--- a/src/lib/ai/goalExtractor.ts
+++ b/src/lib/ai/goalExtractor.ts
@@ -67,9 +67,6 @@ export async function extractGoalsFromNarrative(
   }
 }
 
-/**
- * Build prompt for goal extraction
- */
 function buildGoalExtractionPrompt(request: GoalExtractionRequest): string {
   const existingGoalsText =
     request.existingGoals && request.existingGoals.length > 0
@@ -152,9 +149,6 @@ Respond with JSON in this exact format:
 \`\`\``;
 }
 
-/**
- * Parse goal extraction response from AI
- */
 function parseGoalExtractionResponse(
   content: string,
   request: GoalExtractionRequest
@@ -267,9 +261,6 @@ function createFallbackExtractionResult(
   return result;
 }
 
-/**
- * Extract goal from pattern match
- */
 function extractGoalFromPattern(
   content: string,
   pattern: RegExp
@@ -278,9 +269,6 @@ function extractGoalFromPattern(
   return match ? match[1]?.trim() || match[2]?.trim() : null;
 }
 
-/**
- * Create basic goal from extracted text
- */
 function createBasicGoal(
   title: string,
   request: GoalExtractionRequest,
@@ -302,9 +290,6 @@ function createBasicGoal(
   };
 }
 
-/**
- * Validate and clean goal data
- */
 function validateAndCleanGoal(
   goal: Record<string, unknown>
 ): Omit<NarrativeGoal, 'id' | 'createdAt' | 'updatedAt'> {
@@ -358,9 +343,6 @@ function validateAndCleanGoal(
   };
 }
 
-/**
- * Validate goal updates
- */
 function validateGoalUpdates(
   updates: Record<string, unknown>
 ): Partial<NarrativeGoal> {

--- a/src/lib/ai/playerDecisionTracker.ts
+++ b/src/lib/ai/playerDecisionTracker.ts
@@ -191,16 +191,10 @@ export class PlayerDecisionTracker {
     };
   }
 
-  /**
-   * Gets decisions for a specific session
-   */
   getSessionDecisions(sessionId: EntityID): PlayerDecision[] {
     return this.decisions.filter(decision => decision.sessionId === sessionId);
   }
 
-  /**
-   * Gets decisions for a specific world
-   */
   getWorldDecisions(worldId: EntityID): PlayerDecision[] {
     return this.decisions.filter(decision => decision.worldId === worldId);
   }
@@ -217,16 +211,10 @@ export class PlayerDecisionTracker {
     );
   }
 
-  /**
-   * Gets all decisions
-   */
   getAllDecisions(): PlayerDecision[] {
     return [...this.decisions];
   }
 
-  /**
-   * Analyzes choice patterns
-   */
   analyzeChoicePatterns(decisions?: PlayerDecision[]): {
     dominantChoiceTypes: ChoiceTypePreference[];
     choiceDistribution: Record<ChoiceTypePreference, number>;
@@ -253,17 +241,11 @@ export class PlayerDecisionTracker {
     };
   }
 
-  /**
-   * Clears all decisions
-   */
   clearDecisions(): void {
     this.decisions = [];
     this.saveDecisions();
   }
 
-  /**
-   * Clears decisions for a specific session
-   */
   clearSessionDecisions(sessionId: EntityID): void {
     this.decisions = this.decisions.filter(decision => decision.sessionId !== sessionId);
     this.saveDecisions();

--- a/src/lib/ai/providers/adapterRegistry.ts
+++ b/src/lib/ai/providers/adapterRegistry.ts
@@ -8,7 +8,7 @@ import { openAICompatibleAdapter } from './openai-compatible/adapter';
 /**
  * Which wire format each provider type speaks.
  *
- * Split out from `factory.ts` so that request-path code (`resolveProvider`)
+ * Kept separate from `factory.ts` so that request-path code (`resolveProvider`)
  * can ask "can we talk to this type?" without pulling the Gemini SDK and the
  * client classes in behind it.
  *

--- a/src/lib/devtools/devToolsSettings.ts
+++ b/src/lib/devtools/devToolsSettings.ts
@@ -15,9 +15,6 @@ export interface DevToolsSettings {
   showPromptDebugInfo: boolean;
 }
 
-/**
- * Default settings
- */
 export const DEFAULT_DEVTOOLS_SETTINGS: DevToolsSettings = {
   showPromptDebugInfo: false,
 };
@@ -40,9 +37,6 @@ function isStorageAvailable(): boolean {
   }
 }
 
-/**
- * Load DevTools settings from localStorage
- */
 export function loadDevToolsSettings(): DevToolsSettings {
   if (!isStorageAvailable()) {
     return { ...DEFAULT_DEVTOOLS_SETTINGS };
@@ -68,9 +62,6 @@ export function loadDevToolsSettings(): DevToolsSettings {
   }
 }
 
-/**
- * Save DevTools settings to localStorage
- */
 export function saveDevToolsSettings(settings: DevToolsSettings): void {
   if (!isStorageAvailable()) {
     return;
@@ -83,9 +74,6 @@ export function saveDevToolsSettings(settings: DevToolsSettings): void {
   }
 }
 
-/**
- * Update a specific setting
- */
 export function updateSetting<K extends keyof DevToolsSettings>(
   key: K,
   value: DevToolsSettings[K]

--- a/src/lib/lore/loreContext.ts
+++ b/src/lib/lore/loreContext.ts
@@ -91,10 +91,8 @@ function parseCharacterFact(fact: LoreFact): ConsistencyLoreContext['characters'
   const name = safeTrim(nameMatch[1]);
   const description = safeTrim(nameMatch[2] || '') || value;
 
-  // Extract traits from description
   const traits = extractTraitsFromDescription(description);
   
-  // Extract background information
   const background = extractBackgroundFromDescription(description);
 
   // Determine importance based on source and content
@@ -108,9 +106,6 @@ function parseCharacterFact(fact: LoreFact): ConsistencyLoreContext['characters'
   };
 }
 
-/**
- * Parses location fact into enhanced location format
- */
 function parseLocationFact(fact: LoreFact): ConsistencyLoreContext['locations'][0] | null {
   const value = safeTrim(fact.value);
   if (!value) return null;
@@ -122,10 +117,8 @@ function parseLocationFact(fact: LoreFact): ConsistencyLoreContext['locations'][
   const name = safeTrim(nameMatch[1]);
   const description = safeTrim(nameMatch[2] || '') || value;
 
-  // Extract location type from description
   const type = extractLocationTypeFromDescription(description);
 
-  // Determine importance
   const importance = determineImportance(fact, description);
 
   return {
@@ -136,9 +129,6 @@ function parseLocationFact(fact: LoreFact): ConsistencyLoreContext['locations'][
   };
 }
 
-/**
- * Parses world rule fact into enhanced world rule format
- */
 function parseWorldRuleFact(fact: LoreFact): ConsistencyLoreContext['worldRules'][0] | null {
   const value = safeTrim(fact.value);
   if (!value) return null;
@@ -158,9 +148,6 @@ function parseWorldRuleFact(fact: LoreFact): ConsistencyLoreContext['worldRules'
   };
 }
 
-/**
- * Parses historical event fact into enhanced historical event format
- */
 function parseHistoricalEventFact(fact: LoreFact): ConsistencyLoreContext['historicalEvents'][0] | null {
   const value = safeTrim(fact.value);
   if (!value) return null;
@@ -172,7 +159,6 @@ function parseHistoricalEventFact(fact: LoreFact): ConsistencyLoreContext['histo
   const event = safeTrim(eventMatch[1]);
   const description = safeTrim(eventMatch[2] || '') || value;
 
-  // Determine importance
   const importance = determineImportance(fact, description);
 
   return {
@@ -182,9 +168,6 @@ function parseHistoricalEventFact(fact: LoreFact): ConsistencyLoreContext['histo
   };
 }
 
-/**
- * Extracts character traits from description text
- */
 function extractTraitsFromDescription(description: string): string[] {
   const traits: string[] = [];
   
@@ -211,9 +194,6 @@ function extractTraitsFromDescription(description: string): string[] {
   return traits.length > 0 ? traits : ['undefined'];
 }
 
-/**
- * Extracts background information from description
- */
 function extractBackgroundFromDescription(description: string): string {
   // Remove common prefixes and return cleaned description
   const result = description
@@ -223,9 +203,6 @@ function extractBackgroundFromDescription(description: string): string {
   return safeTrim(result);
 }
 
-/**
- * Extracts location type from description
- */
 function extractLocationTypeFromDescription(description: string): string {
   const lowerDescription = description.toLowerCase();
   

--- a/src/lib/utils/formatters.ts
+++ b/src/lib/utils/formatters.ts
@@ -61,8 +61,6 @@ export interface DateTimeFormatOptions extends DateFormatOptions {
   hour12?: boolean;
 }
 
-// === DATE FORMATTING ===
-
 /**
  * Validates and parses a date input, handling both Date objects and strings
  * 
@@ -407,10 +405,6 @@ export function safeTrim(text: string | null | undefined): string {
   if (text === null || text === undefined) return '';
   return text.trim();
 }
-
-// =============================================================================
-// SERIALIZATION AND DEBUGGING UTILITIES
-// =============================================================================
 
 /**
  * Safely serializes objects for JSON storage, handling functions, dates, and circular references.

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,4 +1,3 @@
-// === CORE UTILITIES ===
 
 /** UUID generation utilities */
 export { generateUniqueId } from './generateId';
@@ -11,8 +10,6 @@ export { formatAIResponse } from './textFormatter';
 
 /** CSS class name utilities */
 export { cssClasses } from './classNames';
-
-// === FORMATTING UTILITIES ===
 
 /**
  * Formatting utilities for dates, strings, and numbers

--- a/src/lib/world/worldStateManager.ts
+++ b/src/lib/world/worldStateManager.ts
@@ -27,8 +27,6 @@ import {
 
 type SessionStatusLookup = (sessionId: EntityID) => SessionLifecycleStatus | undefined;
 
-// === Public API ===
-
 export const mergeState = (current: WorldState, incoming: WorldState): WorldState => {
   const version = Math.max(current.version, incoming.version);
   const lastModified =

--- a/src/state/journalStore.ts
+++ b/src/state/journalStore.ts
@@ -48,7 +48,6 @@ interface JournalStore {
   setLoading: (loading: boolean) => void;
 }
 
-// Initial state
 const initialState = {
   entries: {},
   sessionEntries: {},
@@ -62,7 +61,6 @@ export const useJournalStore = create<JournalStore>()(
     (set, get) => ({
   ...initialState,
 
-  // Add entry
   addEntry: (sessionId, entryData) => {
     if (!entryData.content || safeTrim(entryData.content) === '') {
       throw new Error('Entry content is required');
@@ -98,7 +96,6 @@ export const useJournalStore = create<JournalStore>()(
     return entryId;
   },
 
-  // Update entry
   updateEntry: (entryId, updates) => set((state) => {
     if (!state.entries[entryId]) {
       return { error: createStoreError('Entry Not Found', 'The specified journal entry could not be found') };
@@ -118,7 +115,6 @@ export const useJournalStore = create<JournalStore>()(
     };
   }),
 
-  // Delete entry
   deleteEntry: (entryId) => set((state) => {
     const entry = state.entries[entryId];
     if (!entry) {
@@ -142,7 +138,6 @@ export const useJournalStore = create<JournalStore>()(
     };
   }),
 
-  // Mark as read
   markAsRead: (entryId) => set((state) => {
     if (!state.entries[entryId]) {
       return { error: createStoreError('Entry Not Found', 'The specified journal entry could not be found') };
@@ -197,7 +192,6 @@ export const useJournalStore = create<JournalStore>()(
     return sorted.filter((entry) => new Date(entry.createdAt).getTime() >= startTimestamp);
   },
 
-  // Get entries by type
   getEntriesByType: (type) => {
     const state = get();
     return Object.values(state.entries).filter((entry) => entry.type === type);

--- a/src/state/narrativeStore.segments.ts
+++ b/src/state/narrativeStore.segments.ts
@@ -20,7 +20,6 @@ export const createNarrativeSegmentActions = (
   set: NarrativeStoreSet,
   get: NarrativeStoreGet
 ) => ({
-  // Add segment
   addSegment: (sessionId: EntityID, segmentData: Omit<NarrativeSegment, 'id' | 'sessionId' | 'createdAt'>): EntityID => {
     const normalizedContent = normalizeText(segmentData.content || '', NORM_DESC);
     if (!normalizedContent) {
@@ -77,7 +76,7 @@ export const createNarrativeSegmentActions = (
       }
     }
 
-    // Link to the most recent decision (if any) - Issue #971
+    // Link to the most recent decision (if any)
     const sessionDecisionIds = get().sessionDecisions[sessionId] || [];
     const latestDecisionId = sessionDecisionIds[sessionDecisionIds.length - 1];
 
@@ -204,7 +203,6 @@ export const createNarrativeSegmentActions = (
     return segmentId;
   },
 
-  // Update segment
   updateSegment: (segmentId: EntityID, updates: Partial<NarrativeSegment>) => set((state) => {
     if (!state.segments[segmentId]) {
       return { error: 'Segment not found' };
@@ -224,7 +222,6 @@ export const createNarrativeSegmentActions = (
     };
   }),
 
-  // Delete segment
   deleteSegment: (segmentId: EntityID) => set((state) => {
     const segment = state.segments[segmentId];
     if (!segment) {
@@ -248,7 +245,6 @@ export const createNarrativeSegmentActions = (
     };
   }),
 
-  // Get session segments
   getSessionSegments: (sessionId: EntityID): NarrativeSegment[] => {
     const state = get();
     const segmentIds = state.sessionSegments[sessionId] || [];

--- a/src/state/sessionStore.ts
+++ b/src/state/sessionStore.ts
@@ -41,7 +41,7 @@ const buildLifecycleMetadata = (
 /**
  * Keep the crash-recovery marker in step with the live session. Only an active
  * session with full world/character context is recoverable, so that's the only
- * shape we record. Called on activation and on each save/heartbeat (issue #221).
+ * shape we record. Called on activation and on each save/heartbeat.
  */
 const syncRecoveryMarker = (
   state: Pick<SessionStore, 'id' | 'status' | 'worldId' | 'characterId'>,
@@ -189,12 +189,12 @@ export const useSessionStore = create<SessionStore>()(
         };
       });
 
-      // Mark the session live for crash recovery (issue #221)
+      // Mark the session live for crash recovery
       syncRecoveryMarker(get(), activationTimestamp);
 
 
-      // Session-start journal entry (Issue #176) — created by the
-      // SESSION_STARTED subscriber in src/lib/session/sessionJournalEntries.ts
+      // Session-start journal entry, created by the SESSION_STARTED subscriber
+      // in src/lib/session/sessionJournalEntries.ts
       await storeEvents.emit<SessionStartedEvent>(StoreEventTypes.SESSION_STARTED, {
         sessionId,
         worldId,
@@ -218,7 +218,7 @@ export const useSessionStore = create<SessionStore>()(
   // re-running activation. The play surface clears the marker on a clean
   // refresh (pagehide), but remounting an already-active session skips
   // initializeSession/resumeSavedSession — so without this, a crash in the
-  // window before the next save would leave no marker and no recovery (issue #221).
+  // window before the next save would leave no marker and no recovery.
   refreshRecoveryMarker: () => {
     syncRecoveryMarker(get(), getTimestamp());
   },
@@ -229,13 +229,13 @@ export const useSessionStore = create<SessionStore>()(
     const lifecycleUpdateTime = getTimestamp();
 
     // Clean exit: drop the crash-recovery marker so the next load doesn't
-    // mistake this for an abnormal end (issue #221)
+    // mistake this for an abnormal end
     clearRecoveryMarker();
 
     if (state.id && state.worldId && state.characterId) {
 
-      // Session-end journal entry with duration + segment count (Issue #176) —
-      // created by the SESSION_ENDED subscriber in
+      // Session-end journal entry with duration + segment count, created by
+      // the SESSION_ENDED subscriber in
       // src/lib/session/sessionJournalEntries.ts. Emitted while this store
       // still holds the session identity (state resets just below).
       await storeEvents.emit<SessionEndedEvent>(StoreEventTypes.SESSION_ENDED, {
@@ -296,22 +296,18 @@ export const useSessionStore = create<SessionStore>()(
     }
   },
 
-  // Set session status
   setStatus: (status) => {
     set({ status });
   },
 
-  // Set error message
   setError: (error) => {
     set({ error });
   },
 
-  // Set player choices
   setPlayerChoices: (choices) => {
     set({ playerChoices: choices });
   },
 
-  // Select a player choice
   selectChoice: (choiceId) => {
     const { playerChoices } = get();
     const updatedChoices = playerChoices.map(choice => ({
@@ -322,37 +318,30 @@ export const useSessionStore = create<SessionStore>()(
     set({ playerChoices: updatedChoices });
   },
 
-  // Clear player choices
   clearPlayerChoices: () => {
     set({ playerChoices: [] });
   },
 
-  // Set current scene
   setCurrentScene: (sceneId) => {
     set({ currentSceneId: sceneId });
   },
 
-  // Pause the session
   pauseSession: () => {
     set({ status: 'paused' });
   },
 
-  // Resume the session from paused state
   resumeSession: () => {
     set({ status: 'active' });
   },
   
-  // Set session ID
   setSessionId: (id) => {
     set({ id });
   },
   
-  // Set character ID
   setCharacterId: (characterId: string) => {
     set({ characterId });
   },
   
-  // Get saved session for a world/character combination
   getSavedSession: (worldId: string, characterId: string) => {
     const { savedSessions } = get();
     const found = Object.values(savedSessions).find(
@@ -361,7 +350,6 @@ export const useSessionStore = create<SessionStore>()(
     return found;
   },
   
-  // Resume a saved session
   resumeSavedSession: (sessionId: string) => {
     const { savedSessions } = get();
     const savedSession = savedSessions[sessionId];
@@ -400,14 +388,13 @@ export const useSessionStore = create<SessionStore>()(
           sessionLifecycle: nextLifecycle,
         };
       });
-      // Mark the resumed session live for crash recovery (issue #221)
+      // Mark the resumed session live for crash recovery
       syncRecoveryMarker(get(), activationTimestamp);
       return true;
     }
     return false;
   },
   
-  // Delete a saved session
   deleteSavedSession: (sessionId: string) => {
     set(state => {
       const { [sessionId]: _, ...remainingSessions } = state.savedSessions;
@@ -518,7 +505,7 @@ export const useSessionStore = create<SessionStore>()(
     });
 
     // Heartbeat: refresh the crash-recovery marker as the story progresses so a
-    // crash recovers state from at most a few minutes ago (issue #221)
+    // crash recovers state from at most a few minutes ago
     syncRecoveryMarker(get(), getTimestamp());
   },
 

--- a/src/stories/03-organisms/narrative/controls/ChoiceSelector.stories.tsx
+++ b/src/stories/03-organisms/narrative/controls/ChoiceSelector.stories.tsx
@@ -67,8 +67,6 @@ export const WithCustomInput: Story = {
     },
   },
 };
-
-// === ALIGNMENT STORIES ===
 // Mock aligned decision for alignment testing
 const createAlignedDecision = (): Decision => ({
   id: 'mock-decision-aligned',

--- a/src/types/continuity.types.ts
+++ b/src/types/continuity.types.ts
@@ -3,7 +3,7 @@
 import type { EntityID } from './common.types';
 
 /**
- * Types for the runtime continuity guardrail (#409/#412): deterministic
+ * Types for the runtime continuity guardrail: deterministic
  * contradiction detection over generated narrative, with a single corrective
  * AI call when an issue is found.
  */

--- a/src/types/inventory.types.ts
+++ b/src/types/inventory.types.ts
@@ -4,7 +4,7 @@ import { EntityID, NamedEntity, TimestampedEntity, ISODateString, GeneratedImage
 
 /**
  * Standard inventory category types for organizing items in any narrative genre.
- * Following the proven pattern from lore categorization (issue #183).
+ * Follows the same categorization pattern as lore facts.
  *
  * Genre-agnostic categories that work across fantasy, sci-fi, modern, historical, etc.:
  * - equipment: Items used for tasks or carried regularly (tools, devices, gear)

--- a/src/types/journal.types.ts
+++ b/src/types/journal.types.ts
@@ -53,12 +53,12 @@ interface JournalMetadata {
   tags: string[];
   automaticEntry: boolean;
   narrativeSegmentId?: EntityID;
-  // Decision-specific metadata for issue #174
+  // Decision-specific metadata
   decisionId?: EntityID;
   choiceText?: string;
   decisionPrompt?: string;
   outcomeSegmentId?: EntityID;
-  // Session-specific metadata for issue #176
+  // Session-specific metadata
   sessionDuration?: number;
   sessionStartTime?: string;
   sessionEndTime?: string;
@@ -71,6 +71,6 @@ interface JournalMetadata {
     characterName?: string;
     sessionNumber?: number;
   };
-  // AI-generated visual for the entry (issue #975)
+  // AI-generated visual for the entry
   image?: GeneratedImage;
 }

--- a/src/types/lore.types.ts
+++ b/src/types/lore.types.ts
@@ -1,6 +1,6 @@
 /**
  * Lore Management Type Definitions
- * Issue #434: Basic lore consistency tracking
+ * Basic lore consistency tracking
  */
 
 import type { EntityID, TimestampedEntity } from './common.types';

--- a/src/types/narrative.types.ts
+++ b/src/types/narrative.types.ts
@@ -276,7 +276,7 @@ export interface NarrativeMetadata {
   itemsLost?: LostItemMetadata[];
   // Major event tracking
   majorEvent?: string;
-  // Decision consequence tracking (Issue #971)
+  // Decision consequence tracking
   causedByDecisionId?: EntityID;
   causedByDecisionText?: string;
   decisionOutcome?: DecisionOutcome;
@@ -286,7 +286,7 @@ export interface NarrativeMetadata {
    * quiet streak, so the guard paces itself instead of firing every turn.
    */
   pacingEscalationRequested?: boolean;
-  // Continuity guardrail outcome (#409/#412)
+  // Continuity guardrail outcome
   continuity?: ContinuitySegmentNote;
   // Debug information (dev mode only)
   debugInfo?: PromptDebugInfo;
@@ -396,7 +396,7 @@ export interface NarrativeGenerationResult {
     itemsLost?: LostItemMetadata[];
     // Major event tracking
     majorEvent?: string;
-    // Continuity guardrail outcome (#409/#412)
+    // Continuity guardrail outcome
     continuity?: ContinuitySegmentNote;
     // Debug information (dev mode only)
     debugInfo?: PromptDebugInfo;

--- a/src/types/provider.types.ts
+++ b/src/types/provider.types.ts
@@ -5,7 +5,7 @@
  *
  * Only Gemini works end-to-end in this release; the other types exist so the
  * presets UI can list popular services and so the schema is ready for the
- * post-1.0 multi-provider work (epic #878).
+ * post-1.0 multi-provider work.
  */
 
 export type ProviderType = 'gemini' | 'openai-compatible' | 'claude' | 'ollama';


### PR DESCRIPTION
## Description

Works the twelve ranked findings from this week's comment sweep, plus the two trailing notes at the bottom of that issue. The diff is deletions and comment rewording only. No code changed.

Three things came out. Issue numbers pasted into comments lost the number and kept the sentence, because the prose around them is usually real design rationale and only the number goes stale once the issue closes. Comments that just named the method below them are gone outright, which is most of the `sessionStore` and `journalStore` action blocks. And the ceremony went: seven section-divider banners across production files, the 54-line docblock sitting on top of the toast barrel's two exports, and 25 JSDoc one-liners that repeated the function name without an `@param` or `@returns` carrying a unit, range, or contract.

Tier 3 is untouched on purpose. The 73 issue citations inside test files are regression anchors where the number IS the information, and the history in `shouldExposeStoreOnWindow` and `resolveApiKey` is a live constraint wearing a costume rather than archaeology.

Measured with the repo's own `npm run audit:comments`, before and after:

| metric | before | after | delta |
|---|---|---|---|
| Tier 1 (mechanical) | 344 | 284 | -60 |
| Tier 2 (judgment) | 113 | 84 | -29 |
| comment lines in `src/` | 14639 | 14471 | -168 |
| issue citations in tests (Tier 3) | 73 | 73 | 0 |

## Related Issue

Closes #1892

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
N/A. Comment-only change, so there is no behavior to write a test against. The existing suite is the regression check: if a deletion had taken an `eslint-disable` directive or a doc-comment something depended on with it, lint or tsc would have caught it.

- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed

N/A

## Flow Diagrams

N/A

## Component Development
N/A. No component rendering, props, or styling changed. `ActiveGameSession.tsx`, `NarrativeController.tsx`, `GameSession.tsx`, `Faq.tsx`, `CharacterSuggestions.tsx`, and `dashboard/page.tsx` are in the diff for their comments only.

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes

Two places where stripping a number would have left a dangling reference, so the sentence got reworded instead of just trimmed:

- `ActiveGameSession.tsx:295` said "the remaining common actions the issue calls out". With `#276` gone, "the issue" pointed at nothing, so it now just names the actions.
- `src/components/ui/toast/index.ts` lost its whole `@example`/`@integration`/`@mobile`/`@accessibility` shrine. What survives is the one constraint you cannot infer from the two export lines: `useToast` throws outside a `ToastProvider` (verified at `toaster.tsx:75`), and toasts stay invisible unless a `Toaster` renders inside that provider (`ToastProvider` only holds state, `Toaster` owns the portal). The file also had a trailing `// Type definitions` banner heading no exports at all.

Four archaeological comments got rewritten in present tense rather than deleted, since each one had a live constraint inside the history: `dashboard/page.tsx:8`, `Faq.tsx:7`, `adapterRegistry.ts:11`, `GameSession.tsx:374`.

Two small scope calls worth flagging. In `sessionStore.ts` the audit flagged 5 restating comments inside one action block, but the block held 13 of the same thing, so all 13 went. Leaving 8 behind would have looked like the remaining ones meant something. Same reasoning in `loreContext.ts`, where `parseLocationFact` got the same treatment as its four flagged siblings.

What is deliberately left: 284 Tier 1 and 84 Tier 2 findings, mostly the long tail of issue citations spread thin across `src/components`. The sweep issue only ranked the top twelve clusters, and sweeping the rest in this PR would have made the diff unreviewable.

## Screenshots

N/A

## Visual Baseline Changes

None. This PR does not touch `tests/visual/**-snapshots/**`.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

```
npm run type-check   exit 0
npm run lint         exit 0  (0 errors, 127 warnings, all pre-existing in tests/visual)
npm run test:ci      exit 0  (435 suites, 3022 tests, all passing)
```

`npm run lint:css` was not run because no `.css` file is in the diff.

## Testing Instructions

Reviewing the diff is the test. Two checks worth doing by eye:

1. `git diff -U0 origin/develop...HEAD | grep '^+' | grep -v '^+++' | grep -vE '^\+\s*(//|\*|/\*)'` returns nothing. Every added line is a comment or blank.
2. Spot-check that no stripped comment took a WHY with it. `sessionStore.ts` is the densest file to look at.

## Checklist
- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

File size limits are unchecked because this PR only makes files shorter, and `formatters.ts` was already over 300 lines before it. The banners came out of that file, which is the sweep's hint that it wants splitting, but that is a separate change.
