### PR TITLE
Stop Storybook shipping the 11 MB Gemini tokenizer

### DIFF
--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -7,8 +7,7 @@ const path = require('path');
 const config = {
   stories: [
     // Include all stories from the atomic design structure
-    '../src/stories/**/*.stories.@(js|jsx|ts|tsx)',
-    '../src/stories/**/*.mdx'
+    '../src/stories/**/*.stories.@(js|jsx|ts|tsx)'
   ],
   addons: [
     '@storybook/addon-essentials',
@@ -17,7 +16,7 @@ const config = {
   framework: {
     name: '@storybook/nextjs',
     options: {
-      nextConfigPath: path.resolve(__dirname, '../next.config.js'),
+      nextConfigPath: path.resolve(__dirname, '../next.config.ts'),
     }
   },
   staticDirs: [
@@ -28,7 +27,17 @@ const config = {
   webpackFinal: async (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      '@': path.resolve(__dirname, '../src')
+      '@': path.resolve(__dirname, '../src'),
+      // Same swap as next.config.ts's webpack() hook: the Gemini tokenizer's
+      // BPE vocabulary is 11 MB and every story that reaches
+      // baseNarrativeTemplate pulls it in. @storybook/nextjs reads
+      // next.config.ts but never calls its webpack() hook, so the alias has to
+      // be repeated here. Storybook is browser-only, so there's no isServer
+      // branch to mirror.
+      '@lenml/tokenizer-gemini': path.resolve(
+        __dirname,
+        '../src/lib/promptContext/geminiTokenizerBrowserStub.ts'
+      )
     };
     return config;
   },

--- a/__tests__/storybook-config.test.js
+++ b/__tests__/storybook-config.test.js
@@ -1,0 +1,27 @@
+import fs from 'fs';
+import path from 'path';
+
+import storybookConfig from '../.storybook/main.cjs';
+
+const repoRoot = path.resolve(__dirname, '..');
+
+describe('.storybook/main.cjs', () => {
+  it('points nextConfigPath at a file that exists', () => {
+    const nextConfigPath = storybookConfig.framework.options.nextConfigPath;
+    expect(fs.existsSync(nextConfigPath)).toBe(true);
+  });
+
+  it('does not glob for story formats the repo has none of', () => {
+    expect(storybookConfig.stories).not.toContain('../src/stories/**/*.mdx');
+  });
+
+  it('swaps the 11 MB Gemini tokenizer for the browser stub', async () => {
+    const config = await storybookConfig.webpackFinal({ resolve: { alias: {} } });
+
+    const stubPath = config.resolve.alias['@lenml/tokenizer-gemini'];
+    expect(stubPath).toBe(
+      path.join(repoRoot, 'src/lib/promptContext/geminiTokenizerBrowserStub.ts')
+    );
+    expect(fs.existsSync(stubPath)).toBe(true);
+  });
+});

--- a/src/lib/promptContext/geminiTokenizerBrowserStub.ts
+++ b/src/lib/promptContext/geminiTokenizerBrowserStub.ts
@@ -1,6 +1,7 @@
 /**
  * Browser stand-in for `@lenml/tokenizer-gemini`, swapped in by the client-side
- * webpack alias in next.config.ts.
+ * webpack alias in next.config.ts and by the matching alias in
+ * .storybook/main.cjs.
  *
  * The real package carries an 11 MB BPE merge table. Webpack emitted the whole
  * thing into the client build, and the `next/dynamic` GameSession import pulled


### PR DESCRIPTION
## Description

The published Storybook was still emitting an 11 MB chunk carrying the `@lenml/tokenizer-gemini` BPE merge table, which is the exact payload #1669 stripped out of the app. Adding the same alias to `.storybook/main.cjs`'s `webpackFinal` takes `storybook-static` from 36 MB to 26 MB and removes the chunk entirely.

This is scoped to findings **1, 2 and 6** of #1847. Findings 3, 4, 5, 7 and 8 are untouched and stay open.

Storybook builds through its own `webpackFinal`, and `@storybook/nextjs` never calls `next.config.ts`'s `webpack()` hook - it reads the config object and applies specific keys (css, images, SWC, runtime config), so a user `webpack()` function is ignored. That's why the swap never ran there. It matters beyond gh-pages, since `npm run build` ends in `cp -r storybook-static public/` and `vercel.json` rewrites `/storybook` to it, so the app's own deployment was carrying that chunk too.

**One correction to the issue.** Finding 2 says Storybook reads no Next config at all because `nextConfigPath` names `next.config.js`, a file that doesn't exist. That part doesn't hold up. `resolveNextConfig` in `@storybook/nextjs` does `dirname(nextConfigPath)` and hands the *directory* to Next's own loader, which then finds `next.config.ts` by itself:

```js
resolveNextConfig = async ({ nextConfigPath }) => {
  let dir = nextConfigPath ? dirname(nextConfigPath) : getProjectRoot();
  return loadConfig(PHASE_DEVELOPMENT_SERVER, dir, void 0);
}
```

A `process.stdout.write` probe added temporarily to `next.config.ts` fired on both the old path and the new one, so `optimizePackageImports`, `serverExternalPackages` and `images.remotePatterns` were never absent for the stated reason. The path is still wrong and still names a file that isn't there, so it's fixed, but fixing it changes nothing at build time and it was never the cause of finding 1. Finding 1 needed its own alias regardless.

## Related Issue

Refs #1847 - partial, findings 1, 2 and 6 only. This PR targets `develop`, so GitHub won't auto-close the issue, and it shouldn't: five findings remain.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Tests came after the config edits rather than before, so the first box stays unchecked. They were verified to fail without the fix: reverting `.storybook/main.cjs` alone takes all three from pass to fail.

```
EXIT_WITHOUT_FIX=1
  x points nextConfigPath at a file that exists
  x does not glob for story formats the repo has none of
  x swaps the 11 MB Gemini tokenizer for the browser stub
Tests: 3 failed, 3 total
```

## User Stories Addressed

N/A - build-output cleanup, no user-facing behavior change.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

No stories or components changed. This touches Storybook's build config only, and stories render the same - the stub returns an array whose `.length` is the token estimate, which is all `countTokens` reads.

## Implementation Notes

The alias is duplicated between `next.config.ts` and `.storybook/main.cjs` rather than shared. Extracting it would mean a CJS module that a TypeScript ESM config and a `.cjs` config both import, which is more machinery than one path string justifies. The comment in `main.cjs` points at the Next config so the pairing is findable, and `__tests__/storybook-config.test.js` fails if the Storybook side drifts.

The docblock in `geminiTokenizerBrowserStub.ts` said the alias lives in `next.config.ts`. That's now two places, so it says so.

## Screenshots

N/A

## Visual Baseline Changes

None. This PR doesn't touch `tests/visual/**-snapshots/**`.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit wasn't run - no dependency changes here.

## Testing Instructions

The evidence is the build output, from a clean `rm -rf storybook-static && npm run build-storybook` before and after.

| | before | after |
|---|---|---|
| `storybook-static` total | 36,820 KB | 25,820 KB |
| tokenizer chunk | `2438.4298fae3.iframe.bundle.js`, 11,263,732 bytes | not emitted |
| chunks matching `tokenizer_config` | 1 | 0 |
| chunks matching `lenml/tokenizer-gemini` | 1 | 0 |
| `No story files found` warnings | 1 | 0 |
| largest chunk | 11,263,732 bytes | 2,441,873 bytes |

To reproduce:

1. Run `rm -rf storybook-static && npm run build-storybook`.
2. Check the chunk is gone: `grep -l tokenizer_config storybook-static/*.js` returns nothing.
3. Check the warning is gone: the build log has no `No story files found for the specified pattern`.
4. Check the size: `du -sk storybook-static` reports roughly 25,800 KB.

For the `next.config.ts` pickup, add `process.stdout.write("PROBE\n")` above the `nextConfig` object and rebuild - the marker appears in the build log once. It also appears with the old `next.config.js` path, which is the correction described above.

Unit tests: `npm test` is 3092 passing across 444 suites. `npm run type-check` and `npm run lint` both exit 0, with lint at its usual 127 warnings and no new ones. `lint:css` wasn't run since no `.css` file changed. Visual and e2e suites weren't run - nothing here touches them.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed

Accessibility is N/A - build config, no rendered output changed.
