### PR TITLE
Rotate the alignment glossary order and log the choice prompt (#1829 round 6)

### DIFF
--- a/src/components/GameSession/hooks/useActiveGameSessionActions.ts
+++ b/src/components/GameSession/hooks/useActiveGameSessionActions.ts
@@ -217,6 +217,9 @@ export const useActiveGameSessionActions = ({
       selectedOptionId: decision.selectedOptionId,
       decisionWeight: decision.decisionWeight,
       contextSummary: decision.contextSummary,
+      // Dev-mode only (#1829 round 6) - dropped here, same as the store
+      // call site in usePlayerChoices.ts, before a codex review caught it.
+      debugInfo: decision.debugInfo,
     };
 
     // Update the current decision state with the copy

--- a/src/components/Narrative/hooks/usePlayerChoices.ts
+++ b/src/components/Narrative/hooks/usePlayerChoices.ts
@@ -187,6 +187,10 @@ export function usePlayerChoices({
           options: decision.options,
           decisionWeight: decision.decisionWeight,
           contextSummary: decision.contextSummary,
+          // Dev-mode only (#1829 round 6) - without this, the persisted
+          // decision never carries the prompt/response a later playtest
+          // round would need to check the model's actual compliance.
+          debugInfo: decision.debugInfo,
         });
 
       // Update the decision with the stored ID before passing to parent

--- a/src/lib/ai/__tests__/choiceGenerator.test.ts
+++ b/src/lib/ai/__tests__/choiceGenerator.test.ts
@@ -45,6 +45,11 @@ jest.mock('@/lib/promptTemplates/narrativeTemplateManager', () => ({
   })
 }));
 
