### PR TITLE
Give the scene prompt readable skill and attribute names

### DIFF
--- a/src/lib/ai/__tests__/attributeSkillFormatter.test.ts
+++ b/src/lib/ai/__tests__/attributeSkillFormatter.test.ts
@@ -41,6 +41,7 @@ describe('attributeSkillFormatter - MVP Tests', () => {
   });
 
   describe('normalizeSkillArray', () => {
+    // The label goes into a prompt, so the readable name wins over the world id.
     test('normalizes skills with name property to skillId format', () => {
       const nameFormat = [
         { name: 'Lockpicking', level: 7, worldSkillId: 'skill-lockpicking' },
@@ -49,7 +50,7 @@ describe('attributeSkillFormatter - MVP Tests', () => {
       const result = normalizeSkillArray(nameFormat);
 
       expect(result).toEqual([
-        { skillId: 'skill-lockpicking', level: 7 },
+        { skillId: 'Lockpicking', level: 7 },
         { skillId: 'Stealth', level: 5 }
       ]);
     });
@@ -212,7 +213,7 @@ describe('attributeSkillFormatter - MVP Tests', () => {
 
       const result = formatSkillsForNarrative(skills);
 
-      expect(result).toContain('skill-lockpicking (Expert)');
+      expect(result).toContain('Lockpicking (Expert)');
       expect(result).toContain('Stealth (Competent)');
     });
   });

--- a/src/lib/ai/__tests__/narrativeGenerator.skill.testHelpers.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.skill.testHelpers.ts
@@ -91,30 +91,33 @@ export function createMockCharacterWithSkills(): Character {
       fears: ['Failure'],
       relationships: [],
     },
+    // Attribute values sit on the 1-10 scale worlds actually use (worldAnalyzer
+    // pins minValue 1 / maxValue 10), so the narrative descriptors resolve to
+    // Exceptional / High / Moderate rather than falling off the scale.
     attributes: [
       {
         id: 'attr-1',
         characterId: 'char-1',
         worldAttributeId: 'strength',
         name: 'Strength',
-        baseValue: 16,
-        modifiedValue: 16,
+        baseValue: 9,
+        modifiedValue: 9,
       },
       {
         id: 'attr-2',
         characterId: 'char-1',
         worldAttributeId: 'intelligence',
         name: 'Intelligence',
-        baseValue: 14,
-        modifiedValue: 14,
+        baseValue: 7,
+        modifiedValue: 7,
       },
       {
         id: 'attr-3',
         characterId: 'char-1',
         worldAttributeId: 'dexterity',
         name: 'Dexterity',
-        baseValue: 12,
-        modifiedValue: 12,
+        baseValue: 4,
+        modifiedValue: 4,
       },
     ],
     skills: [

--- a/src/lib/ai/__tests__/narrativeGenerator.skillContext.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.skillContext.test.ts
@@ -99,13 +99,14 @@ describe('NarrativeGenerator - Skill Context Integration', () => {
   });
 
   /**
-   * What the scene prompt actually carries about the player character. Skills
-   * are NOT in it: `formatSkillsForNarrative` is wired into the choice prompt
-   * (choiceGenerator.prompt.ts), not this path. This case guards the character
-   * context that IS supposed to be here, and the player-identity rules that
-   * keep the narrator from writing the player as a third party.
+   * What the scene prompt carries about the player character: the background,
+   * the player-identity rules that keep the narrator from writing the player as
+   * a third party, and (the part #1912 was about) the character's skills and
+   * notable attributes under names the model can actually read. The labels are
+   * asserted with their descriptors attached ("Athletics (Master)") so this
+   * can't pass off a stray "Athletics" from somewhere else in the 16k prompt.
    */
-  test('carries the player character background into the scene prompt', async () => {
+  test('carries the player character background, skills and attributes into the scene prompt', async () => {
     const mockResponse = {
       content: "You assess your options, drawing on your athletic prowess and magical knowledge.",
       finishReason: 'stop' as const,
@@ -133,6 +134,16 @@ describe('NarrativeGenerator - Skill Context Integration', () => {
     expect(calledPrompt).toContain('Skilled adventurer with years of experience');
     expect(calledPrompt).toContain('Brave and resourceful');
     expect(calledPrompt).toContain('The player IS Test Hero');
+
+    // Every skill the player invested in, named and rated.
+    expect(calledPrompt).toContain('Athletics (Master)');
+    expect(calledPrompt).toContain('Magic (Expert)');
+    expect(calledPrompt).toContain('Stealth (Competent)');
+
+    // Notable attributes only. Dexterity sits at 4 and stays out.
+    expect(calledPrompt).toContain('Strength (Exceptional)');
+    expect(calledPrompt).toContain('Intelligence (High)');
+    expect(calledPrompt).not.toContain('Dexterity (');
   });
 
   // Lore extraction is a full extra Gemini round-trip that only enriches

--- a/src/lib/ai/attributeSkillFormatter.ts
+++ b/src/lib/ai/attributeSkillFormatter.ts
@@ -21,6 +21,9 @@ interface NormalizedAttribute {
 
 /**
  * Normalized skill format for internal processing
+ *
+ * `skillId` is the label that ends up in the prompt, so it holds the skill's
+ * display name whenever one is available rather than its world id.
  */
 interface NormalizedSkill {
   skillId: string;
@@ -69,12 +72,15 @@ export function normalizeSkillArray(skills: SkillInput): NormalizedSkill[] {
   }
 
   // Check if skills have 'name' property (from Character.skills)
+  // Prefer the name over worldSkillId: these strings are read by the model, and
+  // a world skill's id is a generated `skill_<uuid>` that says nothing about
+  // what the character can do.
   const firstSkill = skills[0];
   if (firstSkill && 'name' in firstSkill) {
     return (
       skills as Array<{ name: string; level: number; worldSkillId?: string }>
     ).map((skill) => ({
-      skillId: skill.worldSkillId || skill.name,
+      skillId: skill.name || skill.worldSkillId || '',
       level: skill.level,
     }));
   }

--- a/src/lib/ai/narrativeGenerator.prompt.personalization.ts
+++ b/src/lib/ai/narrativeGenerator.prompt.personalization.ts
@@ -144,9 +144,14 @@ export const convertToPersonalizationCharacter = (
     id: storeCharacter.id,
     name: storeCharacter.name,
     background,
+    // attributeId is a prompt label here, never a lookup key, so prefer the
+    // display name. A world attribute's id is a generated `attr_<uuid>` and
+    // the model can't read anything into that.
     attributes: Array.isArray(storeCharacter.attributes)
       ? storeCharacter.attributes.map((attribute) => ({
-          attributeId: String(attribute.worldAttributeId ?? attribute.id),
+          attributeId: String(
+            attribute.name || attribute.worldAttributeId || attribute.id
+          ),
           value: Number(attribute.modifiedValue ?? attribute.baseValue ?? 0),
         }))
       : {},


### PR DESCRIPTION
## Description

The scene prompt was already carrying a `SKILLS` line, so the wiring #1912 asked for was mostly there. What it carried was useless. `formatSkillsForNarrative` labels each skill with its `worldSkillId`, and in a real world that id comes out of `generateUniqueId('skill')` as `skill_<uuid>`. The model was reading this every turn:

```
CHARACTER: Test Hero

SKILLS: skill_9f2c8a1b-4d3e-... (Master), skill_2a7b-... (Expert)
```

Which says the character is good at something without ever saying what. Attributes had the identical problem one line away in `convertToPersonalizationCharacter`, where the label came from `worldAttributeId` (a generated `attr_<uuid>`).

Both now prefer the display name and fall back to the id. The prompt reads:

```
CHARACTER: Test Hero

ATTRIBUTES: Strength (Exceptional), Intelligence (High)

SKILLS: Athletics (Master), Magic (Expert), Stealth (Competent)
```

The choice prompt gets the same fix for free, since `choiceGenerator.prompt.ts` calls the same formatter. That's a side effect of fixing the shared function rather than a second change.

So the issue's symptom was real and its diagnosis was off. `formatSkillsForNarrative` was already wired into the scene path through `enhancePromptWithPersonalization`, not missing from it.

## Related Issue

Refs #1912

This PR targets `develop`, so GitHub will not auto-close the issue on merge. It needs closing by hand after the release merge.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The red came first and is worth recording, because #1911 filed this issue precisely for a test that stayed green while the thing it was named for never happened. Adding the assertions to `narrativeGenerator.skillContext.test.ts` before touching any source gave:

```
● carries the player character background, skills and attributes into the scene prompt
  Expected substring: "Athletics (Master)"
  Received string:    "Continue the fantasy narrative for \"Fantasy Realm\" ...
```

Same test after the fix, plus the whole file:

```
Tests: 2 passed, 2 total
```

The assertions pin the descriptor to the name (`Athletics (Master)`, not bare `Athletics`) so they can't pass off some unrelated word elsewhere in the 16k-character prompt.

## User Stories Addressed

As a player, a character built around Stealth should read differently from one built around Athletics, because the model writing the scene knows which one it's looking at.

## Flow Diagrams

N/A

## Component Development

N/A, no UI in this change.

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes

Two one-line label changes plus comments:

| File | Change |
|---|---|
| `src/lib/ai/attributeSkillFormatter.ts` | `normalizeSkillArray` prefers `skill.name` over `skill.worldSkillId` |
| `src/lib/ai/narrativeGenerator.prompt.personalization.ts` | `convertToPersonalizationCharacter` labels attributes by `name` |

No prompt template changed and no prompt string was inlined, so the registry under `src/lib/promptTemplates/` is untouched. This only changes the data an existing enhancer puts into an existing section.

`normalizeSkillArray`'s `skillId` field now holds a display name. That reads oddly, but the value was only ever printed as prompt prose, never used as a lookup key. `formatAttributesForNarrative` and `formatSkillsForNarrative` are the only consumers and both just interpolate it into a string.

**On token cost, which the issue flagged as the thing to decide.** The issue asked whether all skills go in or only those above a threshold, on the grounds that every turn pays. Measured with `estimateTokenCount`, the change is cost-negative, because uuids tokenize terribly and names don't:

| | Tokens |
|---|---|
| Before, 6 skills + 3 attributes as uuids | 375 |
| After, same as names | 47 |
| Delta | -328 per turn |

So no threshold. Every skill still goes in, which keeps the formatter's existing documented rule that skills are player-chosen investments and all of them signal intent, and the prompt got cheaper anyway. A threshold would trade story signal for tokens this change already gave back.

**What this PR does not claim.** Whether the prose actually improves is not measured here. Facts reaching the prompt and facts reaching the page are different problems, which is the whole point of #1828. Reading the story-quality effect needs a playtest run against live Gemini, and that isn't in this change.

One test fixture moved too. `narrativeGenerator.skill.testHelpers.ts` gave its character attributes of 16, 14 and 12, which character creation can't produce, since `worldAnalyzer` pins every world attribute to minValue 1 and maxValue 10. Those values fell off the descriptor scale and read as "Moderate", which the narrative formatter filters out, so the attribute path was untestable through that fixture. They're now 9, 7 and 4.

## Screenshots

N/A

## Visual Baseline Changes

None. This PR doesn't touch `tests/visual/**-snapshots/**`.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit wasn't run locally, CI covers it.

## Testing Instructions

```bash
npm test
npm run type-check
npm run lint
```

Local results on this branch: 443 suites and 3089 tests passed, `tsc --noEmit` clean, ESLint 0 errors (127 pre-existing warnings, all `no-explicit-any` in files this PR doesn't touch).

To see the prompt itself rather than the assertion, drop a `writeFileSync` on `calledPrompt` in the scene-prompt test in `src/lib/ai/__tests__/narrativeGenerator.skillContext.test.ts` and look for the `CHARACTER:` block near the end.

Visual and E2E suites weren't run. Nothing here renders.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

Docs untouched: no doc describes the label format, and the registry is truth for prompt behavior. Accessibility is N/A for a prompt-construction change.
