### PR TITLE
Keep an NPC's claim about the player's family out of the lore ledger

### DIFF
--- a/.claude/skills/narraitor-prompt-template-governance/eval-logs/1926-player-sheet-guard.md
+++ b/.claude/skills/narraitor-prompt-template-governance/eval-logs/1926-player-sheet-guard.md
@@ -1,0 +1,121 @@
+# Prompt/template eval log - the player sheet guard on the lore extractor (#1926, re-entry item 1 of #1828)
+
+- Change: one variable - the lore extractor is told the player's character sheet (history, personality) and that the player's family and past are the sheet's to state, and a deterministic guard drops what gets recorded about them anyway: a character entry tied to the player by kinship whose name nothing in the game vouches for (sheet, world description, NPC roster), and any event tied to the player by kinship. The same predicate excludes such assertions from the continuity contract. Prompt text lives in `structuredLoreExtractor.ts` (the extraction prompt is not a registry template and reads no `NarrativeTemplateContext`); the pure logic in `src/lib/lore/playerSheetGuard.ts`.
+- Diff: `src/lib/lore/playerSheetGuard.ts` (new), `src/lib/ai/structuredLoreExtractor.ts`, `src/lib/ai/narrativeGenerator.ts` (both call sites pass the sheet), `src/lib/lore/continuityLedger.ts`, `src/lib/lore/continuityGuardrail.ts` and `src/lib/utils/textNormalization.ts` (`escapeRegExp` moved to utils), tests alongside. Branch `claude/narraitor-1828-canon-engagement-41bbad` off develop `d7f3f3fa`.
+- Date / evaluator: 2026-08-23, autonomous build session, live Gemini key from `.env.local`.
+
+## Declared before the measurement (2026-08-23)
+
+### Why this shape
+
+Round 13 of #1828 (`1828-raised-background-answered.md`) held because the prose, once it engages the player's sheet, invents the specifics the sheet leaves blank (grandparents named Arthur and Eleanor, or Clara and Thomas; a mother named Sarah) on 7 of 9 treatment raises, and the names then recur for the rest of the session. The memo's first re-entry condition is an app-side guard so an invented name is a slip in one passage instead of ledger canon. The two exclusions that exist do not reach this class: `reservePlayerCharacterName` drops only entries carrying the player's own name, and `buildAssertions` matches the player's full name only, so "Wren's grandparents, Clara and Thomas" passes both.
+
+The predicate is a kinship tie to the player ("Wren's grandmother", "the protagonist's mother", "your aunt", "grandfather of Wren"), not a mention of the player. #1860 measured a subject-match event filter against the round-4 ledger and rejected it (16 true facts lost for 2 poisoned). The kinship tie, run over those 78 facts plus the two #1831 step-2 ledgers (163 facts in all), matches exactly one, and that one restates the sheet ("Wren Calloway's grandmother and grandfather worked the looms until 2014"); the on-screen relative in those sessions, Aunt Carol, is always written by name. So a kin-tied event is either redundant with the sheet or the invention, and goes either way; a kin-tied character entry stays only when the game already vouches for the name, which is how an on-screen relative the NPC roster already holds keeps her entry.
+
+What the predicate cannot see, stated up front: an event in the player's past with no kinship word ("Arthur and I were at that meeting", "you were the only one who raised a hand"). The prompt rule is the only reach at that class, and it is unverified until measured; if it measures as nothing, it comes out and the deterministic half ships alone.
+
+### Gates
+
+- G1 (input contract): the extraction prompt is not a registry template. The new option is `ExtractStructuredLoreOptions.playerSheet`, built at both call sites in `narrativeGenerator.ts` from data they already hold (character background, world description, NPC roster).
+- G2 (leakage): the sheet's history and personality already reach the scene prompt every turn (`formatPlayerBackground`); showing the same two fields to the extractor leaks nothing new. The canon string (whole sheet, world text, roster names) never reaches the model; it is the guard's input only.
+- G3 (parser safety): outbound prompt text plus a post-parse filter. The JSON schema is unchanged.
+- G6 (cost): measured below as the extraction-prompt delta in characters; the extraction call is off the player's critical path.
+- G7 (integration): the replay runs the real `extractStructuredLore` (the production code path minus the store write), not a harness re-implementation.
+
+### Matrix
+
+An offline replay, not a live play loop: every segment of round 13 (120 passages across the eight captures, 72 generated on the control build and 48 on the treatment build, with H4's first twelve base-build turns inside its capture) is run through the real extractor twice on live Gemini:
+
+- Arm A ("today"): `{playerCharacterName}`, what develop does.
+- Arm B ("change"): `{playerCharacterName, playerSheet}`, the prompt rule plus the guard.
+- guardOnly: the pure guard applied to arm A's output, so the deterministic half is read on today's extractions without the prompt rule.
+
+The roster per turn is the capture's `newCharacters` accumulated to that turn. Existing-lore context and continuity topics are not passed: the predicate does not read them, and the dedup they drive belongs to the store, downstream of the guard.
+
+Why a replay: the guard is a function of the prose, and round 13's prose is the population that produced the invention. Nine live sessions would reproduce that prose only by chance. The live re-run is step 4 of the memo (same nine-session design), where the persistence claim gets its before/after.
+
+Premise check, recorded as a finding and not a gate: the port-3092 origin of round 13 still holds its IndexedDB, so the lore store the live sessions wrote is read for the invented names before the replay. If the live ledger never recorded them, round 13's persistence was prose-window chaining, and this guard's value is prevention rather than the cure the memo assumed.
+
+### Judging
+
+- Precision (deterministic half): every entry guardOnly drops from arm A is read against the sheet by the evaluator; it is a checkable comparison, not a taste call. Correct: the entry asserts a relative of the player, or an event in the player's past, that the sheet does not state, or it restates the sheet. Incorrect: a world fact, or an on-screen fact about a person the roster holds.
+- Recall (what still lands): a blind subagent reads every kept entry of arm B from one file, with each session's sheet and world description and nothing else, and flags entries that assert a relative of the player by name, or an event in the player's past, that the sheet does not state. The same read over arm A gives the before count. Flags are verified by the evaluator against the prose.
+- Prompt-rule effect: arm B's pre-guard output (its kept entries plus the guard's captured drops) against arm A's raw flagged count.
+
+### Decision rule
+
+- SHIP when all hold: incorrect drops at most 1 across the 120 segments; flagged entries in arm B at most 2 across the 120 segments, and 0 on the seven round-13 treatment raise turns judged as invented history (H1t T8 and T12, H2t T4, T8 and T12, H4 T16 and T20); arm B's empty-extraction rate at or below arm A's (no parse or event-limit regression).
+- The prompt rule is kept only if arm B's pre-guard flagged count is below arm A's raw flagged count by at least 3; otherwise it is removed before the PR and the verdict is re-read on guardOnly.
+- HOLD otherwise, naming the gate.
+
+## Measured (2026-08-23)
+
+Verdict by the rule above: HOLD, on the recall gate. Precision, shape, and cost pass. The prompt rule stays. The five entries that survive in arm B are the two classes the declaration named as out of the predicate's reach, and an evaluator read past the judge's rules found the invented names coming back in kin-free entries the predicate was never pointed at. Details below; the PR goes up as a draft.
+
+### Run
+
+120 segments, two live calls each on `gemini-2.5-flash`, 9.8 minutes wall clock, median 4.7 s per segment. Arm B's inline guard ran with the capture's cumulative roster; a second pass (`reguard.ts`) re-applied the pure guard to both arms with the roster the app actually has at extraction time, the NPCs introduced before the turn (`context.npcRoster` is built before generation and `syncNpcMetadata` runs after the extraction is kicked off). That strict pass dropped nothing further from arm B, so the inline numbers hold for the app. Every file is under `~/.claude/projects/-Users-jackhaas-Projects-personal-narraitor/artifacts/1926-replay/` (input, both outputs, judge items, unblinding map, flags, prompts, scripts, log). The round-13 lore store dump from the premise check is beside it as `1828-round13-live-lore-store.json`.
+
+### Shape and cost
+
+| arm | entries | characters | events | locations | rules | empty | over the 3-event cap |
+|---|---|---|---|---|---|---|---|
+| A (today) | 651 | 210 | 273 | 166 | 2 | 0 | 0 |
+| B (change, after guard) | 592 | 179 | 257 | 154 | 2 | 0 | 0 |
+
+Prompt delta from the sheet rule: 700 characters on Harrowgate, 645 on Crystal Lake. No parse failures in either arm.
+
+### Precision: the deterministic half on today's extractions
+
+The guard dropped 32 entries from arm A (6 from the 60 control-build segments, 26 from the 60 treatment-build segments, which is the round-13 split). Each one read against the sheet:
+
+| class | count | example |
+|---|---|---|
+| named relative the sheet does not have | 22 | "Eleanor Calloway, the protagonist's grandmother, a former loom worker"; "Sarah Calloway, Wren Calloway's mother" |
+| unnamed relative with a detail the sheet does not give | 4 | "grandparents operated the looms until their last days"; "believed a mill was a living thing" |
+| restates the sheet | 2 | "Wren Calloway's mother was sick, which led to Wren's return" |
+| restates the sheet inside a present-story act | 3 | "The Mayor stated that Wren Calloway's family's connection will be noted in the minutes" |
+| on-screen relative on the turn that introduced him | 1 | Uncle Frank, h3 T1 |
+
+Incorrect drops under the declared definition: 0 (no world fact, no on-screen fact about a roster-held person). Gate passes. Two costs disclosed anyway. The three present-act wrappers lose the act (the Mayor put the connection on the record) along with the sheet restatement they carry. And roster timing means an on-screen relative's first entry goes: Uncle Frank at h3 T1 is in the NPC roster from T2 and his entries are kept from there (22 of 24 turns record him, in both arms). The same timing takes Eleanor Miller and Arthur Miller whole at h4 T18, because their introduction entries carry "Wren's grandmother, Clara"; the NPC store still gets them from the segment's `newCharacters`, and T19 onward records them.
+
+### Recall: the blind judge
+
+One subagent, the items file and the rule set only, 1256 notes under opaque ids (651 arm A raw, 592 arm B kept, 13 arm B guard-dropped, shuffled with seed 1926, unblinding map in a separate file). It returned 53 flags. Every one holds as written when read against the prose. Ten of them are Uncle Frank, the on-screen relative the narrator itself put in the h3 scene at T1; the design keeps a roster-held relative on purpose, so he is counted apart.
+
+| | arm A raw | guard alone (arm A after the guard) | arm B before its guard | arm B kept |
+|---|---|---|---|---|
+| flags of the memo's kind | 28 | 4 | 15 | 5 |
+| Uncle Frank | 9 | 8 | 1 | 1 |
+
+The five that survive in arm B:
+
+| segment | form | note |
+|---|---|---|
+| h1 treatment T3 | pronoun | "referencing their grandmother Eleanor's similar qualities" |
+| h2 treatment T3 | pronoun | "their grandfather understood some things couldn't be measured on a balance sheet" |
+| h2 treatment T8 | kin-free past event | "appointed by a group of eleven people, including herself" |
+| h4 treatment T20 | kin-free past event | Arthur "was at the council meeting where Wren Calloway was appointed, alongside Eleanor" |
+| h4 treatment T20 | kin-free past event | "Eleanor states that Arthur and she were present at the council meeting" |
+
+On the seven raise turns: 3 (h2t T8 one, h4t T20 two). The gate asked for at most 2 across the run and 0 on the seven. Fails on both.
+
+### The prompt rule
+
+Arm B's pre-guard flagged count is 15 against arm A's 28, a difference of 13, so by the rule it stays. Where the difference sits matters, though: it is almost entirely in the named-relative class the guard catches anyway. On the two classes the predicate cannot see, the guard alone leaves 4 and the prompt rule leaves 5, which is noise. What the rule measurably buys is cleaner entries for on-screen NPCs who carry the invention. Eleanor Miller's T18 entry survives in arm B as "Her husband worked at the textile factory"; the guard alone drops her whole entry. Mr. Henderson's T16 entry under the guard alone keeps "worked with Wren Calloway's grandfather, Thomas" because his own name is vouched; in arm B the kinship is gone from it.
+
+### Past the judge's rules: the name walks in kin-free
+
+The judge flags a note only when it asserts the relative or the past. Read for the five invented names themselves, the kept entries tell a different story. Once the prose has "Eleanor", she comes back without a kinship word: "Old Man Hemlock ... spoke highly of Eleanor's skill", the event "Eleanor organized a potluck on the factory floor during the '87 strike", the location "factory floor, where Eleanor organized a potluck", "Harrowgate, whose history is connected to Eleanor's legacy". In h4 the grandparents return as bare character entries, "Clara, mill operator (historical), known for her sharp mind", and as a location, "Rowan, a place with looms where Clara and Thomas Calloway worked until 2014". Mr. Henderson's arm B entry reads "taught by Thomas Calloway": the kinship stripped, the name kept.
+
+| | guard alone | arm B kept |
+|---|---|---|
+| kept entries carrying an invented relative's name with no kinship tie | 24 | 8 |
+
+So the kinship predicate closes the entry that makes the claim and leaves the entries the claim seeds. The recall count above understates what lands, and this is the persistence vector the memo was written about.
+
+### Re-entry
+
+The change of shape that would move the verdict: remember the name. When the guard drops an entry naming X and nothing vouches for X, X goes on a session quarantine list; the extractor prompt shows the list and the guard scrubs later entries against it. That is stateful (the guard is pure today; the list belongs with the session), and its deterministic half is measurable on this replay with no model calls. The pronoun form is a narrower question: adding "their" to the player stand-ins needs a count of how often the extractor writes "their <kin>" about an NPC, which this replay's 1243 entries can answer offline before any code moves.
+
+Held as a draft PR on the branch; not merged.

