### PR TITLE
Space out the lethal moments so a tense genre can't end every run early

### DIFF
--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -23,6 +23,7 @@ import {
   isFatalCriticalDecision,
 } from '@/lib/narrative/evaluateDecisionSkillChecks';
 import { computeTurnsSinceComplication, isPacingStale } from '@/lib/narrative/turnsSinceComplication';
+import { isFatalCadenceOffCooldown } from '@/lib/narrative/fatalDecisionCadence';
 import { buildWorldClockPromptContext } from '@/lib/narrative/worldClock';
 import { isFeatureEnabled } from '@/lib/featureFlags';
 import { mergeTurnTags } from '@/lib/narrative/turnTags';
@@ -724,10 +725,16 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
       // survivable setback the AI narrates (and can still escalate via the
       // fatal-outcome tag the extraction stamps), so one unlucky-but-ordinary
       // roll does not end the story.
-      const isFatalCriticalFailure = isFatalCriticalDecision(
-        decisionWeight,
-        rollResults
-      );
+      //
+      // Critical weight is model-assigned and unbudgeted, so a tense genre can
+      // mark every turn pivotal and turn that natural 1 into a per-turn death
+      // roll. The cadence guard is what budgets it: only a decision off
+      // cooldown may be fatal, and taking that permission is what spends it,
+      // whichever way the dice then fall.
+      const fatalRiskAllowed =
+        decisionWeight === 'critical' && isFatalCadenceOffCooldown(segments);
+      const isFatalCriticalFailure =
+        fatalRiskAllowed && isFatalCriticalDecision(decisionWeight, rollResults);
 
       if (isFatalCriticalFailure) {
         suggestEnding(
@@ -824,6 +831,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
           tags: [...(result.metadata.tags || []), ...skillCheckTags],
           decisionOutcome,
           pacingEscalationRequested,
+          fatalRiskAllowed,
         },
         sessionId, // Explicitly set sessionId
         worldId, // Explicitly set worldId

--- a/src/components/Narrative/__tests__/NarrativeController.fatalCadence.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeController.fatalCadence.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * A natural 1 on a pivotal decision is allowed to end a story, but the model
+ * decides which decisions are pivotal and a high-tension world marks nearly
+ * all of them. The controller has to space those lethal moments out, so a
+ * long run is not decided by whichever early turn happens to roll a 1.
+ */
+
+import React from 'react';
+import { act, render } from '@testing-library/react';
+
+import { NarrativeController } from '../NarrativeController';
+import { useNarrativeStore } from '@/state/narrativeStore';
+import { useCharacterStore } from '@/state/characterStore';
+import { useWorldStore } from '@/state/worldStore';
+import { useNPCStore } from '@/state/npcStore';
+import {
+  createMockCharacter,
+  createMockCharacterStore,
+  createMockNarrativeStore,
+  createMockNPCStore,
+  createMockWorld,
+  createMockWorldStore,
+  mockZustandStore,
+} from '@/lib/test-utils';
+import { ToastProvider } from '@/components/ui/toast/toaster';
+import { FATAL_DECISION_COOLDOWN_TURNS } from '@/lib/narrative/fatalDecisionCadence';
+import { evaluateSkillCheck } from '@/utils/skillCheckEvaluator';
+import type { NarrativeSegment } from '@/types/narrative.types';
+
+const mockGenerateSegment = jest.fn();
+const mockAddSegment = jest.fn();
+
+jest.mock('@/lib/ai/defaultGeminiClient', () => ({
+  createDefaultGeminiClient: jest.fn(() => ({ generateContent: jest.fn() })),
+}));
+jest.mock('@/lib/ai/narrativeGenerator', () => ({
+  NarrativeGenerator: jest.fn().mockImplementation(() => ({
+    generateInitialScene: jest.fn(),
+    generateSegment: mockGenerateSegment,
+    generatePlayerChoices: jest.fn(),
+  })),
+}));
+jest.mock('@/utils/skillCheckEvaluator', () => ({
+  evaluateSkillCheck: jest.fn(),
+}));
+jest.mock('@/state/narrativeStore', () => ({ useNarrativeStore: jest.fn() }));
+jest.mock('@/state/characterStore', () => ({ useCharacterStore: jest.fn() }));
+jest.mock('@/state/worldStore', () => ({ useWorldStore: jest.fn() }));
+jest.mock('@/state/npcStore', () => ({ useNPCStore: jest.fn() }));
+jest.mock('../NarrativeHistory', () => ({
+  NarrativeHistory: () => <div data-testid="narrative-history" />,
+}));
+
+const mockEvaluateSkillCheck = evaluateSkillCheck as jest.MockedFunction<
+  typeof evaluateSkillCheck
+>;
+
+const naturalOne = {
+  diceRoll: 1,
+  skillLevel: 3,
+  attributeBonus: 1,
+  total: 5,
+  dc: 20,
+  success: false,
+  isCriticalSuccess: false,
+  isCriticalFailure: true,
+  skillId: 'nerve-skill',
+  skillName: 'Nerve',
+  timestamp: new Date().toISOString(),
+};
+
+const makeSegment = (index: number, fatalRiskAllowed?: boolean): NarrativeSegment => ({
+  id: `seg-${index}`,
+  content: 'The cabin door holds, for now.',
+  type: 'scene',
+  sessionId: 'test-session',
+  worldId: 'test-world',
+  characterIds: [],
+  metadata: { tags: [], fatalRiskAllowed },
+  timestamp: new Date(),
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+});
+
+const testCharacter = createMockCharacter({
+  id: 'test-character',
+  worldId: 'test-world',
+  skills: [
+    {
+      id: 'nerve-skill',
+      characterId: 'test-character',
+      worldSkillId: 'nerve-skill',
+      name: 'Nerve',
+      level: 3,
+    },
+  ],
+});
+
+const testWorld = createMockWorld({ id: 'test-world', genre: 'horror' });
+
+const criticalDecision = {
+  id: 'decision-1',
+  prompt: 'The door splinters. What do you do?',
+  decisionWeight: 'critical' as const,
+  options: [
+    {
+      id: 'choice-1',
+      text: 'Hold the door',
+      alignment: 'neutral' as const,
+      isCustomInput: false,
+      requirements: [
+        { type: 'skill' as const, targetId: 'nerve-skill', value: 10 },
+      ],
+    },
+  ],
+};
+
+const seedStores = (segments: NarrativeSegment[]) => {
+  mockZustandStore(
+    useNarrativeStore as jest.MockedFunction<typeof useNarrativeStore>,
+    createMockNarrativeStore({
+      _hasHydrated: true,
+      addSegment: mockAddSegment,
+      getSessionSegments: jest.fn().mockReturnValue(segments),
+      getSessionDecisions: jest.fn().mockReturnValue([criticalDecision]),
+    })
+  );
+  mockZustandStore(
+    useCharacterStore as jest.MockedFunction<typeof useCharacterStore>,
+    createMockCharacterStore({
+      characters: { 'test-character': testCharacter },
+    })
+  );
+  mockZustandStore(
+    useWorldStore as jest.MockedFunction<typeof useWorldStore>,
+    createMockWorldStore({ worlds: { 'test-world': testWorld } })
+  );
+  mockZustandStore(
+    useNPCStore as jest.MockedFunction<typeof useNPCStore>,
+    createMockNPCStore()
+  );
+};
+
+const playCriticalTurn = async (
+  segments: NarrativeSegment[],
+  onEndingSuggested: jest.Mock
+) => {
+  seedStores(segments);
+  await act(async () => {
+    render(
+      <ToastProvider>
+        <NarrativeController
+          worldId="test-world"
+          sessionId="test-session"
+          characterId="test-character"
+          choiceId="choice-1"
+          triggerGeneration={true}
+          generateChoices={false}
+          onEndingSuggested={onEndingSuggested}
+        />
+      </ToastProvider>
+    );
+  });
+};
+
+const quietTurns = (count: number) =>
+  Array.from({ length: count }, (_, index) => makeSegment(index));
+
+describe('NarrativeController - fatal cadence on pivotal decisions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEvaluateSkillCheck.mockReturnValue(naturalOne);
+    mockGenerateSegment.mockResolvedValue({
+      content: 'The door gives way.',
+      segmentType: 'scene',
+      metadata: { characterIds: [], tags: [] },
+    });
+  });
+
+  it('does not end the run on a natural 1 while the fatal cadence is on cooldown', async () => {
+    const onEndingSuggested = jest.fn();
+    await playCriticalTurn(quietTurns(3), onEndingSuggested);
+
+    expect(onEndingSuggested).not.toHaveBeenCalled();
+  });
+
+  it('ends the run on a natural 1 once the cadence is off cooldown', async () => {
+    const onEndingSuggested = jest.fn();
+    await playCriticalTurn(quietTurns(FATAL_DECISION_COOLDOWN_TURNS), onEndingSuggested);
+
+    expect(onEndingSuggested).toHaveBeenCalledTimes(1);
+    expect(onEndingSuggested.mock.calls[0][0]).toMatch(/^fatal:/);
+  });
+
+  it('records the spent fatal risk on the segment so the next pivotal turn is spaced out', async () => {
+    await playCriticalTurn(quietTurns(FATAL_DECISION_COOLDOWN_TURNS), jest.fn());
+
+    expect(mockAddSegment).toHaveBeenCalled();
+    const stored = mockAddSegment.mock.calls[0][1];
+    expect(stored.metadata.fatalRiskAllowed).toBe(true);
+  });
+
+  it('leaves the marker off a turn whose pivotal decision could not be fatal', async () => {
+    await playCriticalTurn(quietTurns(3), jest.fn());
+
+    expect(mockAddSegment).toHaveBeenCalled();
+    const stored = mockAddSegment.mock.calls[0][1];
+    expect(stored.metadata.fatalRiskAllowed).toBe(false);
+  });
+});

