### PR TITLE
Apply the 2026-08-17 plain-language sweep findings

### DIFF
--- a/public_docs/architecture/ADR-009-guided-onboarding-system.md
+++ b/public_docs/architecture/ADR-009-guided-onboarding-system.md
@@ -11,7 +11,7 @@ updated: 2026-08-01
 **Date**: 2025-06-20
 
 ## Context
-So we had a problem with new users hitting Narraitor and just bouncing. The world creation process was asking too much of them upfront - they needed to understand attributes, skills, and settings before they could even get started. There wasn't a clear path for first-time users, and the cognitive load was just too high. People were dropping off before they got to experience what the app actually does.
+New users were hitting Narraitor and bouncing. The world creation process asked too much of them upfront - they needed to understand attributes, skills, and settings before they could even get started. There wasn't a clear path for first-time users, and the cognitive load was too high. People were dropping off before they got to see what the app does.
 
 ## Decision
 Built a guided onboarding system for new users:
@@ -20,7 +20,7 @@ Built a guided onboarding system for new users:
 2. **Simplifies world creation** to just 2 essential steps (concept + details) instead of the full complex flow
 3. **Uses AI to enhance user input** with contextually appropriate defaults so they don't have to figure everything out
 4. **Moves straight from world to character creation** with no dead end in between
-5. **Maintains professional UX standards** with responsive design and proper error handling
+5. **Keeps the flow usable on small screens** and surfaces an explicit error state when an AI call fails
 
 ## Implementation Architecture
 
@@ -34,7 +34,7 @@ Built a guided onboarding system for new users:
 
 #### State Management
 - **Choice**: Integrate with existing sessionStore rather than creating separate state
-- **Rationale**: Why reinvent the wheel? We already had auto-save infrastructure and persistence working
+- **Rationale**: The auto-save infrastructure and persistence were already working
 - **Implementation**: Just added onboarding completion tracking to the existing session state
 
 #### AI Integration Strategy