--- a/src/lib/ai/__tests__/narrativeGenerator.continuity.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.continuity.test.ts
@@ -316,7 +316,13 @@ describe('NarrativeGenerator - continuity guardrail', () => {
     expect(extractStructuredLore).toHaveBeenCalledWith(
       CLEAN_PROSE,
       expect.anything(),
-      { continuityTopics: ['mill debt'], playerCharacterName: 'Hero' }
+      {
+        continuityTopics: ['mill debt'],
+        playerCharacterName: 'Hero',
+        playerSheet: expect.objectContaining({
+          sheet: 'History: A brave warrior\nPersonality: Courageous',
+        }),
+      }
     );
   });
 

--- a/src/lib/ai/__tests__/structuredLoreExtractor.playerSheet.test.ts
+++ b/src/lib/ai/__tests__/structuredLoreExtractor.playerSheet.test.ts
@@ -1,0 +1,80 @@
+/**
+ * With the player's sheet in hand, the extractor tells the model the player's
+ * family and past are the sheet's to state, and drops what gets recorded
+ * about them anyway. Without a sheet, nothing changes.
+ */
+
+jest.mock('@/lib/ai/defaultGeminiClient');
+
+import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
+import { extractStructuredLore } from '../structuredLoreExtractor';
+
+const mockedCreateClient = createDefaultGeminiClient as jest.Mock;
+
+const respondWith = (json: unknown) => {
+  const generateContent = jest.fn().mockResolvedValue({
+    content: '```json\n' + JSON.stringify(json) + '\n```',
+  });
+  mockedCreateClient.mockReturnValue({ generateContent });
+  return generateContent;
+};
+
+const PLAYER_SHEET = {
+  sheet: 'History: Both grandparents worked the looms until 2014.\nPersonality: Careful.',
+  canon: 'Both grandparents worked the looms until 2014.\nCareful.\nAunt Carol',
+};
+
+const FAMILY_CLAIMS = {
+  characters: [
+    { name: 'Clara', description: "Wren's grandmother, a weaver" },
+    { name: 'Aunt Carol', description: 'Your aunt, in the front row' },
+  ],
+  locations: [],
+  rules: [],
+  events: [
+    { description: "Mr. Henderson recalls Wren's grandparents Clara and Thomas at the looms." },
+    { description: 'Wren Calloway asks who holds the mill debt.' },
+  ],
+};
+
+describe('extractStructuredLore with the player sheet', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('drops a relative the game does not know and keeps one the roster does', async () => {
+    respondWith(FAMILY_CLAIMS);
+
+    const result = await extractStructuredLore('prose', undefined, {
+      playerCharacterName: 'Wren Calloway',
+      playerSheet: PLAYER_SHEET,
+    });
+
+    expect(result.characters.map((character) => character.name)).toEqual(['Aunt Carol']);
+    expect(result.events.map((event) => event.description)).toEqual([
+      'Wren Calloway asks who holds the mill debt.',
+    ]);
+  });
+
+  it('leaves the extraction alone without a sheet', async () => {
+    respondWith(FAMILY_CLAIMS);
+
+    const result = await extractStructuredLore('prose', undefined, {
+      playerCharacterName: 'Wren Calloway',
+    });
+
+    expect(result.characters).toHaveLength(2);
+    expect(result.events).toHaveLength(2);
+  });
+
+  it("tells the model the sheet owns the player's family and past", async () => {
+    const generateContent = respondWith({ characters: [], locations: [], rules: [], events: [] });
+
+    await extractStructuredLore('prose', undefined, {
+      playerCharacterName: 'Wren Calloway',
+      playerSheet: PLAYER_SHEET,
+    });
+
+    const prompt = generateContent.mock.calls[0][0] as string;
+    expect(prompt).toContain('belong to their character sheet, which reads:');
+    expect(prompt).toContain('History: Both grandparents worked the looms until 2014.');
+  });
+});

