### PR TITLE
Keep item use out of world clock turns

### DIFF
--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -24,7 +24,7 @@ import {
 } from '@/lib/narrative/evaluateDecisionSkillChecks';
 import { computeTurnsSinceComplication, isPacingStale } from '@/lib/narrative/turnsSinceComplication';
 import { isFatalCadenceOffCooldown } from '@/lib/narrative/fatalDecisionCadence';
-import { buildWorldClockPromptContext } from '@/lib/narrative/worldClock';
+import { buildWorldClockPromptContext, countWorldClockTurns } from '@/lib/narrative/worldClock';
 import { isFeatureEnabled } from '@/lib/featureFlags';
 import { mergeTurnTags } from '@/lib/narrative/turnTags';
 import { logger } from '@/lib/utils/logger';
@@ -664,7 +664,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
       // this segment lands (sessionSegments length after add), and the local
       // segments state can lag the store, so read the store count directly.
       const currentTurn =
-        useNarrativeStore.getState().getSessionSegments(sessionId).length + 1;
+        countWorldClockTurns(useNarrativeStore.getState().getSessionSegments(sessionId)) + 1;
       const worldClock = isFeatureEnabled('WORLD_CLOCK')
         ? buildWorldClockPromptContext(
             useWorldThreadStore

--- a/src/components/devtools/WorldClockSection/WorldClockSection.tsx
+++ b/src/components/devtools/WorldClockSection/WorldClockSection.tsx
@@ -5,8 +5,9 @@ import { clsx } from 'clsx';
 import { useSessionStore } from '@/state/sessionStore';
 import { useNarrativeStore } from '@/state/narrativeStore';
 import { useWorldThreadStore } from '@/state/worldThreadStore';
-import { isOverdue, turnsSinceWorldMoved } from '@/lib/narrative/worldClock';
+import { countWorldClockTurns, isOverdue, turnsSinceWorldMoved } from '@/lib/narrative/worldClock';
 import type { WorldThread } from '@/types/worldThread.types';
+import type { NarrativeSegment } from '@/types/narrative.types';
 import './WorldClockSection.css';
 
 const RECENT_CLOSED_LIMIT = 5;
@@ -56,7 +57,14 @@ const ClosedThreadRow = ({ thread }: { thread: WorldThread }) => (
 export const WorldClockSection = () => {
   const sessionId = useSessionStore((state) => state.id);
   const currentTurn = useNarrativeStore(
-    (state) => (sessionId ? state.sessionSegments[sessionId]?.length ?? 0 : 0)
+    (state) =>
+      sessionId
+        ? countWorldClockTurns(
+            (state.sessionSegments[sessionId] ?? [])
+              .map((id) => state.segments?.[id])
+              .filter((segment): segment is NarrativeSegment => Boolean(segment))
+          )
+        : 0
   );
   // Subscribe to the raw slices rather than calling the selector methods so the
   // section re-renders when the ledger moves; the methods read get() and would

--- a/src/components/devtools/WorldClockSection/__tests__/WorldClockSection.test.tsx
+++ b/src/components/devtools/WorldClockSection/__tests__/WorldClockSection.test.tsx
@@ -13,7 +13,16 @@ jest.mock('@/state/sessionStore', () => {
 });
 jest.mock('@/state/narrativeStore', () => {
   const state = {
-    sessionSegments: { 'session-1': ['seg-1', 'seg-2', 'seg-3', 'seg-4', 'seg-5', 'seg-6'] },
+    sessionSegments: { 'session-1': ['seg-1', 'seg-2', 'seg-item', 'seg-3', 'seg-4', 'seg-5', 'seg-6'] },
+    segments: {
+      'seg-1': { metadata: { tags: [] } },
+      'seg-2': { metadata: { tags: [] } },
+      'seg-item': { metadata: { tags: ['item-usage'] } },
+      'seg-3': { metadata: { tags: [] } },
+      'seg-4': { metadata: { tags: [] } },
+      'seg-5': { metadata: { tags: [] } },
+      'seg-6': { metadata: { tags: [] } },
+    },
   };
   return { useNarrativeStore: (selector: (s: typeof state) => unknown) => selector(state) };
 });

--- a/src/lib/narrative/__tests__/applyWorldClockUpdates.test.ts
+++ b/src/lib/narrative/__tests__/applyWorldClockUpdates.test.ts
@@ -135,6 +135,33 @@ describe('applyWorldClockUpdates', () => {
     expect(note?.worldClock).toEqual({ turn: 2, open: 1, overdue: 0, opened: [], advanced: [], resolved: [] });
   });
 
+  it('keeps item-usage segments off the world clock even when the flag is on', async () => {
+    mockIsFeatureEnabled.mockReturnValue(true);
+    processSpy.mockResolvedValue({
+      newGoalsCreated: 0,
+      goalsUpdated: 0,
+      goalsCompleted: 0,
+      worldThreads: {
+        opened: [{ kind: 'consequence', summary: 'The item attracted attention' }],
+        advanced: [],
+        resolved: [],
+      },
+    });
+
+    const note = await applyWorldClockUpdates({
+      segment: segment(worldId, {
+        type: 'action',
+        metadata: { tags: ['item-usage', 'quest-items'] },
+      }),
+      sessionId: 'session-1',
+      currentTurn: 2,
+    });
+
+    expect(processSpy).toHaveBeenCalledWith(expect.anything(), 'session-1', undefined, undefined, undefined);
+    expect(note).toBeUndefined();
+    expect(useWorldThreadStore.getState().hasSessionLedger('session-1')).toBe(false);
+  });
+
   it('runs a session\'s extractions in turn order, so a fast turn 2 waits for turn 1 and seeds once', async () => {
     mockIsFeatureEnabled.mockReturnValue(true);
     let releaseTurnOne: (value: unknown) => void = () => undefined;

--- a/src/lib/narrative/__tests__/turnTags.test.ts
+++ b/src/lib/narrative/__tests__/turnTags.test.ts
@@ -18,6 +18,10 @@ describe('mergeTurnTags', () => {
       )
     ).toEqual(['forest', 'skill-success:a', 'skill-roll:19']);
   });
+
+  it('drops previous item-usage tags before building the next turn', () => {
+    expect(mergeTurnTags(['forest', 'item-usage'], ['combat'])).toEqual(['forest', 'combat']);
+  });
 });
 
 describe('scene prompt built from merged turn tags', () => {

--- a/src/lib/narrative/__tests__/worldClock.test.ts
+++ b/src/lib/narrative/__tests__/worldClock.test.ts
@@ -3,8 +3,11 @@ import {
   turnsSinceWorldMoved,
   selectThreadsForPrompt,
   buildWorldClockPromptContext,
+  countWorldClockTurns,
+  isWorldClockTurnSegment,
   summarizeLedgerForSegment,
 } from '../worldClock';
+import type { NarrativeSegment } from '@/types/narrative.types';
 import type { WorldThread } from '@/types/worldThread.types';
 
 let nextId = 0;
@@ -21,6 +24,18 @@ const makeThread = (overrides: Partial<WorldThread> = {}): WorldThread => ({
   createdAt: '2026-01-01T00:00:00.000Z',
   updatedAt: '2026-01-01T00:00:00.000Z',
   ...overrides,
+});
+
+const makeSegment = (id: string, tags: string[] = []): NarrativeSegment => ({
+  id,
+  sessionId: 'session-a',
+  worldId: 'world-1',
+  content: 'A scene unfolds.',
+  type: tags.includes('item-usage') ? 'action' : 'scene',
+  metadata: { tags },
+  timestamp: new Date('2026-01-01T00:00:00.000Z'),
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
 });
 
 describe('worldClock', () => {
@@ -73,6 +88,16 @@ describe('worldClock', () => {
       turnsSinceWorldMoved: 1,
       threads: [{ kind: 'consequence', summary: 'The debt collector is coming', ageTurns: 4, overdue: true }],
     });
+  });
+
+  test('countWorldClockTurns treats item usage as a beat, not a clock turn', () => {
+    const opening = makeSegment('seg-1');
+    const itemUse = makeSegment('seg-2', ['item-usage', 'quest-items']);
+    const nextScene = makeSegment('seg-3');
+
+    expect(isWorldClockTurnSegment(opening)).toBe(true);
+    expect(isWorldClockTurnSegment(itemUse)).toBe(false);
+    expect(countWorldClockTurns([opening, itemUse, nextScene])).toBe(2);
   });
 
   test('summarizeLedgerForSegment counts open and overdue and passes the applied summaries through', () => {

--- a/src/lib/narrative/applyWorldClockUpdates.ts
+++ b/src/lib/narrative/applyWorldClockUpdates.ts
@@ -9,7 +9,7 @@ import type {
 import type { WorldCostExtractionInput, WorldCostSegmentNote } from '@/types/worldCost.types';
 import { logger } from '@/lib/utils/logger';
 import { isFeatureEnabled } from '@/lib/featureFlags';
-import { summarizeLedgerForSegment } from '@/lib/narrative/worldClock';
+import { isWorldClockTurnSegment, summarizeLedgerForSegment } from '@/lib/narrative/worldClock';
 import { applyWorldCost } from '@/lib/narrative/applyWorldCost';
 import { useCharacterStore } from '@/state/characterStore';
 import { useGoalStore } from '@/state/goalStore';
@@ -79,7 +79,7 @@ async function reconcileSegment({
   currentTurn,
 }: ApplyWorldClockUpdatesParams): Promise<ReconciledSegmentNotes | undefined> {
   const goalStore = useGoalStore.getState();
-  const clockOn = isFeatureEnabled('WORLD_CLOCK');
+  const clockOn = isFeatureEnabled('WORLD_CLOCK') && isWorldClockTurnSegment(segment);
   const costOn = isFeatureEnabled('WORLD_COST');
 
   if (!clockOn && !costOn) {
@@ -105,7 +105,7 @@ async function reconcileSegment({
       notes.worldCost = applyWorldCost({ sessionId, characterId: playerCharacterId, result: result.worldCost });
     }
 
-    if (result.worldThreads && worldId) {
+    if (clockOn && result.worldThreads && worldId) {
       const applied = useWorldThreadStore
         .getState()
         .applyExtraction(sessionId, worldId, result.worldThreads, currentTurn);

--- a/src/lib/narrative/turnTags.ts
+++ b/src/lib/narrative/turnTags.ts
@@ -1,4 +1,5 @@
 const SKILL_CHECK_TAG_PREFIX = 'skill-';
+const TRANSIENT_TURN_TAGS = new Set(['item-usage']);
 
 /**
  * Builds the tag list a turn's prompt sees.
@@ -12,6 +13,8 @@ export const mergeTurnTags = (
   previousSegmentTags: string[],
   currentTurnTags: string[]
 ): string[] => [
-  ...previousSegmentTags.filter((tag) => !tag.startsWith(SKILL_CHECK_TAG_PREFIX)),
+  ...previousSegmentTags.filter(
+    (tag) => !tag.startsWith(SKILL_CHECK_TAG_PREFIX) && !TRANSIENT_TURN_TAGS.has(tag)
+  ),
   ...currentTurnTags,
 ];

--- a/src/lib/narrative/worldClock.ts
+++ b/src/lib/narrative/worldClock.ts
@@ -2,6 +2,7 @@
  * Turn arithmetic over the world-thread ledger. Pure functions: the store
  * owns the data, the scene prompt and the segment stamp consume these shapes.
  */
+import type { NarrativeSegment } from '@/types/narrative.types';
 import type {
   WorldThread,
   WorldClockPromptContext,
@@ -57,6 +58,12 @@ export const buildWorldClockPromptContext = (
     })),
   };
 };
+
+export const isWorldClockTurnSegment = (segment: NarrativeSegment): boolean =>
+  !segment.metadata?.tags?.includes('item-usage');
+
+export const countWorldClockTurns = (segments: NarrativeSegment[]): number =>
+  segments.filter(isWorldClockTurnSegment).length;
 
 export const summarizeLedgerForSegment = (
   sessionThreads: WorldThread[],

--- a/src/state/narrativeStore.segments.ts
+++ b/src/state/narrativeStore.segments.ts
@@ -6,6 +6,7 @@ import { normalizeText, NORM_DESC } from '../lib/utils/textNormalization';
 import { applyNarrativeContentGate } from '../lib/narrative/narrativeContentGate';
 import { applyWorldStateThreadUpdates } from '../lib/narrative/applyWorldStateThreadUpdates';
 import { applyWorldClockUpdates } from '../lib/narrative/applyWorldClockUpdates';
+import { countWorldClockTurns } from '../lib/narrative/worldClock';
 import { formatDecisionText } from '../lib/narrative/formatDecisionText';
 import { useSessionStore } from './sessionStore';
 import { trackFunnelStep } from '@/lib/analytics/trackFunnelStep';
@@ -173,7 +174,11 @@ export const createNarrativeSegmentActions = (
     // ledger. Fire-and-forget: nothing in this turn's UI waits on it. The
     // ledger note is stamped back onto the segment once reconciled so the
     // per-turn record survives reloads and the playtest harness can read it.
-    const currentTurn = (get().sessionSegments[sessionId] || []).length;
+    const currentTurn = countWorldClockTurns(
+      (get().sessionSegments[sessionId] || [])
+        .map((id) => get().segments[id])
+        .filter((segment): segment is NarrativeSegment => Boolean(segment))
+    );
     void Promise.resolve().then(async () => {
       try {
         // characterIds lists the NPCs in the scene; the player is the session's character.


### PR DESCRIPTION
## Description
Item-use prose is now treated as a beat instead of a world-clock turn. The shared world-clock turn helper excludes `item-usage` segments, the controller uses that helper when naming the next turn in the prompt, and post-segment reconciliation refuses to apply ledger results when the segment is not clock-eligible.

The devtools summary now reads the same turn count, so the debug panel matches what the model and ledger see.

## Related Issue
Closes #1875

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
MVP tests were added for the world-clock turn rule, item-use reconciliation, and the devtools display. This was not a strict test-first pass because the root cause came from the existing issue analysis.

- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
Using an inventory item should not spend a world-clock turn or age open threads before the next real scene.

## Flow Diagrams
None.

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes
The world-clock turn rule lives in `src/lib/narrative/worldClock.ts` so prompt construction, segment reconciliation, and the devtools panel all use the same definition.

Item-use segments still go through goal/cost processing as before. They just do not pass world-thread input or apply returned ledger movement.

## Screenshots
Not applicable. This is a narrative-engine/devtools logic change with no visual surface change.

## Visual Baseline Changes
None.

## Code Review Summary (if applicable)
Self-review checked the diff for scope and whitespace. The change is limited to world-clock turn counting, item-use reconciliation, and related tests.

## Chrome DevTools MCP Verification Summary (if applicable)
Not applicable.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. Run `npm test -- src/lib/narrative/__tests__/worldClock.test.ts src/lib/narrative/__tests__/applyWorldClockUpdates.test.ts src/lib/inventory/__tests__/itemUsageService.test.ts src/components/devtools/WorldClockSection/__tests__/WorldClockSection.test.tsx --runInBand`.
2. Run `npm test -- --runInBand`.
3. Run `npm run type-check`, `npm run lint`, and `NEXT_PUBLIC_SITE_URL=http://localhost:3000 npm run build:app`.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed
