### PR TITLE
Give the post-segment extraction its own output budget

### DIFF
--- a/src/lib/ai/__tests__/clientGeminiClient.test.ts
+++ b/src/lib/ai/__tests__/clientGeminiClient.test.ts
@@ -74,6 +74,21 @@ describe('ClientGeminiClient.generateContent', () => {
     expect(result.content).toBe('Hello');
   });
 
+  it('sends the caller output ceiling when one is given, and the default otherwise', async () => {
+    const doneLine = JSON.stringify({ done: true, content: 'Hello', finishReason: 'STOP' });
+    mockedAiFetch.mockResolvedValue(fakeStreamingResponse([doneLine]) as unknown as Response);
+
+    const client = new ClientGeminiClient();
+    await client.generateContent('a prompt', { maxTokens: 6144 });
+    mockedAiFetch.mockResolvedValue(fakeStreamingResponse([doneLine]) as unknown as Response);
+    await client.generateContent('a prompt');
+
+    const sentMaxTokens = mockedAiFetch.mock.calls.map(
+      ([, init]) => JSON.parse(String(init?.body)).config.maxTokens
+    );
+    expect(sentMaxTokens).toEqual([6144, 2048]);
+  });
+
   it('rejects with a friendly message when the stream carries an error event', async () => {
     mockedAiFetch.mockResolvedValue(
       fakeStreamingResponse([JSON.stringify({ error: 'connection reset' })]) as unknown as Response

--- a/src/lib/ai/__tests__/goalExtractor.truncation.test.ts
+++ b/src/lib/ai/__tests__/goalExtractor.truncation.test.ts
@@ -43,14 +43,17 @@ const loggedText = (spy: jest.SpyInstance): string =>
 
 describe('goalExtractor output budget and failure visibility', () => {
   let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
 
   beforeEach(() => {
     mockGenerateContent.mockReset();
     warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
     warnSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it('asks for more output room than a narrative beat gets', async () => {
@@ -69,7 +72,7 @@ describe('goalExtractor output budget and failure visibility', () => {
     expect(options.maxTokens).toBeGreaterThan(NARRATIVE_MAX_OUTPUT_TOKENS);
   });
 
-  it('says so when a response cut at the ceiling costs the turn its stamp', async () => {
+  it('reports a response cut at the ceiling at error level, where production keeps it', async () => {
     mockGenerateContent.mockResolvedValue({
       content: '```json\n{\n  "newGoals": [\n    {\n      "title": "Reach the ford before',
       finishReason: 'MAX_TOKENS',
@@ -78,7 +81,9 @@ describe('goalExtractor output budget and failure visibility', () => {
     const result = await extractGoalsFromNarrative(buildRequest());
 
     expect(result.worldThreads).toBeUndefined();
-    expect(loggedText(warnSpy)).toContain('truncated');
+    expect(loggedText(errorSpy)).toContain('truncated');
+    const reported = errorSpy.mock.calls.flat().find((arg) => arg instanceof Error);
+    expect((reported as Error).name).toBe('ExtractionTruncatedError');
   });
 
   it('names a prose answer as a parse failure, not a truncation', async () => {

--- a/src/lib/ai/__tests__/goalExtractor.truncation.test.ts
+++ b/src/lib/ai/__tests__/goalExtractor.truncation.test.ts
@@ -1,0 +1,97 @@
+import { extractGoalsFromNarrative } from '../goalExtractor';
+import type { GoalExtractionRequest } from '../../../types/goal.types';
+import { getTimestamp } from '@/lib/utils/timestamp';
+
+const mockGenerateContent = jest.fn();
+jest.mock('../defaultGeminiClient', () => ({
+  createDefaultGeminiClient: () => ({ generateContent: mockGenerateContent }),
+}));
+
+/** The narrative panel's ceiling, which the extraction used to inherit. */
+const NARRATIVE_MAX_OUTPUT_TOKENS = 2048;
+
+const buildRequest = (): GoalExtractionRequest => ({
+  content: 'The magistrate rides for the capital and the ford is still out.',
+  sessionId: 'session-1',
+  segmentId: 'segment-1',
+  existingGoals: [],
+  worldThreads: {
+    currentTurn: 27,
+    openThreads: [
+      {
+        id: 'thread-abc',
+        sessionId: 'session-1',
+        worldId: 'world-1',
+        kind: 'actor',
+        summary: 'The magistrate is riding for the capital',
+        openedAtTurn: 4,
+        lastAdvancedAtTurn: 21,
+        status: 'open',
+        notes: [],
+        createdAt: getTimestamp(),
+        updatedAt: getTimestamp(),
+      },
+    ],
+  },
+});
+
+const loggedText = (spy: jest.SpyInstance): string =>
+  spy.mock.calls
+    .flat()
+    .filter((arg): arg is string => typeof arg === 'string')
+    .join(' ');
+
+describe('goalExtractor output budget and failure visibility', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockGenerateContent.mockReset();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('asks for more output room than a narrative beat gets', async () => {
+    mockGenerateContent.mockResolvedValue({
+      content: '```json\n{"newGoals":[],"updatedGoals":[],"completedGoals":[],"confidence":0.8}\n```',
+      finishReason: 'STOP',
+    });
+
+    await extractGoalsFromNarrative(buildRequest());
+
+    expect(mockGenerateContent).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ maxTokens: expect.any(Number) })
+    );
+    const options = mockGenerateContent.mock.calls[0][1];
+    expect(options.maxTokens).toBeGreaterThan(NARRATIVE_MAX_OUTPUT_TOKENS);
+  });
+
+  it('says so when a response cut at the ceiling costs the turn its stamp', async () => {
+    mockGenerateContent.mockResolvedValue({
+      content: '```json\n{\n  "newGoals": [\n    {\n      "title": "Reach the ford before',
+      finishReason: 'MAX_TOKENS',
+    });
+
+    const result = await extractGoalsFromNarrative(buildRequest());
+
+    expect(result.worldThreads).toBeUndefined();
+    expect(loggedText(warnSpy)).toContain('truncated');
+  });
+
+  it('names a prose answer as a parse failure, not a truncation', async () => {
+    mockGenerateContent.mockResolvedValue({
+      content: 'The magistrate reaches the capital by nightfall.',
+      finishReason: 'STOP',
+    });
+
+    const result = await extractGoalsFromNarrative(buildRequest());
+
+    expect(result.worldThreads).toBeUndefined();
+    const logged = loggedText(warnSpy);
+    expect(logged).toContain('No JSON block');
+    expect(logged).not.toContain('truncated');
+  });
+});

--- a/src/lib/ai/clientGeminiClient.ts
+++ b/src/lib/ai/clientGeminiClient.ts
@@ -8,6 +8,9 @@ import { SINGLE_ATTEMPT_TEXT_TIMEOUT_MS } from '@/lib/constants/aiTimeouts';
 import Logger from '@/lib/utils/logger';
 const logger = new Logger('ClientGeminiClient');
 
+/** Output ceiling for a narrative beat: 3-4 paragraphs plus its JSON metadata. */
+const NARRATIVE_MAX_OUTPUT_TOKENS = 2048;
+
 /**
  * Client-side proxy for Gemini API that routes through Next.js API routes
  * This ensures API keys are never exposed to the client
@@ -166,7 +169,7 @@ export class ClientGeminiClient implements AIClient {
   async generateContent(prompt: string, options?: AIGenerateOptions): Promise<AIResponse> {
     return this.postNdjsonStream(
       '/api/narrative/generate',
-      { prompt, config: { temperature: 0.7, maxTokens: 2048 } },
+      { prompt, config: { temperature: 0.7, maxTokens: options?.maxTokens ?? NARRATIVE_MAX_OUTPUT_TOKENS } },
       'generation',
       // The route makes a single 30s Gemini attempt (makeGeminiRequest), so
       // the wait ceiling is that budget + headroom, not the retry worst case.

--- a/src/lib/ai/goalExtractor.ts
+++ b/src/lib/ai/goalExtractor.ts
@@ -18,6 +18,22 @@ import {
 } from './worldThreadExtraction';
 import { buildWorldCostPromptSection, parseWorldCostExtraction } from './worldCostExtraction';
 
+import Logger from '@/lib/utils/logger';
+const logger = new Logger('GoalExtractor');
+
+/**
+ * This call answers with a JSON object, not prose, and the object grows with
+ * the session: goals, then the thread ledger, then what the world took. On the
+ * narrative panel's 2048 ceiling a late-session extraction ran past the limit
+ * and came back with an unterminated fence, which parses as nothing at all —
+ * the ledger then went a turn staler with every miss. Sized so the whole
+ * object fits with room for a fat ledger.
+ */
+const EXTRACTION_MAX_OUTPUT_TOKENS = 6144;
+
+/** Gemini and the OpenAI-compatible providers both normalize to this. */
+const TRUNCATED_FINISH_REASON = 'MAX_TOKENS';
+
 // Created on first use, not at import time — the class singleton used to
 // construct a client as a module side effect.
 let defaultClient: AIClient | null = null;
@@ -44,9 +60,15 @@ export async function extractGoalsFromNarrative(
     const prompt = buildGoalExtractionPrompt(request);
 
     // Call AI service
-    const response = await getClient().generateContent(prompt);
+    const response = await getClient().generateContent(prompt, {
+      maxTokens: EXTRACTION_MAX_OUTPUT_TOKENS,
+    });
 
     if (!response.content) {
+      logger.warn('Extraction returned no content', {
+        segmentId: request.segmentId,
+        finishReason: response.finishReason,
+      });
       return {
         newGoals: [],
         updatedGoals: [],
@@ -56,8 +78,9 @@ export async function extractGoalsFromNarrative(
     }
 
     // Parse AI response
-    return parseGoalExtractionResponse(response.content, request);
-  } catch {
+    return parseGoalExtractionResponse(response.content, request, response.finishReason);
+  } catch (error) {
+    logger.warn('Extraction call failed', { segmentId: request.segmentId, error });
     return {
       newGoals: [],
       updatedGoals: [],
@@ -151,12 +174,23 @@ Respond with JSON in this exact format:
 
 function parseGoalExtractionResponse(
   content: string,
-  request: GoalExtractionRequest
+  request: GoalExtractionRequest,
+  finishReason?: string
 ): GoalExtractionResult {
+  const wasTruncated = finishReason === TRUNCATED_FINISH_REASON;
   try {
     // Extract JSON from the fenced block; fall back when absent.
     const jsonStr = extractFencedJson(content);
     if (jsonStr === null) {
+      // Named apart so a miss can be counted as one or the other: a response
+      // cut at the output ceiling never closes its fence, which is a different
+      // problem from a model that answered in prose.
+      logger.warn(
+        wasTruncated
+          ? 'Extraction response was truncated at the output-token ceiling; no JSON block to reconcile'
+          : 'No JSON block in the extraction response',
+        { segmentId: request.segmentId, finishReason, contentLength: content.length }
+      );
       return createFallbackExtractionResult(request);
     }
 
@@ -205,7 +239,12 @@ function parseGoalExtractionResponse(
     }
 
     return result;
-  } catch {
+  } catch (error) {
+    logger.warn('Extraction JSON could not be parsed', {
+      segmentId: request.segmentId,
+      finishReason,
+      error,
+    });
     return createFallbackExtractionResult(request);
   }
 }

--- a/src/lib/ai/goalExtractor.ts
+++ b/src/lib/ai/goalExtractor.ts
@@ -34,6 +34,17 @@ const EXTRACTION_MAX_OUTPUT_TOKENS = 6144;
 /** Gemini and the OpenAI-compatible providers both normalize to this. */
 const TRUNCATED_FINISH_REASON = 'MAX_TOKENS';
 
+/**
+ * Carries the truncation to the first-party error sink, where the name is what
+ * makes a miss countable — a report's free-form text never leaves the browser.
+ */
+class ExtractionTruncatedError extends Error {
+  constructor() {
+    super('Extraction response truncated at the output-token ceiling');
+    this.name = 'ExtractionTruncatedError';
+  }
+}
+
 // Created on first use, not at import time — the class singleton used to
 // construct a client as a module side effect.
 let defaultClient: AIClient | null = null;
@@ -184,13 +195,23 @@ function parseGoalExtractionResponse(
     if (jsonStr === null) {
       // Named apart so a miss can be counted as one or the other: a response
       // cut at the output ceiling never closes its fence, which is a different
-      // problem from a model that answered in prose.
-      logger.warn(
-        wasTruncated
-          ? 'Extraction response was truncated at the output-token ceiling; no JSON block to reconcile'
-          : 'No JSON block in the extraction response',
-        { segmentId: request.segmentId, finishReason, contentLength: content.length }
-      );
+      // problem from a model that answered in prose. Truncation goes out at
+      // error level because that is the only level production keeps by
+      // default, and it's the failure worth counting where players are.
+      const context = {
+        segmentId: request.segmentId,
+        finishReason,
+        contentLength: content.length,
+      };
+      if (wasTruncated) {
+        logger.error(
+          'Extraction response truncated at the output-token ceiling; no JSON block to reconcile',
+          new ExtractionTruncatedError(),
+          context
+        );
+      } else {
+        logger.warn('No JSON block in the extraction response', context);
+      }
       return createFallbackExtractionResult(request);
     }
 

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -82,10 +82,16 @@ export interface AIImageResponse {
  * ClientGeminiClient.generateContent) invoke it with each newly-visible
  * slice of narrative prose as it arrives, ahead of the final resolved
  * AIResponse. Implementations that don't stream simply never call it.
+ * `maxTokens` raises or lowers the output ceiling for one call: callers whose
+ * answer is longer than a narrative beat (structured extraction, which returns
+ * a JSON object that grows with the session) need more room than the panel's
+ * default, and a response cut at the ceiling comes back unparseable rather
+ * than short. Implementations that can't vary it per call ignore it.
  */
 export interface AIGenerateOptions {
   signal?: AbortSignal;
   onChunk?: (delta: string) => void;
+  maxTokens?: number;
 }
 
 /**


### PR DESCRIPTION
## Description

The post-segment extraction was running out of output room, and nothing said so.

That call goes out through `ClientGeminiClient.generateContent`, which hardcoded `maxTokens: 2048` for every caller. That number was sized for the narrative panel - 3-4 paragraphs plus its metadata. The extraction answers with a JSON object instead, and the object grows all session: goals, then the thread ledger, then the cost block. Late in a run the answer ran past 2048, Gemini cut it mid-object with `finishReason: MAX_TOKENS`, and the fenced block never closed. `extractFencedJson` needs the closing fence, so it returned null, and `parseGoalExtractionResponse` fell through to the pattern-matching fallback - which carries no `worldThreads` and no `worldCost` at all. `applyWorldClockUpdates` then had nothing to reconcile, stamped nothing on the segment, and returned undefined. Fail-open all the way down, with no log line anywhere along it. That is exactly the reported shape: the call goes out carrying the ledger, no JSON comes back, the stamp is missing, and the miss rate is invisible.

Two changes. `AIGenerateOptions` grows an optional `maxTokens` so a caller can set its own ceiling, and the extractor asks for 6144. And the three ways this can fail now name themselves in the log - the call failed, the response was truncated at the ceiling, or the model answered in prose - so a miss can be counted as one or the other rather than guessed at. Truncation goes out at error level, because Logger's production minimum is ERROR and error is what reaches the first-party sink; it carries an `ExtractionTruncatedError` since the sink transports the class name and never the message. Behaviour is unchanged otherwise: still fail-open, still the same fallback.

The late-turn clustering in the report backs the diagnosis. The misses were t16, 17, 23, 24, 25, 27, 28, 29, 31 - none early, when the ledger is thin, and most of them past turn 20, when it isn't.

## Related Issue

Closes #1887

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Both halves were checked red before green by stashing the source change and re-running:

```
● asks for more output room than a narrative beat gets
    Expected: Any<String>, ObjectContaining {"maxTokens": Any<Number>}
    Number of calls: 1   (the prompt alone, no options)

● reports a response cut at the ceiling at error level, where production keeps it
    Expected substring: "truncated"
    Received string:    ""

● names a prose answer as a parse failure, not a truncation
    Expected substring: "No JSON block"
    Received string:    ""

● sends the caller output ceiling when one is given, and the default otherwise
    - Expected  - 1
    + Received  + 1
      Array [
    -   6144,
    +   2048,
        2048,
      ]
```

## User Stories Addressed

N/A - defect fix behind the world-clock and world-cost channels.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A - no UI in this change.

## Implementation Notes

| File | What changed |
| --- | --- |
| `src/lib/ai/types.ts` | `AIGenerateOptions` gains optional `maxTokens` |
| `src/lib/ai/clientGeminiClient.ts` | `generateContent` sends the caller's ceiling, else the 2048 default (now a named constant) |
| `src/lib/ai/goalExtractor.ts` | Asks for 6144, and names the three failure modes apart: call failure and prose-only at warn, truncation at error so the sink keeps it |

`maxTokens` follows the same contract `onChunk` already set: optional, honoured by the implementations that can, ignored by the ones that can't. The server-side `GeminiClient` reads its ceiling from config and ignores per-call options - it never serves this path, since goal extraction runs from a browser store.

6144 is a ceiling, not a spend. Gemini bills generated tokens, and `thinkingBudget` is already 0 on this path, so a normal-sized extraction costs exactly what it did before.

## Screenshots

N/A

## Visual Baseline Changes

None

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

`npm test` 442 suites / 3067 tests, exit 0. `npm run type-check` exit 0. `npm run lint` exit 0 (127 pre-existing warnings, none in the touched files). `npm run deps:validate` exit 0. No CSS touched, so `lint:css` was not run. Security audit not run.

## Testing Instructions

1. `npm test src/lib/ai/__tests__/goalExtractor.truncation.test.ts src/lib/ai/__tests__/clientGeminiClient.test.ts` - covers the budget and all three log paths.
2. To see it red, stash `src/lib/ai/goalExtractor.ts`, `src/lib/ai/clientGeminiClient.ts` and `src/lib/ai/types.ts` and run the same command.
3. In a live session with `WORLD_CLOCK` on, watch the console past turn 20. A miss now prints a `[GoalExtractor]` warning naming which failure it was; before this it printed nothing.

## Checklist

- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file) - `goalExtractor.ts` was already 379 lines and is 418 after this; splitting it is out of scope here
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
