### PR TITLE
Fix story-checkpoints doc to match what the code actually does

### DIFF
--- a/public_docs/features/story-checkpoints.md
+++ b/public_docs/features/story-checkpoints.md
@@ -11,7 +11,7 @@ Automatically, with no button to press. `useStoryCheckpointManager` watches the 
 Major events are what drive all of this, and they're gated two different ways:
 
 - The first narrative segment of a session always records one, so the recap has something in it from the start.
-- Every candidate after that goes through `POST /api/narrative/validate-event-significance`, and only the events the AI calls consequential get recorded.
+- Every candidate after that goes through `POST /api/narrative/validate-event-significance`, and only the events the AI calls consequential get recorded. That check fails open: if the request errors or the response won't parse, the candidate is recorded anyway rather than dropped. So an event that looks insignificant in the recap may have arrived that way, not because the AI approved it.
 
 The hook also listens for a `narraitor:finalize-checkpoint` window event so a session can capture one last checkpoint on the way out, though nothing in the app dispatches that event right now. Checkpoint generation is skipped entirely under Playwright (`isPlaywrightEnv`), because seeded E2E and visual pages have no AI key and the request would just hang.
 
@@ -24,7 +24,9 @@ Each checkpoint stores:
 - The narrative segment, 50 to 75 words, covering only the events in that checkpoint
 - Highlights distilled from the included events
 - The ids of every major event and decision merged into the segment
-- Metadata: included event and decision counts, the last event timestamp, the prompt version, and the model that produced it
+- Metadata: included event and decision counts, the last event timestamp, the prompt version, and a model name
+
+Treat that model name as a default rather than provenance. The route calls `generateStoryCheckpointSummary` without a model argument, so the value stored is whatever `getAIConfig().modelName` returns, not the model the resolved provider actually used. On Claude, Ollama, an OpenAI-compatible provider, or any non-default model, it will misattribute. The fallback path records the literal string `fallback` instead.
 
 Because the system tracks which event IDs have already been summarized, you won't accidentally double-count the same moment in multiple checkpoints.
 

--- a/public_docs/features/story-checkpoints.md
+++ b/public_docs/features/story-checkpoints.md
@@ -1,19 +1,30 @@
 # Story Checkpoints
 
-The story checkpoint system keeps long sessions coherent by letting players capture "story so far" summaries whenever the narrative hits a major beat. Checkpoints combine the AI-detected major events with the player's most recent decisions so future prompts can keep context without replaying the entire session history.
+Story checkpoints are what fills the "Story So Far" recap. As major events pile up during a session, the AI writes a short narrative segment covering just those events, and the recap is built by concatenating every segment for the session in order.
 
-## When to Create a Checkpoint
+Checkpoints are a display feature. Segments surface in the Story So Far panel during play and in the "Your Story" block on the ending screen, and that's it. The narrative generator doesn't read them, so a checkpoint has no effect on what the AI writes for the next turn. The one place a segment does get reused is the checkpoint prompt itself, which receives the last three segments as context so each new one continues the story instead of starting over.
 
-Manual checkpoints live at the bottom of the active Game Session view (under the inventory block). The Story So Far panel stays collapsed by default; expanding it shows the latest AI-generated summary, pending major events, and a `Create Checkpoint` button. The button lights up whenever the current session records at least one new major event that hasn't been summarized yet. This makes it easy to capture summaries after boss fights, big reveals, or any turning point the AI tagged as critical.
+## When a Checkpoint Gets Created
+
+Automatically, with no button to press. `useStoryCheckpointManager` watches the session's major events in world state, and once at least one of them hasn't been summarized yet, a 3 second debounce fires and the request goes out. A failed attempt won't retry the same batch of events, so it stays quiet until genuinely new events show up.
+
+Major events are what drive all of this, and they're gated two different ways:
+
+- The first narrative segment of a session always records one, so the recap has something in it from the start.
+- Every candidate after that goes through `POST /api/narrative/validate-event-significance`, and only the events the AI calls consequential get recorded.
+
+The hook also listens for a `narraitor:finalize-checkpoint` window event so a session can capture one last checkpoint on the way out, though nothing in the app dispatches that event right now. Checkpoint generation is skipped entirely under Playwright (`isPlaywrightEnv`), because seeded E2E and visual pages have no AI key and the request would just hang.
+
+Where the recap shows up depends on the progressive disclosure flag. With the flag off it sits in the support column below the narrative, and with it on it moves into the Story So Far drawer.
 
 ## What Gets Captured
 
 Each checkpoint stores:
 
