### PR TITLE
Keep the player out of their own choice options

### DIFF
--- a/src/lib/ai/__tests__/choiceGenerator.prompt.alignedAssembly.test.ts
+++ b/src/lib/ai/__tests__/choiceGenerator.prompt.alignedAssembly.test.ts
@@ -162,4 +162,28 @@ describe('the player character in their own choice prompt', () => {
 
     expect(knownCharacterRoster(buildAlignedPrompt())).toContain('Mayor Thorn');
   });
+
+  it('keeps a scene NPC that shares the character list with the player', () => {
+    (useCharacterStore.getState as jest.Mock).mockReturnValue({
+      characters: {
+        'char-1': playerCharacter,
+        'npc-thorn': { ...playerCharacter, id: 'npc-thorn', name: 'Mayor Thorn', isPlayer: false },
+      },
+    });
+    seedNpcs([npc('npc-thorn', 'Mayor Thorn')]);
+
+    const roster = knownCharacterRoster(
+      buildChoicePrompt({
+        world: createMockWorld({ id: 'world-1', name: 'Test World' }),
+        worldId: 'world-1',
+        narrativeContext,
+        characterIds: ['char-1', 'npc-thorn'],
+        sessionId: 'session-1',
+        includeDecisionHistory: false,
+        useAlignedChoices: true,
+      })
+    );
+
+    expect(roster).toContain('Mayor Thorn');
+  });
 });

--- a/src/lib/ai/__tests__/choiceGenerator.prompt.alignedAssembly.test.ts
+++ b/src/lib/ai/__tests__/choiceGenerator.prompt.alignedAssembly.test.ts
@@ -3,6 +3,8 @@ import type { NarrativeContext } from '@/types/narrative.types';
 import { createMockWorld } from '@/lib/test-utils/testDataFactory';
 import { useCharacterStore } from '@/state/characterStore';
 import type { Character as StoreCharacter } from '@/state/characterStore';
+import { useNPCStore } from '@/state/npcStore';
+import type { NPC } from '@/types/npc.types';
 
 // The template registry is deliberately NOT mocked here. Every other suite
 // stubs it out, which is why a contradiction between the aligned template and
