### PR TITLE
Remove the dead finalize-checkpoint listener

### DIFF
--- a/src/components/GameSession/hooks/useStoryCheckpointManager.ts
+++ b/src/components/GameSession/hooks/useStoryCheckpointManager.ts
@@ -310,18 +310,6 @@ export const useStoryCheckpointManager = ({ worldId, sessionId, characterId }: U
     return () => clearTimeout(timeoutId);
   }, [pendingEvents, status, createCheckpoint]);
 
-  // Listen for session end event to capture final checkpoint
-  React.useEffect(() => {
-    const handleFinalCheckpoint = () => {
-      if (pendingEvents.length > 0 && status !== 'loading') {
-        createCheckpoint();
-      }
-    };
-
-    window.addEventListener('narraitor:finalize-checkpoint', handleFinalCheckpoint);
-    return () => window.removeEventListener('narraitor:finalize-checkpoint', handleFinalCheckpoint);
-  }, [pendingEvents.length, status, createCheckpoint]);
-
   return {
     status,
     error,


### PR DESCRIPTION
## Description

Removes a `window` listener in `useStoryCheckpointManager` that nothing has ever dispatched, so it reads as a working end-of-session hook when it is dead code.

The effect at `useStoryCheckpointManager.ts:313-323` listened for `narraitor:finalize-checkpoint`, meaning to capture one last checkpoint as a session wraps up. A repo-wide grep finds only the `addEventListener` / `removeEventListener` pair. No component, hook, store or test dispatches the event, and no test covers the effect.

I looked at wiring it up instead, and the wiring is worse than it sounds. `ActiveGameSession.tsx:376` does `if (currentEnding) return <EndingScreen />`, which unmounts the whole active-session tree, and `StorySummarySection` is the only thing that mounts this hook. So by the time a session-end dispatch could plausibly fire - `endSession()` from the ending screen at `EndingScreen.tsx:261`, or the unmount path at `GameSession.tsx:245` - the listener is already gone. Making it work means dispatching earlier, from inside `handleEndStory`, and then racing the checkpoint AI call against the ending AI call. That is a feature with a real player-facing tradeoff, not a dead-code cleanup, so it belongs in its own issue if it is wanted.

The behavior gap this leaves is smaller than it looks. The auto-checkpoint at `:294-311` already fires 3 seconds after any unsummarized major event, so events are only lost when a story ends inside that window, or when the same batch already failed once.

## Related Issue

N/A - no issue filed. Surfaced while verifying the doc claims in #1863 / PR #1914.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

N/A. This deletes an unreachable code path with no callers and no test coverage. There is no behavior to write a test against, and adding one to guard an absence would be noise.

- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed

N/A.

## Flow Diagrams

N/A.

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A - no rendered output changes.

## Implementation Notes

Straight deletion, 12 lines, one file. Nothing else in the hook referenced `handleFinalCheckpoint`, and the `pendingEvents` / `status` / `createCheckpoint` values it depended on are all still used by the auto-checkpoint effect above it.

Worth knowing for whoever picks up the end-of-session checkpoint properly:

| Fact | Where |
| --- | --- |
| Ending screen replaces the active session tree | `ActiveGameSession.tsx:376` |
| Only mount point for the hook | `StorySummarySection.tsx:19` |
| Earliest still-mounted dispatch point | `useActiveGameSessionEnding.ts:53` (`handleEndStory`) |
| Recap is reactive to store state | `EndingScreen.tsx:78` (`useMemo` over `sessionCheckpoints`) |

## Screenshots

N/A.

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

N/A.

## Chrome DevTools MCP Verification Summary (if applicable)

N/A.

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

`npm run lint` exits 0 with 128 warnings, all pre-existing. Security audit is CI's job on this PR.

## Testing Instructions

1. `grep -rn "finalize-checkpoint" src/` returns nothing.
2. `npx jest src/components/GameSession` - 28 suites, 150 tests, all pass.
3. Play a session past a major event, wait 3 seconds, and confirm the Story So Far panel still fills. The auto-checkpoint path is untouched.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

On documentation: `public_docs/features/story-checkpoints.md` on `develop` does not mention this event at all. The sentence that does - "though nothing in the app dispatches that event right now" - only exists on PR #1914's branch. Once #1914 merges, that clause needs dropping. Flagging it here rather than editing a file this branch cannot see.