-- The AI-generated summary (2–3 sentences)
-- Bulleted highlights from the included events
-- References to every major event and decision merged into the summary
-- Metadata like the Gemini model/version and last event timestamp
+- The narrative segment, 50 to 75 words, covering only the events in that checkpoint
+- Highlights distilled from the included events
+- The ids of every major event and decision merged into the segment
+- Metadata: included event and decision counts, the last event timestamp, the prompt version, and the model that produced it
 
 Because the system tracks which event IDs have already been summarized, you won't accidentally double-count the same moment in multiple checkpoints.
 
@@ -47,15 +58,18 @@ Server-side AI work happens through `POST /api/narrative/story-checkpoint`. The 
 }
 ```
 
-The response mirrors what the UI displays:
+That's the minimum the route needs. It also takes `characterName`, `currentLocation`, `activeGoals`, `toneSettings`, and `previousSegments`, which carries the last three checkpoint segments and is the only reason consecutive segments read as one story. There's a `narrativeSummary` field too, but the prompt builder ignores it. The full shape lives in `src/types/story-checkpoint.types.ts`. Events are capped at 10 per request and decisions at 5.
+
+The response:
 
 ```json
 {
-  "summary": "Maera dissolved the council and forced the player into open rebellion.",
+  "segment": "Maera dissolved the council and forced the player into open rebellion.",
   "highlights": ["Council disbanded", "Royal guard split"],
   "majorEvents": ["Maera dissolved the council"],
   "characterDevelopment": ["Player now leads a rebel cell"],
   "nextHooks": ["Secure funding", "Recruit officers"],
+  "themes": ["Loyalty tested"],
   "includedEvents": 1,
   "includedDecisions": 1,
   "lastEventTimestamp": "2025-11-20T18:00:00Z",
@@ -63,12 +77,14 @@ The response mirrors what the UI displays:
 }
 ```
 
+`segment` is the only field the UI renders. `highlights` is stored on the checkpoint but nothing displays it yet, and `characterDevelopment`, `nextHooks`, and `themes` get dropped on the way into the store.
+
 The browser calls this endpoint directly, through `aiFetch` rather than a bare `fetch` (see
 `useStoryCheckpointManager`). `aiFetch` attaches the player's key as a request header and the
 route resolves it server-side.
 
 ## Troubleshooting
 
-- **Button disabled?** The UI waits for at least one unsummarized major event in the active session. Keep playing until the Major Event detector fires again.  
-- **Empty summary returned?** The API falls back to a simple joined string of event descriptions when Gemini can't return valid JSON. You can retry immediately—failures usually happen when the events list is extremely short.
-- **Need to re-run a checkpoint?** Delete the IndexedDB entry for that world or clear storage via the devtools panel, then replay the moment with new events before creating another checkpoint.
+- **Recap still empty?** The panel waits for a major event, and the first narrative segment of a session records one, so an empty recap after a few turns means either the segment never landed or the checkpoint request failed. Until then you'll see "Your story will appear here once major events occur."
+- **Segment reads like a flat list of event descriptions?** That's the fallback the generator uses when Gemini returns something that isn't valid JSON or leaves `segment` out. You can tell from the stored `aiModel`, which comes back as `fallback` instead of a real model name.
+- **Need to re-run a checkpoint?** You can't. Segments are immutable, event IDs are only summarized once, and there's no per-checkpoint delete anywhere in the UI. Starting a fresh session is the clean way to try again; the devtools Test Data Generator has "Delete All Worlds" and "NUKE EVERYTHING" if you want the persisted state gone as well.


### PR DESCRIPTION
## Description
`public_docs/features/story-checkpoints.md` described three things the code doesn't do, so anyone reading it to understand checkpoints came away with the wrong model. Each claim was re-checked against the tree at `origin/develop` rather than trusting the issue's line numbers.

| Claim in the doc | What the code does | Checked against |
|---|---|---|
| Response field is `summary` | Route returns `segment` | `src/types/story-checkpoint.types.ts:36`, `src/app/api/narrative/story-checkpoint/route.ts`, `src/lib/ai/storyCheckpointGenerator.ts:129` |
| A manual "Create Checkpoint" button at the bottom of the game session | No button exists. Creation is automatic: a 3 second debounce fires once an unsummarized major event lands, plus a `narraitor:finalize-checkpoint` listener | `src/components/GameSession/hooks/useStoryCheckpointManager.ts:294-323`, `src/components/GameSession/StorySummarySection.tsx`, `src/components/GameSession/ActiveGameSessionControls.tsx` |
| Checkpoints "feed future prompts" | Segments reach the Story So Far panel and the ending screen's Your Story block. Nothing in `src/lib/ai/narrativeGenerator*.ts` reads them. The one reuse is `previousSegments`, which feeds the next checkpoint's own prompt | grep for `storyCheckpoints` and `buildStoryFromCheckpoints` across `src/`; `src/lib/ai/storyCheckpointGenerator.ts:64` |

That third one is the claim worth killing. It made checkpoints look like a memory mechanism when they only ever reach the screen, which is exactly the wrong starting point for the next long-arc-memory investigation.

The rest of the file got a pass too, since leaving a known-false neighbouring sentence in place would be half a job. Four more corrections came out of it:

- The troubleshooting "Button disabled?" bullet leaned on the same button that doesn't exist. Replaced with what an empty recap actually means.
- "The AI-generated summary (2-3 sentences)" undersold it. The prompt explicitly asks for continuous narrative prose, not a summary, at 50-75 words.
- The response example was missing `themes`, and didn't say that `segment` is the only field the UI renders. `highlights` is stored but never displayed, and `characterDevelopment`, `nextHooks`, and `themes` get dropped by `buildCheckpointFromResponse` on the way into the store.
- "Delete the IndexedDB entry ... then replay the moment with new events before creating another checkpoint" doesn't work, because creation isn't manual and there's no per-checkpoint delete anywhere in the UI. Replaced with the honest answer plus the devtools controls that do exist (`Delete All Worlds`, `NUKE EVERYTHING` in the Test Data Generator section).

Some accurate detail got added where the corrected sentences needed it to make sense: the significance gate at `POST /api/narrative/validate-event-significance`, the first-segment seeding in `applyWorldStateThreadUpdates.ts:163`, the Playwright skip, where the panel sits under the progressive disclosure flag, and the 10 event / 5 decision request caps.

## Related Issue
Refs #1863. This targets `develop`, so GitHub won't auto-close the issue on merge.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
N/A. Documentation only, no application code changed.

- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A.

## Flow Diagrams
N/A.

## Component Development
N/A. No components touched.

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes
No behavior changed, deliberately. If the prompt feed is actually wanted, that's a feature, not a doc fix, and it deserves its own issue rather than riding along here.

Two things turned up during verification that are real code smells but out of scope for a doc PR:

- Nothing in the repo dispatches `narraitor:finalize-checkpoint`. The listener in `useStoryCheckpointManager` is dead, which means the intended end-of-session final checkpoint never fires. The doc now says so out loud rather than quietly describing it as working.
- The route accepts `narrativeSummary`, the hook populates it from the last three narrative segments, and `buildPrompt` in `storyCheckpointGenerator.ts` never reads it. Also documented as-is.

## Screenshots
N/A.

## Visual Baseline Changes
None. No files under `tests/visual/**-snapshots/**` touched.

## Code Review Summary (if applicable)
N/A.

## Chrome DevTools MCP Verification Summary (if applicable)
N/A.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
Run in the worktree:

```
npm run lint          # exit 0, 127 pre-existing warnings, 0 errors
npm run type-check    # exit 0
npm test              # exit 0, 443 suites / 3089 tests passed
npm run docs:check-links    # 93 docs checked, no broken links
npm run docs:check-symbols  # advisory; story-checkpoints.md has no unresolved references
```

Reading check: open `public_docs/features/story-checkpoints.md` alongside `useStoryCheckpointManager.ts` and `storyCheckpointGenerator.ts` and confirm the described flow matches. Visual and E2E suites weren't run, since nothing rendering changed.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed
