### PR TITLE
Retry the world clock seed when it comes back empty

### DIFF
--- a/src/lib/ai/__tests__/worldThreadExtraction.test.ts
+++ b/src/lib/ai/__tests__/worldThreadExtraction.test.ts
@@ -65,6 +65,18 @@ describe('buildWorldThreadPromptSection', () => {
     expect(section).toContain('Tone instructions: Slow-burn political dread');
     expect(section).toContain('- Find the missing ledger');
   });
+
+  it('lifts the per-turn OPEN rules and offers consequence while seeding', () => {
+    const section = buildWorldThreadPromptSection({
+      openThreads: [],
+      currentTurn: 16,
+      segmentSignals: { location: 'The lake' },
+      seed: { worldDescription: 'Something watches from the woods', activeGoals: [] },
+    });
+
+    expect(section).toContain('The OPEN rules above do not apply while seeding');
+    expect(section).toContain("'consequence'");
+  });
 });
 
 describe('parseWorldThreadExtraction', () => {

--- a/src/lib/ai/worldThreadExtraction.ts
+++ b/src/lib/ai/worldThreadExtraction.ts
@@ -45,7 +45,7 @@ const formatSeed = (seed: WorldThreadSeedContext): string => {
     material.push(`Player's goals:\n${seed.activeGoals.map((goal) => `- ${goal}`).join('\n')}`);
   }
   return `${SEEDING_HEADING}:
-This session's ledger is empty. Derive its starting pressure sources from the world description, tone instructions and the player's goals below as 'deadline' or 'actor' threads (3 to 5), each with a rough dueByTurn where the prose gives a timescale (treat one turn as a few minutes to an hour of story time; 'six weeks' is roughly turn 30). Prefer pressures that can act without the player: a named antagonist, a vote, a storm, a debt.
+This session's ledger is empty. Open 3 to 5 threads on THIS turn from the material below. The OPEN rules above do not apply while seeding: seed threads come from the world's standing pressures rather than from this segment's prose, the two-per-segment cap is lifted, and 'be conservative' does not apply. Use 'deadline', 'actor' or 'consequence', whichever fits the pressure; a threat that is unnamed or unseen is still an 'actor'. Give each a rough dueByTurn where the prose gives a timescale (treat one turn as a few minutes to an hour of story time; 'six weeks' is roughly turn 30). Prefer pressures that can act without the player: a named antagonist, a vote, a storm, a debt, something in the woods.
 ${material.join('\n')}`;
 };
 

--- a/src/lib/narrative/__tests__/applyWorldClockUpdates.test.ts
+++ b/src/lib/narrative/__tests__/applyWorldClockUpdates.test.ts
@@ -29,7 +29,7 @@ describe('applyWorldClockUpdates', () => {
   let worldId: string;
 
   beforeEach(() => {
-    useWorldThreadStore.setState({ threads: {}, entities: {}, sessionThreads: {} });
+    useWorldThreadStore.setState({ threads: {}, entities: {}, sessionThreads: {}, seedAttempts: {} });
     // jest.setup.ts swaps worldStore for its manual mock, which has no
     // setState; seed the one world through the mock's own createWorld.
     (useWorldStore as unknown as { __resetMocks: () => void }).__resetMocks();
@@ -88,6 +88,28 @@ describe('applyWorldClockUpdates', () => {
     );
     expect(note?.worldClock).toEqual({ turn: 1, open: 1, overdue: 0, opened: ['The council vote'], advanced: [], resolved: [] });
     expect(useWorldThreadStore.getState().getOpenThreadsBySession('session-1')).toHaveLength(1);
+  });
+
+  it('with the flag on, a seed that opened nothing carries the seed into the next turn', async () => {
+    mockIsFeatureEnabled.mockReturnValue(true);
+    processSpy.mockResolvedValue({
+      newGoalsCreated: 0,
+      goalsUpdated: 0,
+      goalsCompleted: 0,
+      worldThreads: { opened: [], advanced: [], resolved: [] },
+    });
+
+    await applyWorldClockUpdates({ segment: segment(worldId), sessionId: 'session-1', currentTurn: 1 });
+
+    expect(useWorldThreadStore.getState().hasSessionLedger('session-1')).toBe(false);
+
+    await applyWorldClockUpdates({ segment: segment(worldId), sessionId: 'session-1', currentTurn: 2 });
+
+    expect(processSpy.mock.calls[1][3].seed).toEqual({
+      worldDescription: 'The council votes in six weeks.',
+      toneInstructions: 'civic drama',
+      activeGoals: [],
+    });
   });
 
   it('with the flag on and a seeded ledger, passes the open threads and no seed', async () => {

--- a/src/state/__tests__/worldThreadStore.test.ts
+++ b/src/state/__tests__/worldThreadStore.test.ts
@@ -34,6 +34,7 @@ describe('worldThreadStore', () => {
       threads: {},
       entities: {},
       sessionThreads: {},
+      seedAttempts: {},
       currentEntityId: null,
       error: null,
       loading: false,
@@ -115,11 +116,36 @@ describe('worldThreadStore', () => {
       expect(state.threads[foreignId]).toMatchObject({ status: 'open', lastAdvancedAtTurn: 1, notes: [] });
     });
 
-    test('an all-empty result still seeds the session ledger', () => {
+    test('a seed that opened nothing leaves the ledger unseeded so the next turn retries', () => {
       expect(useWorldThreadStore.getState().hasSessionLedger('session-a')).toBe(false);
       useWorldThreadStore.getState().applyExtraction('session-a', 'world-1', emptyResult(), 1);
+      expect(useWorldThreadStore.getState().hasSessionLedger('session-a')).toBe(false);
+    });
+
+    test('stops retrying the seed after three empty attempts', () => {
+      const store = () => useWorldThreadStore.getState();
+      store().applyExtraction('session-a', 'world-1', emptyResult(), 1);
+      store().applyExtraction('session-a', 'world-1', emptyResult(), 2);
+      expect(store().hasSessionLedger('session-a')).toBe(false);
+
+      store().applyExtraction('session-a', 'world-1', emptyResult(), 3);
+
+      expect(store().hasSessionLedger('session-a')).toBe(true);
+      expect(store().getOpenThreadsBySession('session-a')).toEqual([]);
+    });
+
+    test('an empty result on a seeded ledger leaves it seeded', () => {
+      const threadId = openThread('session-a', 'The debt collector is coming');
+      useWorldThreadStore.getState().applyExtraction(
+        'session-a',
+        'world-1',
+        { opened: [], advanced: [], resolved: [{ id: threadId, resolution: 'Paid', outcome: 'resolved' }] },
+        2
+      );
+
       expect(useWorldThreadStore.getState().hasSessionLedger('session-a')).toBe(true);
-      expect(useWorldThreadStore.getState().getOpenThreadsBySession('session-a')).toEqual([]);
+      useWorldThreadStore.getState().applyExtraction('session-a', 'world-1', emptyResult(), 3);
+      expect(useWorldThreadStore.getState().hasSessionLedger('session-a')).toBe(true);
     });
   });
 

--- a/src/state/__tests__/worldThreadStore.test.ts
+++ b/src/state/__tests__/worldThreadStore.test.ts
@@ -175,6 +175,16 @@ describe('worldThreadStore', () => {
     });
   });
 
+  test('migration drops a persisted ledger key that never got a thread', () => {
+    const migrate = useWorldThreadStore.persist.getOptions().migrate;
+    const migrated = migrate?.(
+      { threads: {}, sessionThreads: { 'session-a': [], 'session-b': ['thread-1'] } },
+      1
+    ) as { sessionThreads: Record<string, string[]> };
+
+    expect(migrated.sessionThreads).toEqual({ 'session-b': ['thread-1'] });
+  });
+
   test('clearSessionThreads drops the threads and the ledger key', () => {
     openThread('session-a', 'The debt collector is coming');
     openThread('session-b', 'The king is dying');

--- a/src/state/worldThreadStore.ts
+++ b/src/state/worldThreadStore.ts
@@ -321,12 +321,24 @@ export const useWorldThreadStore = create<WorldThreadStore>()(
     {
       name: 'narraitor-world-thread-store',
       storage: createIndexedDBStorage(),
-      version: 1,
+      version: 2,
       partialize: (state) => ({
         threads: state.threads,
         sessionThreads: state.sessionThreads,
       }),
-      migrate: (persistedState) => persistedState || getInitialState(),
+      // A stored session key with no threads was written by a seed that opened
+      // nothing and marked the ledger seeded anyway. Dropping those keys hands
+      // the sessions that hit that back to the capped retry.
+      migrate: (persistedState) => {
+        const state = (persistedState || getInitialState()) as { sessionThreads?: Record<EntityID, EntityID[]> };
+        if (!state.sessionThreads) return state;
+        return {
+          ...state,
+          sessionThreads: Object.fromEntries(
+            Object.entries(state.sessionThreads).filter(([, threadIds]) => threadIds.length > 0)
+          ),
+        };
+      },
     }
   )
 );

--- a/src/state/worldThreadStore.ts
+++ b/src/state/worldThreadStore.ts
@@ -31,6 +31,12 @@ export interface WorldThreadStore extends CrudStore<WorldThread> {
    * that would make the next turn re-seed a ledger the model already judged.
    */
   sessionThreads: Record<EntityID, EntityID[]>;
+  /**
+   * Seed turns a session has spent without opening anything. Deliberately not
+   * persisted: it only exists to stop a world with nothing to seed paying for
+   * the seed block on every turn of a run.
+   */
+  seedAttempts: Record<EntityID, number>;
   error: UserFriendlyError | null;
   loading: boolean;
 
@@ -50,10 +56,14 @@ export interface WorldThreadStore extends CrudStore<WorldThread> {
 
 const THREAD_KINDS: readonly WorldThreadKind[] = ['consequence', 'actor', 'deadline'];
 
+/** Seed turns that may come back empty before the ledger is taken as seeded anyway. */
+const MAX_SEED_ATTEMPTS = 3;
+
 const getInitialState = () => ({
   threads: {} as Record<EntityID, WorldThread>,
   entities: {} as Record<EntityID, WorldThread>,
   sessionThreads: {} as Record<EntityID, EntityID[]>,
+  seedAttempts: {} as Record<EntityID, number>,
   currentEntityId: null as EntityID | null,
   error: null as UserFriendlyError | null,
   loading: false,
@@ -212,15 +222,7 @@ export const useWorldThreadStore = create<WorldThreadStore>()(
 
       applyExtraction: (sessionId, worldId, result, currentTurn) => {
         const applied: AppliedExtraction = { opened: [], advanced: [], resolved: [] };
-
-        // Seed the session key first so an all-empty result still marks the
-        // ledger as seeded and the next turn doesn't re-run the seed prompt.
-        set((state) => ({
-          sessionThreads: {
-            ...state.sessionThreads,
-            [sessionId]: state.sessionThreads[sessionId] || [],
-          },
-        }));
+        const wasSeeded = sessionId in get().sessionThreads;
 
         for (const entry of result.opened) {
           try {
@@ -239,6 +241,21 @@ export const useWorldThreadStore = create<WorldThreadStore>()(
           } catch {
             // An invalid entry from the model is dropped, not fatal.
           }
+        }
+
+        // A seed that opened nothing is not a seeded ledger: leaving the key
+        // absent lets the next turn seed again, since the model reading an
+        // established session can read the per-turn rules over the seed's.
+        // After MAX_SEED_ATTEMPTS take the empty ledger as the answer.
+        if (!wasSeeded && applied.opened.length === 0) {
+          const attempts = (get().seedAttempts[sessionId] ?? 0) + 1;
+          set((state) => ({
+            seedAttempts: { ...state.seedAttempts, [sessionId]: attempts },
+            sessionThreads:
+              attempts >= MAX_SEED_ATTEMPTS
+                ? { ...state.sessionThreads, [sessionId]: state.sessionThreads[sessionId] || [] }
+                : state.sessionThreads,
+          }));
         }
 
         // Only this session's open threads may move; the model can echo a
@@ -290,7 +307,8 @@ export const useWorldThreadStore = create<WorldThreadStore>()(
         // Dropping the key (unlike delete) is what lets a fresh session re-seed.
         set((state) => {
           const { [sessionId]: _removedSession, ...remainingSessionThreads } = state.sessionThreads;
-          return { sessionThreads: remainingSessionThreads };
+          const { [sessionId]: _removedAttempts, ...remainingSeedAttempts } = state.seedAttempts;
+          return { sessionThreads: remainingSessionThreads, seedAttempts: remainingSeedAttempts };
         });
       },
 


### PR DESCRIPTION
## Description

The world clock's ledger seed could come back with nothing and still mark the session seeded, after which it never ran again. Camp Crystal Lake round 5 hit exactly that: the seed ran at turn 16, opened zero threads, and the empty-ledger fallback carried the remaining 29 turns even though the world description was handing the seed four pressure sources on a plate.

Both suspected causes reproduced in the current code, so the diagnosis in the issue still holds. Two halves to the fix:

**The prompt (`src/lib/ai/worldThreadExtraction.ts:48`).** The seed block asked for 3-5 threads while the per-turn rules two paragraphs above said "OPEN a thread only when THIS segment's prose loads one (max 2 per segment)" and "if the observable-changes line shows nothing changed, be conservative". On an established session there is no reason the model has to read the seed as the winner. The seed now says outright that the OPEN rules are lifted while seeding — seed threads come from the world's standing pressures rather than this segment's prose, the two-per-segment cap is off, and "be conservative" does not apply. It also offers `consequence` alongside `deadline` and `actor`, and says a threat that is unnamed or unseen is still an `actor`, which is what an unseen horror needed to land as anything at all.

**The retry (`src/state/worldThreadStore.ts:222`).** `applyExtraction` used to write the session key before doing anything else, so an all-empty result marked the ledger seeded. It now counts the attempt instead: a seed that opened nothing leaves the key absent and the next turn seeds again. Capped at three attempts (`MAX_SEED_ATTEMPTS`) so a world with genuinely nothing to seed stops carrying the seed block every turn. The counter is a memory-only store field, deliberately outside `partialize` — it is a per-run backstop, not ledger data worth persisting. `clearSessionThreads` drops it alongside the key so a fresh session gets its attempts back.

The decision keys off what was actually opened, not what the model claimed, so a seed whose entries all fail validation retries too.

**The migration (second commit, from Codex's P1).** The sessions this fix exists for already have `sessionThreads[sessionId] = []` sitting in IndexedDB, written by the seed that opened nothing — they would read as seeded forever and never see the retry. The store goes to version 2 and the migration drops stored keys with no threads. A key with an empty list can only mean no thread was ever created for that session (resolving a thread keeps its id in the list), so this hands back exactly the affected sessions and nothing else.

## Related Issue

Closes #1873

Parent: #1822.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Red first, on the pre-change tree — 4 failures for the right reasons:

```
● buildWorldThreadPromptSection > lifts the per-turn OPEN rules and offers consequence while seeding
  Expected substring: "The OPEN rules above do not apply while seeding"
● worldThreadStore > applyExtraction > a seed that opened nothing leaves the ledger unseeded so the next turn retries
  Expected: false  Received: true
● worldThreadStore > applyExtraction > stops retrying the seed after three empty attempts
  Expected: false  Received: true
● applyWorldClockUpdates > with the flag on, a seed that opened nothing carries the seed into the next turn
  Expected: false  Received: true
```

The store test the issue asked for is the second one. The `applyWorldClockUpdates` test covers the half a store test cannot: that the next turn actually rebuilds the seed context and hands it back to the extractor.

The migration got the same treatment: `migration drops a persisted ledger key that never got a thread` failed on the version-1 identity migration before the bump.

One existing test asserted the old behavior ("an all-empty result still seeds the session ledger") and was rewritten, since that assertion is the bug. Its useful half — an empty result on an already-seeded ledger leaves it seeded — is kept as its own test.

## User Stories Addressed

As a player resuming a session with the world clock on, I want the world to carry its own pressures rather than an empty ledger, so the story keeps moving without me.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A - no UI in this change.

## Implementation Notes

`WORLD_CLOCK` gates all of this; nothing changes with the flag off.

The prompt half is an AI-behavior change and has not been validated against a live multi-turn run — this is a prompt wording change with a plausible mechanism, not a measured improvement. The retry cap is what makes that acceptable: if the new wording still comes back empty, the session gets two more turns to seed instead of one shot, and worst case it settles where it already was. Measuring whether the reworded seed actually opens threads on an established session belongs to the next playtest round, on the parent epic.

`src/state/worldThreadStore.ts` is 370 lines, over the 300-line guideline. It was 340 before this change; splitting it is out of scope for a complexity:small fix.

## Screenshots

N/A

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit not run - no dependency or auth surface touched.

## Testing Instructions

```
npm test           # 435 suites, 3027 tests, exit 0
npm run type-check # exit 0
npm run lint       # exit 0 (127 pre-existing warnings, 0 errors)
```

Targeted:

```
npx jest src/state/__tests__/worldThreadStore.test.ts \
         src/lib/narrative/__tests__/applyWorldClockUpdates.test.ts \
         src/lib/ai/__tests__/worldThreadExtraction.test.ts
```

In the app, with `WORLD_CLOCK` on: start or resume a session and watch the DevTools world clock section. Before, a seed that returned nothing left "No ledger for this session yet" forever; now the seed block goes back out on the following turns until something opens or three attempts are spent.

## Checklist

- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

File size: `worldThreadStore.ts` was already over the limit before this change, see Implementation Notes. Docs: none describe the seeding rule; the store's own comments carry it.