--- a/src/lib/narrative/__tests__/fatalDecisionCadence.test.ts
+++ b/src/lib/narrative/__tests__/fatalDecisionCadence.test.ts
@@ -1,0 +1,84 @@
+// Guards the cadence budget on lethal pivotal decisions. Critical weight is
+// model-assigned and unbudgeted, so a high-tension world can mark every turn
+// pivotal; without a cooldown the per-turn kill chance compounds into a
+// coin-flip over a long run.
+
+import {
+  FATAL_DECISION_COOLDOWN_TURNS,
+  isFatalCadenceOffCooldown,
+  turnsSinceFatalRiskAllowed,
+} from '../fatalDecisionCadence';
+import type { NarrativeSegment } from '@/types/narrative.types';
+
+const makeSegment = (fatalRiskAllowed?: boolean): NarrativeSegment => ({
+  id: `seg-${Math.random()}`,
+  content: 'The corridor narrows.',
+  type: 'scene',
+  sessionId: 'test-session',
+  worldId: 'test-world',
+  characterIds: [],
+  metadata: { tags: [], fatalRiskAllowed },
+  timestamp: new Date(),
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+});
+
+const quietTurns = (count: number) =>
+  Array.from({ length: count }, () => makeSegment());
+
+describe('turnsSinceFatalRiskAllowed', () => {
+  it('counts every segment when no turn has put a fatal outcome on the table', () => {
+    expect(turnsSinceFatalRiskAllowed(quietTurns(4))).toBe(4);
+  });
+
+  it('counts back only to the last turn that allowed a fatal outcome', () => {
+    const segments = [
+      ...quietTurns(5),
+      makeSegment(true),
+      ...quietTurns(2),
+    ];
+    expect(turnsSinceFatalRiskAllowed(segments)).toBe(2);
+  });
+
+  it('is zero on the turn straight after one that allowed a fatal outcome', () => {
+    expect(turnsSinceFatalRiskAllowed([...quietTurns(3), makeSegment(true)])).toBe(0);
+  });
+});
+
+describe('isFatalCadenceOffCooldown', () => {
+  it('holds a fatal outcome back over the opening turns of a fresh session', () => {
+    expect(isFatalCadenceOffCooldown([])).toBe(false);
+    expect(
+      isFatalCadenceOffCooldown(quietTurns(FATAL_DECISION_COOLDOWN_TURNS - 1))
+    ).toBe(false);
+  });
+
+  it('allows a fatal outcome once the opening turns have passed', () => {
+    expect(
+      isFatalCadenceOffCooldown(quietTurns(FATAL_DECISION_COOLDOWN_TURNS))
+    ).toBe(true);
+  });
+
+  it('holds every following pivotal decision back until the cooldown runs out', () => {
+    const spent = [
+      ...quietTurns(FATAL_DECISION_COOLDOWN_TURNS),
+      makeSegment(true),
+    ];
+    expect(isFatalCadenceOffCooldown(spent)).toBe(false);
+    expect(
+      isFatalCadenceOffCooldown([
+        ...spent,
+        ...quietTurns(FATAL_DECISION_COOLDOWN_TURNS - 1),
+      ])
+    ).toBe(false);
+  });
+
+  it('allows another fatal outcome a full cooldown after the last one', () => {
+    const segments = [
+      ...quietTurns(FATAL_DECISION_COOLDOWN_TURNS),
+      makeSegment(true),
+      ...quietTurns(FATAL_DECISION_COOLDOWN_TURNS),
+    ];
+    expect(isFatalCadenceOffCooldown(segments)).toBe(true);
+  });
+});