--- a/public_docs/architecture/ADR-010-decision-relevance-simplification.md
+++ b/public_docs/architecture/ADR-010-decision-relevance-simplification.md
@@ -95,7 +95,7 @@ export function getMostRelevantDecisions(
 **simpleDecisionFormatter.ts** (48 lines):
 - Single consistent format for all decisions
 - No adaptive levels, no token optimization
-- Works perfectly because we only pass 10-15 decisions anyway
+- Fine at this scale, since only 10-15 decisions ever get passed
 
 ### Files Changed
 **Deleted:**

--- a/public_docs/design-system/icon-usage-guide.md
+++ b/public_docs/design-system/icon-usage-guide.md
@@ -376,7 +376,7 @@ When you find an emoji in the code, here's how to fix it:
 
 ### Badge Component
 
-The Badge component is designed to work seamlessly with lucide-react icons:
+The Badge component takes lucide-react icons directly:
 
 ```tsx
 // The icon prop accepts React.ReactNode

--- a/public_docs/development/github-sync-guide.md
+++ b/public_docs/development/github-sync-guide.md
@@ -7,7 +7,7 @@ updated: 2026-07-21
 
 # GitHub Integration Guide
 
-So I built some automation to keep GitHub issues and project documentation in sync. The goal was to reduce the manual work involved in managing user stories and project tracking.
+This is the automation that keeps GitHub issues and project documentation in sync. The goal was to cut the manual work involved in managing user stories and project tracking.
 
 ## Getting Started
 

--- a/public_docs/development/testing-guide.md
+++ b/public_docs/development/testing-guide.md
@@ -215,7 +215,7 @@ test('creates character and updates store', async () => {
 });
 ```
 
-## What Actually Works
+## Test-Writing Habits
 
 **Descriptive test names** save so much debugging time. When a test fails, you should immediately know what broke:
 

--- a/public_docs/development/visual-regression-testing.md
+++ b/public_docs/development/visual-regression-testing.md
@@ -405,7 +405,6 @@ We use a **Darwin-only visual testing strategy**, meaning all baseline screensho
 
 **Benefits of Docker migration**:
 - **True consistency**: Same rendering environment across all platforms
-- **Industry standard**: Docker containers are the 2025 best practice for visual testing
 - **CI/CD reliability**: Eliminates "works on my machine" issues for visual tests
 
 **Multi-Platform Baseline Management**:

--- a/public_docs/development/visual-testing-best-practices.md
+++ b/public_docs/development/visual-testing-best-practices.md
@@ -5,7 +5,7 @@ created: 2025-08-20
 updated: 2026-08-14
 ---
 
-# What actually works for visual testing
+# Visual Testing Best Practices
 
 Here's what I've learned about writing visual tests that catch real issues without driving you crazy with false positives.
 

--- a/public_docs/features/ai-consistency-validation.md
+++ b/public_docs/features/ai-consistency-validation.md
@@ -42,7 +42,7 @@ The most common debugging scenarios and what to look for:
 
 **Instructions are gibberish**: Check the structured context output. If the raw data is messy, the instructions will be too.
 
-## How This Actually Works Behind the Scenes
+## What Happens Behind the Scenes
 
 ### The Components That Do the Work
 - **ConsistencyValidationSection**: The main debugging interface

--- a/public_docs/features/custom-player-input.md
+++ b/public_docs/features/custom-player-input.md
@@ -11,7 +11,7 @@ Most AI narrative games limit you to the choices the model generated. Climbing t
 
 This feature adds one. Players type what they want to try and the AI responds to it, alongside the suggested actions rather than instead of them.
 
-## How This Actually Works
+## How It Works
 
 **The Input Field** - A text area sits above the suggested actions, capped at 250 characters. The cap keeps a submission to an action rather than a paragraph of stage direction.
 

--- a/public_docs/features/narrative-consistency-tracking.md
+++ b/public_docs/features/narrative-consistency-tracking.md
@@ -4,7 +4,7 @@ Here's what happens without this system: you're in the middle of a tense investi
 
 This system solves that by automatically detecting and tracking goals throughout your narrative. It figures out what the player is supposed to be doing and makes sure the AI keeps those objectives front and center when generating new content.
 
-## How This Actually Works
+## How It Works
 
 **The AI Reads Between the Lines** - It's pretty smart about picking up both obvious goals ("Find the Sword of Light") and implied ones. When the wizard says "The dragon will attack at dawn," the system figures out that means "Stop the dragon attack" even though nobody explicitly said that. If the AI extraction fails for some reason, it falls back to pattern matching so you don't lose functionality.
 

--- a/public_docs/features/portrait-generation-guide.md
+++ b/public_docs/features/portrait-generation-guide.md
@@ -7,7 +7,7 @@ updated: 2026-07-21
 
 # Portrait Generation Guide
 
-Let's be honest - character portraits make everything better. There's something about seeing your character's face that makes the whole experience more immersive. This system generates AI-powered portraits that actually fit with your character's description and the world they live in.
+This system generates character portraits from the character's own description and the setting of the world they live in.
 
 The challenge was making this work with character creation while handling AI image generation issues - rate limits, failed generations, inappropriate content.
 
@@ -106,7 +106,7 @@ const CharacterCreationWizard = () => {
 };
 ```
 
-The beauty of this approach is that character creation never fails just because portrait generation does. If the AI service is down or hits rate limits, you still get your character - they just don't have a picture yet.
+Character creation never fails just because portrait generation does. If the AI service is down or hits rate limits, you still get your character - they just don't have a picture yet.
 
 ## Display Components
 

--- a/public_docs/features/world-management.md
+++ b/public_docs/features/world-management.md
@@ -9,7 +9,7 @@ updated: 2026-07-21
 
 World creation is where the magic starts - it's where players define the rules and tone that make their narrative experience unique. The challenge was building something flexible enough for any fictional universe (Star Wars, Lovecraft, your own weird sci-fi thing) while keeping it simple enough that someone can just jump in and start playing.
 
-So whether you want "Force Sensitivity" for Star Wars or "Sanity" for horror games, the system adapts to what you need while keeping character creation from becoming a spreadsheet nightmare.
+Whether you want "Force Sensitivity" for Star Wars or "Sanity" for horror games, the system adapts to what you need while keeping character creation from becoming a spreadsheet nightmare.
 
 ## The Building Blocks of Your World
 

--- a/public_docs/project-overview.md
+++ b/public_docs/project-overview.md
@@ -35,7 +35,7 @@ The core functionality is working and stable. All the main systems (world creati
 
 **Adaptive AI Narratives**: This is the interesting part. The AI doesn't just generate random fantasy stories. It maintains context about your world's rules, your character's abilities, and the ongoing story to create narratives that feel consistent with your setting.
 
-**Choice Weighting**: Decisions get labeled by importance (Minor/Major/Critical) and alignment (Lawful/Neutral/Chaotic) so you can see what really matters for your character's development.
+**Choice Weighting**: Decisions get labeled by importance (Minor/Major/Critical) and alignment (Lawful/Neutral/Chaotic) so you can see which decisions carry weight for your character's development.
 
 **Session Persistence**: Games save automatically using IndexedDB with graceful fallback to memory-only if storage fails. Pick up where you left off anytime.
 

--- a/public_docs/systems/mvp-type-simplification.md
+++ b/public_docs/systems/mvp-type-simplification.md
@@ -82,4 +82,4 @@ By cutting the complex stuff, we ended up with:
 - No advanced feature dependencies
 - Much lower overall type complexity
 
-The result? An MVP that's actually achievable instead of a six-month type engineering project. We can always add the complex stuff back later when we have users who actually want it.
+That leaves an MVP that's achievable now rather than a six-month type engineering project. The complex stuff can come back later, once there are users asking for it.

--- a/public_docs/systems/narrative-generation.md
+++ b/public_docs/systems/narrative-generation.md
@@ -142,7 +142,7 @@ Each turn fans out into a few separate Gemini calls, and on a free tier (50 requ
 - **Ending detection** — 1 call (once the session has at least 3 segments). `useEndingDetection` asks the AI whether the story has reached a natural conclusion. This is easy to forget when counting calls, but it's a real request every turn.
 - **Choice generation** — 1 call to produce the player's next decision.
 
-So a normal turn is up to 3 calls, not 2. Using an item adds its own item-usage narrative call plus a choice regeneration call on top.
+A normal turn is up to 3 calls, not 2. Using an item adds its own item-usage narrative call plus a choice regeneration call on top.
 
 To trim the obvious waste, choice generation is skipped when the turn already ends the session — there's no point generating choices nobody will ever see. The path that actually fires today is a **critical-decision failure**: `NarrativeController` already treats a failed roll on a `critical`-weight decision as fatal (it auto-generates the ending), so it skips choices on that turn. The `isSessionEndingSegment` helper (`src/lib/narrative/isSessionEndingSegment.ts`) covers the other terminal cases — an `ending`-type segment or committed ending data (`endingId`/`endingData`) — and a `fatal-outcome` tag. Note the `fatal-outcome` tag isn't currently emitted by generation (the AI tags narrative deaths freely, e.g. `death`), so that branch is forward-looking parity with the existing `hasFatalTag` check rather than something that fires in practice. Ending detection short-circuits too — once an ending's been suggested for the session, it won't fire another AI call.
 

--- a/public_docs/technical-guides/coding-naming-conventions.md
+++ b/public_docs/technical-guides/coding-naming-conventions.md
@@ -7,7 +7,7 @@ updated: 2025-06-26
 
 # How We Name Things
 
-So file naming was getting inconsistent across the project, which makes it harder to find what you're looking for. Here's the approach that's been working:
+File naming was getting inconsistent across the project, which makes it harder to find what you're looking for. Here's the approach that's been working:
 
 ## The Basic Rules
 

--- a/public_docs/technical-guides/components/recovery-notification.md
+++ b/public_docs/technical-guides/components/recovery-notification.md
@@ -4,7 +4,7 @@ This is the modal dialog that pops up when someone returns to character creation
 
 ## What It's For
 
-So you've got the auto-save system quietly saving character data in the background. When users come back to character creation later - maybe they closed their browser yesterday, or accidentally navigated away - this component shows up to let them know we found their previous work.
+The auto-save system quietly saves character data in the background while users work. When they come back to character creation later - maybe they closed their browser yesterday, or accidentally navigated away - this component shows up to tell them their previous work is still there.
 
 The tricky part is handling conflicts. If they've already started entering new data in the current session, we need to warn them that recovering will overwrite what they've typed. That's where the conflict detection comes in.
 
@@ -278,7 +278,7 @@ return (
 
 ### With Auto-Save Hook
 
-The component is designed to work seamlessly with `useCharacterCreationAutoSave`:
+The component is built to pair with `useCharacterCreationAutoSave`:
 
 ```typescript
 const {

--- a/public_docs/technical-guides/goal-system-integration.md
+++ b/public_docs/technical-guides/goal-system-integration.md
@@ -1,6 +1,6 @@
 # Goal System Integration Guide
 
-So the goal tracking system was built to solve the problem of AI narratives that wander aimlessly. Players would start with clear objectives, but the AI would gradually drift away from them because it had no memory of what the player was trying to achieve.
+The goal tracking system exists because AI narratives wander. Players would start with clear objectives, but the AI would gradually drift away from them because it had no memory of what the player was trying to achieve.
 
 ## Architecture Overview
 
@@ -141,7 +141,7 @@ export const useGoalStore = create<GoalStore>()(
 ```
 
 ### State Hydration
-Goals load automatically when the application starts. The persistence middleware handles this seamlessly, but you can add integrity checks to clean up any corrupted data.
+Goals load automatically when the application starts. The persistence middleware handles the rehydration, but you can add integrity checks to clean up any corrupted data.
 
 ```typescript
 // Application initialization

--- a/public_docs/technical-guides/lore-tracking-system.md
+++ b/public_docs/technical-guides/lore-tracking-system.md
@@ -7,7 +7,7 @@ updated: 2025-06-26
 
 # Lore Tracking System
 
-So this system solves a major problem with AI storytelling: the AI forgetting important details from earlier in the story. You know how you're playing through a narrative and suddenly the AI forgets that your character's name is Marcus, or that the tavern you've been staying at is called The Prancing Pony? This tracks characters, locations, events, and world rules automatically so the AI can maintain consistency.
+AI storytelling has a memory problem: the model forgets details it established earlier in the story, so a character's name or the tavern the player has been staying at drifts between turns. This system tracks characters, locations, events, and world rules automatically so the AI can stay consistent.
 
 ## What It Does
 
@@ -116,4 +116,4 @@ Continue the story...
 - `npm test -- choiceGenerator.loreContext.test.ts` - Choice generation integration
 - `npm test -- narrativeGenerator.loreContext.test.ts` - Narrative generation integration
 
-This gives you confidence that the lore extraction and context building actually works as expected.
+Between them these cover extraction, prompt-context formatting, and both generators that consume the context.

--- a/public_docs/technical-guides/navigation-loading-system.md
+++ b/public_docs/technical-guides/navigation-loading-system.md
@@ -1,6 +1,6 @@
 # Navigation Loading System
 
-So this system handles one of those user experience details that really matters: showing loading states during navigation. Without it, users click something and wonder if it worked, especially on slower connections or when there's a lot of data to load.
+This system shows loading states during navigation. Without it, users click something and wonder if it worked, especially on slower connections or when there's a lot of data to load.
 
 ## How It Works
 

--- a/public_docs/technical-guides/state-management-usage.md
+++ b/public_docs/technical-guides/state-management-usage.md
@@ -7,7 +7,7 @@ updated: 2025-06-26
 
 # Working with State Management
 
-So here's how to actually work with the Zustand stores in practice. The idea is that each major area of the app gets its own store - World stuff, Character stuff, Narrative stuff - which keeps things organized and makes it easier to reason about what's changing and why.
+This is how the Zustand stores work in practice. Each major area of the app gets its own store - World stuff, Character stuff, Narrative stuff - which keeps things organized and makes it easier to reason about what's changing and why.
 
 ## How the Stores Work
 

--- a/public_docs/technical-guides/type-guards-usage-guide.md
+++ b/public_docs/technical-guides/type-guards-usage-guide.md
@@ -1,6 +1,6 @@
 # Type Guards Usage Guide
 
-So here's the thing - TypeScript gives you compile-time safety, but at runtime you're still dealing with unknown data from APIs, user input, and localStorage. The type guards system solves this by giving you runtime validation that actually works.
+TypeScript gives you compile-time safety, but at runtime you're still handling unknown data from APIs, user input, and localStorage. The type guards system covers that gap with runtime validation.
 
 ## Why This Exists
 

--- a/src/app/api/generate-ending-image/__tests__/route.test.ts
+++ b/src/app/api/generate-ending-image/__tests__/route.test.ts
@@ -154,6 +154,6 @@ describe('/api/generate-ending-image', () => {
     const data = await response.json();
 
     expect(response.status).toBe(500);
-    expect(data.error).toBe('Unable to load ending image. Please try again.');
+    expect(data.error).toBe("Couldn't generate the ending image. Try again in a moment.");
   });
 });

--- a/src/app/api/generate-ending-image/route.ts
+++ b/src/app/api/generate-ending-image/route.ts
@@ -205,7 +205,7 @@ Requirements:
   } catch (error) {
     logger.error('generate-ending-image', 'Ending image generation failed:', error);
     return NextResponse.json(
-      { error: 'Unable to load ending image. Please try again.' },
+      { error: "Couldn't generate the ending image. Try again in a moment." },
       { status: 500 }
     );
   }

