### PR TITLE
Catch a re-promise that names the delivered item by its inventory name

### DIFF
--- a/src/lib/ai/narrativeGenerator.continuity.ts
+++ b/src/lib/ai/narrativeGenerator.continuity.ts
@@ -12,6 +12,7 @@ import { useWorldStore } from '@/state/worldStore';
 import { useNPCStore } from '@/state/npcStore';
 import { useLoreStore } from '@/state/loreStore';
 import { useContinuityStore } from '@/state/continuityStore';
+import { useInventoryStore } from '@/state/inventoryStore';
 import { generateUniqueId } from '@/lib/utils/generateId';
 import { logger } from '@/lib/utils/logger';
 import type { AIClient } from './types';
@@ -72,6 +73,24 @@ const readSessionFacts = (request: NarrativeGenerationRequest): LoreFact[] => {
 };
 
 /**
+ * Names of what the player is carrying. A delivered commitment matches these
+ * against its own topic so prose can name the thing the way the inventory does
+ * ("a copy", "the envelope") and still be recognised as that commitment.
+ */
+const readInventoryItemNames = (request: NarrativeGenerationRequest): string[] => {
+  const inventoryStoreState = useInventoryStore.getState();
+  if (typeof inventoryStoreState?.getCharacterItems !== 'function') return [];
+
+  const names: string[] = [];
+  for (const characterId of request.characterIds ?? []) {
+    for (const item of inventoryStoreState.getCharacterItems(characterId) ?? []) {
+      if (item?.name) names.push(item.name);
+    }
+  }
+  return names;
+};
+
+/**
  * Topic labels already in the ledger, handed to the lore extractor so a
  * repeated question lands on the same label. Empty on any store failure.
  */
@@ -128,6 +147,7 @@ export const buildContinuityContractFromStores = (
       npcNames,
       recentDecisions: collectRecentDecisions(request),
       playerName: options?.playerName,
+      inventoryItemNames: readInventoryItemNames(request),
     });
 
     if (carriesNothingForTheModel(contract)) {

--- a/src/lib/lore/__tests__/continuityGuardrail.test.ts
+++ b/src/lib/lore/__tests__/continuityGuardrail.test.ts
@@ -202,13 +202,18 @@ const makeEvent = (
     metadata: { importance: 'high', continuity },
   });
 
-const buildLedgerContract = (facts: LoreFact[], playerName?: string) =>
+const buildLedgerContract = (
+  facts: LoreFact[],
+  playerName?: string,
+  inventoryItemNames?: string[]
+) =>
   buildContinuityContract({
     facts,
     npcRelationships: {},
     npcNames: {},
     recentDecisions: [],
     playerName,
+    inventoryItemNames,
   });
 
 describe('ledger-fed contract', () => {
@@ -331,6 +336,35 @@ describe('ledger-fed contract', () => {
     ).toHaveLength(0);
     expect(
       detectContinuityIssues('Thorn promises to look into the drainage complaint.', contract)
+    ).toHaveLength(0);
+  });
+
+  it('flags a future-tense re-promise that names the delivered item by an inventory alias', () => {
+    const contract = buildLedgerContract(
+      [
+        makeEvent('e1', 'Councilman Davies hands over the parcel appraisal.', {
+          kind: 'commitment',
+          topic: 'parcel appraisal documents',
+          speaker: 'Councilman Davies',
+          status: 'delivered',
+        }),
+      ],
+      undefined,
+      ['Copy of the parcel appraisal']
+    );
+
+    expect(
+      detectContinuityIssues(
+        'Davies spreads his hands. "You\'ll have a copy. Before the vote, just as I said."',
+        contract
+      )
+    ).toMatchObject([{ type: 'stale-promise', entity: 'parcel appraisal documents' }]);
+
+    expect(
+      detectContinuityIssues(
+        '"You\'ll have my answer before the vote," Davies says.',
+        contract
+      )
     ).toHaveLength(0);
   });
 

--- a/src/lib/lore/__tests__/continuityGuardrail.test.ts
+++ b/src/lib/lore/__tests__/continuityGuardrail.test.ts
@@ -368,6 +368,28 @@ describe('ledger-fed contract', () => {
     ).toHaveLength(0);
   });
 