+// Mock providerStore for the debugInfo test below (getActiveProviderModel)
+jest.mock('@/state/providerStore', () => ({
+  getActiveProviderModel: jest.fn().mockReturnValue('test-model'),
+}));
+
 // Generate simple mock narrative context
 const createMockNarrativeContext = (): NarrativeContext => {
   const createSegment = (id: string, content: string): NarrativeSegment => ({
@@ -131,6 +136,47 @@ describe('ChoiceGenerator', () => {
       });
 
       expect(result.options).toHaveLength(3);
+    });
+
+    it('attaches debugInfo with the sent prompt and the raw response when debug info is enabled (#1829 round 6)', async () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      Object.defineProperty(process.env, 'NODE_ENV', {
+        value: 'development',
+        writable: true,
+        configurable: true,
+      });
+
+      try {
+        const rawResponse = `Alignment Mix: NEUTRAL, CHAOTIC, LAWFUL - a quiet moment before the plan
+        Decision: What will you do in the forest?
+
+        Options:
+        1. [NEUTRAL] Investigate the strange noise
+        2. [CHAOTIC] Climb a tree to get a better view
+        3. [LAWFUL] Draw your sword and prepare for combat`;
+
+        mockAIClient.generateContent.mockResolvedValueOnce({
+          content: rawResponse,
+          finishReason: 'STOP',
+        });
+
+        const result = await generateChoices(mockAIClient, {
+          worldId: 'world-1',
+          narrativeContext: createMockNarrativeContext(),
+          characterIds: ['char-1'],
+        });
+
+        expect(result.debugInfo).toBeDefined();
+        expect(result.debugInfo?.fullPrompt).toContain('Generate player choices for this scenario');
+        expect(result.debugInfo?.rawResponse).toBe(rawResponse);
+        expect(result.debugInfo?.modelUsed).toBe('test-model');
+      } finally {
+        Object.defineProperty(process.env, 'NODE_ENV', {
+          value: originalNodeEnv,
+          writable: true,
+          configurable: true,
+        });
+      }
     });
 
     it('falls back to exactly three options so nothing generated goes unshown', async () => {

--- a/src/lib/ai/choiceGenerator.prompt.ts
+++ b/src/lib/ai/choiceGenerator.prompt.ts
@@ -4,6 +4,7 @@ import type { Character as StoreCharacter } from '@/state/characterStore';
 import { useInventoryStore } from '@/state/inventoryStore';
 import { useNPCStore } from '@/state/npcStore';
 import { useSessionStore } from '@/state/sessionStore';
+import { useNarrativeStore } from '@/state/narrativeStore';
 import { DEFAULT_TONE_SETTINGS } from '@/types/tone-settings.types';
 import { getDetailedToneInstructions } from './toneSettingsGuidance';
 import { getLoreContextForPrompt } from './loreContextHelper';
@@ -46,7 +47,8 @@ export const buildChoicePrompt = ({
     world,
     narrativeContext,
     resolvedCharacterIds,
-    maxOptions
+    maxOptions,
+    getTurnIndex(sessionId)
   );
   const basePrompt = template(context);
   const inventoryAwarePrompt = enhancePromptWithInventory(
@@ -109,7 +111,8 @@ const buildContext = (
   world: World,
   narrativeContext: NarrativeContext,
   characterIds: string[],
-  maxOptions?: number
+  maxOptions?: number,
+  turnIndex?: number
 ) => {
   const playerCharacter = getPlayerCharacter(characterIds);
 
@@ -120,6 +123,7 @@ const buildContext = (
     narrativeContext,
     characterIds,
     optionCount: maxOptions,
+    turnIndex,
     playerCharacterName: playerCharacter?.name,
     worldSkills:
       world.skills?.map((skill) => ({
@@ -129,6 +133,22 @@ const buildContext = (
       })) || [],
     worldNpcs: getWorldNpcs(world.id, playerCharacter),
   };
+};
+
+/**
+ * Decisions already made this session - uncapped, unlike
+ * NarrativeContext.previousSegments, which every production caller populates
+ * from a 5-segment slice (see usePlayerChoices.ts). A codex review on round 6
+ * caught that the glossary rotation had keyed off previousSegments.length and
+ * would freeze on one order past turn 5.
+ */
+const getTurnIndex = (sessionId?: EntityID): number => {
+  if (!sessionId) return 0;
+  try {
+    return useNarrativeStore.getState().getSessionDecisions(sessionId).length;
+  } catch {
+    return 0;
+  }
 };
 
 const getPlayerCharacter = (characterIds: string[]) => {

--- a/src/lib/ai/choiceGenerator.ts
+++ b/src/lib/ai/choiceGenerator.ts
@@ -12,6 +12,9 @@ import { parseChoiceResponse, applyAlignmentConsequences, type KnownNpc } from '
 import { generateFallbackChoices } from './choiceGenerator.fallback';
 import { matchSkillToOption } from './choiceGenerator.skillMatch';
 import { recordRequestCalibration } from './narrativeGenerator.calibration';
+import { buildPromptDebugInfo, isDebugInfoEnabled, type DebugInfoContext } from './debugInfoBuilder';
+import { getActiveProviderModel } from '@/state/providerStore';
+import { DEFAULT_TEXT_MODEL } from './config';
 
 /**
  * Parameters for choice generation
@@ -66,6 +69,21 @@ export async function generateChoices(
     }
 
     const decision = parseChoiceResponse(response.content, narrativeContext, world, getKnownNpcs(worldId));
+
+    // Nothing captured this call's prompt or response before #1829 round 6,
+    // which made prompt-level instructions particular to choice generation
+    // (the Alignment Mix line among them) unverifiable after the fact.
+    if (isDebugInfoEnabled()) {
+      const debugInfoContext: DebugInfoContext = {
+        fullPrompt: prompt,
+        templateName: useAlignedChoices ? 'Aligned Choice Template' : 'Player Choice Template',
+        world,
+        characterIds,
+        modelUsed: getActiveProviderModel() ?? DEFAULT_TEXT_MODEL,
+        rawResponse: response.content,
+      };
+      decision.debugInfo = buildPromptDebugInfo(debugInfoContext);
+    }
 
     try {
       checkAndRecordLoreMentions(worldId, sessionId, response.content, 'choices');

--- a/src/lib/ai/debugInfoBuilder.ts
+++ b/src/lib/ai/debugInfoBuilder.ts
@@ -33,6 +33,8 @@ export interface DebugInfoContext {
     totalTokens: number;
   };
   modelUsed: string;
+  /** The unparsed AI response text - see PromptDebugInfo.rawResponse. */
+  rawResponse?: string;
 }
 
 /**
@@ -82,6 +84,7 @@ export function buildPromptDebugInfo(context: DebugInfoContext): PromptDebugInfo
     tokenUsage: context.tokenUsage,
     modelUsed: context.modelUsed,
     generatedAt: new Date(),
+    rawResponse: context.rawResponse,
   };
 }
 

--- a/src/lib/promptTemplates/templates/narrative/__tests__/choiceTemplates.alignmentSpread.test.ts
+++ b/src/lib/promptTemplates/templates/narrative/__tests__/choiceTemplates.alignmentSpread.test.ts
@@ -121,4 +121,27 @@ describe('aligned choice template: alignment spread instructions', () => {
 
     expect(prompt).toMatch(/there is no quota/i);
   });
+
+  it('rotates the glossary listing order across turns instead of holding one order for the whole session (#1829 round 6)', () => {
+    const ordersByTurn = [0, 1, 2, 3, 4].map((turnCount) => {
+      const context = {
+        ...baseContext,
+        narrativeContext: {
+          ...narrativeContext,
+          previousSegments: Array(turnCount).fill(segment),
+        },
+      };
+      const glossary = sectionBetween(alignedChoiceTemplate(context), 'ALIGNMENT DEFINITIONS', 'CHOOSING THE MIX');
+      return tagOrderIn(glossary);
+    });
+
+    // Every order stays a full three-tag glossary...
+    ordersByTurn.forEach((order) => expect(order).toHaveLength(3));
+    // ...but not the same order turn after turn - that's the pattern round 5 measured.
+    const distinctOrders = new Set(ordersByTurn.map((order) => order.join(',')));
+    expect(distinctOrders.size).toBeGreaterThan(1);
+    // Turn 4 cycles back to turn 0's order (four permitted orders), proving the
+    // rotation is turn-keyed rather than incidental.
+    expect(ordersByTurn[4]).toEqual(ordersByTurn[0]);
+  });
 });

--- a/src/lib/promptTemplates/templates/narrative/__tests__/choiceTemplates.alignmentSpread.test.ts
+++ b/src/lib/promptTemplates/templates/narrative/__tests__/choiceTemplates.alignmentSpread.test.ts
@@ -123,15 +123,12 @@ describe('aligned choice template: alignment spread instructions', () => {
   });
 
   it('rotates the glossary listing order across turns instead of holding one order for the whole session (#1829 round 6)', () => {
-    const ordersByTurn = [0, 1, 2, 3, 4].map((turnCount) => {
-      const context = {
-        ...baseContext,
-        narrativeContext: {
-          ...narrativeContext,
-          previousSegments: Array(turnCount).fill(segment),
-        },
-      };
-      const glossary = sectionBetween(alignedChoiceTemplate(context), 'ALIGNMENT DEFINITIONS', 'CHOOSING THE MIX');
+    const ordersByTurn = [0, 1, 2, 3, 4].map((turnIndex) => {
+      const glossary = sectionBetween(
+        alignedChoiceTemplate({ ...baseContext, turnIndex }),
+        'ALIGNMENT DEFINITIONS',
+        'CHOOSING THE MIX'
+      );
       return tagOrderIn(glossary);
     });
 
@@ -143,5 +140,22 @@ describe('aligned choice template: alignment spread instructions', () => {
     // Turn 4 cycles back to turn 0's order (four permitted orders), proving the
     // rotation is turn-keyed rather than incidental.
     expect(ordersByTurn[4]).toEqual(ordersByTurn[0]);
+  });
+
+  it('keeps rotating past turn 5, where previousSegments.length would have frozen (codex catch on round 6)', () => {
+    // Every production caller caps previousSegments at a 5-segment slice
+    // (see usePlayerChoices.ts), so a rotation keyed off that count would
+    // land on ALIGNMENT_GLOSSARY_ORDERS[1] forever past turn 5. turnIndex is
+    // sourced from the session's decision count instead, which isn't capped.
+    const ordersPastFive = [5, 6, 7, 8].map((turnIndex) => {
+      const glossary = sectionBetween(
+        alignedChoiceTemplate({ ...baseContext, turnIndex }),
+        'ALIGNMENT DEFINITIONS',
+        'CHOOSING THE MIX'
+      );
+      return tagOrderIn(glossary).join(',');
+    });
+
+    expect(new Set(ordersPastFive).size).toBeGreaterThan(1);
   });
 });

--- a/src/lib/promptTemplates/templates/narrative/choiceTypeTemplates.ts
+++ b/src/lib/promptTemplates/templates/narrative/choiceTypeTemplates.ts
@@ -20,17 +20,40 @@ interface PlayerChoiceTemplateContext {
   playerCharacterName?: string;
 }
 
+/** Definition text for each alignment tag, kept separate from the glossary's listing order (see ALIGNMENT_GLOSSARY_ORDERS) so the order can rotate without touching the wording. */
+const ALIGNMENT_DEFINITIONS: Record<'NEUTRAL' | 'CHAOTIC' | 'LAWFUL', string> = {
+  NEUTRAL: 'Balanced approach, practical solutions, adapts to situation, moderate response',
+  CHAOTIC:
+    'WILDLY UNEXPECTED and DISRUPTIVE actions that completely change the situation. Dramatic, potentially dangerous, creative solutions that ignore social norms, defy expectations, and could lead to entirely different story outcomes. VARY THE KIND of chaos and do NOT default to making noise (yelling, shouting, singing). Draw from a wide range, fitted to the scene: sudden physical risk ("leap from the balcony onto the chandelier," "kick over the lantern to set the drapes alight"), trickery or deception ("impersonate the captain and bark orders," "bluff an outrageous lie with total confidence"), sabotage or destruction ("cut the rope bridge behind you," "smash the control panel," "throw open the cells and free the prisoners"), turning the tables ("start a brawl to scatter the room," "switch sides mid-negotiation"), or abandoning the obvious goal for something no one expects. The goal is options that dramatically shift the narrative in surprising ways.',
+  LAWFUL: 'Follows rules, respects authority, seeks order, honors agreements, protects others',
+};
+
+/**
+ * The glossary orders in rotation. Excludes LAWFUL/NEUTRAL/CHAOTIC (the
+ * canonical running order #1877 removed from the numbered slots) and any
+ * order ending in CHAOTIC (the slot-3 tell round 5 found still holding at
+ * 83% even with the order shuffled) - the two shapes the alignment-spread
+ * tests forbid.
+ */
+const ALIGNMENT_GLOSSARY_ORDERS: Array<Array<'NEUTRAL' | 'CHAOTIC' | 'LAWFUL'>> = [
+  ['NEUTRAL', 'CHAOTIC', 'LAWFUL'],
+  ['CHAOTIC', 'LAWFUL', 'NEUTRAL'],
+  ['CHAOTIC', 'NEUTRAL', 'LAWFUL'],
+  ['LAWFUL', 'CHAOTIC', 'NEUTRAL'],
+];
+
 /**
  * Prompt template for generating alignment-tagged player choices.
  *
  * The mix of alignments is chosen per scene rather than mandated. Removing the
  * quota was not enough on its own: the model kept returning lawful, neutral,
- * chaotic in that order because the prompt itself taught the pattern. The
- * glossary listed the tags in exactly the order the numbered slots wanted
- * them, and the chaotic entry dwarfed the other two, which marked it as the
- * showy one that always turns up last. So the mix is now a decision the model
- * has to state before it writes anything, the glossary no longer runs in slot
- * order, and a chaotic option has to be one a player might really take.
+ * chaotic in that order because the prompt itself taught the pattern. #1877
+ * moved the mix decision earlier and took the glossary out of slot order, but
+ * a FIXED reordering is still a pattern - round 5 (#1829) measured 70% one
+ * dominant order and 83-87% slot-predicts-tag against a single static
+ * glossary. So the glossary's own listing order now rotates per turn (see
+ * ALIGNMENT_GLOSSARY_ORDERS below) instead of landing on one order and
+ * staying there for the rest of the session.
  */
 export const alignedChoiceTemplate = (context: PlayerChoiceTemplateContext): string => {
   const { worldName, genre, narrativeContext, worldSkills, worldNpcs, optionCount, playerCharacterName } = context;
@@ -69,6 +92,19 @@ ${worldSkills.map(skill => `- ${skill.name}: ${skill.description}`).join('\n')}`
   }
 
   const protagonistInfo = protagonistGuidance(playerCharacterName);
+
+  // Round 5 (#1829) measured slot-predicts-tag at 87%/70%/83% even after the
+  // glossary stopped running in slot order: a FIXED glossary order is still a
+  // pattern to learn against, just one call removed from the numbered slots.
+  // Rotate which of the four permitted orders (no LAWFUL-NEUTRAL-CHAOTIC, none
+  // ending in CHAOTIC - the two orders the alignment-spread tests forbid) is
+  // shown, keyed off the turn count so it's deterministic and testable rather
+  // than reaching for Math.random in a prompt builder.
+  const turnIndex = narrativeContext?.previousSegments?.length ?? 0;
+  const glossaryOrder = ALIGNMENT_GLOSSARY_ORDERS[turnIndex % ALIGNMENT_GLOSSARY_ORDERS.length];
+  const glossaryText = glossaryOrder
+    .map((tag) => `- ${tag}: ${ALIGNMENT_DEFINITIONS[tag]}`)
+    .join('\n');
 
   // Known-character roster + consequence contract; only emitted when the
   // world has NPCs so the parser has names to resolve against.
@@ -109,9 +145,7 @@ You MUST create choices that directly respond to the specific situation describe
 Based on the SPECIFIC narrative situation above, create ${choiceCount} distinct action choices, each tagged with the alignment it expresses:
 
 ALIGNMENT DEFINITIONS (a glossary, not a running order - see CHOOSING THE MIX below):
-- NEUTRAL: Balanced approach, practical solutions, adapts to situation, moderate response
-- CHAOTIC: WILDLY UNEXPECTED and DISRUPTIVE actions that completely change the situation. Dramatic, potentially dangerous, creative solutions that ignore social norms, defy expectations, and could lead to entirely different story outcomes. VARY THE KIND of chaos and do NOT default to making noise (yelling, shouting, singing). Draw from a wide range, fitted to the scene: sudden physical risk ("leap from the balcony onto the chandelier," "kick over the lantern to set the drapes alight"), trickery or deception ("impersonate the captain and bark orders," "bluff an outrageous lie with total confidence"), sabotage or destruction ("cut the rope bridge behind you," "smash the control panel," "throw open the cells and free the prisoners"), turning the tables ("start a brawl to scatter the room," "switch sides mid-negotiation"), or abandoning the obvious goal for something no one expects. The goal is options that dramatically shift the narrative in surprising ways.
-- LAWFUL: Follows rules, respects authority, seeks order, honors agreements, protects others
+${glossaryText}
 
 CHOOSING THE MIX (IMPORTANT):
 - Always tag every choice [LAWFUL], [NEUTRAL], or [CHAOTIC].

--- a/src/lib/promptTemplates/templates/narrative/choiceTypeTemplates.ts
+++ b/src/lib/promptTemplates/templates/narrative/choiceTypeTemplates.ts
@@ -18,6 +18,13 @@ interface PlayerChoiceTemplateContext {
     name: string;
   }>;
   playerCharacterName?: string;
+  /**
+   * Decisions already made this session, uncapped - see getTurnIndex in
+   * choiceGenerator.prompt.ts. NOT narrativeContext.previousSegments.length:
+   * every production caller populates previousSegments from a 5-segment
+   * slice, so that count freezes once a session passes turn 5.
+   */
+  turnIndex?: number;
 }
 
 /** Definition text for each alignment tag, kept separate from the glossary's listing order (see ALIGNMENT_GLOSSARY_ORDERS) so the order can rotate without touching the wording. */
@@ -56,7 +63,7 @@ const ALIGNMENT_GLOSSARY_ORDERS: Array<Array<'NEUTRAL' | 'CHAOTIC' | 'LAWFUL'>> 
  * staying there for the rest of the session.
  */
 export const alignedChoiceTemplate = (context: PlayerChoiceTemplateContext): string => {
-  const { worldName, genre, narrativeContext, worldSkills, worldNpcs, optionCount, playerCharacterName } = context;
+  const { worldName, genre, narrativeContext, worldSkills, worldNpcs, optionCount, playerCharacterName, turnIndex } = context;
   const choiceCount =
     typeof optionCount === 'number' && Number.isFinite(optionCount)
       ? Math.max(1, Math.floor(optionCount))
@@ -98,10 +105,9 @@ ${worldSkills.map(skill => `- ${skill.name}: ${skill.description}`).join('\n')}`
   // pattern to learn against, just one call removed from the numbered slots.
   // Rotate which of the four permitted orders (no LAWFUL-NEUTRAL-CHAOTIC, none
   // ending in CHAOTIC - the two orders the alignment-spread tests forbid) is
-  // shown, keyed off the turn count so it's deterministic and testable rather
-  // than reaching for Math.random in a prompt builder.
-  const turnIndex = narrativeContext?.previousSegments?.length ?? 0;
-  const glossaryOrder = ALIGNMENT_GLOSSARY_ORDERS[turnIndex % ALIGNMENT_GLOSSARY_ORDERS.length];
+  // shown, keyed off turnIndex so it's deterministic and testable rather than
+  // reaching for Math.random in a prompt builder.
+  const glossaryOrder = ALIGNMENT_GLOSSARY_ORDERS[(turnIndex ?? 0) % ALIGNMENT_GLOSSARY_ORDERS.length];
   const glossaryText = glossaryOrder
     .map((tag) => `- ${tag}: ${ALIGNMENT_DEFINITIONS[tag]}`)
     .join('\n');

--- a/src/types/narrative.types.ts
+++ b/src/types/narrative.types.ts
@@ -45,6 +45,13 @@ export interface Decision {
   contextSummary?: string;
   decisionWeight?: DecisionWeight;
   narrativeSegmentId?: EntityID;
+  /**
+   * The prompt that produced this decision's options (dev mode only). Segments
+   * carry the scene/prose prompt on metadata.debugInfo; this is the choice
+   * generator's own prompt, which nothing captured before #1829 round 6 - a
+   * gap that made the alignment-mix instruction itself unverifiable.
+   */
+  debugInfo?: PromptDebugInfo;
 }
 
 export interface DecisionHistoryEntry {
@@ -245,6 +252,15 @@ export interface PromptDebugInfo {
   modelUsed: string;
   /** Timestamp when this prompt was generated */
   generatedAt: Date;
+  /**
+   * The unparsed AI response text (dev mode only). Parsing throws away
+   * anything the model wrote outside the fields a parser extracts, which
+   * hides whether the model complied with a prompt instruction that isn't
+   * itself one of those fields - e.g. whether it emitted an Alignment Mix
+   * line before #1829 round 6, nothing captured this and the question was
+   * unanswerable after the fact.
+   */
+  rawResponse?: string;
 }
 
 /**


### PR DESCRIPTION
## Description
Round 6 on #1829, scoped in the [round 6 comment](https://github.com/jerseycheese/Narraitor/issues/1829#issuecomment-5389251396) to two mechanical items and explicitly leaves the mix quota alone (two different mechanisms already failed to move it, per [the stop rule this saga produced](https://github.com/jerseycheese/Narraitor/blob/develop/.claude/skills/narraitor-ai-quality-discipline/SKILL.md)).

1. The aligned choice glossary's own listing order now rotates through four permitted orders, keyed off turn count, instead of holding one fixed order for the whole session. Round 5 measured that a static reorder is still a pattern to learn against: 70% one dominant order, slot-predicts-tag at 87%/70%/83%.
2. `choiceGenerator.ts` never attached `debugInfo`, so round 5 couldn't tell whether the model actually emits the `Alignment Mix:` line - nothing captured the prompt or the raw response before parsing threw the unparsed text away. It's wired in now, gated the same way the scene generator's is, and `PromptDebugInfo` gets a `rawResponse` field so a future round can read the model's actual output, not just what was asked of it.

This is unmeasured, the same way #1877 shipped unmeasured. Template tests prove the instructions exist and the rotation happens; they cannot prove the model complies. Do not close #1829 off this PR - it needs a live read first.

## Related Issue
Related to #1829 (does not close it - see above)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
None - internal prompt/instrumentation fix, no player-facing story.

## Flow Diagrams
Not applicable.

## Component Development
Not applicable - no UI change.

## Implementation Notes
- The four permitted glossary orders exclude LAWFUL/NEUTRAL/CHAOTIC (the running order #1877 already removed) and any order ending in CHAOTIC (the slot-3 tell round 5 measured at 83%) - the same two shapes the existing `choiceTemplates.alignmentSpread.test.ts` tests already forbid.
- Rotation is keyed off `narrativeContext.previousSegments.length % 4` rather than `Math.random()`, so it stays deterministic and testable without mocking randomness.
- `debugInfo` on `choiceGenerator.ts` only attaches on the success path (parsed decision), not on the empty-response or error fallback paths, since there's no real prompt/response pair to log there.

## Screenshots
Not applicable.

## Visual Baseline Changes
None.

## Code Review Summary (if applicable)
Not applicable.

## Chrome DevTools MCP Verification Summary (if applicable)
Not applicable - no browser-observable change; verified via the quality gate below and a template-level test asserting the rotation.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed (CI)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm test -- src/lib/promptTemplates/templates/narrative/__tests__/choiceTemplates.alignmentSpread.test.ts` - the new rotation test plus the existing forbidden-shape tests.
2. `npm test -- src/lib/ai/__tests__/choiceGenerator.test.ts` - the new debugInfo test.
3. `npm test && npx tsc --noEmit && npm run lint` - full gate, all green locally (444 suites / 3081 tests, 0 type errors, 0 lint errors).

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) - N/A, no docs reference this prompt's internals
- [x] No new warnings generated
- [x] Accessibility considerations addressed - N/A, no UI change