--- a/src/app/api/generate-journal-image/__tests__/route.test.ts
+++ b/src/app/api/generate-journal-image/__tests__/route.test.ts
@@ -140,6 +140,6 @@ describe('/api/generate-journal-image', () => {
     const data = await response.json();
 
     expect(response.status).toBe(500);
-    expect(data.error).toBe('Failed to generate journal image. Please try again.');
+    expect(data.error).toBe("Couldn't generate the journal image. Try again in a moment.");
   });
 });

--- a/src/app/api/generate-journal-image/route.ts
+++ b/src/app/api/generate-journal-image/route.ts
@@ -79,7 +79,7 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     logger.error('generate-journal-image', 'Journal image generation failed:', error);
     return NextResponse.json(
-      { error: 'Failed to generate journal image. Please try again.' },
+      { error: "Couldn't generate the journal image. Try again in a moment." },
       { status: 500 }
     );
   }

--- a/src/app/api/generate-world-image/__tests__/route.test.ts
+++ b/src/app/api/generate-world-image/__tests__/route.test.ts
@@ -391,7 +391,7 @@ describe('/api/generate-world-image', () => {
       const data = await response.json();
 
       expect(response.status).toBe(500);
-      expect(data.error).toBe('Failed to generate world image. Please try again.');
+      expect(data.error).toBe("Couldn't generate the world image. Try again in a moment.");
     });
   });
 