--- a/src/lib/narrative/fatalDecisionCadence.ts
+++ b/src/lib/narrative/fatalDecisionCadence.ts
@@ -1,0 +1,50 @@
+import type { NarrativeSegment } from '@/types/narrative.types';
+
+/**
+ * Turns that must pass before a pivotal decision may carry a fatal outcome
+ * again.
+ *
+ * A decision's critical weight is assigned by the model, and nothing budgets
+ * it: a siege or a chase can read as pivotal on every single turn. Weight plus
+ * a natural 1 alone therefore works out to a flat ~5% chance of death per turn
+ * in those worlds, which compounds to better-than-even odds across a long run
+ * and ends most of them in the first act. Spacing the lethal moments keeps the
+ * odds proportional to the story's length rather than to how tense its genre
+ * reads, without softening what a natural 1 means when it lands.
+ */
+export const FATAL_DECISION_COOLDOWN_TURNS = 10;
+
+/**
+ * Turns since the run last let a pivotal decision be fatal, walking backward
+ * from the most recent segment.
+ *
+ * The marker records permission, not death: a turn that was allowed to be
+ * fatal and rolled well still spends the budget. That is what spaces the
+ * lethal moments out instead of letting every critical decision in a tense
+ * stretch take its own 5% swing.
+ *
+ * A session with no marker at all counts every segment, which gives the
+ * opening turns of a story the same protection the cooldown gives the rest.
+ */
+export function turnsSinceFatalRiskAllowed(
+  segments: NarrativeSegment[]
+): number {
+  let count = 0;
+  for (let i = segments.length - 1; i >= 0; i--) {
+    if (segments[i]?.metadata?.fatalRiskAllowed) {
+      break;
+    }
+    count++;
+  }
+  return count;
+}
+
+/**
+ * Whether the run may put a fatal outcome on the table this turn. The caller
+ * still needs a critical-weight decision and a natural 1 for anyone to die.
+ */
+export function isFatalCadenceOffCooldown(
+  segments: NarrativeSegment[]
+): boolean {
+  return turnsSinceFatalRiskAllowed(segments) >= FATAL_DECISION_COOLDOWN_TURNS;
+}

