### PR TITLE
Stop guessing major events from fantasy phrasing

### DIFF
--- a/src/state/__tests__/narrativeStore.worldState.integration.test.ts
+++ b/src/state/__tests__/narrativeStore.worldState.integration.test.ts
@@ -3,6 +3,8 @@ import { useWorldStore } from '../worldStore';
 import { useSessionStore } from '../sessionStore';
 import { useCharacterStore } from '../characterStore';
 import { createTestCharacterData } from './characterStore.testHelpers';
+import { extractWorldStateImpacts } from '../narrativeStore.worldStateImpacts';
+import type { Decision } from '../../types/narrative.types';
 const resetSessionStore = () => {
   useSessionStore.setState(() => ({
     id: null,
@@ -435,5 +437,63 @@ describe('Narrative store world state integration', () => {
       'Story begins at Ancient Chamber'
     );
     jest.restoreAllMocks();
+  });
+});
+
+describe('extractWorldStateImpacts major-event detection', () => {
+  const buildDecision = (prompt: string, optionText: string): Decision => ({
+    id: 'decision-1',
+    prompt,
+    options: [{ id: 'option-1', text: optionText }],
+  });
+
+  it('reads the same major events out of a decision whatever genre its prose wears', () => {
+    const fantasy = buildDecision(
+      'The square fills as word spreads. What do you do?',
+      "Join the kingdom's celebration in the square."
+    );
+    const civic = buildDecision(
+      'The square fills as word spreads. What do you do?',
+      "Join the borough's ribbon-cutting in the square."
+    );
+
+    const fantasyEvents = extractWorldStateImpacts(
+      fantasy,
+      fantasy.options[0],
+      'character-1'
+    ).events.map((event) => event.description);
+    const civicEvents = extractWorldStateImpacts(
+      civic,
+      civic.options[0],
+      'character-1'
+    ).events.map((event) => event.description);
+
+    expect(fantasyEvents).toEqual(civicEvents);
+  });
+
+  it('still records an event a consequence explicitly declares', () => {
+    const decision: Decision = {
+      id: 'decision-2',
+      prompt: 'The council calls the vote. How do you argue?',
+      options: [{ id: 'option-1', text: 'Read the inspection report aloud.' }],
+      consequences: [
+        {
+          type: 'narrative',
+          action: 'add',
+          targetId: 'event',
+          value: 'The council dissolved the water board.',
+        },
+      ],
+    };
+
+    const { events } = extractWorldStateImpacts(
+      decision,
+      decision.options[0],
+      'character-1'
+    );
+
+    expect(events.map((event) => event.description)).toEqual([
+      'The council dissolved the water board.',
+    ]);
   });
 });

--- a/src/state/narrativeStore.worldStateImpacts.ts
+++ b/src/state/narrativeStore.worldStateImpacts.ts
@@ -10,6 +10,10 @@ import {
  * Pure extraction of structured world-state impacts from a selected decision
  * option. No store coupling — narrativeStore.decisions.ts consumes the result
  * and pushes it into worldStore.
+ *
+ * Major events come only from what a consequence explicitly declares. Detecting
+ * a major event in prose is the model's job, via metadata.majorEvent and the
+ * significance-validation route, so it works for any world the player builds.
  */
 export interface ExtractedWorldStateImpact {
   relationships: Record<EntityID, NPCRelationshipUpdate>;
@@ -25,18 +29,6 @@ export type DecisionWorldStatePayload = {
   events: WorldStateMajorEventInput[];
   alignmentDelta: number;
 };
-
-const MAJOR_EVENT_PATTERNS: RegExp[] = [
-  /world[-\s]?changing/i,
-  /major\s+event/i,
-  /kingdom\s+(?:falls|celebrates|rejoices|crumbles)/i,
-  /celebration/i,
-  /catastrophe/i,
-  /disaster/i,
-  /uprising/i,
-  /war\s+erupts/i,
-  /reputation\s+(?:soars|plummets|spreads)/i,
-];
 
 const parseNumericValue = (value: unknown): number | undefined => {
   if (typeof value === 'number' && Number.isFinite(value)) {
@@ -177,39 +169,6 @@ export const extractWorldStateImpacts = (
   const optionConsequences = selectedOption.consequences ?? [];
   optionConsequences.forEach(handleConsequence);
   (decision.consequences ?? []).forEach(handleConsequence);
-
-  const candidateTexts: string[] = [];
-  const optionText = safeTrim(selectedOption.text || '');
-  if (optionText) candidateTexts.push(optionText);
-
-  const customText = safeTrim((selectedOption as { customText?: string }).customText ?? '');
-  if (customText) candidateTexts.push(customText);
-
-  const hintText = safeTrim((selectedOption as { hint?: string }).hint ?? '');
-  if (hintText) candidateTexts.push(hintText);
-
-  const decisionPrompt = safeTrim(decision.prompt || '');
-  if (decisionPrompt) candidateTexts.push(decisionPrompt);
-
-  const consequenceDescriptions = [...optionConsequences, ...(decision.consequences ?? [])]
-    .map((cons) => safeTrim(cons?.description || (typeof cons?.value === 'string' ? cons.value : '')))
-    .filter(Boolean) as string[];
-
-  candidateTexts.push(...consequenceDescriptions);
-
-  candidateTexts.forEach(text => {
-    const sentences = text.split(/(?<=[.!?])\s+/u);
-    sentences.forEach(sentence => {
-      const trimmed = safeTrim(sentence);
-      if (!trimmed) {
-        return;
-      }
-
-      if (MAJOR_EVENT_PATTERNS.some(pattern => pattern.test(trimmed))) {
-        queueMajorEvent(trimmed, characterId, processedDescriptions, events);
-      }
-    });
-  });
 
   for (const [npcId, update] of Object.entries(relationships)) {
     const meaningful =


### PR DESCRIPTION
## Description

`MAJOR_EVENT_PATTERNS` in `src/state/narrativeStore.worldStateImpacts.ts` was a list of fantasy regexes — `kingdom falls`, `celebration`, `catastrophe`, `uprising`, `war erupts`. It ran over the player's choice text, the option hint, and the decision prompt. In a civic drama or a slasher none of those words show up, so major-event detection silently never fired. It was the only genre-flavoured signal in the engine.

**I took option (a) from the issue — dropped the scan — and here's the verification behind it.**

**What the scan actually contributed.** It never gated the whole `events` array. `handleConsequence` already queues events unconditionally from `narrative` consequence values and `relationship` consequence descriptions. The regex pass was a *second* sweep over `selectedOption.text`, `customText`, `hint`, `decision.prompt`, and consequence descriptions. And in live play the choice parser (`parseConsequencesText` in `choiceGenerator.parser.ts`) only ever emits `relationship` consequences shaped `{ trustDelta }` with no `description` — so the scan's real-world input narrowed to the choice text, its hint, and the prompt. A choice a player is *considering* isn't an event that happened, and the prompt is the situation being posed, not an outcome.

**The significance-validator route genuinely covers this, and I checked it end to end rather than taking the issue's word:**

- `majorEventGuidelines` is imported by all five live narrative templates — `baseNarrativeTemplate`, `sceneTemplate`, `actionTemplate`, `transitionTemplate`, `initialSceneTemplate`. Its rules and worked examples are genre-neutral (the lead example is Groundhog Day, not a kingdom).
- `narrativeGenerator.response.parse.ts:179` lifts `metadata.majorEvent`; `narrativeStore.segments.ts:121` carries it through the metadata whitelist into `applyWorldStateThreadUpdates`, which runs on every `addSegment`.
- That function POSTs to `/api/narrative/validate-event-significance` → `validateEventSignificance`, fail-open, and on `isSignificant` writes to **the same sink** the regex path wrote to: `worldStore.updateWorldState(..., { majorEvents })`.
- Downstream consumers (`useStoryCheckpointManager`, `app/characters/page.tsx`) read `worldState.majorEvents` and don't care which path filled it.

So dropping the scan leaves no gap — it removes a duplicate, worse detector that only worked in one genre.

**Why not option (b), genre-neutral patterns.** A neutral lexicon is still a lexicon. Worse, it would start firing on the player's own choice text in *every* world instead of just fantasy ones, turning a silent fantasy-only bug into a noisy all-worlds one. The repo has already measured this dead end once: the continuity guardrail's lexicon step fired 1/33 (a false positive) and then 0/42, and the settled conclusion there was to feed the step from lore rather than from word lists.

**Archaeology check.** No doctrine entry covers this constant. `git log -S` traces it to #823 (the original active-session world-state persistence work); #1406 only moved it during the mechanical `narrativeStore` split. It was a placeholder heuristic, not a deliberate keep. Nothing else in the repo — code, tests, or docs — references `MAJOR_EVENT_PATTERNS`.

## Related Issue

Refs #1866

<!-- Note: this repo merges into `develop`, not the default branch, so a
`Closes` keyword would not auto-close. Closing #1866 manually post-merge. -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Both tests were added to the existing `src/state/__tests__/narrativeStore.worldState.integration.test.ts` rather than a parallel file.

**Red — before the fix:**

```
  extractWorldStateImpacts major-event detection
    ✕ reads the same major events out of a decision whatever genre its prose wears (6 ms)
    ✓ still records an event a consequence explicitly declares

  ● extractWorldStateImpacts major-event detection › reads the same major events
    out of a decision whatever genre its prose wears

    expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 3

    - Array []
    + Array [
    +   "Join the kingdom's celebration in the square.",
    + ]

Tests:       1 failed, 6 skipped, 1 passed, 8 total
EXIT=1
```

Two decisions with identical structure — one worded "Join the kingdom's celebration in the square", one "Join the borough's ribbon-cutting in the square". The fantasy wording stored the player's own choice text as a world major event; the civic wording stored nothing. That gap is the bug, in one assertion.

**Green — after the fix (whole file, including the six pre-existing tests):**

```
    ✓ updates world state when a decision with consequences is selected (50 ms)
    ✓ applies option-level trust deltas and alignment shifts from one selection (4 ms)
    ✓ writes nothing when the selected option has no consequences (6 ms)
    ✓ drops relationship deltas for NPCs not present in the latest segment (6 ms)
    ✓ marks session lifecycle status as ended when markSessionEnded is called (2 ms)
    ✓ creates checkpoint from opening scene ensuring Story So Far has content (1509 ms)
    ✓ reads the same major events out of a decision whatever genre its prose wears
    ✓ still records an event a consequence explicitly declares (1 ms)

Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
EXIT=0
```

The second test is the guard against over-deleting: a civic-drama decision whose consequence explicitly declares `"The council dissolved the water board."` still records it. It passes before and after, on purpose — it proves the drop removed the guessing, not the detection.

No existing test asserted the fantasy regexes, so nothing needed removing. The file's pre-existing major-event assertion (`'The kingdom celebrates your diplomatic victory.'`) reaches `queueMajorEvent` through the unconditional `narrative`-consequence path, not the regex, and still passes untouched.

## User Stories Addressed

As a player building a world that isn't fantasy, I want the story's major beats tracked the same way they would be in a fantasy world, so "The Story So Far" and my character's event history aren't empty.

## Flow Diagrams

N/A

## Component Development

N/A — no UI in this change.

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes

Net 45 lines deleted, 15 added (a doc comment plus the tests). The change is contained to `src/state/`; no new files, no new imports, no cross-domain moves.

Two incidental wins from the deletion: the `as { customText?: string }` and `as { hint?: string }` casts went with it, so the module now has no structural casts. `ExtractedWorldStateImpact.events` keeps its shape, so `narrativeStore.decisions.ts` needed no change at all.

The doc comment I added on `ExtractedWorldStateImpact` records the rationale — major events come only from what a consequence declares, because detecting one in prose is the model's job. No ticket number in it.

## Screenshots

N/A

## Visual Baseline Changes

None. This PR doesn't touch `tests/visual/**-snapshots/**`.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks

- [x] Linting passed
- [ ] Security audit passed
- [x] Type checking passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Run in the worktree, exit codes captured directly rather than piped:

```
npm run test:ci      FULL_TEST_EXIT=0   443 suites, 3071 tests, all passed
npm run type-check   TYPECHECK_EXIT=0
npm run lint         LINT_EXIT=0
npm run deps:validate DEPS_EXIT=0
npm run deps:check   DEPS_CHECK_EXIT=0  baseline holds at 17, all still reproducing
```

`lint:css` not run — no CSS touched. Security audit left unchecked; I didn't run it.

## Testing Instructions

```bash
npm test -- src/state/__tests__/narrativeStore.worldState.integration.test.ts
```

To see the original bug, revert the deletion in `src/state/narrativeStore.worldStateImpacts.ts` and re-run — the genre-parity test goes red with the diff quoted above.

In-app: play a turn in a non-fantasy world and confirm "The Story So Far" still fills from `metadata.majorEvent` via the significance-validation route. That path is unchanged by this PR and is already covered by the "creates checkpoint from opening scene" test in the same file.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) — N/A, nothing in `public_docs/` or the root docs referenced this
- [x] No new warnings generated
- [x] Accessibility considerations addressed — N/A, no UI