@@ -22,9 +24,7 @@ jest.mock('@/state/inventoryStore', () => ({
 
 jest.mock('@/state/npcStore', () => ({
   useNPCStore: {
-    getState: jest.fn().mockReturnValue({
-      getNPCsByWorld: jest.fn(() => []),
-    }),
+    getState: jest.fn(),
   },
 }));
 
@@ -85,11 +85,31 @@ const buildAlignedPrompt = (): string =>
     useAlignedChoices: true,
   });
 
+const npc = (id: string, name: string): NPC =>
+  ({
+    id,
+    name,
+    worldId: 'world-1',
+    description: 'Someone in the scene.',
+    createdAt: '2023-01-01',
+    updatedAt: '2023-01-01',
+  }) as NPC;
+
+const seedNpcs = (npcs: NPC[]) => {
+  (useNPCStore.getState as jest.Mock).mockReturnValue({
+    getNPCsByWorld: jest.fn(() => npcs),
+  });
+};
+
+const knownCharacterRoster = (prompt: string): string =>
+  prompt.split('KNOWN CHARACTERS (use these exact names):')[1]?.split('\n\n')[0] ?? '';
+
 describe('assembled aligned choice prompt', () => {
   beforeEach(() => {
     (useCharacterStore.getState as jest.Mock).mockReturnValue({
       characters: { 'char-1': playerCharacter },
     });
+    seedNpcs([]);
   });
 
   it('asks for three options', () => {
@@ -103,5 +123,43 @@ describe('assembled aligned choice prompt', () => {
     expect(prompt).not.toMatch(/required alignment distribution/i);
     expect(prompt).not.toMatch(/NOT the distribution/i);
     expect(prompt).not.toContain('1 lawful, 2 neutral, 1 chaotic');
+  });
+});
+
+describe('the player character in their own choice prompt', () => {
+  beforeEach(() => {
+    (useCharacterStore.getState as jest.Mock).mockReturnValue({
+      characters: { 'char-1': playerCharacter },
+    });
+  });
+
+  it('drops an NPC-store entry wearing the player name from the known-characters roster', () => {
+    seedNpcs([npc('npc-thorn', 'Mayor Thorn'), npc('npc-stray', 'Player One')]);
+
+    const roster = knownCharacterRoster(buildAlignedPrompt());
+
+    expect(roster).toContain('Mayor Thorn');
+    expect(roster).not.toContain('Player One');
+  });
+
+  it('drops the player even when the store entry differs only by spacing and case', () => {
+    seedNpcs([npc('npc-thorn', 'Mayor Thorn'), npc('npc-stray', '  player  one ')]);
+
+    expect(knownCharacterRoster(buildAlignedPrompt())).not.toMatch(/player\s+one/i);
+  });
+
+  it('tells the prompt who the protagonist is so options are their own actions', () => {
+    seedNpcs([npc('npc-thorn', 'Mayor Thorn')]);
+
+    const prompt = buildAlignedPrompt();
+
+    expect(prompt).toContain('PROTAGONIST: The player is Player One.');
+    expect(prompt).toMatch(/never the person an option targets/i);
+  });
+
+  it('still emits the roster when every NPC is a genuine third party', () => {
+    seedNpcs([npc('npc-thorn', 'Mayor Thorn')]);
+
+    expect(knownCharacterRoster(buildAlignedPrompt())).toContain('Mayor Thorn');
   });
 });

--- a/src/lib/ai/choiceGenerator.prompt.ts
+++ b/src/lib/ai/choiceGenerator.prompt.ts
@@ -1,5 +1,6 @@
 import { getNarrativeTemplate } from '../promptTemplates/narrativeTemplateManager';
 import { useCharacterStore } from '@/state/characterStore';
+import type { Character as StoreCharacter } from '@/state/characterStore';
 import { useInventoryStore } from '@/state/inventoryStore';
 import { useNPCStore } from '@/state/npcStore';
 import { useSessionStore } from '@/state/sessionStore';
@@ -110,7 +111,7 @@ const buildContext = (
   characterIds: string[],
   maxOptions?: number
 ) => {
-  const playerCharacterName = getPlayerCharacter(characterIds)?.name;
+  const playerCharacter = getPlayerCharacter(characterIds);
 
   return {
     worldName: world.name,
@@ -119,14 +120,14 @@ const buildContext = (
     narrativeContext,
     characterIds,
     optionCount: maxOptions,
-    playerCharacterName,
+    playerCharacterName: playerCharacter?.name,
     worldSkills:
       world.skills?.map((skill) => ({
         id: skill.id,
         name: skill.name,
         description: skill.description,
       })) || [],
-    worldNpcs: getWorldNpcs(world.id, characterIds, playerCharacterName),
+    worldNpcs: getWorldNpcs(world.id, playerCharacter),
   };
 };
 
@@ -155,13 +156,12 @@ const getPlayerCharacter = (characterIds: string[]) => {
  */
 const getWorldNpcs = (
   worldId: string,
-  characterIds: string[],
-  playerCharacterName?: string
+  playerCharacter?: StoreCharacter
 ): Array<{ id: string; name: string }> => {
   try {
-    const playerIds = new Set(characterIds);
-    const reservedName = playerCharacterName
-      ? canonicalizeName(playerCharacterName)
+    const playerId = playerCharacter?.id;
+    const reservedName = playerCharacter?.name
+      ? canonicalizeName(playerCharacter.name)
       : '';
 
     return useNPCStore
@@ -169,7 +169,7 @@ const getWorldNpcs = (
       .getNPCsByWorld(worldId)
       .filter((npc) => {
         const isPlayer =
-          playerIds.has(npc.id) ||
+          (!!playerId && npc.id === playerId) ||
           (!!reservedName && canonicalizeName(npc.name) === reservedName);
         if (isPlayer) {
           logger.debug('Dropped an NPC entry claiming the player identity', {

--- a/src/lib/ai/choiceGenerator.prompt.ts
+++ b/src/lib/ai/choiceGenerator.prompt.ts
@@ -16,6 +16,7 @@ import type { NarrativeContext } from '@/types/narrative.types';
 import type { World } from '@/types/world.types';
 import type { EntityID } from '@/types/common.types';
 import { logger } from '@/lib/utils/logger';
+import { canonicalizeName } from '@/lib/utils/textNormalization';
 interface ChoicePromptInput {
   world: World;
   worldId: string;
@@ -108,27 +109,76 @@ const buildContext = (
   narrativeContext: NarrativeContext,
   characterIds: string[],
   maxOptions?: number
-) => ({
-  worldName: world.name,
-  worldDescription: world.description,
-  genre: world.genre,
-  narrativeContext,
-  characterIds,
-  optionCount: maxOptions,
-  worldSkills:
-    world.skills?.map((skill) => ({
-      id: skill.id,
-      name: skill.name,
-      description: skill.description,
-    })) || [],
-  worldNpcs: getWorldNpcs(world.id),
-});
+) => {
+  const playerCharacterName = getPlayerCharacter(characterIds)?.name;
 
-const getWorldNpcs = (worldId: string): Array<{ id: string; name: string }> => {
+  return {
+    worldName: world.name,
+    worldDescription: world.description,
+    genre: world.genre,
+    narrativeContext,
+    characterIds,
+    optionCount: maxOptions,
+    playerCharacterName,
+    worldSkills:
+      world.skills?.map((skill) => ({
+        id: skill.id,
+        name: skill.name,
+        description: skill.description,
+      })) || [],
+    worldNpcs: getWorldNpcs(world.id, characterIds, playerCharacterName),
+  };
+};
+
+const getPlayerCharacter = (characterIds: string[]) => {
   try {
+    if (!characterIds || characterIds.length === 0) return undefined;
+    const { characters } = useCharacterStore.getState();
+    for (const characterId of characterIds) {
+      const character = characters[characterId];
+      if (character?.isPlayer) return character;
+    }
+    return characterIds.length === 1 ? characters[characterIds[0]] : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * The world's NPCs minus the player.
+ *
+ * Nothing stops the player landing in the NPC store: every entry the narrative
+ * model puts in metadata.characters is synced there, and a model that writes
+ * the protagonist into that list mints them an NPC. Left in, they arrive here
+ * under a heading that tells the model to use these exact names, and it duly
+ * writes options that negotiate with the player.
+ */
+const getWorldNpcs = (
+  worldId: string,
+  characterIds: string[],
+  playerCharacterName?: string
+): Array<{ id: string; name: string }> => {
+  try {
+    const playerIds = new Set(characterIds);
+    const reservedName = playerCharacterName
+      ? canonicalizeName(playerCharacterName)
+      : '';
+
     return useNPCStore
       .getState()
       .getNPCsByWorld(worldId)
+      .filter((npc) => {
+        const isPlayer =
+          playerIds.has(npc.id) ||
+          (!!reservedName && canonicalizeName(npc.name) === reservedName);
+        if (isPlayer) {
+          logger.debug('Dropped an NPC entry claiming the player identity', {
+            npcId: npc.id,
+            name: npc.name,
+          });
+        }
+        return !isPlayer;
+      })
       .map((npc) => ({ id: npc.id, name: npc.name }));
   } catch {
     return [];
@@ -235,19 +285,7 @@ const enhancePromptWithPersonality = (
   useAlignedChoices: boolean
 ): string => {
   try {
-    if (!characterIds || characterIds.length === 0) return prompt;
-    const { characters } = useCharacterStore.getState();
-    let playerCharacter;
-    for (const characterId of characterIds) {
-      const character = characters[characterId];
-      if (character?.isPlayer) {
-        playerCharacter = character;
-        break;
-      }
-    }
-    if (!playerCharacter && characterIds.length === 1) {
-      playerCharacter = characters[characterIds[0]];
-    }
+    const playerCharacter = getPlayerCharacter(characterIds);
     if (!playerCharacter) return prompt;
     const personalitySection = formatPersonalityForChoices(
       playerCharacter,

--- a/src/lib/ai/structuredLoreExtractor.ts
+++ b/src/lib/ai/structuredLoreExtractor.ts
@@ -5,7 +5,7 @@
 
 import { createDefaultGeminiClient } from './defaultGeminiClient';
 import { extractFencedJson } from './parseJSON';
-import { normalizeText, NORM_NAME } from '@/lib/utils/textNormalization';
+import { canonicalizeName } from '@/lib/utils/textNormalization';
 import type {
   LoreContinuityAnnotation,
   LoreContinuityKind,
@@ -280,9 +280,6 @@ function validateAndCleanExtraction(extraction: unknown): StructuredLoreExtracti
 
   return cleaned;
 }
-
-const canonicalizeName = (name: string): string =>
-  normalizeText(name, NORM_NAME).trim().toLowerCase();
 
 /**
  * Reserves the player character's name against the extracted lore.

--- a/src/lib/promptTemplates/templates/narrative/__tests__/choiceTemplates.test.ts
+++ b/src/lib/promptTemplates/templates/narrative/__tests__/choiceTemplates.test.ts
@@ -66,3 +66,19 @@ describe('choice templates ask for as many options as the interface shows', () =
     expect(prompt).toMatch(/do NOT repeat the same mix turn after turn/i);
   });
 });
+
+describe('choice templates keep the player out of their own options', () => {
+  it('names the protagonist and rules them out as a target in the aligned template', () => {
+    const prompt = alignedChoiceTemplate({
+      ...baseContext,
+      playerCharacterName: 'Wren Calloway',
+    });
+
+    expect(prompt).toContain('PROTAGONIST: The player is Wren Calloway.');
+    expect(prompt).toMatch(/never the person an option targets/i);
+  });
+
+  it('says nothing about a protagonist when no player name is supplied', () => {
+    expect(alignedChoiceTemplate(baseContext)).not.toContain('PROTAGONIST:');
+  });
+});

--- a/src/lib/promptTemplates/templates/narrative/choiceTypeTemplates.ts
+++ b/src/lib/promptTemplates/templates/narrative/choiceTypeTemplates.ts
@@ -1,4 +1,5 @@
 import { NarrativeContext } from '@/types/narrative.types';
+import { protagonistGuidance } from './protagonistGuidance';
 
 interface PlayerChoiceTemplateContext {
   worldName: string;
@@ -16,6 +17,7 @@ interface PlayerChoiceTemplateContext {
     id: string;
     name: string;
   }>;
+  playerCharacterName?: string;
 }
 
 /**
@@ -31,7 +33,7 @@ interface PlayerChoiceTemplateContext {
  * order, and a chaotic option has to be one a player might really take.
  */
 export const alignedChoiceTemplate = (context: PlayerChoiceTemplateContext): string => {
-  const { worldName, genre, narrativeContext, worldSkills, worldNpcs, optionCount } = context;
+  const { worldName, genre, narrativeContext, worldSkills, worldNpcs, optionCount, playerCharacterName } = context;
   const choiceCount =
     typeof optionCount === 'number' && Number.isFinite(optionCount)
       ? Math.max(1, Math.floor(optionCount))
@@ -66,6 +68,8 @@ AVAILABLE SKILLS IN THIS WORLD:
 ${worldSkills.map(skill => `- ${skill.name}: ${skill.description}`).join('\n')}`;
   }
 
+  const protagonistInfo = protagonistGuidance(playerCharacterName);
+
   // Known-character roster + consequence contract; only emitted when the
   // world has NPCs so the parser has names to resolve against.
   const hasNpcs = !!worldNpcs && worldNpcs.length > 0;
@@ -97,7 +101,7 @@ LOCATION: ${location || 'Unknown location'}
 SITUATION: ${narrativeContext?.currentSituation || 'General scenario'}
 
 FULL CONTEXT:
-${shortContext}${skillsInfo}${npcInfo}
+${shortContext}${skillsInfo}${protagonistInfo}${npcInfo}
 
 === CRITICAL INSTRUCTIONS ===
 You MUST create choices that directly respond to the specific situation described above. Do NOT create generic choices. Reference the specific characters, objects, and events mentioned in the context.

--- a/src/lib/promptTemplates/templates/narrative/playerChoiceTemplate.ts
+++ b/src/lib/promptTemplates/templates/narrative/playerChoiceTemplate.ts
@@ -1,5 +1,6 @@
 import { NarrativeContext } from '@/types/narrative.types';
 import { CHOICE_EXAMPLES, shouldIncludeExamples } from '../../examples';
+import { protagonistGuidance } from './protagonistGuidance';
 
 interface PlayerChoiceTemplateContext {
   worldName: string;
@@ -17,6 +18,7 @@ interface PlayerChoiceTemplateContext {
     id: string;
     name: string;
   }>;
+  playerCharacterName?: string;
 }
 
 /**
@@ -24,7 +26,7 @@ interface PlayerChoiceTemplateContext {
  * Generates a decision prompt and options based on the current narrative context
  */
 export const playerChoiceTemplate = (context: PlayerChoiceTemplateContext): string => {
-  const { worldName, genre, narrativeContext, worldSkills, worldNpcs, optionCount } = context;
+  const { worldName, genre, narrativeContext, worldSkills, worldNpcs, optionCount, playerCharacterName } = context;
   const choiceCount =
     typeof optionCount === 'number' && Number.isFinite(optionCount)
       ? Math.max(1, Math.floor(optionCount))
@@ -60,6 +62,8 @@ AVAILABLE SKILLS IN THIS WORLD:
 ${worldSkills.map(skill => `- ${skill.name}: ${skill.description}`).join('\n')}`;
   }
 
+  const protagonistInfo = protagonistGuidance(playerCharacterName);
+
   // Build the known-character roster + consequence instructions. Only emitted
   // when the world has NPCs, so the parser has names to resolve against.
   const hasNpcs = !!worldNpcs && worldNpcs.length > 0;
@@ -88,7 +92,7 @@ ${genre ? `Genre: ${genre}` : ''}
 
 CURRENT CONTEXT (brief summary):
 ${shortContext}
-${location ? `Current location: ${location}` : ''}${skillsInfo}${npcInfo}
+${location ? `Current location: ${location}` : ''}${skillsInfo}${protagonistInfo}${npcInfo}
 
 INSTRUCTIONS:
 Based on the ENTIRE narrative context (both beginning and end if provided), create ${choiceCount} distinct action choices that:

--- a/src/lib/promptTemplates/templates/narrative/protagonistGuidance.ts
+++ b/src/lib/promptTemplates/templates/narrative/protagonistGuidance.ts
@@ -1,0 +1,18 @@
+/**
+ * The one place a choice prompt learns who the player is.
+ *
+ * Choice prompts carry a roster of named characters and a slab of narrative
+ * prose, and the player's name turns up in both - other characters address
+ * them by name, so it is in the passage whether or not it is in the roster.
+ * Without this block nothing marks which of those names belongs to the person
+ * making the choice, and the model writes options that question, negotiate
+ * with, or demand answers from the player themselves.
+ */
+export const protagonistGuidance = (playerCharacterName?: string): string => {
+  const name = playerCharacterName?.trim();
+  if (!name) return '';
+
+  return `
+
+PROTAGONIST: The player is ${name}. Every option is an action they take, so ${name} is never the person an option targets, questions, or bargains with. Any other name in the context belongs to someone else in the scene.`;
+};

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -27,7 +27,7 @@ export {
 } from './formatters';
 
 /** Text normalization utilities for consistent text formatting */
-export { normalizeText, NORM_NAME, NORM_DESC } from './textNormalization';
+export { normalizeText, NORM_NAME, NORM_DESC, canonicalizeName } from './textNormalization';
 
 // Validation utilities
 export { type ValidationResult } from './validationUtils';

--- a/src/lib/utils/textNormalization.ts
+++ b/src/lib/utils/textNormalization.ts
@@ -135,3 +135,14 @@ function normalizeSpecialCharacters(text: string): string {
     .replace(/–/g, '-')   // En dash → hyphen
     .replace(/…/g, '...'); // Ellipsis → three periods
 }
+
+/**
+ * Folds a character name to a comparison key.
+ *
+ * Names reach us from three places that punctuate differently - the character
+ * sheet, AI-generated metadata, and prose - so an exact match is too strict to
+ * tell "the player" from "a third party wearing the player's name".
+ */
+export function canonicalizeName(name: string): string {
+  return normalizeText(name, NORM_NAME).trim().toLowerCase();
+}


### PR DESCRIPTION
## Description

Generated choices were casting the player as somebody else in the scene — asking Mayor Thorn what the player wanted, demanding documentation of the player's deadline. This fixes that half of #1830.

The root cause is that the choice prompt never knew who the player was. It emitted a roster headed `KNOWN CHARACTERS (use these exact names)` plus a slab of narrative prose, and the player's name could be in either one. It's in the prose by design — `sceneTemplate` tells the narrative model to use the player's name when other characters address them. And nothing kept the player out of the NPC store that feeds the roster: `syncNpcMetadata` creates an NPC for every entry the narrative model puts in `metadata.characters`, and `baseNarrativeTemplate` never tells it to leave the protagonist out. The lore extractor got exactly this guard in #1855 (`reservePlayerCharacterName`); the NPC sync and the choice roster never did.

So the model saw a list of names, no marker for which one was the player, and an instruction to use those exact names. It duly wrote options targeting the protagonist.

Two changes, both small:

1. **Filter the data.** `getWorldNpcs` in `choiceGenerator.prompt.ts` now drops any NPC matching the player by id or canonicalized name, mirroring `reservePlayerCharacterName`.
2. **Name the protagonist.** The choice templates now emit a `PROTAGONIST:` line stating who the player is and that they are never the target of their own options. This is the half that still holds when the model picks the name out of the prose rather than the roster — filtering alone wouldn't cover that vector.

`canonicalizeName` moves from `structuredLoreExtractor.ts` into `textNormalization.ts` so there's one copy rather than two.

## Related Issue

Refs #1830 — deliberately **not** a closing keyword.

This PR implements only the first acceptance criterion, "the player character never appears as a target or counterparty in their own options". The second half of the issue — options re-offering business the story already settled — is a separate no-ledger problem in the #1822 family and stays open. The issue should stay open too.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Tests went in first and failed for the right reason. Red, before any fix:

```
● the player character in their own choice prompt › drops an NPC-store entry
  wearing the player name from the known-characters roster

    expect(received).not.toContain(expected) // indexOf

    Expected substring: not "Player One"
    Received string:        "
    - Mayor Thorn
    - Player One"

Test Suites: 2 failed, 2 total
Tests:       4 failed, 8 passed, 12 total
```

That received string is the bug itself: the player sitting in the roster next to a real NPC.

Green, after:

```
Test Suites: 2 passed, 2 total
Tests:       12 passed, 12 total
```

Two of the twelve are controls that passed in both runs on purpose — the roster still lists genuine third parties, and no `PROTAGONIST:` line appears when there's no player name to state.

## User Stories Addressed

As a player, I want the options I'm offered to be actions my character can actually take, so that a turn always has a real move on it. At T20 of the round-4 playtest all three options asked an NPC about the player, so there was no correct option at all.

## Flow Diagrams

N/A

## Component Development

N/A — no UI in this change.

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes

Where the fix sits, and why: the filtering happens in the assembly layer (`choiceGenerator.prompt.ts`), not inside the templates, matching how `reservePlayerCharacterName` filters lore before it reaches a prompt. Templates stay formatters. That also means both choice templates get the roster fix for free.

`playerChoiceTemplate` gets the same treatment as `alignedChoiceTemplate`. It isn't the live path — both real call sites pass `useAlignedChoices: true` — but it isn't dead either: it's the default branch of `generateChoices`, one argument away from being used, and it had the identical roster bug. Leaving a known-broken default in place seemed worse than the four lines it took to fix.

Prompt governance gates: the context contract grew one deliberate field (`playerCharacterName`), no new state is leaked to the prompt, and no parser-visible structure changed — the `PROTAGONIST:` block is prose inserted ahead of the roster, and the Options/Requirements/Consequences format the parsers key off is untouched. Cost delta is roughly 45 tokens per choice turn.

One honest gap: `choiceGenerator.prompt.ts` is 361 lines, over the 300-line guideline. It was already 323 before this change, so this isn't where it went wrong, and splitting it felt like scope creep on a bug fix. Worth a follow-up.

## Screenshots

N/A

## Visual Baseline Changes

None — this PR doesn't touch `tests/visual/**-snapshots/**`.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Run locally in the worktree, exit codes checked directly:

| Gate | Exit | Result |
|---|---|---|
| `npm test` | 0 | 443 suites, 3075 tests, all passing |
| `npm run type-check` | 0 | clean |
| `npm run lint` | 0 | 0 errors, 127 pre-existing warnings |
| `npm run deps:validate` | 0 | no violations, 17 known ignored |

`npm run lint:css` wasn't run — no `.css` file is touched. Security audit wasn't run locally; CI covers it.

## Testing Instructions

Unit level:

```bash
npx jest src/lib/ai/__tests__/choiceGenerator.prompt.alignedAssembly.test.ts \
         src/lib/promptTemplates/templates/narrative/__tests__/choiceTemplates.test.ts
```

To see it fail first, revert the filter in `getWorldNpcs` and re-run.

Live: start a session, play until the narrative names your character in dialogue, then read the options. They should be actions your character takes, never questions put to someone else *about* your character.

**The live verification is not done.** The issue's third acceptance criterion asks for a real run per `narraitor-playtest-loop`, and that hasn't happened for this change. A prompt change is a behavior change, and unit tests only prove the prompt is assembled correctly — they can't prove the model stopped doing it. Treat this as the mechanism being fixed, not the behavior being confirmed. The measurement round should cover it alongside the rest of the #1830 work.

## Checklist

- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file) — see Implementation Notes
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) — not required
- [x] No new warnings generated
- [x] Accessibility considerations addressed — N/A, no UI