+  it('leaves an unrelated future event that happens to share one topic word', () => {
+    const contract = buildLedgerContract(
+      [
+        makeEvent('e1', 'Councilman Davies hands over the parcel appraisal.', {
+          kind: 'commitment',
+          topic: 'parcel appraisal documents',
+          speaker: 'Councilman Davies',
+          status: 'delivered',
+        }),
+      ],
+      undefined,
+      ['Copy of the parcel appraisal']
+    );
+
+    expect(
+      detectContinuityIssues(
+        '"You\'ll have the parcel rezoned before the vote," Davies says.',
+        contract
+      )
+    ).toHaveLength(0);
+  });
+
   it('collects distinct topic labels for the extractor hint', () => {
     const topics = collectContinuityTopics([
       makeEvent('e1', 'a', { kind: 'assertion', topic: 'Mill debt' }),

--- a/src/lib/lore/__tests__/continuityGuardrail.test.ts
+++ b/src/lib/lore/__tests__/continuityGuardrail.test.ts
@@ -368,6 +368,36 @@ describe('ledger-fed contract', () => {
     ).toHaveLength(0);
   });
 
+  it('flags a re-promise naming an item the delivery prose named but the topic never did', () => {
+    const contract = buildLedgerContract(
+      [
+        makeEvent('e1', 'The mayor hands you a sealed envelope.', {
+          kind: 'commitment',
+          topic: "mayor's letter",
+          speaker: 'The mayor',
+          status: 'delivered',
+        }),
+      ],
+      undefined,
+      ['Sealed Envelope', 'Rusted Lantern']
+    );
+
+    expect(
+      detectContinuityIssues(
+        '"You\'ll have the envelope before dawn," the mayor says.',
+        contract
+      )
+    ).toMatchObject([{ type: 'stale-promise', entity: "mayor's letter" }]);
+
+    // An item the delivery prose never mentioned stays out of the trigger list.
+    expect(
+      detectContinuityIssues(
+        '"You\'ll have the lantern before dawn," the mayor says.',
+        contract
+      )
+    ).toHaveLength(0);
+  });
+
   it('leaves an unrelated future event that happens to share one topic word', () => {
     const contract = buildLedgerContract(
       [

--- a/src/lib/lore/continuityGuardrail.ts
+++ b/src/lib/lore/continuityGuardrail.ts
@@ -282,7 +282,11 @@ export function detectContinuityIssues(
     const terms = topicTerms(commitment.topic);
     if (terms.length === 0) continue;
     const termPatterns = terms.map(termPattern);
-    const referencePatterns = commitment.terms.map(termPattern);
+    // Only the words the topic label doesn't already use. A topic word on its own
+    // is far too common in ordinary prose to carry a correction by itself.
+    const aliasPatterns = commitment.terms
+      .filter((term) => !terms.includes(term))
+      .map(termPattern);
 
     const sentence = sentences.find((candidate) => {
       if (RECAP_GUARD.test(candidate)) return false;
@@ -293,11 +297,13 @@ export function detectContinuityIssues(
       ) {
         return true;
       }
-      // Named obliquely: a future delivery to the player plus any one word the
-      // thing goes by, so a pronoun or a synonym still lands.
+      // Named obliquely: a future delivery to the player, plus either a name only
+      // the delivered item goes by or the whole topic spelled out. Anything looser
+      // fires on prose that merely reuses a topic word for something else.
       return (
         FUTURE_DELIVERY_LEXICON.test(candidate) &&
-        referencePatterns.some((pattern) => pattern.test(candidate))
+        (aliasPatterns.some((pattern) => pattern.test(candidate)) ||
+          termPatterns.every((pattern) => pattern.test(candidate)))
       );
     });
     if (sentence) {

--- a/src/lib/lore/continuityGuardrail.ts
+++ b/src/lib/lore/continuityGuardrail.ts
@@ -58,6 +58,11 @@ const MEMORY_GUARD =
 // A fresh promise of something the ledger says was already delivered.
 const PROMISE_LEXICON =
   /\b(promis(?:e|es|ing)|vow(?:s|ing)?|swear(?:s)?|pledg(?:e|es|ing)|assur(?:e|es|ing) you|guarantee(?:s|ing)?|(?:I|we)(?:'ll| will| shall) (?:make sure|see to it|get you|bring you|have|provide|send|give))\b/i;
+// The other shape a re-promise takes: no promise verb at all, just a future
+// delivery aimed at the player ("You'll have a copy"). Second person only —
+// first-person futures are already the promise lexicon's job.
+const FUTURE_DELIVERY_LEXICON =
+  /\byou(?:['’]ll| will| shall| ['’]re going to| are going to)\s+(?:have|get|receive|be given|be handed)\b/i;
 const RECAP_GUARD =
   /\b(as (?:I |he |she |they |we )?promised|promised (?:earlier|before|you)|already|kept (?:his|her|their|my|our) (?:word|promise)|delivered|gave|handed|as agreed|in your (?:hands?|lap|possession))\b/i;
 
@@ -74,6 +79,12 @@ export interface BuildContinuityContractArgs {
    * character context.
    */
   playerName?: string;
+  /**
+   * Names of items the player is carrying. A delivered commitment borrows the
+   * names of the items that match it, so prose can refer to the thing the way
+   * the player's inventory does rather than the way the topic label does.
+   */
+  inventoryItemNames?: string[];
 }
 
 /**
@@ -109,7 +120,14 @@ function dedupeTerms(terms: Array<string | undefined>): string[] {
 export function buildContinuityContract(
   args: BuildContinuityContractArgs
 ): ContinuityContract {
-  const { facts, npcRelationships, npcNames, recentDecisions, playerName } = args;
+  const {
+    facts,
+    npcRelationships,
+    npcNames,
+    recentDecisions,
+    playerName,
+    inventoryItemNames,
+  } = args;
   const characterFacts = facts.filter((fact) => fact?.category === 'characters');
 
   const npcs: ContinuityNpcExpectation[] = [];
@@ -169,7 +187,7 @@ export function buildContinuityContract(
     canonFacts,
     recentDecisions: recentDecisions.slice(-MAX_RECENT_DECISIONS),
     assertions: buildAssertions(ledger, playerName),
-    commitments: buildCommitments(ledger),
+    commitments: buildCommitments(ledger, inventoryItemNames),
     sceneChanges: buildSceneChanges(ledger),
   };
 }
@@ -183,6 +201,11 @@ export function isContinuityContractEmpty(contract: ContinuityContract): boolean
     contract.commitments.length === 0 &&
     contract.sceneChanges.length === 0
   );
+}
+
+/** Word-start match, so "document" also catches "documents". */
+function termPattern(term: string): RegExp {
+  return new RegExp(`\\b${escapeRegExp(term)}`, 'i');
 }
 
 function findOffendingSentence(
@@ -258,13 +281,25 @@ export function detectContinuityIssues(
     if (commitment.status !== 'delivered') continue;
     const terms = topicTerms(commitment.topic);
     if (terms.length === 0) continue;
-    const termPatterns = terms.map((term) => new RegExp(`\\b${escapeRegExp(term)}`, 'i'));
-    const sentence = sentences.find(
-      (candidate) =>
+    const termPatterns = terms.map(termPattern);
+    const referencePatterns = commitment.terms.map(termPattern);
+
+    const sentence = sentences.find((candidate) => {
+      if (RECAP_GUARD.test(candidate)) return false;
+      // Named outright: a promise verb plus every word of the topic.
+      if (
         PROMISE_LEXICON.test(candidate) &&
-        !RECAP_GUARD.test(candidate) &&
         termPatterns.every((pattern) => pattern.test(candidate))
-    );
+      ) {
+        return true;
+      }
+      // Named obliquely: a future delivery to the player plus any one word the
+      // thing goes by, so a pronoun or a synonym still lands.
+      return (
+        FUTURE_DELIVERY_LEXICON.test(candidate) &&
+        referencePatterns.some((pattern) => pattern.test(candidate))
+      );
+    });
     if (sentence) {
       issues.push({
         type: 'stale-promise',

--- a/src/lib/lore/continuityLedger.ts
+++ b/src/lib/lore/continuityLedger.ts
@@ -144,7 +144,7 @@ export function buildCommitments(
       by: annotation.speaker?.trim() || existing?.by || NARRATION_SPEAKER,
       statement: fact.value.trim(),
       status,
-      terms: referenceTerms(topic, itemNames),
+      terms: referenceTerms(topic, itemNames, fact.value),
     });
   }
   return Array.from(byTopic.values()).slice(-MAX_COMMITMENTS);
@@ -181,18 +181,26 @@ export function topicTerms(topic: string): string[] {
 
 /**
  * Every word a sentence might use to point at this commitment: the topic's own
- * terms, plus the terms of any inventory item that overlaps the topic. That is
- * what lets "You'll have a copy" land on "parcel appraisal documents". The item
- * in the player's hands is called a copy; the topic label never is.
+ * terms, plus the terms of any inventory item the commitment actually names.
+ * That is what lets "You'll have a copy" land on "parcel appraisal documents".
+ * The item in the player's hands is called a copy; the topic label never is.
+ *
+ * An item counts as named when it overlaps the topic or the delivering line.
+ * A topic label and its item are often genuine synonyms sharing no word at all
+ * — "mayor's letter" against a Sealed Envelope — and the prose that handed it
+ * over is what ties them together. Items neither one mentions contribute
+ * nothing, otherwise the whole backpack becomes a trigger word list.
  */
-export function referenceTerms(topic: string, itemNames: string[] = []): string[] {
+export function referenceTerms(
+  topic: string,
+  itemNames: string[] = [],
+  statement = ''
+): string[] {
   const terms = topicTerms(topic);
-  const topicSet = new Set(terms);
+  const named = new Set([...terms, ...significantTerms(statement)]);
   for (const name of itemNames) {
     const itemTerms = significantTerms(name);
-    // Only items the topic actually names contribute; otherwise the whole
-    // backpack becomes a trigger word list.
-    if (!itemTerms.some((term) => topicSet.has(term))) continue;
+    if (!itemTerms.some((term) => named.has(term))) continue;
     for (const term of itemTerms) {
       if (!terms.includes(term)) terms.push(term);
     }

--- a/src/lib/lore/continuityLedger.ts
+++ b/src/lib/lore/continuityLedger.ts
@@ -25,6 +25,7 @@ const MAX_COMMITMENTS = 6;
 const MAX_SCENE_CHANGES = 4;
 const MIN_TOPIC_TERM_LENGTH = 4;
 const MAX_TOPIC_TERMS = 3;
+const MAX_REFERENCE_TERMS = 6;
 const NARRATION_SPEAKER = 'narration';
 /** Shortest name or alias worth matching as a whole word. */
 export const MIN_TERM_LENGTH = 3;
@@ -123,7 +124,10 @@ export function buildAssertions(ledger: LoreFact[], playerName?: string): Contin
 }
 
 /** Delivered beats promised on the same topic; the delivering fact is the statement kept. */
-export function buildCommitments(ledger: LoreFact[]): ContinuityCommitment[] {
+export function buildCommitments(
+  ledger: LoreFact[],
+  itemNames: string[] = []
+): ContinuityCommitment[] {
   const byTopic = new Map<string, ContinuityCommitment>();
   for (const fact of ledger) {
     const annotation = fact.metadata!.continuity!;
@@ -140,6 +144,7 @@ export function buildCommitments(ledger: LoreFact[]): ContinuityCommitment[] {
       by: annotation.speaker?.trim() || existing?.by || NARRATION_SPEAKER,
       statement: fact.value.trim(),
       status,
+      terms: referenceTerms(topic, itemNames),
     });
   }
   return Array.from(byTopic.values()).slice(-MAX_COMMITMENTS);
@@ -162,10 +167,35 @@ export function buildSceneChanges(ledger: LoreFact[]): ContinuitySceneChange[] {
   return Array.from(latestByTopic.values()).slice(-MAX_SCENE_CHANGES);
 }
 
+/** Words of a label worth matching on: long enough to be distinctive, not filler. */
+function significantTerms(label: string): string[] {
+  return normalizeTopic(label)
+    .split(' ')
+    .filter((term) => term.length >= MIN_TOPIC_TERM_LENGTH && !TOPIC_STOPWORDS.has(term));
+}
+
 /** Significant words of a topic label; all must appear in a sentence for a stale-promise hit. */
 export function topicTerms(topic: string): string[] {
-  return normalizeTopic(topic)
-    .split(' ')
-    .filter((term) => term.length >= MIN_TOPIC_TERM_LENGTH && !TOPIC_STOPWORDS.has(term))
-    .slice(0, MAX_TOPIC_TERMS);
+  return significantTerms(topic).slice(0, MAX_TOPIC_TERMS);
+}
+
+/**
+ * Every word a sentence might use to point at this commitment: the topic's own
+ * terms, plus the terms of any inventory item that overlaps the topic. That is
+ * what lets "You'll have a copy" land on "parcel appraisal documents" — the
+ * item in the player's hands is called a copy, the topic label never is.
+ */
+export function referenceTerms(topic: string, itemNames: string[] = []): string[] {
+  const terms = topicTerms(topic);
+  const topicSet = new Set(terms);
+  for (const name of itemNames) {
+    const itemTerms = significantTerms(name);
+    // Only items the topic actually names contribute; otherwise the whole
+    // backpack becomes a trigger word list.
+    if (!itemTerms.some((term) => topicSet.has(term))) continue;
+    for (const term of itemTerms) {
+      if (!terms.includes(term)) terms.push(term);
+    }
+  }
+  return terms.slice(0, MAX_REFERENCE_TERMS);
 }

--- a/src/lib/lore/continuityLedger.ts
+++ b/src/lib/lore/continuityLedger.ts
@@ -182,8 +182,8 @@ export function topicTerms(topic: string): string[] {
 /**
  * Every word a sentence might use to point at this commitment: the topic's own
  * terms, plus the terms of any inventory item that overlaps the topic. That is
- * what lets "You'll have a copy" land on "parcel appraisal documents" — the
- * item in the player's hands is called a copy, the topic label never is.
+ * what lets "You'll have a copy" land on "parcel appraisal documents". The item
+ * in the player's hands is called a copy; the topic label never is.
  */
 export function referenceTerms(topic: string, itemNames: string[] = []): string[] {
   const terms = topicTerms(topic);

--- a/src/types/continuity.types.ts
+++ b/src/types/continuity.types.ts
@@ -64,6 +64,12 @@ export interface ContinuityCommitment {
   by: string;
   statement: string;
   status: 'promised' | 'delivered';
+  /**
+   * Words a sentence can use to refer to this commitment — the topic's own
+   * significant terms plus those of a matching inventory item. Detection only;
+   * these never reach the prompt.
+   */
+  terms: string[];
 }
 
 /** A lasting change the player made to the scene, still true until undone on-page. */


### PR DESCRIPTION
## Description

The `stale-promise` check in `detectContinuityIssues` could only see a re-promise that used a promise verb and named its topic outright. That missed the phrasing the #1831 step-2 eval log recorded at run A T9, where the player baited Davies into re-promising an appraisal he'd already handed over at T5 and he answered "You'll have a copy. Before the vote, just as I said." No promise verb, no topic word, so the regex had nothing to match on even with DELIVERED sitting in the contract block.

Two deterministic additions close that. A delivered commitment now carries a set of reference terms: its own topic terms plus the terms of any inventory item whose name overlaps that topic. So when the player is carrying "Copy of the parcel appraisal" and the commitment topic is "parcel appraisal documents", the word "copy" becomes a way to point at that commitment. Alongside it, a second-person future-delivery lexicon (`you'll have`, `you will receive`, `you're going to get`) gives detection a verb to match when the promise verb is absent entirely.

The two paths stay separate on purpose. The original path is unchanged: a promise verb plus every significant word of the topic. The new one requires a future delivery aimed at the player plus any single reference term. Both are gated behind a DELIVERED commitment existing at all, and both still yield to the recap guard, so a sentence that refers back to the handover ("as promised, the documents sit in your lap") stays clean.

No AI call was added. The issue offered a semantic check as the alternative; the deterministic route reaches the T9 case, so it wasn't needed and the fail-open and one-corrective-call-per-turn invariants are untouched.

## Related Issue

Closes #1858

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The new test was written and run against the unmodified detector first, using the real T9 phrasing as the fixture. It failed the way the issue predicts, with an empty issue list:

```
● ledger-fed contract › flags a future-tense re-promise that names the delivered item by an inventory alias

    expect(received).toMatchObject(expected)

    - Expected  - 6
    + Received  + 1

    - Array [
    -   Object {
    -     "entity": "parcel appraisal documents",
    -     "type": "stale-promise",
    -   },
    - ]
    + Array []

Tests: 1 failed, 19 skipped, 20 total
```

The same test has a negative half that guards against the obvious false positive: "You'll have my answer before the vote" hits the future-delivery lexicon but carries no reference term, so it doesn't fire.

## User Stories Addressed

As a player, when an NPC has already handed me something, I don't want them promising it to me again a few turns later just because I asked them to.

This is one of the acceptance criteria on #1831 ("does not promise what the player already has"), which the step-2 eval scored as mixed: prevention held when the player asked neutrally at run A T22, and lost to a direct re-promise bait at T9.

## Flow Diagrams

N/A

## Component Development

N/A - no UI in this change.

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes

| File | What changed |
|---|---|
| `src/lib/lore/continuityLedger.ts` | Extracted `significantTerms`, added `referenceTerms(topic, itemNames)`, `buildCommitments` takes an optional item-name list |
| `src/lib/lore/continuityGuardrail.ts` | Added `FUTURE_DELIVERY_LEXICON` and the second detection path, `inventoryItemNames` on the contract args, extracted `termPattern` |
| `src/lib/ai/narrativeGenerator.continuity.ts` | Reads the player's inventory item names for the contract |
| `src/types/continuity.types.ts` | `ContinuityCommitment.terms` |

Two things worth calling out on false positives, since that's the cost that keeps this check narrow.

Inventory items only contribute terms when their name already shares a significant word with the commitment topic. Without that filter, every item in the player's pack becomes a trigger word and a sentence like "you'll have a lantern" starts flagging an unrelated delivered promise. The overlap test runs against the topic's own terms, not the accumulating set, so one matched item can't pull in a second unrelated one. Reference terms are capped at six.

The future-delivery lexicon is second person only. First-person futures ("I'll send you", "we'll provide") are already the promise lexicon's job, and duplicating them there would widen the first path by the back door. Step 1 of #1831 already showed a wider promise lexicon mostly buys false positives.

The inventory read sits inside the existing try/catch in `buildContinuityContractFromStores` and guards on `getCharacterItems` being a function, so a store that isn't there yet returns an empty list rather than killing the contract.

## Screenshots

N/A

## Visual Baseline Changes

None

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

`npm run lint` reports 0 errors (127 pre-existing warnings, all in `tests/visual/**` files this PR doesn't touch). `npm run type-check` clean.

## Testing Instructions

```bash
npx jest src/lib/lore --silent                                    # 41 passed
npx jest src/lib/ai/__tests__/narrativeGenerator.continuity.test.ts  # wiring layer, 8 passed with its sibling
npm run type-check
npm run lint
npm run test:ci                                                   # 444 suites / 3093 tests, all green
```

To see the new path fail without the fix, check the two `src/lib/lore` files out from the parent commit (`git checkout HEAD~1 -- src/lib/lore`) and rerun the guardrail spec: the T9 fixture returns an empty issue array.

Live verification is a separate matter. This lands the detector; whether it actually fires on a real session, and whether it fires on anything it shouldn't, needs a play round against live Gemini with the DevTools continuity panel open. The step-2 eval measured 0 fires across 42 turns with the old check, so there's no baseline rate to compare against yet.

## Checklist

- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

On the file-size box: `continuityGuardrail.ts` goes 378 to 413 lines and `narrativeGenerator.continuity.ts` goes 287 to 307. The first was already over the 300 limit before this change and the second crosses it here. Splitting the guardrail module is a real cleanup but it isn't this PR's job, so the box stays unticked rather than quietly ignored.