--- a/src/lib/ai/narrativeGenerator.ts
+++ b/src/lib/ai/narrativeGenerator.ts
@@ -16,6 +16,7 @@ import { EntityID } from '@/types/common.types';
 import { generateChoices } from './choiceGenerator';
 import { getLoreContextForPrompt, checkAndRecordLoreMentions } from './loreContextHelper';
 import { extractStructuredLore } from './structuredLoreExtractor';
+import { buildPlayerSheetCanon } from '@/lib/lore/playerSheetGuard';
 import { DEFAULT_TONE_SETTINGS } from '@/types/tone-settings.types';
 import { processAcquiredItems } from '@/lib/narrative/itemAcquisitionProcessor';
 import { processLostItems } from '@/lib/narrative/itemLossProcessor';
@@ -219,6 +220,11 @@ export class NarrativeGenerator {
         void extractStructuredLore(result.content, existingLoreContext, {
           continuityTopics: collectContinuityTopicsFromStores(request),
           playerCharacterName: context.playerCharacterName,
+          playerSheet: buildPlayerSheetCanon({
+            background: context.playerCharacterBackground,
+            worldDescription: world.description,
+            knownNames: context.npcRoster.map((npc) => npc.name),
+          }),
         })
           .then(async (structuredLore) => {
             const { useLoreStore } = await import('@/state/loreStore');
@@ -446,6 +452,11 @@ export class NarrativeGenerator {
         });
         void extractStructuredLore(response.content, existingLoreContext, {
           playerCharacterName: playerCharacter?.name,
+          playerSheet: buildPlayerSheetCanon({
+            background: playerCharacter?.background,
+            worldDescription: world.description,
+            knownNames: npcRoster.map((npc) => npc.name),
+          }),
         })
           .then(async (structuredLore) => {
             const { useLoreStore } = await import('@/state/loreStore');

--- a/src/lib/ai/structuredLoreExtractor.ts
+++ b/src/lib/ai/structuredLoreExtractor.ts
@@ -6,6 +6,10 @@
 import { createDefaultGeminiClient } from './defaultGeminiClient';
 import { extractFencedJson } from './parseJSON';
 import { canonicalizeName } from '@/lib/utils/textNormalization';
+import {
+  guardExtractionAgainstPlayerSheet,
+  type PlayerSheetCanon,
+} from '@/lib/lore/playerSheetGuard';
 import type {
   LoreContinuityAnnotation,
   LoreContinuityKind,
@@ -30,6 +34,12 @@ export interface ExtractStructuredLoreOptions {
    * player, so nothing extracted under that name can be new information.
    */
   playerCharacterName?: string;
+  /**
+   * The player's character sheet, and what else can vouch for a name. With it
+   * the prompt tells the model the player's family and past are the sheet's
+   * to state, and the guard drops whatever gets recorded about them anyway.
+   */
+  playerSheet?: PlayerSheetCanon;
 }
 
 /**
@@ -46,7 +56,8 @@ export async function extractStructuredLore(
       narrativeText,
       existingLoreContext,
       options?.continuityTopics,
-      options?.playerCharacterName
+      options?.playerCharacterName,
+      options?.playerSheet
     );
     const response = await geminiClient.generateContent(prompt);
     
@@ -65,10 +76,11 @@ export async function extractStructuredLore(
     }
 
     const extractedLore = JSON.parse(jsonStr) as StructuredLoreExtraction;
-    return reservePlayerCharacterName(
+    const reserved = reservePlayerCharacterName(
       validateAndCleanExtraction(extractedLore),
       options?.playerCharacterName
     );
+    return guardPlayerSheet(reserved, options?.playerCharacterName, options?.playerSheet);
 
   } catch (error) {
     logger.warn('Failed to extract structured lore:', error);
@@ -83,12 +95,17 @@ function buildLoreExtractionPrompt(
   narrativeText: string,
   existingLoreContext?: string,
   continuityTopics?: string[],
-  playerCharacterName?: string
+  playerCharacterName?: string,
+  playerSheet?: PlayerSheetCanon
 ): string {
   const existingContext = existingLoreContext ? `\n\nExisting Lore Context:\n${existingLoreContext}` : '';
   const playerNameRule = playerCharacterName
     ? `\n- "${playerCharacterName}" is the PLAYER CHARACTER, not an NPC. Never create a character entry for them. If the text names a separate person who happens to share that name, that is a mistake in the prose — do not record them as a character.`
     : '';
+  const playerSheetRule =
+    playerCharacterName && playerSheet
+      ? `\n- The family and past of "${playerCharacterName}" belong to their character sheet, which reads:\n${playerSheet.sheet}\n  Do not record a relative of the player character, or an event in the player character's past, that the sheet does not state. A character in the text asserting one (a relative's name, something the player character once did) is making a claim, not stating a fact: leave it out of every category.`
+      : '';
   const topicHint =
     continuityTopics && continuityTopics.length > 0
       ? `\n- Continuity topics already in use (reuse the exact label when an event is about the same question, promise, or object): ${continuityTopics.join('; ')}`
@@ -121,7 +138,7 @@ CRITICAL QUALITY RULES:
 - Characters must be specific named individuals. Do NOT create character entries for unnamed or generic groups (e.g. "a guard", "unnamed warrior", "the villagers").
 - If a person is unnamed, keep it as part of an event description instead of a character entity.
 - Prefer stable locations ("Vaes Leisi", "Vaes Leisi marketplace") over micro-locations ("marketplace edge", "near a stall"). If you mention a micro-location, include it as an alias in the location entry.
-- Keep events concise and non-redundant: **extract EXACTLY 3 or fewer** high-signal events that add lasting story state. Never exceed this limit.${playerNameRule}
+- Keep events concise and non-redundant: **extract EXACTLY 3 or fewer** high-signal events that add lasting story state. Never exceed this limit.${playerNameRule}${playerSheetRule}
 
 CONTINUITY TAGGING (within the 3-event limit, prefer events that carry one of these):
 - Add "continuity" to an event when it is one of:
@@ -315,6 +332,28 @@ function reservePlayerCharacterName(
   });
 
   return { ...extraction, characters };
+}
+
+/**
+ * The deterministic half of the sheet rule: whatever the model records about
+ * the player's family despite being told not to still goes, so a relative
+ * invented in the prose cannot become ledger canon.
+ */
+function guardPlayerSheet(
+  extraction: StructuredLoreExtraction,
+  playerCharacterName?: string,
+  playerSheet?: PlayerSheetCanon
+): StructuredLoreExtraction {
+  if (!playerCharacterName || !playerSheet) return extraction;
+  const { extraction: guarded, dropped } = guardExtractionAgainstPlayerSheet(
+    extraction,
+    playerCharacterName,
+    playerSheet.canon
+  );
+  if (dropped.length > 0) {
+    logger.debug("Dropped extracted lore about the player character's family", { dropped });
+  }
+  return guarded;
 }
 
 const trimmedString = (value: unknown): string | undefined =>

--- a/src/lib/lore/__tests__/continuityGuardrail.test.ts
+++ b/src/lib/lore/__tests__/continuityGuardrail.test.ts
@@ -250,6 +250,20 @@ describe('ledger-fed contract', () => {
     expect(contract.assertions.map((a) => a.topic)).toEqual(['mill debt']);
   });
 
+  it("drops assertions about the player's family, even when they only use the first name", () => {
+    const contract = buildLedgerContract(
+      [
+        makeEvent('e1', "Mr. Henderson says Wren's grandparents, Clara and Thomas, worked the looms until 2014.",
+          { kind: 'assertion', topic: "Wren's grandparents", speaker: 'Mr. Henderson' }),
+        makeEvent('e2', 'The bank held the mortgage on the mill.',
+          { kind: 'assertion', topic: 'mill debt', speaker: 'Aunt Carol' }),
+      ],
+      'Wren Calloway'
+    );
+
+    expect(contract.assertions.map((a) => a.topic)).toEqual(['mill debt']);
+  });
+
   it('drops assertions the player spoke, which are questions the extractor mis-tagged', () => {
     const contract = buildLedgerContract(
       [

--- a/src/lib/lore/__tests__/playerSheetGuard.test.ts
+++ b/src/lib/lore/__tests__/playerSheetGuard.test.ts
@@ -1,0 +1,132 @@
+/**
+ * The player character's family and past belong to the character sheet. An
+ * NPC naming the player's grandmother is a claim, not a fact, and the lore
+ * extractor must not write it into the ledger as one.
+ */
+
+import {
+  buildPlayerSheetCanon,
+  claimsPlayerKin,
+  guardExtractionAgainstPlayerSheet,
+} from '../playerSheetGuard';
+import type { StructuredLoreExtraction } from '@/types/lore.types';
+
+const WREN = 'Wren Calloway';
+
+const SHEET = {
+  history:
+    'Grew up four streets from the mill; both grandparents worked the looms until 2014. Left for a decade, came back when their mother got sick.',
+  personality: 'Careful, slow to commit, uncomfortable being owed favours.',
+  goals: ['Find out what the mill is actually worth'],
+  fears: [],
+  relationships: [],
+};
+
+const WORLD =
+  'Harrowgate has been arguing about the mill for eleven years. Everyone in town has a position, and several of them are related to you.';
+
+const extraction = (
+  characters: StructuredLoreExtraction['characters'] = [],
+  events: StructuredLoreExtraction['events'] = []
+): StructuredLoreExtraction => ({
+  characters,
+  locations: [],
+  events,
+  rules: [],
+  relationships: [],
+});
+
+describe('claimsPlayerKin', () => {
+  it.each([
+    "Mr. Henderson remembers Wren's grandmother, Clara, at the looms.",
+    "Evelyn Hayes recalls Wren Calloway's grandfather Arthur as a skilled weaver.",
+    "The protagonist's mother, Sarah, tended the sick in 2008.",
+    'Your aunt, perched in the front row with her knitting bag.',
+    'Clara, grandmother of Wren, taught Henderson to adjust a warp beam.',
+    "Wren Calloway's late father ran the union local.",
+  ])('ties a relative to the player: %s', (text) => {
+    expect(claimsPlayerKin(text, WREN)).toBe(true);
+  });
+
+  it.each([
+    "Wren Calloway questions Councilman Davies about who holds the mill's debt.",
+    "Aunt Carol expresses clear disapproval of Wren Calloway's actions during the council meeting.",
+    "Wren's question about the old mill families goes unanswered.",
+    "Mayor Thompson's father, Old Man Hemlock, owned the brickworks.",
+  ])("leaves the player's own actions and other people's relatives alone: %s", (text) => {
+    expect(claimsPlayerKin(text, WREN)).toBe(false);
+  });
+});
+
+describe('guardExtractionAgainstPlayerSheet', () => {
+  const canon = buildPlayerSheetCanon({
+    background: SHEET,
+    worldDescription: WORLD,
+    knownNames: ['Aunt Carol', 'Mr. Henderson'],
+  })!;
+
+  it('drops a relative of the player that nothing in the game names', () => {
+    const { extraction: kept, dropped } = guardExtractionAgainstPlayerSheet(
+      extraction([
+        { name: 'Clara', role: "Wren's grandmother", description: 'Worked the looms at Rowan Textiles.' },
+        { name: 'Mr. Henderson', description: 'The mill foreman.' },
+      ]),
+      WREN,
+      canon.canon
+    );
+
+    expect(kept.characters.map((character) => character.name)).toEqual(['Mr. Henderson']);
+    expect(dropped).toHaveLength(1);
+  });
+
+  it('keeps a relative the roster already holds, and drops one it only names now', () => {
+    const { extraction: kept } = guardExtractionAgainstPlayerSheet(
+      extraction([
+        { name: 'Aunt Carol', description: 'Your aunt, perched in the front row.' },
+        { name: 'Sarah', description: "Wren's mother, who was sick for years." },
+      ]),
+      WREN,
+      canon.canon
+    );
+
+    expect(kept.characters.map((character) => character.name)).toEqual(['Aunt Carol']);
+  });
+
+  it('drops an event that tells the player their own family history', () => {
+    const { extraction: kept } = guardExtractionAgainstPlayerSheet(
+      extraction(
+        [],
+        [
+          { description: "Mr. Henderson recalls Wren's grandparents Clara and Thomas working the looms." },
+          { description: 'Wren Calloway questions Councilman Davies about the mill debt.' },
+          {
+            description: 'Henderson names the weavers he learned from as Clara and Thomas.',
+            continuity: { kind: 'assertion', topic: "Wren's grandparents", speaker: 'Mr. Henderson' },
+          },
+        ]
+      ),
+      WREN,
+      canon.canon
+    );
+
+    expect(kept.events.map((event) => event.description)).toEqual([
+      'Wren Calloway questions Councilman Davies about the mill debt.',
+    ]);
+  });
+});
+
+describe('buildPlayerSheetCanon', () => {
+  it('is nothing without sheet text, so the guard stays off for a blank sheet', () => {
+    expect(
+      buildPlayerSheetCanon({ background: { history: '', personality: ' ' }, worldDescription: WORLD })
+    ).toBeUndefined();
+  });
+
+  it('shows the model history and personality, and vouches with the whole sheet plus the roster', () => {
+    const canon = buildPlayerSheetCanon({ background: SHEET, knownNames: ['Aunt Carol'] })!;
+
+    expect(canon.sheet).toBe(`History: ${SHEET.history}\nPersonality: ${SHEET.personality}`);
+    expect(canon.canon).toContain('Find out what the mill is actually worth');
+    expect(canon.canon).toContain('Aunt Carol');
+  });
+});

--- a/src/lib/lore/continuityGuardrail.ts
+++ b/src/lib/lore/continuityGuardrail.ts
@@ -24,12 +24,12 @@ import type {
   ContinuityRecentDecision,
   ContinuityTone,
 } from '../../types/continuity.types';
+import { escapeRegExp } from '../utils';
 import {
   MIN_TERM_LENGTH,
   buildAssertions,
   buildCommitments,
   buildSceneChanges,
-  escapeRegExp,
   ledgerFacts,
   topicTerms,
 } from './continuityLedger';

--- a/src/lib/lore/continuityLedger.ts
+++ b/src/lib/lore/continuityLedger.ts
@@ -17,6 +17,8 @@ import type {
   ContinuityCommitment,
   ContinuitySceneChange,
 } from '../../types/continuity.types';
+import { escapeRegExp } from '../utils';
+import { claimsPlayerKin } from './playerSheetGuard';
 
 // Ledger caps bound prompt growth: the block was measured at 3 lines before the
 // ledger existed and the whole prompt already runs 20-34k chars over a session.
@@ -38,10 +40,6 @@ const TOPIC_STOPWORDS = new Set([
 // The extractor tags the player's own questions as assertions spoken by "the
 // protagonist"; a question is not an answer, so player-spoken lines are dropped.
 const PLAYER_SPEAKER = /^(?:the )?(?:protagonist|player|you)$/i;
-
-export function escapeRegExp(term: string): string {
-  return term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
 
 /** Topic labels compare case- and punctuation-insensitively so "Mill debt" and "mill debt" line up. */
 function normalizeTopic(topic: string): string {
@@ -105,7 +103,10 @@ export function buildAssertions(ledger: LoreFact[], playerName?: string): Contin
     const topicKey = normalizeTopic(topic);
     if (!topicKey) continue;
     mentionsByTopic.set(topicKey, (mentionsByTopic.get(topicKey) ?? 0) + 1);
-    if (mentionsPlayer(`${topic} ${fact.value}`, playerName)) continue;
+    // An NPC's claim about the player, or about the player's family, is the
+    // ledger's known poison path: the sheet owns those, not the story.
+    const text = `${topic} ${fact.value}`;
+    if (mentionsPlayer(text, playerName) || claimsPlayerKin(text, playerName)) continue;
 
     const speaker = annotation.speaker?.trim() || NARRATION_SPEAKER;
     if (isPlayerSpeaker(speaker, playerName)) continue;

--- a/src/lib/lore/playerSheetGuard.ts
+++ b/src/lib/lore/playerSheetGuard.ts
@@ -1,0 +1,189 @@
+/**
+ * Player Sheet Guard
+ *
+ * The player character's family and past belong to the character sheet. When
+ * the prose has an NPC name the player's grandmother, or recall something the
+ * player once did, the lore extractor would record it and the ledger would
+ * carry it into every later prompt as canon, so the invented name outlives the
+ * turn that made it up. This module decides, without an AI call, which
+ * extracted entries make that kind of claim and whether the game already
+ * vouches for the name.
+ *
+ * Like `loreContext.ts`, it takes data as parameters and imports no stores.
+ */
+
+import type { StructuredLoreExtraction } from '../../types/lore.types';
+import { escapeRegExp } from '../utils';
+
+/** Shortest name token worth vouching for as a whole word. */
+const MIN_NAME_TOKEN_LENGTH = 3;
+
+const KIN_WORDS = [
+  'grandmother', 'grandfather', 'grandparent', 'grandparents', 'grandma', 'grandpa',
+  'mother', 'father', 'mom', 'mum', 'dad', 'parent', 'parents',
+  'sister', 'brother', 'sibling', 'siblings', 'cousin', 'cousins',
+  'aunt', 'uncle', 'niece', 'nephew',
+  'wife', 'husband', 'spouse', 'daughter', 'son', 'child', 'children', 'kids',
+  'family', 'kin',
+];
+const KIN = `(?:${KIN_WORDS.join('|')})`;
+
+// How the extractor refers to the player when it is not using the name.
+const PLAYER_STANDINS = [
+  'the protagonist',
+  'protagonist',
+  'the player character',
+  'player character',
+  'the player',
+  'player',
+];
+
+// Words that sit inside a name without being one: honorifics, descriptors,
+// and the kinship terms themselves ("Aunt Carol", "Old Man Rowan").
+const NAME_NOISE = new Set([
+  'the', 'old', 'young', 'little', 'big', 'man', 'woman',
+  'mr', 'mrs', 'ms', 'miss', 'dr', 'sir', 'lady', 'lord', 'madam',
+  ...KIN_WORDS,
+]);
+
+export interface PlayerSheetCanon {
+  /** The sheet's own words, shown to the extraction model: history and personality. */
+  sheet: string;
+  /** Everything that can vouch for a name: the whole sheet, the world description, the NPC roster. */
+  canon: string;
+}
+
+export interface PlayerSheetGuardResult {
+  extraction: StructuredLoreExtraction;
+  /** The entries that went, for the debug log. */
+  dropped: string[];
+}
+
+function collectStrings(value: unknown, out: string[]): void {
+  if (typeof value === 'string') {
+    if (value.trim()) out.push(value.trim());
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectStrings(item, out));
+    return;
+  }
+  if (value && typeof value === 'object') {
+    Object.values(value).forEach((item) => collectStrings(item, out));
+  }
+}
+
+/**
+ * The sheet as the model sees it and as the guard vouches with it. Undefined
+ * when the sheet has no history or personality text, which turns the guard off:
+ * a blank sheet owns nothing.
+ *
+ * Shows the same two fields the scene prompt shows (`formatPlayerBackground`
+ * in sceneTemplate.ts), so the extractor and the narrator read one sheet.
+ */
+export function buildPlayerSheetCanon(args: {
+  background?: unknown;
+  worldDescription?: string;
+  knownNames?: string[];
+}): PlayerSheetCanon | undefined {
+  const { background, worldDescription, knownNames } = args;
+  const sheetLines: string[] = [];
+
+  if (typeof background === 'string') {
+    if (background.trim()) sheetLines.push(background.trim());
+  } else if (background && typeof background === 'object') {
+    const { history, personality } = background as { history?: unknown; personality?: unknown };
+    if (typeof history === 'string' && history.trim()) {
+      sheetLines.push(`History: ${history.trim()}`);
+    }
+    if (typeof personality === 'string' && personality.trim()) {
+      sheetLines.push(`Personality: ${personality.trim()}`);
+    }
+  }
+  if (sheetLines.length === 0) return undefined;
+
+  const canon: string[] = [];
+  collectStrings(background, canon);
+  if (worldDescription?.trim()) canon.push(worldDescription.trim());
+  canon.push(...(knownNames ?? []).filter((name) => name?.trim()));
+
+  return { sheet: sheetLines.join('\n'), canon: canon.join('\n') };
+}
+
+function playerReferences(playerName?: string): string[] {
+  const refs = [...PLAYER_STANDINS];
+  const name = playerName?.trim() ?? '';
+  if (name.length >= MIN_NAME_TOKEN_LENGTH) refs.push(name);
+  const first = name.split(/\s+/)[0] ?? '';
+  if (first !== name && first.length >= MIN_NAME_TOKEN_LENGTH) refs.push(first);
+  return refs.map(escapeRegExp);
+}
+
+/**
+ * True when the text ties a relative to the player: "Wren's grandmother",
+ * "the protagonist's mother", "your aunt", "grandfather of Wren". Other
+ * people's relatives and the player's own actions do not match, which is what
+ * keeps real on-screen facts ("Aunt Carol disapproves of Wren's actions") out
+ * of the guard's way.
+ */
+export function claimsPlayerKin(text: string, playerName?: string): boolean {
+  const ref = `(?:${playerReferences(playerName).join('|')})`;
+  const possessive = new RegExp(`\\b(?:${ref}['’]s?|your)\\s+(?:\\w+\\s+)?${KIN}\\b`, 'i');
+  const ofForm = new RegExp(`\\b${KIN}\\s+(?:of|to)\\s+(?:the\\s+)?${ref}\\b`, 'i');
+  return possessive.test(text) || ofForm.test(text);
+}
+
+function nameTokens(name: string, playerName: string): string[] {
+  const playerTokens = new Set(playerName.toLowerCase().split(/\s+/));
+  return name
+    .toLowerCase()
+    .split(/[^\p{L}]+/u)
+    .filter(
+      (token) =>
+        token.length >= MIN_NAME_TOKEN_LENGTH &&
+        !NAME_NOISE.has(token) &&
+        !playerTokens.has(token)
+    );
+}
+
+function vouchedFor(token: string, canon: string): boolean {
+  return new RegExp(`\\b${escapeRegExp(token)}\\b`, 'i').test(canon);
+}
+
+/**
+ * Drops what the extraction claims about the player's family that the game
+ * does not already vouch for.
+ *
+ * A character entry tied to the player by kinship stays only when every word
+ * of its name appears in the canon (the sheet, the world text, or the NPC
+ * roster, which is how an on-screen relative earns their place). An event
+ * tied to the player by kinship goes outright: when it restates the sheet it
+ * adds nothing, and when it adds a name or a memory it is the invention.
+ */
+export function guardExtractionAgainstPlayerSheet(
+  extraction: StructuredLoreExtraction,
+  playerName: string,
+  canon: string
+): PlayerSheetGuardResult {
+  const dropped: string[] = [];
+
+  const characters = extraction.characters.filter((character) => {
+    const text = [character.name, character.role, character.description]
+      .filter(Boolean)
+      .join(' ');
+    if (!claimsPlayerKin(text, playerName)) return true;
+    const tokens = nameTokens(character.name, playerName);
+    const vouched = tokens.length > 0 && tokens.every((token) => vouchedFor(token, canon));
+    if (!vouched) dropped.push(text);
+    return vouched;
+  });
+
+  const events = extraction.events.filter((event) => {
+    const text = [event.description, event.continuity?.topic].filter(Boolean).join(' ');
+    if (!claimsPlayerKin(text, playerName)) return true;
+    dropped.push(text);
+    return false;
+  });
+
+  return { extraction: { ...extraction, characters, events }, dropped };
+}

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -27,7 +27,13 @@ export {
 } from './formatters';
 
 /** Text normalization utilities for consistent text formatting */
-export { normalizeText, NORM_NAME, NORM_DESC, canonicalizeName } from './textNormalization';
+export {
+  normalizeText,
+  NORM_NAME,
+  NORM_DESC,
+  canonicalizeName,
+  escapeRegExp,
+} from './textNormalization';
 
 // Validation utilities
 export { type ValidationResult } from './validationUtils';

--- a/src/lib/utils/textNormalization.ts
+++ b/src/lib/utils/textNormalization.ts
@@ -146,3 +146,8 @@ function normalizeSpecialCharacters(text: string): string {
 export function canonicalizeName(name: string): string {
   return normalizeText(name, NORM_NAME).trim().toLowerCase();
 }
+
+/** Escapes a string so it matches literally inside a RegExp source. */
+export function escapeRegExp(term: string): string {
+  return term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
## Description
When a character in the story names the player's grandmother, or tells the player what they once did, the lore extractor writes it down as a fact and every later prompt carries it. Round 13 of #1828 produced grandparents named Arthur and Eleanor in one session and Clara and Thomas in another, a mother named Sarah, and a neighbour who was at the appointment meeting, and the names recurred for the rest of each session. The live round-13 lore store (still on the port-3092 origin) had them recorded as facts, most of them `world-shared`, so the invention follows the world, not just the session.

This PR gives the extractor the character sheet (history and personality, the same two fields the scene prompt already shows) with a rule that the player's family and past are the sheet's to state, and adds a deterministic guard in `src/lib/lore/playerSheetGuard.ts` that drops what gets recorded anyway: a character entry tied to the player by kinship whose name nothing in the game vouches for (the sheet, the world text, the NPC roster), and any event tied to the player by kinship. The same predicate keeps those assertions out of the continuity contract in `buildAssertions`.

It is a draft because the measurement came back HOLD. The replay ran all 120 round-13 segments through the real extractor on live Gemini, today's options against the change, with a blind judge over 1256 shuffled notes. The kin-tied class closes; the name itself does not stay out.

| | today | guard alone | this change |
|---|---|---|---|
| entries the judge flags as an unsupported relative or past event | 28 | 4 | 5 |
| kept entries carrying an invented relative's name with no kinship tie | 24 | 24 | 8 |
| incorrect drops (world fact, or on-screen fact about a roster-held person) | | 0 of 32 | 0 of 13 |

The five that survive are the two classes the eval log declared as out of the predicate's reach before the run: the pronoun form ("referencing their grandmother Eleanor's similar qualities") and the kin-free past event ("Arthur and she were present at the council meeting where Wren was appointed"). The second row is the finding that matters: once the prose has "Eleanor", she comes back as "Old Man Hemlock spoke highly of Eleanor's skill", the event "Eleanor organized a potluck during the '87 strike", and a location "where Clara and Thomas Calloway worked until 2014". Full numbers, the per-entry reads, and the re-entry condition are in `.claude/skills/narraitor-prompt-template-governance/eval-logs/1926-player-sheet-guard.md`; the replay inputs, outputs, judge items, and unblinding map are under `~/.claude/projects/-Users-jackhaas-Projects-personal-narraitor/artifacts/1926-replay/`.

## Related Issue
Closes #1926

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [ ] Test coverage maintained or improved

The pure module's tests were red before it existed (the pre-commit hook failed on the missing `playerSheetGuard` import). The extractor, ledger, and generator cases were written with the change, so the first box stays unticked. Coverage was not measured. Gate on the commit: 446 suites / 3098 tests, `tsc --noEmit` clean, ESLint 0 errors (the 126 warnings are the pre-existing count), `deps:validate` and `deps:check` pass. No CSS touched.

## User Stories Addressed
As a player, a character answering me with my grandmother's name is a line in one scene, not a fact the game holds about me for the rest of the session.

## Flow Diagrams
Not applicable.

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

Not applicable, no UI change.

## Implementation Notes
The predicate is a kinship tie to the player ("Wren's grandmother", "the protagonist's mother", "your aunt", "grandfather of Wren"), not a mention of the player. #1860 measured a subject-match filter and rejected it (16 true facts lost for 2 poisoned); the kinship tie matches 1 of 163 earlier ledger facts, and that one restates the sheet. A kin-tied character entry stays when every word of its name is vouched for, which is how an on-screen relative the roster already holds (Aunt Carol in the #1860 data, Uncle Frank here) keeps their entry.

Roster timing is a known cost: `context.npcRoster` is built before the turn and `syncNpcMetadata` runs after the extraction is kicked off, so an on-screen relative's first entry goes and the next turn's is kept. The replay's second pass re-applied the guard with that exact roster and it matched the inline numbers.

The prompt rule stays by the declared kill switch (28 flagged pre-guard entries down to 15). Its effect sits almost entirely in the class the guard catches anyway; what it measurably buys is cleaner entries for on-screen NPCs who carry the invention (Eleanor Miller's introduction survives as "Her husband worked at the textile factory" instead of being dropped whole, and Mr. Henderson's entry loses "worked with Wren Calloway's grandfather, Thomas"). The guard's debug line (`Dropped extracted lore about the player character's family`) is how the drops were attributed per call.

`escapeRegExp` moved from `continuityLedger.ts` to `src/lib/utils/textNormalization.ts` so the ledger, the guardrail, and the guard import one copy.

Re-entry for the HOLD, from the eval log: remember the dropped name. When the guard drops an entry naming X and nothing vouches for X, X goes on a session quarantine list the extractor prompt shows and the guard scrubs later entries against. Stateful, so it is a separate change; its deterministic half is measurable on this replay with no model calls.

## Screenshots
Not applicable.

## Visual Baseline Changes
None.

## Code Review Summary (if applicable)
Not applicable.

## Chrome DevTools MCP Verification Summary (if applicable)
Not applicable. The measurement is an offline replay of captured prose, not a browser run; the live nine-session re-run is step 4 of the #1828 memo and waits on the HOLD.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit not run; the change adds no dependency.

## Testing Instructions
1. `npm test -- playerSheetGuard structuredLoreExtractor.playerSheet continuityGuardrail narrativeGenerator.continuity` covers the predicate, the extractor option, the ledger exclusion, and the call site.
2. To re-run the replay, `artifacts/1926-replay/run.sh` bundles `replay.ts` with the worktree's tsconfig and needs the worktree path and a Gemini key in `.env.local`; `reguard.ts` then `assemble_judge.py` then a blind read with `judge-prompt.md`, scored by `score_judge.py`.
3. Live, on Harrowgate Mills as Wren Calloway: type "I tell them my grandparents both worked the looms at Rowan Textiles until it closed in 2014, and ask whether anyone has talked to the old mill families." When a character answers with names, the lore store (IndexedDB, `narraitor-lore`) no longer holds a kin-tied entry for them; a kin-free mention in a later turn still can, which is the HOLD.

## Checklist
- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed

The new module is 189 lines. `structuredLoreExtractor.ts` (388) and `narrativeGenerator.ts` (829) were over the limit before this change. Accessibility is not applicable, no UI.