--- a/src/state/__tests__/narrativeStore.segments.fatalCadence.test.ts
+++ b/src/state/__tests__/narrativeStore.segments.fatalCadence.test.ts
@@ -1,0 +1,89 @@
+/**
+ * addSegment persists the spent-fatal-risk marker on segment metadata. The
+ * finalMetadata whitelist drops anything it doesn't list, and the cooldown is
+ * recomputed from stored segments whenever the controller rehydrates, so a
+ * dropped marker hands a resumed session a fresh licence to kill.
+ */
+
+import { useNarrativeStore } from '../narrativeStore';
+import { useWorldStore } from '../worldStore';
+import { useSessionStore } from '../sessionStore';
+import {
+  FATAL_DECISION_COOLDOWN_TURNS,
+  isFatalCadenceOffCooldown,
+  turnsSinceFatalRiskAllowed,
+} from '@/lib/narrative/fatalDecisionCadence';
+
+describe('addSegment fatal cadence metadata', () => {
+  let worldId: string;
+  const sessionId = 'session-fatal-cadence-test';
+
+  beforeEach(() => {
+    jest.useRealTimers();
+    useWorldStore.getState().reset();
+    useNarrativeStore.getState().reset();
+    global.fetch = jest.fn();
+
+    worldId = useWorldStore.getState().createWorld({
+      name: 'Test World',
+      description: 'A test world',
+      genre: 'horror',
+      attributes: [],
+      skills: [],
+      settings: {
+        maxAttributes: 5,
+        maxSkills: 5,
+        attributePointPool: 10,
+        skillPointPool: 10,
+      },
+    });
+    useSessionStore.getState().upsertSessionLifecycle({
+      id: sessionId,
+      worldId,
+      characterId: 'char-test',
+      status: 'active',
+      lastActivity: new Date().toISOString(),
+    });
+  });
+
+  afterEach(() => {
+    useNarrativeStore.getState().reset();
+    useWorldStore.getState().reset();
+    jest.restoreAllMocks();
+  });
+
+  function addSegment(fatalRiskAllowed?: boolean): string {
+    return useNarrativeStore.getState().addSegment(sessionId, {
+      worldId,
+      content: 'The door holds, for now.',
+      type: 'scene',
+      metadata: { tags: [], fatalRiskAllowed },
+      timestamp: new Date(),
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  it('persists the marker so the cooldown survives a reload', () => {
+    const segmentId = addSegment(true);
+    expect(
+      useNarrativeStore.getState().segments[segmentId].metadata.fatalRiskAllowed
+    ).toBe(true);
+  });
+
+  it('reads back as a spent turn when recomputing the cooldown from the store', () => {
+    addSegment(true);
+    addSegment();
+    addSegment();
+
+    const stored = useNarrativeStore.getState().getSessionSegments(sessionId);
+    expect(turnsSinceFatalRiskAllowed(stored)).toBe(2);
+  });
+
+  it('keeps a resumed session on cooldown after a long run spent its fatal risk', () => {
+    for (let i = 0; i < FATAL_DECISION_COOLDOWN_TURNS; i++) addSegment();
+    addSegment(true);
+
+    const stored = useNarrativeStore.getState().getSessionSegments(sessionId);
+    expect(isFatalCadenceOffCooldown(stored)).toBe(false);
+  });
+});

--- a/src/state/narrativeStore.segments.ts
+++ b/src/state/narrativeStore.segments.ts
@@ -112,6 +112,7 @@ export const createNarrativeSegmentActions = (
       causedByDecisionText,
       decisionOutcome: metadata?.decisionOutcome,
       pacingEscalationRequested: metadata?.pacingEscalationRequested,
+      fatalRiskAllowed: metadata?.fatalRiskAllowed,
       continuity: metadata?.continuity,
       debugInfo: metadata?.debugInfo, // Preserve debug info from AI generation
     };

--- a/src/types/narrative.types.ts
+++ b/src/types/narrative.types.ts
@@ -286,6 +286,12 @@ export interface NarrativeMetadata {
    * quiet streak, so the guard paces itself instead of firing every turn.
    */
   pacingEscalationRequested?: boolean;
+  /**
+   * Set by the engine, not the model: this turn's pivotal decision was allowed
+   * to end the run. Permission is what gets spent, so the marker lands whether
+   * or not the dice took it. Read by turnsSinceFatalRiskAllowed.
+   */
+  fatalRiskAllowed?: boolean;
   // Continuity guardrail outcome
   continuity?: ContinuitySegmentNote;
   // Debug information (dev mode only)


### PR DESCRIPTION
## Description

A natural 1 on a pivotal decision is allowed to end a story. That design is right. Its cadence isn't.

`decisionWeight: "critical"` is assigned by the model and nothing budgets it, so a world whose genre reads tense - a siege, a chase, a slasher - comes back critical on nearly every turn. Weight plus a natural 1 then works out to a flat ~5% chance of death per turn, which compounds to better-than-even odds across a 45-turn run and, in practice, ends most runs in the first act. Two of three Crystal Lake playtest arms in round 12 died at turn 5 and turn 8, before treatment started, and the campaign cell was unscorable because nothing reached turn 45.

This adds a deterministic cooldown on the fatal branch rather than more prompt wording. A critical decision may only carry a fatal outcome once every ten turns. Taking that permission is what spends it, whichever way the dice then fall, so the segment records it and the next pivotal turn counts from there. A fresh session carries no marker, so the count starts at the session's first segment and the opening act gets the same cover for free.

What a natural 1 means is unchanged: on an off-cooldown critical decision it still ends the run outright. The fatal-outcome tag path (the model reading a death in its own prose) is untouched.

Sizing, for the record: at ten turns, a 45-turn run in a world that marks every turn critical goes from roughly a 90% chance of an early death to roughly 20%.

New behavior lives in `src/lib/narrative/fatalDecisionCadence.ts`, deliberately shaped like its neighbor `turnsSinceComplication.ts` - a pure function walking segments backward for an engine-set marker, with the marker riding existing segment metadata rather than a new store field. No feature flag: this is a bug fix that only ever reduces lethality, and gating it off by default would leave the defect live.

## Related Issue

Closes #1886

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Both test files were written and run red first. The controller test failed for exactly the reported reason:

```
NarrativeController - fatal cadence on pivotal decisions
  > does not end the run on a natural 1 while the fatal cadence is on cooldown
    expect(jest.fn()).not.toHaveBeenCalled()
    Expected number of calls: 0
    Received number of calls: 1
    1: "fatal: a catastrophic failure on a pivotal decision left the character
        unable to continue.", "story-complete"
```

That is a nat 1 on a critical decision killing the character on turn 3, which is the t5/t8 deaths in miniature. The marker assertions failed as `undefined` alongside it. The "ends the run once off cooldown" case passed before the fix as well as after - it is there to catch an over-correction that switches the fatal path off entirely.

## User Stories Addressed

As a player in a high-tension world, I want a run's length to be decided by the story rather than by whichever early turn happens to roll a 1, so a long campaign is playable to its end.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A - no UI surface changes.

## Implementation Notes

- `src/lib/narrative/fatalDecisionCadence.ts` (new, 49 lines) - `FATAL_DECISION_COOLDOWN_TURNS = 10`, `turnsSinceFatalRiskAllowed(segments)`, `isFatalCadenceOffCooldown(segments)`.
- `src/components/Narrative/NarrativeController.tsx:728` - the fatal branch now reads `fatalRiskAllowed && isFatalCriticalDecision(...)`. `isFatalCriticalDecision` keeps its old meaning (critical weight plus a natural 1); the cadence is a separate gate, so each predicate stays independently readable and testable.
- `src/components/Narrative/NarrativeController.tsx:834` - stamps `fatalRiskAllowed` onto the new segment, alongside the existing `pacingEscalationRequested` stamp it is modelled on.
- `src/types/narrative.types.ts:289` - `fatalRiskAllowed?: boolean` on `NarrativeMetadata`, documented as engine-set.
- `src/state/narrativeStore.segments.ts:115` - the field in `addSegment`'s `finalMetadata` whitelist, next to `pacingEscalationRequested`. That block rebuilds metadata from an explicit list and drops anything missing from it, so without this line the store discarded the marker on every write and a resumed session came back with no memory of a spent fatal risk. Caught by Codex in review. The persistence path needed nothing: `partialize` spreads segment metadata wholesale and only reaches in to serialize `debugInfo` dates, so the whitelist was the only gate.

Two details worth knowing. The marker records permission and not death, which is the whole mechanism - a critical decision that was allowed to be fatal and then rolled well still spends the budget, and that is what spaces the lethal moments instead of letting every critical decision in a tense stretch take its own swing. And the count reads the controller's session segment list, the same list the pacing guard uses; a one-segment lag against a ten-turn cooldown is immaterial.

`desiredTone: 'tragic'` on a critical failure is left alone. Only the ending templates read it, so it is inert on segment generation.

## Screenshots

N/A

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

```
npm test          438 suites, 3036 tests passed   EXIT=0
npm run type-check                                EXIT=0
npm run lint      0 errors, 127 pre-existing warnings   EXIT=0
npm run deps:validate  no violations              EXIT=0
```

No CSS touched, so `lint:css` was not run.

## Testing Instructions

1. `npm test src/lib/narrative/__tests__/fatalDecisionCadence.test.ts` - the cooldown arithmetic, including the opening grace and the reset after a spent turn.
2. `npm test src/state/__tests__/narrativeStore.segments.fatalCadence.test.ts` - the marker survives a round trip through `addSegment`, including a resumed session staying on cooldown after a long run spent its fatal risk.
3. `npm test src/components/Narrative/__tests__/NarrativeController.fatalCadence.test.tsx` - the wiring at the real call site: a mocked natural 1 on a critical decision ends the run at the cooldown boundary and not before, and the segment carries the marker.
4. To see the red, revert `NarrativeController.tsx:734-736` to the old `isFatalCriticalDecision(decisionWeight, rollResults)` and re-run step 3.

Live confirmation belongs to the playtest campaign, not to this PR: the thing being fixed is a rate across dozens of turns, so a single session cannot show it either way. The next Crystal Lake cell should now be able to reach turn 45.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
