### PR TITLE
Drop two checkpoint doc claims that went stale

### DIFF
--- a/public_docs/features/story-checkpoints.md
+++ b/public_docs/features/story-checkpoints.md
@@ -13,7 +13,7 @@ Major events are what drive all of this, and they're gated two different ways:
 - The first narrative segment of a session always records one, so the recap has something in it from the start.
 - Every candidate after that goes through `POST /api/narrative/validate-event-significance`, and only the events the AI calls consequential get recorded. That check fails open: if the request errors or the response won't parse, the candidate is recorded anyway rather than dropped. So an event that looks insignificant in the recap may have arrived that way, not because the AI approved it.
 
-The hook also listens for a `narraitor:finalize-checkpoint` window event so a session can capture one last checkpoint on the way out, though nothing in the app dispatches that event right now. Checkpoint generation is skipped entirely under Playwright (`isPlaywrightEnv`), because seeded E2E and visual pages have no AI key and the request would just hang.
+Checkpoint generation is skipped entirely under Playwright (`isPlaywrightEnv`), because seeded E2E and visual pages have no AI key and the request would just hang.
 
 Where the recap shows up depends on the progressive disclosure flag. With the flag off it sits in the support column below the narrative, and with it on it moves into the Story So Far drawer.
 
@@ -60,7 +60,7 @@ Server-side AI work happens through `POST /api/narrative/story-checkpoint`. The 
 }
 ```
 
-That's the minimum the route needs. It also takes `characterName`, `currentLocation`, `activeGoals`, `toneSettings`, and `previousSegments`, which carries the last three checkpoint segments and is the only reason consecutive segments read as one story. There's a `narrativeSummary` field too, but the prompt builder ignores it. The full shape lives in `src/types/story-checkpoint.types.ts`. Events are capped at 10 per request and decisions at 5.
+That's the minimum the route needs. It also takes `characterName`, `currentLocation`, `activeGoals`, `toneSettings`, and `previousSegments`, which carries the last three checkpoint segments and is the only reason consecutive segments read as one story. The full shape lives in `src/types/story-checkpoint.types.ts`. Events are capped at 10 per request and decisions at 5.
 
 The response:
 


### PR DESCRIPTION
## Description

Drops two sentences from `story-checkpoints.md` that described code deleted in #1917 and #1918. Both were accurate when #1914 landed and went stale within the hour.

| Removed claim | Made stale by |
| --- | --- |
| The hook "listens for a `narraitor:finalize-checkpoint` window event ... though nothing in the app dispatches that event right now" | #1917 removed the listener |
| "There's a `narrativeSummary` field too, but the prompt builder ignores it" | #1918 removed the field from the whole chain |

The Playwright sentence that shared a paragraph with the first one is kept, now as its own paragraph.

## Related Issue

N/A - follow-up to #1914, #1917 and #1918. The underlying doc-accuracy issue is #1863.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

N/A - documentation only, no code changed.

- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed

N/A.

## Flow Diagrams

N/A.

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A.

## Implementation Notes

Two sentences, one file. Verified after the edit that `grep -n "finalize-checkpoint\|narrativeSummary" public_docs/features/story-checkpoints.md` returns nothing, and that neither string survives anywhere in `src/`.

## Screenshots

N/A.

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

N/A.

## Chrome DevTools MCP Verification Summary (if applicable)

N/A.

## Quality Checks
- [ ] Linting passed
- [ ] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

`docs:check-links` exits 0, 93 docs checked, no broken links. Lint and type-check are N/A for a markdown-only change and CI runs them regardless.

## Testing Instructions

1. `grep -rn "finalize-checkpoint\|narrativeSummary" src/ public_docs/` returns nothing.
2. Read `public_docs/features/story-checkpoints.md` end to end and check every remaining claim still has code behind it.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
