### PR TITLE
Stop a 501-character type() leaking keystrokes into the next test

### DIFF
--- a/src/components/world/SkillEditor/__tests__/SkillEditor.test.tsx
+++ b/src/components/world/SkillEditor/__tests__/SkillEditor.test.tsx
@@ -240,8 +240,14 @@ describe('SkillEditor', () => {
       },
     ])('validates $name limits', async ({ input, errorMatch }) => {
       const user = renderAndSetup();
-      await user.type(screen.getByLabelText(/skill name/i), input.name);
-      await user.type(screen.getByLabelText(/description/i), input.description);
+      // Paste instead of type. These inputs run to hundreds of characters, and a
+      // keystroke-by-keystroke loop that long can outrun the test timeout. Jest then
+      // abandons the test while the typing keeps going, and the stray keystrokes land
+      // on whatever input the next test has focused.
+      await user.click(screen.getByLabelText(/skill name/i));
+      await user.paste(input.name);
+      await user.click(screen.getByLabelText(/description/i));
+      await user.paste(input.description);
       await user.click(screen.getByRole('button', { name: /create skill/i }));
       expect(screen.getByText(errorMatch)).toBeInTheDocument();
     });


### PR DESCRIPTION
## Description

Three `SkillEditor` tests failed intermittently on full-suite runs, always the same three and always in the same order. The received values gave it away — the name arrived as `"aCalaiamabaianagaaaa"`, which is `"Climbing"` with an `a` interleaved between every character.

The cause is contained in one test. `validates description length limits` types `'a'.repeat(501)` a keystroke at a time. Under load that loop outruns the test timeout, so Jest fails the test and moves on while the typing promise keeps running. userEvent dispatches each remaining keystroke to `document.activeElement`, which by then is the input the *next* test just rendered. Two keyboard loops writing one field, interleaved. That's why one test is the source and two are downstream victims.

Pasting instead of typing sends the same change in one event rather than roughly six hundred. The inputs carry no `maxLength` and use a plain `onChange`, so the component sees what it saw before.

## Related Issue

None — found while working PR #1922 and split out rather than folded in.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The failing condition was reproduced deterministically before the change and re-checked after, which is the red/green here. No production code moved.

## User Stories Addressed

N/A — test infrastructure.

## Flow Diagrams

N/A

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A — no component or visual change.

## Implementation Notes

The flake needed no waiting around to reproduce. Forcing the timeout makes it appear on demand:

```
npx jest src/components/world/SkillEditor/__tests__/SkillEditor.test.tsx --testTimeout=400
```

Before the change, that fails the same three tests and prints the reported strings byte for byte:

| Field | Expected | Received |
|---|---|---|
| `name` | `Climbing` | `aCalaiamabaianagaaaa` |
| `description` | `Scale sheer walls` | `aSacaaalaea asahaeaeara awaaalalasaaaa` |

After the change the same command is 19/19, and so is `--testTimeout=200`.

Worth naming what this is *not*, since all three were plausible: not a missing `advanceTimers` on `userEvent.setup()`, not unrestored fake timers, and not state leaking from another file in the same worker. The leak is within this one file, between sibling tests.

## Screenshots

N/A

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

N/A

## Chrome DevTools MCP Verification Summary (if applicable)

N/A

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

Run the full suite three times, deleting Jest's cache directory between runs so file ordering actually changes. Jest orders files by cached previous duration, so leaving the cache in place re-runs the same worker packing and proves less than it looks like it does. `npx jest --showConfig` reports the path under `cacheDirectory` (a `jest_*` folder in the system temp dir).

Three runs here, cache confirmed absent before each: 444/444 suites, 3092/3092 tests, no scrambled input. File runtime dropped from 3.31s to 1.76s.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