--- a/src/app/api/generate-world-image/route.ts
+++ b/src/app/api/generate-world-image/route.ts
@@ -162,7 +162,7 @@ Requirements:
   } catch (error) {
     logger.error('generate-world-image', 'World image generation failed:', error);
     return NextResponse.json(
-      { error: 'Failed to generate world image. Please try again.' },
+      { error: "Couldn't generate the world image. Try again in a moment." },
       { status: 500 }
     );
   }

--- a/src/app/api/narrative/ending/route.ts
+++ b/src/app/api/narrative/ending/route.ts
@@ -95,7 +95,7 @@ export async function POST(request: NextRequest) {
       
       if (error.message.includes('API') || error.message.includes('generation')) {
         return NextResponse.json(
-          { error: 'Model provider unavailable', details: 'Please try again later' },
+          { error: 'Model provider unavailable', details: 'Try again in a moment.' },
           { status: 503 }
         );
       }

--- a/src/components/DeleteConfirmationDialog/README.md
+++ b/src/components/DeleteConfirmationDialog/README.md
@@ -57,7 +57,7 @@ function MyComponent() {
 
 ## Features
 
-- **Accessibility**: Built on the Radix dialog primitive, so focus moves into the dialog and stays there while it's open. Both buttons carry an `aria-label` naming the item.
+- **Accessibility**: Built on the Radix dialog primitive, so focus moves into the dialog and stays trapped there while it's open, landing on Cancel because the variant is destructive. The confirm button's `aria-label` names the item (`Delete My Important Item`); the cancel button's doesn't (`Cancel deletion`), so the item name reaches a screen reader through the dialog body and the confirm button rather than through Cancel.
 - **Loading State**: Shows "Deleting..." and disables both buttons, so a slow delete can't be fired twice
 - **Backdrop Click**: Clicking outside closes the dialog. That isn't suppressed mid-delete - only the buttons are disabled.
 - **Escape Key**: Press Escape to bail out quickly

--- a/src/components/DeleteConfirmationDialog/README.md
+++ b/src/components/DeleteConfirmationDialog/README.md
@@ -1,8 +1,8 @@
 # DeleteConfirmationDialog
 
-You know that moment when a user clicks "Delete" and you realize you should probably ask them if they're sure? This component handles that conversation. It's designed to be both user-friendly and hard to dismiss accidentally - because nobody wants to explain to a user why their important data just vanished.
+A confirmation step for destructive actions. It wraps `ConfirmationDialog` with the `destructive` variant, names the thing being deleted, and puts initial focus on Cancel so the dangerous button isn't the one sitting under the return key.
 
-The key thing here is making deletion feel intentional, not accidental. So we use clear language, show what's about to be deleted, and make the dangerous action visually distinct from the safe one.
+The aim is to make deletion take a deliberate second action. The dialog says what's about to go, styles the confirm button as destructive, and disables both buttons while the delete is in flight.
 
 ## Usage
 
@@ -57,11 +57,9 @@ function MyComponent() {
 
 ## Features
 
-This dialog does all the things you'd expect:
-
-- **Accessibility**: Works perfectly with keyboards and screen readers
-- **Loading State**: Shows "Deleting..." and prevents double-clicks during the actual deletion
-- **Backdrop Click**: Clicking outside closes it (but only if it's not currently deleting)
+- **Accessibility**: Built on the Radix dialog primitive, so focus moves into the dialog and stays there while it's open. Both buttons carry an `aria-label` naming the item.
+- **Loading State**: Shows "Deleting..." and disables both buttons, so a slow delete can't be fired twice
+- **Backdrop Click**: Clicking outside closes the dialog. That isn't suppressed mid-delete - only the buttons are disabled.
 - **Escape Key**: Press Escape to bail out quickly
 - **Custom Button Text**: You can change the button labels if "Delete" and "Cancel" don't fit your context
 

--- a/src/components/GameSession/EndingScreen.tsx
+++ b/src/components/GameSession/EndingScreen.tsx
@@ -146,7 +146,7 @@ export function EndingScreen() {
       });
     } catch (error) {
       logger.error('Failed to load ending image:', error);
-      setImageError('Failed to load ending image');
+      setImageError("Couldn't load the ending image.");
       generatedForEndingRef.current = null; // Reset on error so user can retry
     } finally {
       setIsGeneratingImage(false);
@@ -319,7 +319,7 @@ export function EndingScreen() {
             className={`component-ending-screen-hero-frame ending-${currentEnding.tone}`}
           >
             <div className="component-ending-screen-hero-error">
-              <p>Unable to load ending image</p>
+              <p>{imageError}</p>
               <Button
                 onClick={generateEndingImage}
                 variant="link"

--- a/src/components/WorldEditor/README.md
+++ b/src/components/WorldEditor/README.md
@@ -4,7 +4,7 @@ This component handles editing existing worlds after they've been created. The c
 
 ## The Problem We're Solving
 
-So you've got a world created through the wizard, but now you want to tweak it. Maybe add a new skill, adjust some attributes, or just fix a typo in the description. The tricky part is that we're not starting fresh like in the wizard - we're working with existing data that might have characters and stories already attached to it.
+Editing a world means starting from data that already exists. Maybe you're adding a skill, adjusting some attributes, or fixing a typo in the description. Either way the editor is working against a world that might already have characters and stories attached to it, which is the part the creation wizard never has to deal with.
 
 ## Usage
 
@@ -25,14 +25,14 @@ import WorldEditor from '@/components/WorldEditor/WorldEditor';
 
 The editor breaks editing into four logical chunks:
 
-1. **Basic Information** - Name, description, and theme (the easy stuff)
+1. **Basic Information** - Name, description, and theme
 2. **Attributes** - Add, edit, and remove world attributes
-3. **Skills** - Manage skills with attribute linking (this gets complex fast)
+3. **Skills** - Manage skills and the attribute each one links to
 4. **Settings** - Configure limits and point pools
 
 ## State Management Approach
 
-Here's where it gets interesting. The component keeps all changes in its own local form state until you hit save. Why? Because we don't want half-edited worlds sitting in the store if you decide to bail out.
+The component keeps all changes in its own local form state until you hit save, so a half-edited world never lands in the store if you decide to bail out.
 
 The flow is basically:
 1. Load world data from store into local form state
@@ -52,7 +52,7 @@ Both actions take you back to the worlds list because that's usually where you c
 We handle a few different error scenarios:
 - World not found (shows error message with a "go back" button)
 - Save errors (keeps you on the page so you can try again)
-- Loading states (because nobody likes blank screens)
+- Loading states while the world data comes out of the store
 
 ## Example
 

--- a/src/components/shared/wizard/README.md
+++ b/src/components/shared/wizard/README.md
@@ -1,6 +1,6 @@
 # Shared Wizard Components
 
-So we had wizard components scattered all over the place, each doing things slightly differently. This is the unified wizard system that brings consistency to multi-step forms across the app.
+Wizard components were scattered all over the place, each doing things slightly differently. This is the unified wizard system that brings consistency to multi-step forms across the app.
 
 ## The Basic Pattern
 
@@ -49,7 +49,7 @@ function MyWizard() {
 
 ### Form Components
 - **WizardFormSection** - Form section with proper heading hierarchy
-- **ToggleButton** - Styled toggle switches that actually look good
+- **ToggleButton** - Styled toggle switches
 
 - ### Hooks & Utilities
 - **useWizardFlow** - Complete state management with persistence, submit, and cancel (saves you from prop drilling hell). For step state without any of that, there's `useWizardState` in `@/hooks`.
@@ -57,7 +57,7 @@ function MyWizard() {
 
 ## Why Use This Instead of Rolling Your Own
 
-- Responsive design that actually works on mobile
+- Responsive design that holds up on mobile
 - Automatic session persistence (users can close browser and come back)
 - Built-in validation patterns that make sense
 - Consistent styling via `wizardStyles` (no more "does this look right?" questions)

--- a/src/lib/ai/__tests__/toneSettingsGenerator.test.ts
+++ b/src/lib/ai/__tests__/toneSettingsGenerator.test.ts
@@ -75,14 +75,14 @@ describe('generateToneSettings', () => {
       mockClient.generateContent.mockRejectedValueOnce(new Error('rate limit exceeded - 429'));
 
       await expect(generateToneSettings(mockClient, sampleWorldData))
-        .rejects.toThrow('The model provider is busy. Please try again in a moment.');
+        .rejects.toThrow('The model provider is busy. Try again in a moment.');
     });
 
     it('should throw specific error for network issues', async () => {
       mockClient.generateContent.mockRejectedValueOnce(new Error('network timeout occurred'));
 
       await expect(generateToneSettings(mockClient, sampleWorldData))
-        .rejects.toThrow('Network error occurred. Please check your connection and try again.');
+        .rejects.toThrow("Couldn't reach the model provider. Check your connection, then try again.");
     });
 
     it('should throw specific error for parsing failures', async () => {
@@ -94,7 +94,7 @@ describe('generateToneSettings', () => {
       mockClient.generateContent.mockResolvedValueOnce(mockResponse);
 
       await expect(generateToneSettings(mockClient, sampleWorldData))
-        .rejects.toThrow('That response came back unreadable. Please try generating again.');
+        .rejects.toThrow('That response came back unreadable. Try again.');
     });
 
     it('should throw error for empty AI response', async () => {

--- a/src/lib/ai/narrative-generator-usage.md
+++ b/src/lib/ai/narrative-generator-usage.md
@@ -116,7 +116,7 @@ interface NarrativeGenerationResult {
 }
 ```
 
-So you get the actual narrative text plus useful metadata about what kind of content was generated and which characters were involved.
+You get the narrative text plus metadata about what kind of content was generated and which characters were involved.
 
 ## Error Handling
 

--- a/src/lib/ai/toneSettingsGenerator.ts
+++ b/src/lib/ai/toneSettingsGenerator.ts
@@ -130,7 +130,7 @@ function parseResponse(content: string): ToneAnalysisResult {
     }
 
     logger.error('Failed to parse AI tone settings response:', error);
-    throw new Error('That response came back unreadable. Please try again.');
+    throw new Error("That response came back unreadable. Try again.");
   }
 }
 
@@ -154,20 +154,20 @@ export async function generateToneSettings(
       });
 
       if (error.message.includes('rate limit') || error.message.includes('429')) {
-        throw new Error('The model provider is busy. Please try again in a moment.');
+        throw new Error('The model provider is busy. Try again in a moment.');
       } else if (error.message.includes('network') || error.message.includes('timeout')) {
-        throw new Error('Network error occurred. Please check your connection and try again.');
+        throw new Error("Couldn't reach the model provider. Check your connection, then try again.");
         // Matches what parseResponse() throws above — keep the two in step.
       } else if (error.message.includes('No JSON found') || error.message.includes('came back unreadable')) {
-        throw new Error('That response came back unreadable. Please try generating again.');
+        throw new Error("That response came back unreadable. Try again.");
       } else if (error.message.startsWith('Invalid ') || error.message.startsWith('Missing ') || error.message.includes('empty response')) {
         throw error;
       } else {
-        throw new Error('Unable to generate tone settings. Please try again or set them manually.');
+        throw new Error("Couldn't generate tone settings. Try again, or set them manually.");
       }
     } else {
       logger.error('Unknown error generating AI tone settings:', error);
-      throw new Error('An unexpected error occurred. Please try again.');
+      throw new Error("Couldn't generate tone settings. Try again in a moment.");
     }
   }
 }

--- a/src/lib/api/__tests__/endingImageApi.test.ts
+++ b/src/lib/api/__tests__/endingImageApi.test.ts
@@ -49,11 +49,11 @@ describe('endingImageApi', () => {
     mockAiFetch.mockResolvedValue({
       ok: false,
       status: 500,
-      json: async () => ({ error: 'Unable to load ending image. Please try again.' }),
+      json: async () => ({ error: "Couldn't generate the ending image. Try again in a moment." }),
     } as unknown as Response);
 
     await expect(generateEndingImage(params)).rejects.toThrow(
-      'Unable to load ending image. Please try again.'
+      "Couldn't generate the ending image. Try again in a moment."
     );
   });
 

--- a/src/lib/generators/worldGenerator.ts
+++ b/src/lib/generators/worldGenerator.ts
@@ -384,5 +384,5 @@ Make the world interesting and playable with concepts appropriate to the setting
   
   // If we get here, all retries failed
   logger.error('Failed to generate world after all retries:', lastError);
-  throw new Error('Failed to generate world configuration. Please try again.');
+  throw new Error("Couldn't generate this world. Try again in a moment.");
 }

--- a/src/lib/utils/__tests__/errorUtils.test.ts
+++ b/src/lib/utils/__tests__/errorUtils.test.ts
@@ -84,7 +84,7 @@ describe('errorUtils', () => {
       const result = getUserFriendlyError(error);
 
       expect(result.title).toBe('Request Timed Out');
-      expect(result.message).toBe('The request is taking too long. Please try again.');
+      expect(result.message).toBe('The request is taking too long. Try again.');
       expect(result.retryable).toBe(true);
       expect(result.type).toBe(ErrorType.NETWORK);
       expect(result.actionLabel).toBe('Try Again');

--- a/src/lib/utils/errorUtils.ts
+++ b/src/lib/utils/errorUtils.ts
@@ -82,7 +82,7 @@ export function getUserFriendlyError(error: Error): UserFriendlyError {
   if (message.includes('timeout')) {
     return {
       title: 'Request Timed Out',
-      message: 'The request is taking too long. Please try again.',
+      message: 'The request is taking too long. Try again.',
       suggestion: 'This is usually temporary — wait a moment and try again.',
       actionLabel: 'Try Again',
       retryable: true,

--- a/src/utils/rateLimiter.ts
+++ b/src/utils/rateLimiter.ts
@@ -126,12 +126,12 @@ export class RateLimiter {
     const minutesUntilReset = Math.ceil((resetTime - Date.now()) / (60 * 1000));
     
     if (minutesUntilReset <= 1) {
-      return "Rate limit exceeded. Please try again in a minute.";
+      return "Rate limit reached. Try again in a minute.";
     } else if (minutesUntilReset <= 60) {
-      return `Rate limit exceeded. Please try again in ${minutesUntilReset} minutes.`;
+      return `Rate limit reached. Try again in ${minutesUntilReset} minutes.`;
     } else {
       const hoursUntilReset = Math.ceil(minutesUntilReset / 60);
-      return `Rate limit exceeded. Please try again in ${hoursUntilReset} hour${hoursUntilReset > 1 ? 's' : ''}.`;
+      return `Rate limit reached. Try again in ${hoursUntilReset} hour${hoursUntilReset > 1 ? 's' : ''}.`;
     }
   }
 }


### PR DESCRIPTION
## Description

#1849 was a report-only sweep and nothing came out of it. This applies all 12 findings.

Every finding was re-verified against the current tree first, since the sweep ran against `develop` at `621f886b` and the tree has moved since. All 12 still reproduced - none had been fixed in the meantime. The listed false positives ("source of truth", "beacon", "realm", "quietly", "showcase") were left alone, as the issue asks.

The three big ones got worked as patterns rather than as line numbers, which is what the issue calls for:

**"So" as the opening word (14 files).** One grep-and-decide pass across `public_docs/technical-guides/`, the ADRs, two component READMEs and `narrative-generator-usage.md`. In most cases the sentence already had a real claim in it and just needed the throat-clearing removed ("So file naming was getting inconsistent" reads fine without the "So"). A couple needed the whole opener rewritten - `lore-tracking-system.md` opened on a rhetorical question with an invented example inside it, which is finding 8 as well, so both got cleared in the same edit.

**Reassurance in place of description (12 sites).** Four "How This Actually Works" / "What Actually Works" headings became plain ones, and the in-prose cousins ("really matters", "works perfectly", "actually works on mobile") now say what the thing does. `DeleteConfirmationDialog/README.md:62` was the worst of these: "Works perfectly with keyboards and screen readers" is an accessibility claim with nothing behind it. The issue suggested citing the repo's axe suite instead - there isn't one (axe-core only arrives transitively through `@storybook/addon-a11y`), so the bullet now names the Radix dialog primitive that actually does the focus work, which is checkable by reading `SimpleModal.tsx`.

**Player-facing error copy (16 sites).** The house style set by `errorUtils.ts`, `WorldEditor.tsx` and `CharacterEditor.tsx` is "Couldn't X. Try again." The AI generators and image routes were still on "Please try again", and `toneSettingsGenerator.ts:170` said "An unexpected error occurred", which tells a player nothing. All the named sites now match the house register. `toneSettingsGenerator` got the whole file rather than the four named lines, since two more strings in the same function were in the old register - including the pair the existing comment says to "keep in step", which had drifted apart ("Please try again." vs "Please try generating again.").

Two factual claims got corrected while their files were open, both in `DeleteConfirmationDialog/README.md`. The README said backdrop clicks are suppressed mid-delete; they aren't - `ConfirmationDialog` never passes `closeOnBackdropClick`, so it defaults to `true` and only the buttons get disabled. And the accessibility bullet is covered above. Rewriting the prose around a claim I'd just found to be false seemed worse than fixing it.

Finding 9 turned out to be slightly different from how it was filed. The issue describes `EndingScreen.tsx:149` as a bare "Failed to load ending image" shown to the player with no next step. It was never rendered - the markup hard-coded its own separate copy ("Unable to load ending image") next to a Try Again button, so the state string only ever reached the logs. Fixed by rendering the state value, which leaves one string instead of two.

## Related Issue

Closes #1849

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [ ] Test addition or improvement

Player-facing copy changes ride along with the docs work, since they're the same sweep.

## TDD Compliance
- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

N/A on the first two - this is a prose and copy change, no new behavior to drive out with a test. Six existing assertions asserted on the old strings and moved with them: the three image-route tests, `errorUtils.test.ts`, `toneSettingsGenerator.test.ts`, and `endingImageApi.test.ts`. No test was rigged and none were deleted.

## User Stories Addressed

N/A. This is backlog maintenance from the weekly plain-language sweep, not story work.

## Flow Diagrams

N/A.

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A. No component structure or styling changed. The one JSX edit swaps a hard-coded string for the state value that was already being tracked.

## Implementation Notes

Findings and what happened to each:

| # | Finding | Severity | State |
|---|---|---|---|
| 1 | "So" as the standard opening word, 14 docs | high | Fixed, all 14 |
| 2 | Reassurance in place of description, 12 sites | high | Fixed, all 12 |
| 3 | `DeleteConfirmationDialog/README.md` density | high | Fixed |
| 4 | Player error copy split into two registers | high | Fixed at every named site |
| 5 | `WorldEditor/README.md` payoff-promise shape | medium | Fixed, plus `:28`, `:30`, `:55` |
| 6 | `portrait-generation-guide.md` persuasion opener | medium | Fixed, `:10` and `:109` |
| 7 | ADR-009 grades itself, "reinvent the wheel" | medium | Fixed, `:23` and `:37` |
| 8 | `lore-tracking-system.md:10` rhetorical question | medium | Fixed, folded into finding 1 |
| 9 | `EndingScreen.tsx:149` bare "Failed to X" | medium | Fixed, see above |
| 10 | `mvp-type-simplification.md:85` question-as-transition | low | Fixed |
| 11 | "Works seamlessly" in three guides | low | Fixed, all 3 |
| 12 | `visual-regression-testing.md:408` argument from authority | low | Bullet deleted |

Nothing was already clean. All 12 reproduced against the current tree.

Three things deliberately left, all outside the issue's named sites:

- `src/lib/ai/clientGeminiClient.ts:54` and `:107` still say "Rate limit exceeded. Please try again later." Not named in the issue, and it sits close enough to the provider code another lane is working that touching it seemed like a bad trade for two strings.
- Six Storybook story fixtures pass "... Please try again." as example error props. They're fixture data illustrating an error state, not copy the app produces, and the issue doesn't list them.
- `NarrativeController.tsx:899` says "Please check your connection and try again." Different phrase, not in the sweep's grep, not named.

Worth flagging for whoever runs the next sweep: `errorUtils.ts:87` has an em dash in a player-facing suggestion string, which is against the house voice. Out of scope here, no finding covers it.

## Screenshots

N/A. No visual change.

## Visual Baseline Changes

None. Nothing under `tests/visual/**-snapshots/**` is touched.

## Code Review Summary (if applicable)

N/A.

## Chrome DevTools MCP Verification Summary (if applicable)

N/A.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit N/A - no dependency or auth surface touched.

## Testing Instructions

Local gate, all green:

```
npm test              exit 0   444 suites, 3082 tests passed
npm run type-check    exit 0
npm run lint          exit 0   126 warnings, all pre-existing in tests/visual/
npm run docs:check-links  exit 0   93 docs checked, no broken links
```

The lint warnings are `no-explicit-any` in `tests/visual/`, untouched by this PR.

To spot-check the copy by hand: trigger a world generation failure (bad provider key) and the error should read "Couldn't generate this world. Try again in a moment." rather than "Failed to generate world configuration. Please try again."

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

No new comments needed - nothing here is complex enough to warrant one. On accessibility: the change removes an unbacked a11y claim and replaces it with one that names the mechanism, which is a small net gain in doc accuracy rather than a behavior change.
