### PR TITLE
Make eight tests able to fail

### DIFF
--- a/src/components/GameSession/__tests__/ActiveGameSessionChoicesColumn.test.tsx
+++ b/src/components/GameSession/__tests__/ActiveGameSessionChoicesColumn.test.tsx
@@ -4,8 +4,12 @@ import ActiveGameSessionChoicesColumn from '../ActiveGameSessionChoicesColumn';
 import { ChoiceSelector } from '@/components/shared/ChoiceSelector';
 import type { Decision } from '@/types/narrative.types';
 
+// The stub renders whatever lands in inputActions, so a test can assert on the
+// controls the player would actually get rather than on the prop's existence.
 jest.mock('@/components/shared/ChoiceSelector', () => ({
-  ChoiceSelector: jest.fn(() => <div data-testid="choice-selector" />),
+  ChoiceSelector: jest.fn((props: { inputActions?: React.ReactNode }) => (
+    <div data-testid="choice-selector">{props.inputActions}</div>
+  )),
 }));
 
 const baseDecision: Decision = {
@@ -124,7 +128,7 @@ describe('ActiveGameSessionChoicesColumn', () => {
     ).toBeInTheDocument();
   });
 
-  it('passes end story action to desktop input actions when progressive disclosure is enabled', () => {
+  it('puts the end story action in the desktop input row when progressive disclosure is enabled', () => {
     render(
       <ActiveGameSessionChoicesColumn
         {...baseProps}
@@ -133,11 +137,27 @@ describe('ActiveGameSessionChoicesColumn', () => {
       />
     );
 
-    const selectorProps = (ChoiceSelector as jest.Mock).mock.calls[0][0] as {
-      inputActions?: React.ReactNode;
-    };
+    // The action is placed twice, once in the mobile rail and once in the
+    // desktop input row, with CSS picking the one that shows.
+    const placements = screen.getAllByRole('button', { name: 'End Story' });
+    expect(placements).toHaveLength(2);
+    expect(
+      placements.map((button) => button.parentElement?.className)
+    ).toEqual(
+      expect.arrayContaining(['manuscript-end-story-mobile', 'manuscript-end-story-desktop'])
+    );
+  });
 
-    expect(selectorProps.inputActions).toBeTruthy();
+  it('leaves the end story action out when progressive disclosure is off', () => {
+    render(
+      <ActiveGameSessionChoicesColumn
+        {...baseProps}
+        isProgressiveDisclosureEnabled={false}
+        endStoryAction={<button type="button">End Story</button>}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'End Story' })).toBeNull();
   });
 
   describe('generation error surface (#1478)', () => {

--- a/src/components/GameSession/__tests__/CharacterSummary.test.tsx
+++ b/src/components/GameSession/__tests__/CharacterSummary.test.tsx
@@ -46,81 +46,74 @@ describe('CharacterSummary', () => {
   };
 
   describe('Core Functionality', () => {
-    it('displays character name prominently', () => {
+    it('renders the character identity: name, level, and portrait', () => {
       render(<CharacterSummary character={mockCharacter} />);
-      
+
       expect(screen.getByText('Aldric the Bold')).toBeInTheDocument();
+      expect(screen.getByText(/Level 5/)).toBeInTheDocument();
+      expect(screen.getByRole('img', { name: /Aldric the Bold/i })).toBeInTheDocument();
     });
 
-    it('displays character history when expanded', async () => {
+    it('expands the details on request and collapses them again', async () => {
       const user = userEvent.setup();
       render(<CharacterSummary character={mockCharacter} />);
-      
-      // History should be collapsed by default
-      expect(screen.queryByText('Raised in a noble family, trained in the art of combat since childhood')).not.toBeInTheDocument();
-      
-      // Click to expand
-      const expandButton = screen.getByRole('button');
-      await user.click(expandButton);
-      
-      // Now history should be visible
-      expect(screen.getByText('Raised in a noble family, trained in the art of combat since childhood')).toBeInTheDocument();
-    });
 
-    it('displays character level', () => {
-      render(<CharacterSummary character={mockCharacter} />);
-      
-      expect(screen.getByText(/Level 5/)).toBeInTheDocument();
+      const history = 'Raised in a noble family, trained in the art of combat since childhood';
+      const toggle = screen.getByRole('button', { name: /show details/i });
+
+      expect(screen.queryByText(history)).not.toBeInTheDocument();
+      expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+      await user.click(toggle);
+
+      expect(screen.getByText(history)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /hide details/i })).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+
+      await user.click(screen.getByRole('button', { name: /hide details/i }));
+
+      expect(screen.queryByText(history)).not.toBeInTheDocument();
     });
   });
 
   describe('Portrait Handling', () => {
-    it('displays character portrait when available', () => {
-      render(<CharacterSummary character={mockCharacter} />);
-      
-      const portrait = screen.getByRole('img', { name: /Aldric the Bold/i });
-      expect(portrait).toBeInTheDocument();
-    });
+    it('drops the portrait block entirely when the character has none', () => {
+      const { container } = render(
+        <CharacterSummary character={{ ...mockCharacter, portrait: undefined }} />
+      );
 
-    it('handles missing portrait gracefully', () => {
-      const characterWithoutPortrait = {
-        ...mockCharacter,
-        portrait: undefined
-      };
-      
-      render(<CharacterSummary character={characterWithoutPortrait} />);
-      
-      // Should still render without crashing
+      expect(container.querySelector('.manuscript-character-summary-portrait')).toBeNull();
       expect(screen.getByText('Aldric the Bold')).toBeInTheDocument();
     });
 
-    it('handles placeholder portrait type', () => {
-      const characterWithPlaceholder = {
-        ...mockCharacter,
-        portrait: { type: 'placeholder' as const, url: null }
-      };
-      
-      render(<CharacterSummary character={characterWithPlaceholder} />);
-      
-      // Should still render without crashing
-      expect(screen.getByText('Aldric the Bold')).toBeInTheDocument();
+    it('keeps the portrait block for a placeholder portrait', () => {
+      const { container } = render(
+        <CharacterSummary
+          character={{ ...mockCharacter, portrait: { type: 'placeholder' as const, url: null } }}
+        />
+      );
+
+      expect(container.querySelector('.manuscript-character-summary-portrait')).not.toBeNull();
     });
   });
 
   describe('Missing Data Handling', () => {
-    it('handles missing history gracefully', () => {
-      const characterWithoutHistory = {
-        ...mockCharacter,
-        background: {
-          ...mockCharacter.background,
-          history: ''
-        }
-      };
-      
-      render(<CharacterSummary character={characterWithoutHistory} />);
-      
-      // Should still render name and other available info
-      expect(screen.getByText('Aldric the Bold')).toBeInTheDocument();
+    it('omits the history paragraph when the character has no history', async () => {
+      const user = userEvent.setup();
+      const { container } = render(
+        <CharacterSummary
+          character={{
+            ...mockCharacter,
+            background: { ...mockCharacter.background, history: '' },
+          }}
+        />
+      );
+
+      await user.click(screen.getByRole('button', { name: /show details/i }));
+
+      expect(container.querySelector('.manuscript-character-summary-history')).toBeNull();
       expect(screen.getByText(/Level 5/)).toBeInTheDocument();
     });
 
@@ -134,30 +127,21 @@ describe('CharacterSummary', () => {
           fears: []
         }
       };
-      
+
       render(<CharacterSummary character={characterWithoutBackground} />);
-      
-      // Should still render name and level but not background info
+
       expect(screen.getByText('Aldric the Bold')).toBeInTheDocument();
       expect(screen.getByText(/Level 5/)).toBeInTheDocument();
-      // Should not show empty background content
       expect(screen.queryByText('Raised in a noble family, trained in the art of combat since childhood')).not.toBeInTheDocument();
     });
   });
 
-  describe('Responsive Design', () => {
-    it('renders with appropriate structure', () => {
+  describe('Structure', () => {
+    it('exposes the summary as a labelled region', () => {
       const { container } = render(<CharacterSummary character={mockCharacter} />);
-      
-      const summaryElement = container.querySelector('[data-testid="character-summary"]');
-      expect(summaryElement).toBeInTheDocument();
-    });
 
-    it('applies proper accessibility attributes', () => {
-      render(<CharacterSummary character={mockCharacter} />);
-      
-      const summaryRegion = screen.getByRole('region', { name: /character information/i });
-      expect(summaryRegion).toBeInTheDocument();
+      const region = screen.getByRole('region', { name: /character information/i });
+      expect(region).toBe(container.querySelector('[data-testid="character-summary"]'));
     });
   });
 });

--- a/src/hooks/__tests__/useAutoSave.test.ts
+++ b/src/hooks/__tests__/useAutoSave.test.ts
@@ -163,13 +163,16 @@ describe('useAutoSave', () => {
     expect(result.current.isRunning).toBe(true);
   });
 
-  it('should trigger manual save with player choice reason', async () => {
+  it('should carry the player-choice reason through to the save service', async () => {
     const { result } = renderHook(() => useAutoSave());
-    
+
     await act(async () => {
       await result.current.triggerSave('player-choice');
     });
-    
+
+    // The reason is the point: the service debounces or skips on it, so a save
+    // that arrives under the wrong reason behaves differently downstream.
+    expect(mockAutoSaveService.triggerSave).toHaveBeenCalledWith('player-choice');
     expect(mockSessionStore.updateAutoSaveStatus).toHaveBeenCalledWith('saving');
   });
 
@@ -184,13 +187,28 @@ describe('useAutoSave', () => {
   });
 
   it('should allow enabling/disabling auto-save', () => {
-    const { result } = renderHook(() => useAutoSave());
-    
+    // Let the store mock reflect the write, so the hook's reported isEnabled
+    // is read back from state rather than assumed from the call.
+    (mockSessionStore.setAutoSaveEnabled as jest.Mock).mockImplementation((enabled: boolean) => {
+      mockSessionStore.autoSave.enabled = enabled;
+    });
+
+    const { result, rerender } = renderHook(() => useAutoSave());
+    expect(result.current.isEnabled).toBe(true);
+
     act(() => {
       result.current.setEnabled(false);
     });
-    
-    expect(mockSessionStore.setAutoSaveEnabled).toHaveBeenCalledWith(false);
+    rerender();
+
+    expect(result.current.isEnabled).toBe(false);
+
+    act(() => {
+      result.current.setEnabled(true);
+    });
+    rerender();
+
+    expect(result.current.isEnabled).toBe(true);
   });
 
 });

--- a/src/lib/ai/__tests__/narrativeGenerator.skillContext.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.skillContext.test.ts
@@ -98,7 +98,14 @@ describe('NarrativeGenerator - Skill Context Integration', () => {
     narrativeGenerator = new NarrativeGenerator(mockAIClient);
   });
 
-  test('should include character skill information in narrative context', async () => {
+  /**
+   * What the scene prompt actually carries about the player character. Skills
+   * are NOT in it: `formatSkillsForNarrative` is wired into the choice prompt
+   * (choiceGenerator.prompt.ts), not this path. This case guards the character
+   * context that IS supposed to be here, and the player-identity rules that
+   * keep the narrator from writing the player as a third party.
+   */
+  test('carries the player character background into the scene prompt', async () => {
     const mockResponse = {
       content: "You assess your options, drawing on your athletic prowess and magical knowledge.",
       finishReason: 'stop' as const,
@@ -121,13 +128,11 @@ describe('NarrativeGenerator - Skill Context Integration', () => {
       }
     });
 
-    // Verify that the AI client was called with a prompt
-    expect(mockAIClient.generateContent).toHaveBeenCalled();
-    const calledPrompt = mockAIClient.generateContent.mock.calls[0][0];
+    const calledPrompt = mockAIClient.generateContent.mock.calls[0][0] as string;
 
-    // The prompt should include character skill context
-    expect(typeof calledPrompt).toBe('string');
-    expect(calledPrompt.length).toBeGreaterThan(0);
+    expect(calledPrompt).toContain('Skilled adventurer with years of experience');
+    expect(calledPrompt).toContain('Brave and resourceful');
+    expect(calledPrompt).toContain('The player IS Test Hero');
   });
 
   // Lore extraction is a full extra Gemini round-trip that only enriches

--- a/src/lib/services/__tests__/autoSaveService.test.ts
+++ b/src/lib/services/__tests__/autoSaveService.test.ts
@@ -36,29 +36,50 @@ describe('createAutoSave', () => {
   });
 
   describe('Basic Functionality', () => {
-    it('should handle paused sessions appropriately', async () => {
+    it('skips a scheduled save on a paused session but still runs a manual one', async () => {
+      const onSave = jest.fn();
       mockStateProvider.mockResolvedValue({
         session: { id: 'test-session', status: 'paused' },
       });
-      
-      // Test manual trigger with paused session
+      service = createAutoSave(mockStateProvider, { onSave });
+
+      // A scheduled reason on a paused session reports back as a skip. Not
+      // awaited: the debounced promise only settles once the timer runs.
+      void service.triggerSave('player-choice');
+      await jest.advanceTimersByTimeAsync(600);
+
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({ success: false, reason: 'player-choice' })
+      );
+
+      onSave.mockClear();
+
+      // The player asking for a save explicitly still goes through.
       await service.triggerSave('manual');
-      
-      // Should still call state provider for manual saves
-      expect(mockStateProvider).toHaveBeenCalled();
+
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, reason: 'manual' })
+      );
     });
   });
 
   describe('Event-Based Auto-Save', () => {
-    it('should save immediately when triggered manually', async () => {
+    it('saves a manual trigger immediately and debounces every other reason', async () => {
       const mockOnSave = jest.fn();
       service = createAutoSave(mockStateProvider, { onSave: mockOnSave });
-      
-      service.start();
-      await service.triggerSave('manual'); // Manual saves are immediate
-      
-      expect(mockStateProvider).toHaveBeenCalled();
-      expect(mockOnSave).toHaveBeenCalled();
+
+      // No timer is advanced anywhere in this test, so anything that lands is
+      // something that did not wait for the debounce window.
+      await service.triggerSave('manual');
+
+      expect(mockOnSave).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, reason: 'manual' })
+      );
+
+      mockOnSave.mockClear();
+      service.triggerSave('scene-change');
+
+      expect(mockOnSave).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/lib/services/__tests__/autoSaveService.test.ts
+++ b/src/lib/services/__tests__/autoSaveService.test.ts
@@ -77,9 +77,19 @@ describe('createAutoSave', () => {
       );
 
       mockOnSave.mockClear();
-      service.triggerSave('scene-change');
+      const pending = service.triggerSave('scene-change');
 
       expect(mockOnSave).not.toHaveBeenCalled();
+
+      // And it is deferred, not dropped: once the window elapses the save runs.
+      // Without this half, a scheduler that stopped firing entirely would still
+      // pass on the assertion above.
+      await jest.advanceTimersByTimeAsync(600);
+      await pending;
+
+      expect(mockOnSave).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, reason: 'scene-change' })
+      );
     });
   });
 });

--- a/src/state/__tests__/persistence/persistenceIntegration.test.ts
+++ b/src/state/__tests__/persistence/persistenceIntegration.test.ts
@@ -241,9 +241,13 @@ describe('Persistence Integration - MVP', () => {
 
       expect(worldId).toBeDefined();
 
-      // State should work in memory
-      const state = useWorldStore.getState();
-      expect(state.worlds[worldId]).toBeDefined();
+      // State should work in memory, with the world intact rather than merely present.
+      const stored = useWorldStore.getState().worlds[worldId];
+      expect(stored).toMatchObject({
+        id: worldId,
+        name: 'Fallback World',
+        genre: 'fantasy',
+      });
     });
 
     test('should handle persistence errors gracefully', async () => {

--- a/src/state/__tests__/persistence/worldStore.persistence.test.ts
+++ b/src/state/__tests__/persistence/worldStore.persistence.test.ts
@@ -35,7 +35,7 @@ jest.mock('../../persistence', () => {
 jest.unmock('../../worldStore');
 
 import { useWorldStore } from '../../worldStore';
-import { createMockWorld } from '@/lib/test-utils';
+import { createMockWorld, createMockWorldAttribute, createMockWorldSkill } from '@/lib/test-utils';
 import type { World } from '@/types';
 
 const STORE_KEY = 'narraitor-world-store';
@@ -152,34 +152,50 @@ describe('worldStore persistence', () => {
     });
 
     test('preserves every world property through a round trip', async () => {
+      // Every optional field and both collections are populated, and the
+      // comparison is whole-object, so dropping any one of them fails here
+      // rather than passing on the handful a partial match happens to list.
       const worldId = useWorldStore.getState().createWorld(
         worldInput({
           name: 'Full Featured World',
           genre: 'sci-fi',
           description: 'A complex world with all properties',
+          attributes: [createMockWorldAttribute({ id: 'attr-1' })],
+          skills: [createMockWorldSkill({ id: 'skill-1', attributeIds: ['attr-1'] })],
           settings: {
             maxAttributes: 8,
             maxSkills: 10,
             attributePointPool: 32,
             skillPointPool: 25,
           },
+          image: {
+            type: 'ai-generated',
+            url: 'data:image/png;base64,abc',
+            generatedAt: '2024-01-01T00:00:00Z',
+          },
+          reference: 'Dune',
+          relationship: 'inspired_by',
+          toneSettings: {
+            contentRating: 'R',
+            narrativeStyle: 'mysterious',
+            languageComplexity: 'literary',
+            customInstructions: 'Keep the prose lean.',
+          },
         })
       );
+
+      // The in-memory world BEFORE any reload. Comparing the reloaded world
+      // against the persisted bytes would be circular: a field dropped on
+      // write is missing from both sides and the assertion still passes.
+      const inMemory = useWorldStore.getState().worlds[worldId];
+      expect(inMemory.attributes).toHaveLength(1);
+      expect(inMemory.skills).toHaveLength(1);
+      expect(inMemory.toneSettings).toBeDefined();
 
       await flushPersist();
       await reloadFromStorage();
 
-      expect(useWorldStore.getState().worlds[worldId]).toMatchObject({
-        name: 'Full Featured World',
-        genre: 'sci-fi',
-        description: 'A complex world with all properties',
-        settings: {
-          maxAttributes: 8,
-          maxSkills: 10,
-          attributePointPool: 32,
-          skillPointPool: 25,
-        },
-      });
+      expect(useWorldStore.getState().worlds[worldId]).toEqual(inMemory);
     });
   });
 });

--- a/src/state/__tests__/persistence/worldStore.persistence.test.ts
+++ b/src/state/__tests__/persistence/worldStore.persistence.test.ts
@@ -1,248 +1,185 @@
-import { useWorldStore, WorldStore } from '../../worldStore';
-import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+/**
+ * worldStore persistence against the real zustand persist middleware.
+ *
+ * The storage layer is faked, but it is a working fake: a write lands in an
+ * in-memory map and a read gets it back, so every assertion here observes what
+ * the middleware actually serialized rather than that a mock was called.
+ * `../../persistence` is the seam because it is the last point before the
+ * browser, and `worldStore` is unmocked so the store code under test runs.
+ */
+
+// Backed by a real map so persisted state can be read back. Defined inside the
+// factory (not a module const) because jest hoists this above the imports.
+jest.mock('../../persistence', () => {
+  const backing = new Map<string, string>();
+
+  const storage = {
+    backing,
+    getItem: jest.fn(async (name: string) => {
+      const raw = backing.get(name);
+      return raw ? JSON.parse(raw) : null;
+    }),
+    setItem: jest.fn(async (name: string, value: unknown) => {
+      backing.set(name, JSON.stringify(value));
+    }),
+    removeItem: jest.fn(async (name: string) => {
+      backing.delete(name);
+    }),
+  };
+
+  (global as { __worldStoreTestStorage?: typeof storage }).__worldStoreTestStorage = storage;
+
+  return { createIndexedDBStorage: () => storage };
+});
+
+jest.unmock('../../worldStore');
+
+import { useWorldStore } from '../../worldStore';
 import { createMockWorld } from '@/lib/test-utils';
+import type { World } from '@/types';
 
-// Create mock adapter functions
-const mockGetItem = jest.fn().mockResolvedValue(null);
-const mockSetItem = jest.fn().mockResolvedValue(undefined);
-const mockRemoveItem = jest.fn().mockResolvedValue(undefined);
+const STORE_KEY = 'narraitor-world-store';
 
-// Create mock adapter object
-const mockAdapter = {
-  initialize: jest.fn().mockResolvedValue(undefined),
-  getItem: mockGetItem,
-  setItem: mockSetItem,
-  removeItem: mockRemoveItem
+type TestStorage = {
+  backing: Map<string, string>;
+  getItem: jest.Mock;
+  setItem: jest.Mock;
+  removeItem: jest.Mock;
 };
 
-// Mock the IndexedDBAdapter module
-jest.mock('../../../lib/storage/indexedDBAdapter', () => {
-  const MockAdapter = jest.fn().mockImplementation(() => mockAdapter);
-  (MockAdapter as jest.MockedFunction<typeof MockAdapter> & { create: jest.MockedFunction<() => Promise<typeof mockAdapter>> }).create = jest.fn().mockResolvedValue(mockAdapter);
-  
-  return {
-    IndexedDBAdapter: MockAdapter
-  };
-});
+const testStorage = (global as unknown as { __worldStoreTestStorage: TestStorage })
+  .__worldStoreTestStorage;
 
-// Mock zustand persist middleware
-jest.mock('zustand/middleware', () => ({
-  persist: jest.fn((config: (...args: unknown[]) => unknown) => 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (set: any, get: any, api: any) => {
-      // Return the original store config with mock persist behavior
-      return config(set, get, api);
-    })
-}));
+/** The state the middleware most recently wrote, parsed back out of storage. */
+const readPersistedState = (): { worlds: Record<string, World>; currentWorldId: string | null } | null => {
+  const raw = testStorage.backing.get(STORE_KEY);
+  return raw ? JSON.parse(raw).state : null;
+};
 
-// Test world factory
-const createTestWorld = (overrides = {}) => createMockWorld({
-  id: 'test-world-1',
-  settings: {
-    maxAttributes: 6,
-    maxSkills: 8,
-    attributePointPool: 27,
-    skillPointPool: 20
-  },
-  createdAt: '2024-01-01T00:00:00Z',
-  updatedAt: '2024-01-01T00:00:00Z',
-  ...overrides
-});
+/** Persist writes are async; let the middleware's write settle before reading. */
+const flushPersist = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+/**
+ * Model a fresh page load: keep the bytes the last session wrote, drop the
+ * in-memory state, and rehydrate from those bytes. `reset()` alone is not
+ * enough, because the middleware immediately persists the emptied state over
+ * the top of what we are trying to read back.
+ */
+const reloadFromStorage = async () => {
+  const written = testStorage.backing.get(STORE_KEY)!;
+  useWorldStore.getState().reset();
+  await flushPersist();
+  testStorage.backing.set(STORE_KEY, written);
+  await useWorldStore.persist.rehydrate();
+};
+
+const worldInput = (overrides: Partial<World> = {}) => {
+  const { id: _id, createdAt: _createdAt, updatedAt: _updatedAt, ...rest } = createMockWorld(overrides);
+  return rest;
+};
 
 describe('worldStore persistence', () => {
   beforeEach(() => {
-    // Clear all mocks
     jest.clearAllMocks();
-    
-    // Reset the store
+    testStorage.backing.clear();
     useWorldStore.getState().reset();
   });
 
   describe('state persistence', () => {
-    test('should persist state changes to IndexedDB', async () => {
-      // Create a persisted store
-      const worldData = createTestWorld();
-      
-      // Create a world to trigger persistence
-      useWorldStore.getState().createWorld(worldData);
-      
-      // Manually call the mock setItem with expected data
-      mockSetItem('narraitor-world-store', JSON.stringify({
-        state: {
-          worlds: {
-            'test-world-1': worldData
-          },
-          currentWorldId: null,
-          error: null,
-          loading: false
-        },
-        version: 0
-      }));
+    test('writes a created world through to storage', async () => {
+      const worldId = useWorldStore.getState().createWorld(worldInput({ name: 'Persisted World' }));
 
-      // Allow async operations to complete
-      await new Promise(resolve => setTimeout(resolve, 10)); 
-      
-      // Verify that setItem was called with the right key
-      expect(mockSetItem).toHaveBeenCalledWith(
-        'narraitor-world-store',
-        expect.stringContaining('"test-world-1"')
-      );
+      await flushPersist();
+
+      const persisted = readPersistedState();
+      expect(persisted?.worlds[worldId]).toMatchObject({
+        id: worldId,
+        name: 'Persisted World',
+      });
     });
 
-    test('should restore state from IndexedDB on initialization', async () => {
-      // Setup persisted state
-      const persistedState = {
-        state: {
-          worlds: {
-            'world-1': createTestWorld({ id: 'world-1', name: 'Persisted World' })
-          },
-          currentWorldId: 'world-1',
-          error: null,
-          loading: false
-        },
-        version: 0
-      };
-      
-      // Set mock to return persisted state
-      mockGetItem.mockResolvedValue(JSON.stringify(persistedState));
-      
-      // Mock getItem call to simulate state restoration
-      mockGetItem('narraitor-world-store');
+    test('restores worlds from storage on rehydrate', async () => {
+      const stored = createMockWorld({ id: 'world-1', name: 'Restored World' });
+      testStorage.backing.set(
+        STORE_KEY,
+        JSON.stringify({
+          state: { worlds: { 'world-1': stored }, currentWorldId: 'world-1' },
+          version: 5,
+        })
+      );
 
-      // Allow async restoration to complete
-      await new Promise(resolve => setTimeout(resolve, 10));
+      await useWorldStore.persist.rehydrate();
 
-      // Verify the getItem was called
-      expect(mockGetItem).toHaveBeenCalledWith('narraitor-world-store');
+      const state = useWorldStore.getState();
+      expect(state.worlds['world-1']).toMatchObject({ id: 'world-1', name: 'Restored World' });
+      expect(state.currentWorldId).toBe('world-1');
     });
 
-    test('should handle empty persisted state', async () => {
-      // Return null to simulate no persisted state
-      mockGetItem.mockResolvedValue(null);
+    test('rehydrates to empty defaults when storage holds nothing', async () => {
+      await useWorldStore.persist.rehydrate();
 
-      // Create persisted store
-      const persistedStore = create<WorldStore>()(
-        persist(
-          (_set, _get, _api) => useWorldStore.getState(),
-          {
-            name: 'narraitor-world-store',
-            storage: {
-              getItem: mockGetItem,
-              setItem: mockSetItem,
-              removeItem: mockRemoveItem
-            }
-          }
-        )
-      );
-      
-      // Manually trigger getItem call
-      mockGetItem('narraitor-world-store');
-
-      // Allow async operations to complete
-      await new Promise(resolve => setTimeout(resolve, 10));
-
-      // Verify that getItem was called
-      expect(mockGetItem).toHaveBeenCalledWith('narraitor-world-store');
-      
-      // Store should have default state when no persisted state exists
-      const state = persistedStore.getState();
+      const state = useWorldStore.getState();
       expect(state.worlds).toEqual({});
       expect(state.currentWorldId).toBeNull();
+    });
+
+    test('drops a deleted world from storage', async () => {
+      const worldId = useWorldStore.getState().createWorld(worldInput());
+      await flushPersist();
+
+      useWorldStore.getState().deleteWorld(worldId);
+      await flushPersist();
+
+      expect(readPersistedState()?.worlds[worldId]).toBeUndefined();
     });
   });
 
   describe('data integrity', () => {
-    test('should maintain date serialization', async () => {
-      // Create world with dates
-      const worldWithDates = createTestWorld({
-        createdAt: '2024-01-01T00:00:00Z',
-        updatedAt: '2024-01-02T00:00:00Z'
-      });
+    test('survives a full write and read back with its dates intact', async () => {
+      const worldId = useWorldStore
+        .getState()
+        .createWorld(worldInput({ name: 'Dated World' }));
 
-      // Create world to trigger persistence
-      useWorldStore.getState().createWorld(worldWithDates);
-      
-      // Manually simulate persistence
-      mockSetItem('narraitor-world-store', JSON.stringify({
-        state: {
-          worlds: {
-            'test-world-1': worldWithDates
-          },
-          currentWorldId: null,
-          error: null,
-          loading: false
-        },
-        version: 0
-      }));
+      await flushPersist();
+      const written = readPersistedState()!.worlds[worldId];
 
-      // Verify dates are properly serialized
-      expect(mockSetItem).toHaveBeenCalledWith(
-        'narraitor-world-store',
-        expect.stringContaining('2024-01-01')
-      );
-      expect(mockSetItem).toHaveBeenCalledWith(
-        'narraitor-world-store',
-        expect.stringContaining('2024-01-02')
-      );
+      await reloadFromStorage();
+
+      const restored = useWorldStore.getState().worlds[worldId];
+      expect(restored.createdAt).toBe(written.createdAt);
+      expect(restored.updatedAt).toBe(written.updatedAt);
+      expect(typeof restored.createdAt).toBe('string');
     });
 
-    test('should preserve all world properties', async () => {
-      // Create full-featured world
-      const fullWorld = createTestWorld({
+    test('preserves every world property through a round trip', async () => {
+      const worldId = useWorldStore.getState().createWorld(
+        worldInput({
+          name: 'Full Featured World',
+          genre: 'sci-fi',
+          description: 'A complex world with all properties',
+          settings: {
+            maxAttributes: 8,
+            maxSkills: 10,
+            attributePointPool: 32,
+            skillPointPool: 25,
+          },
+        })
+      );
+
+      await flushPersist();
+      await reloadFromStorage();
+
+      expect(useWorldStore.getState().worlds[worldId]).toMatchObject({
         name: 'Full Featured World',
         genre: 'sci-fi',
         description: 'A complex world with all properties',
-        imageUrl: 'https://example.com/world.jpg',
         settings: {
           maxAttributes: 8,
           maxSkills: 10,
           attributePointPool: 32,
           skillPointPool: 25,
-          difficultyLevel: 'hard'
-        }
-      });
-
-      // Manually simulate persistence
-      mockSetItem('narraitor-world-store', JSON.stringify({
-        state: {
-          worlds: {
-            'test-world-1': fullWorld
-          },
-          currentWorldId: null,
-          error: null,
-          loading: false
         },
-        version: 0
-      }));
-
-      // Verify all properties are included
-      expect(mockSetItem).toHaveBeenCalledWith(
-        'narraitor-world-store',
-        expect.stringContaining('Full Featured World')
-      );
-      expect(mockSetItem).toHaveBeenCalledWith(
-        'narraitor-world-store',
-        expect.stringContaining('sci-fi')
-      );
-      expect(mockSetItem).toHaveBeenCalledWith(
-        'narraitor-world-store',
-        expect.stringContaining('description')
-      );
-      expect(mockSetItem).toHaveBeenCalledWith(
-        'narraitor-world-store',
-        expect.stringContaining('imageUrl')
-      );
-      expect(mockSetItem).toHaveBeenCalledWith(
-        'narraitor-world-store',
-        expect.stringContaining('difficultyLevel')
-      );
+      });
     });
   });
-
-  // NOTE: a "fallback behavior / logs errors on persistence failure" test was removed
-  // here. It was self-fulfilling (it called the mock itself, then asserted the mock was
-  // called) and could not be salvaged in place: this file mocks out zustand's `persist`
-  // middleware, so `onRehydrateStorage`'s error handler never runs. Real persistence-error
-  // logging coverage needs a separate test that exercises the un-mocked persist path.
 });


### PR DESCRIPTION
## Description

Rewrites the eight tests the weekly sweep found that pass no matter what the code does. No production code changes.

The headline one is `worldStore.persistence.test.ts`. Every case in it called `mockSetItem(...)` or `mockGetItem(...)` by hand and then asserted that mock had been called, on top of a store that `jest.setup.ts` auto-mocks and the file never unmocked. Five tests named for persistence and restore exercised neither. It now follows the pattern its sibling `persistenceIntegration.test.ts` already used: mock the storage layer only, unmock the store, let the real zustand persist middleware run, and read the state back out through a working in-memory fake.

The skill-context test turned into a finding rather than a fix. It claimed to check that character skills reach the narrative prompt, and asserted only that the prompt was a non-empty string. Skills are not in that prompt at all: `formatSkillsForNarrative` is wired into the choice prompt, not the scene one. Rather than rig it or leave the suite red, the test now guards the character context that path really carries, and the gap is filed as #1912.

The other six: assert the paused-session skip branch instead of that the state provider ran, carry the player-choice reason through to the save service, read `isEnabled` back after a toggle in both directions, put the end story action in the DOM instead of checking a prop is truthy, fold five single-assertion render checks into behavior, and match the fallback world's fields instead of `toBeDefined`.

## Related Issue

Closes #1911

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

"Tests written before implementation" is N/A: the tests are the change, there is no implementation here.

Every rewrite was checked the other way round, which is the part that matters for this issue. Each was run against deliberately broken production code to confirm it goes red, then the break was reverted:

- `partialize: () => ({})` on the worldStore persist config: 4 of 6 persistence cases fail. The old file passed all 5 under the same break.
- `shouldSkipForInactiveSession` forced to `return false`: the paused-session case fails. The old one passed.
- `triggerSave(reason)` hardcoded to `'manual'` and the `setAutoSaveEnabled` store write dropped: both `useAutoSave` cases fail.

## User Stories Addressed

None directly. This is test-suite health: a green suite only means something if part of it could have gone red.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A, no component or style changes.

## Implementation Notes

- `worldStore.persistence.test.ts` needed a `reloadFromStorage` helper rather than a bare `reset()`. Calling `reset()` alone makes the middleware immediately persist the emptied state over the bytes the test is trying to read back, which is a trap worth knowing about for any future persistence test.
- The `ChoiceSelector` stub in `ActiveGameSessionChoicesColumn.test.tsx` now renders its `inputActions` prop. That surfaced something the old `toBeTruthy()` hid: the end story action is placed twice, once in the mobile rail and once in the desktop input row, with CSS picking the one that shows. The test asserts both placements.
- `audit:tests` after: existence-only findings 2 to 0, render-heavy files 2 to 1, mock-only 296 to 291, name/behavior mismatches 29 to 25, single-assertion render checks 49 to 44.
- Four of the rewritten cases still show up in the script's mock-only bucket, because their only assertions are on `onSave` and `triggerSave` jest.fns. That is the heuristic reading assertion shape, not content: those callbacks are the service's actual output channel, the assertions are on real computed payloads (`success: false, reason: 'player-choice'`), and each was proven to fail under mutation.

## Screenshots

N/A

## Visual Baseline Changes

None. This PR does not touch `tests/visual/**-snapshots/**`.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

`npm test` 443 suites, 3089 tests, exit 0. `npm run type-check` exit 0. `npm run lint` exit 0, 127 pre-existing warnings and no errors. `npm run deps:validate` exit 0. Security audit not run; no dependency or production code changes.

## Testing Instructions

```bash
npm test -- src/state/__tests__/persistence src/hooks/__tests__/useAutoSave.test.ts src/lib/services/__tests__/autoSaveService.test.ts src/lib/ai/__tests__/narrativeGenerator.skillContext.test.ts src/components/GameSession/__tests__/CharacterSummary.test.tsx src/components/GameSession/__tests__/ActiveGameSessionChoicesColumn.test.tsx
```

To check the rewrites are honest rather than just green, add `partialize: () => ({}) as never` to the persist options in `src/state/worldStore.ts` and re-run the persistence file. Four cases should fail. Revert it.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

Accessibility: the `CharacterSummary` consolidation keeps the labelled-region check and now ties it to the same element as the test id, and the expand/collapse case asserts `aria-expanded` in both states, which the previous version did not.
