### PR TITLE
Strip the narrativeSummary field nothing reads

### DIFF
--- a/src/app/api/narrative/story-checkpoint/route.ts
+++ b/src/app/api/narrative/story-checkpoint/route.ts
@@ -154,7 +154,6 @@ export async function POST(request: NextRequest) {
       characterId: rawBody?.characterId ? safeTrim(String(rawBody.characterId)) : undefined,
       events,
       decisions: sanitizeDecisions(rawBody?.decisions),
-      narrativeSummary: rawBody?.narrativeSummary ? safeTrim(String(rawBody.narrativeSummary)) : undefined,
       currentLocation: rawBody?.currentLocation ? safeTrim(String(rawBody.currentLocation)) : undefined,
       activeGoals: Array.isArray(rawBody?.activeGoals)
         ? rawBody.activeGoals

--- a/src/components/GameSession/hooks/useStoryCheckpointManager.ts
+++ b/src/components/GameSession/hooks/useStoryCheckpointManager.ts
@@ -17,7 +17,6 @@ interface UseStoryCheckpointManagerArgs {
 }
 
 const MAX_DECISIONS = 5;
-const MAX_SEGMENT_SUMMARY = 600;
 
 const buildCheckpointFromResponse = (
   data: StoryCheckpointResponseBody,
@@ -86,29 +85,12 @@ const buildDecisionPayload = (
     .slice(-MAX_DECISIONS);
 };
 
-const collectNarrativeContext = (
-  sessionId: string,
-): { summary?: string; location?: string } => {
+const collectCurrentLocation = (sessionId: string): string | undefined => {
   const { getSessionSegments } = useNarrativeStore.getState();
   const segments = getSessionSegments(sessionId);
-  if (!segments.length) {
-    return {};
-  }
-
-  const summary = segments
-    .slice(-3)
-    .map((segment) => safeTrim(segment.content))
-    .filter(Boolean)
-    .join(' ')
-    .slice(0, MAX_SEGMENT_SUMMARY);
-
   const latest = segments[segments.length - 1];
-  const location = latest?.metadata?.location ? safeTrim(latest.metadata.location) : undefined;
 
-  return {
-    summary: summary || undefined,
-    location,
-  };
+  return latest?.metadata?.location ? safeTrim(latest.metadata.location) : undefined;
 };
 
 const formatEventsForApi = (
@@ -226,7 +208,7 @@ export const useStoryCheckpointManager = ({ worldId, sessionId, characterId }: U
 
     try {
       const decisions = buildDecisionPayload(sessionId);
-      const narrativeContext = collectNarrativeContext(sessionId);
+      const currentLocation = collectCurrentLocation(sessionId);
 
       // Get last 2-3 checkpoint segments for narrative continuity
       const existingCheckpoints = worldState?.storyCheckpoints ?? [];
@@ -247,8 +229,7 @@ export const useStoryCheckpointManager = ({ worldId, sessionId, characterId }: U
         characterName: characterId ? characterNameLookup[characterId] : undefined,
         events: formattedEvents,
         decisions,
-        narrativeSummary: narrativeContext.summary,
-        currentLocation: narrativeContext.location,
+        currentLocation,
         previousSegments,
         toneSettings: world?.toneSettings,
       });

--- a/src/lib/narrative/storyCheckpointPayload.ts
+++ b/src/lib/narrative/storyCheckpointPayload.ts
@@ -7,7 +7,6 @@ interface BuildStoryCheckpointPayloadParams {
   characterName?: string;
   events: StoryCheckpointRequestBody['events'];
   decisions?: StoryCheckpointRequestBody['decisions'];
-  narrativeSummary?: string;
   currentLocation?: string;
   activeGoals?: string[];
   previousSegments?: string[];
@@ -21,7 +20,6 @@ export const buildStoryCheckpointPayload = ({
   characterName,
   events,
   decisions,
-  narrativeSummary,
   currentLocation,
   activeGoals,
   previousSegments,
@@ -37,7 +35,6 @@ export const buildStoryCheckpointPayload = ({
     characterId,
     events,
     decisions: decisions ?? [],
-    narrativeSummary: narrativeSummary || undefined,
     currentLocation: currentLocation || undefined,
     activeGoals: normalizedGoals && normalizedGoals.length > 0 ? normalizedGoals : undefined,
     characterName: characterName || undefined,

--- a/src/types/story-checkpoint.types.ts
+++ b/src/types/story-checkpoint.types.ts
@@ -25,7 +25,6 @@ export interface StoryCheckpointRequestBody {
   characterName?: string;
   events: StoryCheckpointEventPayload[];
   decisions?: StoryCheckpointDecisionPayload[];
-  narrativeSummary?: string;
   currentLocation?: string;
   activeGoals?: string[];
   previousSegments?: string[]; // Last 2-3 checkpoint segments for narrative continuity


### PR DESCRIPTION
## Description

Strips `narrativeSummary` from the story-checkpoint request. It was collected from the last 3 narrative segments, capped at 600 characters, sanitized by the route, typed in the request body, and then never read by anything.

The full chain, all four links now gone:

| Link | File |
| --- | --- |
| Built from the last 3 segments | `useStoryCheckpointManager.ts:98-103` |
| Passed through the payload builder | `storyCheckpointPayload.ts:10,24,40` |
| Sanitized into the request | `story-checkpoint/route.ts:157` |
| Declared on the request type | `story-checkpoint.types.ts:28` |

`buildPrompt` in `storyCheckpointGenerator.ts` reads `events`, `decisions`, `currentLocation`, `activeGoals`, `characterName`, `previousSegments` and `toneSettings`. Never `narrativeSummary`.

I went with removal rather than wiring it into the prompt, for two reasons. The first is that `previousSegments` already occupies the slot this would fill: `storyCheckpointGenerator.ts:64-66` injects the last 3 checkpoint segments as `RECENT STORY (for context only - DO NOT retell this)`, and the writing requirements below it repeat that instruction. Adding the raw narrative prose to a prompt whose next line says not to retell it works against the prompt rather than with it. The second is evidence: claiming raw recent narrative makes the segment read better is a story-quality claim, and per `narraitor-ai-quality-discipline` that needs a before-and-after read on real play, not a hunch. Nobody has run one. If someone wants to, it should be its own issue with its own measurement, not a field quietly reactivated here.

## Related Issue

N/A - no issue filed. Surfaced while verifying the doc claims in #1863 / PR #1914.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

N/A. This removes a field with no reader and no test coverage - `grep -rn "narrativeSummary" src/ tests/` found zero test references before the change. There is no behavior to write a test against.

- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed

N/A.

## Flow Diagrams

N/A.

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A - no rendered output changes.

## Implementation Notes

Four files, 28 deletions against 4 insertions.

One rename came with it. `collectNarrativeContext` returned `{ summary, location }`, and `location` is genuinely used as `currentLocation`. With `summary` gone the function returns one value, so it is now `collectCurrentLocation(sessionId): string | undefined`. Keeping the old name over a single-purpose location lookup is the kind of thing a later sweep files a finding against.

The empty-session guard went with it and the behavior is identical: on an empty array `segments[segments.length - 1]` is `undefined`, and the optional chain returns `undefined` the same way the old early return did.

On the wire contract: the route no longer reads `narrativeSummary` off the raw body, so a stale client that still sends the key gets it ignored rather than erroring. Nothing rejects unknown keys.

## Screenshots

N/A.

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

N/A.

## Chrome DevTools MCP Verification Summary (if applicable)

N/A.

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

`npm run lint` exits 0. Security audit is CI's job on this PR.

## Testing Instructions

1. `grep -rn "narrativeSummary\|MAX_SEGMENT_SUMMARY\|collectNarrativeContext" src/ tests/` returns nothing.
2. `npx jest src/components/GameSession src/lib/narrative src/app/api` - 54 suites, 364 tests, all pass.
3. Play a session past a major event and confirm the Story So Far panel still fills, and that the segment still reflects the current location. `currentLocation` is the part of the old collector that survived.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

On documentation: `public_docs/features/story-checkpoints.md` on `develop` never mentions `narrativeSummary`. The sentence describing it as accepted-but-ignored exists only on PR #1914's branch, which this branch cannot see. Once #1914 merges, that sentence needs dropping. Same follow-up as the one flagged on #1917.
