### PR TITLE
Tell the model to put a blank line between paragraphs

### DIFF
--- a/src/lib/promptTemplates/templates/__tests__/narrativeLength.test.ts
+++ b/src/lib/promptTemplates/templates/__tests__/narrativeLength.test.ts
@@ -28,18 +28,16 @@ describe('resolveNarrativeLength', () => {
   });
 });
 
-describe('sceneTemplate length instruction', () => {
-  const buildScene = (
-    generationParameters?: Record<string, unknown>
-  ) =>
-    sceneTemplate({
-      worldName: 'Testworld',
-      genre: 'fantasy',
-      tone: 'grim',
-      narrativeContext: { recentSegments: [{ content: 'Something happened.' }] },
-      generationParameters,
-    } as Parameters<typeof sceneTemplate>[0]);
+const buildScene = (generationParameters?: Record<string, unknown>) =>
+  sceneTemplate({
+    worldName: 'Testworld',
+    genre: 'fantasy',
+    tone: 'grim',
+    narrativeContext: { recentSegments: [{ content: 'Something happened.' }] },
+    generationParameters,
+  } as Parameters<typeof sceneTemplate>[0]);
 
+describe('sceneTemplate length instruction', () => {
   it('no longer hardcodes a 3-5 sentence cap', () => {
     const longScene = buildScene({ desiredLength: 'long' });
     expect(longScene).toContain(describeNarrativeLength({ desiredLength: 'long' }));
@@ -51,5 +49,20 @@ describe('sceneTemplate length instruction', () => {
     expect(buildScene({ decisionWeight: 'minor' })).toContain(
       '3-5 sentences (1 focused paragraph)'
     );
+  });
+});
+
+// The renderer splits on a blank line and the model will otherwise satisfy
+// "1-2 paragraphs" as one unbroken block, so the separator has to be asked for
+// in the prompt the loop actually sends.
+describe('sceneTemplate paragraph separator instruction', () => {
+  it('asks for a blank line between paragraphs at medium length', () => {
+    expect(buildScene({ desiredLength: 'medium' })).toMatch(/blank line/i);
+  });
+
+  it('asks for it at every length the loop can request', () => {
+    for (const desiredLength of ['short', 'medium', 'long']) {
+      expect(buildScene({ desiredLength })).toMatch(/blank line/i);
+    }
   });
 });

--- a/src/lib/promptTemplates/templates/narrative/narrativeLength.ts
+++ b/src/lib/promptTemplates/templates/narrative/narrativeLength.ts
@@ -7,6 +7,14 @@ const LENGTH_GUIDE: Record<NarrativeLength, string> = {
 };
 
 /**
+ * The reader only sees paragraphs where the renderer can split on a blank line.
+ * A model told to write "1-2 paragraphs" will happily satisfy that as one
+ * unbroken block, so the separator has to be asked for outright.
+ */
+export const PARAGRAPH_SEPARATOR_INSTRUCTION =
+  'Separate each paragraph with a blank line (one empty line between them), never a single line break';
+
+/**
  * Weightier beats earn more room on the page. Without this every segment comes
  * back the same size, which is a large part of why long sessions read flat.
  * decisionWeight is the only length signal available before generation —

--- a/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
+++ b/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
@@ -1,7 +1,10 @@
 import { PERSPECTIVE_EXAMPLES, shouldIncludeExamples } from '../../examples';
 import { majorEventGuidelines } from './majorEventGuidelines';
 import { worldClockBlock } from './worldClockBlock';
-import { describeNarrativeLength } from './narrativeLength';
+import {
+  describeNarrativeLength,
+  PARAGRAPH_SEPARATOR_INSTRUCTION,
+} from './narrativeLength';
 import type { NarrativeTemplateContext } from './context';
 import { isPacingStale } from '@/lib/narrative/turnsSinceComplication';
 
@@ -192,6 +195,7 @@ Generate a ${segmentType} that:
 4. Advances the story forward in time (never backward)
 5. Maintains the ${tone} tone
 6. Is approximately ${lengthDescription} in length
+7. ${PARAGRAPH_SEPARATOR_INSTRUCTION}
 
 ${(worldName && (worldName.toLowerCase().includes('1990') || worldName.toLowerCase().includes('1980') || worldName.toLowerCase().includes('1970'))) || (genre && (genre.toLowerCase().includes('modern') || genre.toLowerCase().includes('contemporary') || genre.toLowerCase().includes('realistic'))) ? `
 


### PR DESCRIPTION
## Description

Story segments were arriving as one unbroken run of text, so the play surface rendered paragraphs up to 2,600 characters with nothing to break on. The root cause sits in the prompt, not the renderer.

`FormattedNarrativeContent` splits paragraphs on a blank line (`/(?:\n\s*){2,}/`), which is a reasonable contract, but nothing upheld the other end of it. `narrativeLength.ts` asks for "1-2 paragraphs" or "3-4 paragraphs" without ever saying how to separate them, so the model satisfies the instruction semantically and ships the result as one continuous block.

The fix adds a single instruction to the assembled scene prompt, exported as `PARAGRAPH_SEPARATOR_INSTRUCTION` from `narrativeLength.ts` so it lives next to the length guidance that creates the need for it, and stays inside the template registry rather than being inlined into a generator or route.

## Related Issue

Closes #1906

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The test went in first and was confirmed red before the template changed:

```
● sceneTemplate paragraph separator instruction › asks for a blank line between paragraphs at medium length
  expect(received).toMatch(expected)
  Expected pattern: /blank line/i

Tests: 2 failed, 5 passed, 7 total   (exit 1)
```

After the fix:

```
Tests: 7 passed, 7 total   (exit 0)
```

The assertions run against the output of `sceneTemplate(...)`, the assembled prompt, rather than against the exported constant. Asserting that a string you just authored equals itself proves nothing about the layer that produces what the model sees.

## User Stories Addressed

As a player, I want generated prose broken into readable paragraphs instead of a single wall of text.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A. No component or style changes, prompt text only.

## Implementation Notes

Which prompts actually reach the model on a live turn drove where the line went. Four templates produce prose: `scene`, `initialScene`, `transition`, and `skillAcknowledgment` (via `getTemplate` in `narrativeGenerator.ts`). Of those, `sceneTemplate` is the main story loop and the only one whose length can exceed a single paragraph, since it is the one that renders `describeNarrativeLength`. The rest are capped by construction:

| Template | Length instruction | Needs a separator |
|---|---|---|
| `sceneTemplate` | `describeNarrativeLength` (up to "3-4 paragraphs") | Yes |
| `initialSceneTemplate` | "exactly 1 paragraph of 3-5 sentences" | No |
| `transitionTemplate` | "concise (1-2 sentences)" | No |
| `skillAcknowledgmentTemplate` | "focused and concise (2-4 sentences)" | No |
| `actionTemplate` | "2 to 4 sentences max" | No, and never reached by a generator |

`baseNarrativeTemplate` also renders `describeNarrativeLength`, but `getTemplate('base')` is never called, so it is a dead path and was left alone. The choice templates (`playerChoice`, `alignedPlayerChoice`) generate choices rather than prose and are out of scope.

Against the governance gates: the change reads no new context fields (G1), adds no state the narrative shouldn't have (G2), and touches no structure any parser depends on since it only affects whitespace inside the `content` string (G3). Cost delta is roughly 25 tokens per scene turn (G6).

## Screenshots

N/A

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit not run, it isn't part of this repo's gate and nothing here touches dependencies or credentials.

| Command | Exit code |
|---|---|
| `npm test -- src/lib/promptTemplates/templates/__tests__/narrativeLength.test.ts` | 0 |
| `npm run type-check` | 0 |
| `npm run lint` | 0 (127 pre-existing warnings, 0 errors) |
| `npm test` | 0 (443 suites, 3086 tests) |

`npm run lint:css` was skipped since no CSS changed.

## Testing Instructions

Unit level: `npm test -- src/lib/promptTemplates/templates/__tests__/narrativeLength.test.ts`. The two new cases assert the blank-line instruction survives into the assembled scene prompt at every length the loop can request.

Live level, and this is the part that is NOT verified: acceptance criterion 2 ("segments at `medium` length arrive with at least one paragraph break the renderer can split on") needs a real model and has not been checked. Confirming it means playing a session against live Gemini with a world whose decisions carry `major` weight, then counting `\n\n` occurrences per stored segment the way the issue's original 35-turn sample did. The baseline to beat is 19 of 24 segments with zero newlines. Until someone runs that, this PR should be read as fixing the prompt-side cause with the effect unmeasured.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

Documentation needed no update. Readable paragraph structure is a small accessibility win for screen readers and for anyone parsing long prose, since the renderer now has real `<p>` boundaries to emit.
