### PR TITLE
Experiment: render worldDescription in the per-turn scene prompt (#1865)

### DIFF
--- a/.claude/skills/narraitor-prompt-template-governance/eval-logs/1865-world-description-in-scene.md
+++ b/.claude/skills/narraitor-prompt-template-governance/eval-logs/1865-world-description-in-scene.md
@@ -1,0 +1,45 @@
+# Prompt/template eval log - worldDescription in the per-turn scene prompt (#1865)
+
+- Change: one variable, the `WORLD_DESCRIPTION_IN_SCENE` flag (`NEXT_PUBLIC_FEATURE_WORLD_DESCRIPTION_IN_SCENE`, default off). On: `sceneTemplate.ts` renders a `WORLD DESCRIPTION` block (`worldDescriptionBlock.ts`) carrying `world.description`, trimmed to 400 characters at a word boundary. Off: the per-turn prompt is byte-for-byte what it was — `World: <name>` and `Tone: <tone>`, no description.
+- Diff: this PR. Files: `src/lib/promptTemplates/templates/narrative/worldDescriptionBlock.ts` (new), `sceneTemplate.ts` (one import, one flag check, one insertion), `src/lib/featureFlags.ts` (flag registration).
+- Date / evaluator: 2026-08-24, Claude (build session in worktree `issue-1865`).
+
+## Status: UNMEASURED
+
+**No before/after playtest has been run.** This lane has no way to run one: the eval needs a live multi-turn Gemini session against a real provider key and a world whose description carries a deadline (Harrowgate Mills' council vote is the obvious pick, per the issue), and this worktree has no path to drive that. Everything below states what exists, not what it does to play.
+
+Do not read this log as evidence the change helps. It is not evidence either way. The mechanism is wired, gated off, and ready to be measured against `narraitor-ai-quality-discipline`'s coverage matrix (>= 2 worlds x >= 2 characters x 3 runs, arc check over >= 3 consecutive turns, verdict logged back to this file) once a session with a live key can run it.
+
+## What's verified without a live model
+
+- Unit-level: `sceneTemplate.worldDescription.test.ts` and `worldDescriptionBlock.test.ts` confirm the block appears in the assembled prompt only when the flag is on and `worldDescription` is present, is absent when the flag is off (default), and is absent when the flag is on but the field is empty. A long description is confirmed trimmed at a word boundary with an ellipsis rather than rendered in full.
+- `featureFlags.test.ts` confirms `WORLD_DESCRIPTION_IN_SCENE` defaults to `false` and turns on only for the exact string `"true"` (same default-off convention as `WORLD_COST`).
+- G2 leakage: the block renders only `world.description`, plain prose the player already saw in the wizard and the opening scene. No ids, no store internals.
+- G3 determinism: no response schema change. The scene response JSON is untouched.
+
+## Trim choice
+
+Rendered untrimmed, once, on the opening scene (`initialSceneTemplate.ts`) that cost is paid a single time. Rendered every turn, it's paid every turn for the life of the session, and a world's free-text description has no upstream length cap. `worldDescriptionBlock` trims to 400 characters (`truncate`, `src/lib/utils/formatters.ts`, word-boundary + ellipsis, the same helper `inventoryContextBuilder.ts` uses for item descriptions) — roughly 100 tokens at ~4 chars/token, enough to carry a sentence or two including whatever pressure clause the description opens with, without letting an unusually long description dominate every turn's token budget. Not measured against a token-cost target; a reasonable default pending the playtest.
+
+## Coverage matrix
+
+| World (genre/tone) | Character (fresh/established) | Runs | Verdict | Representative excerpt |
+|---|---|---|---|---|
+| (not run) | (not run) | 0 | UNMEASURED | n/a |
+| (not run) | (not run) | 0 | UNMEASURED | n/a |
+
+## Arc check (>= 3 consecutive turns, one cell)
+- Not run.
+
+## Failure drill
+- Not run. Malformed/empty `worldDescription` (empty string, whitespace-only) is covered at the unit level (`worldDescriptionBlock.test.ts` — both render to `''`), not at the live-model level.
+
+## Regression vs prior good outputs
+- Not applicable — no live generations exist to compare.
+
+## Cost/latency
+- Token delta: estimated, not measured. At the 400-char cap, roughly +100 input tokens per turn when the flag is on (same rough char/token ratio the world-clock eval log used). No new API call — the block folds into the existing scene prompt.
+
+## Verdict
+- **UNMEASURED.** The mechanism exists, is unit-tested, and is flagged off by default. Whether it changes play — or does anything besides cost tokens — is the open question the issue names, and it stays open until a session with a live provider key runs the coverage matrix above.
+- Ship/hold decision: not made. Recommend keeping #1865 open (not closed by this PR) until the playtest referenced above runs and this log is filled in with a real verdict.

--- a/src/lib/__tests__/featureFlags.test.ts
+++ b/src/lib/__tests__/featureFlags.test.ts
@@ -61,6 +61,26 @@ describe('featureFlags', () => {
     expect(load({ NEXT_PUBLIC_FEATURE_WORLD_CLOCK: 'FALSE' }).isFeatureEnabled('WORLD_CLOCK')).toBe(true);
   });
 
+  it('defaults WORLD_DESCRIPTION_IN_SCENE to false and enables it only for the exact string "true"', () => {
+    expect(
+      load({ NEXT_PUBLIC_FEATURE_WORLD_DESCRIPTION_IN_SCENE: undefined }).isFeatureEnabled(
+        'WORLD_DESCRIPTION_IN_SCENE'
+      )
+    ).toBe(false);
+    jest.resetModules();
+    expect(
+      load({ NEXT_PUBLIC_FEATURE_WORLD_DESCRIPTION_IN_SCENE: 'true' }).isFeatureEnabled(
+        'WORLD_DESCRIPTION_IN_SCENE'
+      )
+    ).toBe(true);
+    jest.resetModules();
+    expect(
+      load({ NEXT_PUBLIC_FEATURE_WORLD_DESCRIPTION_IN_SCENE: 'TRUE' }).isFeatureEnabled(
+        'WORLD_DESCRIPTION_IN_SCENE'
+      )
+    ).toBe(false);
+  });
+
   it('supports downstream gating decisions for BUFFERED_STREAMING', () => {
     const { isFeatureEnabled } = load({
       NEXT_PUBLIC_FEATURE_BUFFERED_STREAMING: 'false',

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -28,6 +28,12 @@ const FEATURE_FLAG_DEFAULTS = {
   // the character's conditions. Off until the playtest declared in
   // narraitor-prompt-template-governance/eval-logs/1882-world-cost.md measures it.
   WORLD_COST: false,
+  // Renders the world's own founding description in the per-turn scene
+  // prompt (#1865), not just the opening scene. Experiment, not a fix: it
+  // might carry the world's pressures further into the session, or it might
+  // do nothing but cost tokens every turn. Off until a playtest measures it —
+  // see narraitor-prompt-template-governance/eval-logs/1865-world-description-in-scene.md.
+  WORLD_DESCRIPTION_IN_SCENE: false,
 } as const;
 
 export type FeatureFlag = keyof typeof FEATURE_FLAG_DEFAULTS;
@@ -56,6 +62,10 @@ const getFeatureFlags = (): Record<FeatureFlag, boolean> => ({
   WORLD_COST: resolve(
     process.env.NEXT_PUBLIC_FEATURE_WORLD_COST,
     FEATURE_FLAG_DEFAULTS.WORLD_COST
+  ),
+  WORLD_DESCRIPTION_IN_SCENE: resolve(
+    process.env.NEXT_PUBLIC_FEATURE_WORLD_DESCRIPTION_IN_SCENE,
+    FEATURE_FLAG_DEFAULTS.WORLD_DESCRIPTION_IN_SCENE
   ),
 });
 

--- a/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.worldDescription.test.ts
+++ b/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.worldDescription.test.ts
@@ -1,0 +1,72 @@
+import { sceneTemplate } from '../sceneTemplate';
+import type { NarrativeTemplateContext } from '../context';
+
+const WORLD_DESCRIPTION_HEADER =
+  'WORLD DESCRIPTION (established at creation — the pressures this world was built around):';
+const FLAG_ENV_VAR = 'NEXT_PUBLIC_FEATURE_WORLD_DESCRIPTION_IN_SCENE';
+
+function makeContext(worldDescription?: string): NarrativeTemplateContext {
+  return {
+    worldName: 'Harrowgate Mills',
+    worldDescription,
+    genre: 'civic drama',
+    tone: 'tense',
+    playerCharacterName: 'Wren',
+    narrativeContext: {
+      recentSegments: [{ content: 'The council room is quiet.' }],
+      currentSituation: 'Player chose: "Wait for the meeting to open"',
+      currentTags: [],
+    },
+  };
+}
+
+describe('sceneTemplate world description block (#1865, EXPERIMENT — unmeasured)', () => {
+  const originalEnv = process.env[FLAG_ENV_VAR];
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env[FLAG_ENV_VAR];
+    } else {
+      process.env[FLAG_ENV_VAR] = originalEnv;
+    }
+  });
+
+  it('omits worldDescription from the prompt by default (flag unset)', () => {
+    delete process.env[FLAG_ENV_VAR];
+    const prompt = sceneTemplate(
+      makeContext('The council votes on the developer\'s offer in six weeks.')
+    );
+    expect(prompt).not.toContain(WORLD_DESCRIPTION_HEADER);
+    expect(prompt).not.toContain("The council votes on the developer's offer in six weeks.");
+  });
+
+  it('renders worldDescription in the prompt when the flag is on', () => {
+    process.env[FLAG_ENV_VAR] = 'true';
+    const prompt = sceneTemplate(
+      makeContext('The council votes on the developer\'s offer in six weeks.')
+    );
+    expect(prompt).toContain(WORLD_DESCRIPTION_HEADER);
+    expect(prompt).toContain("The council votes on the developer's offer in six weeks.");
+  });
+
+  it('does not render worldDescription when the flag is on but the field is absent', () => {
+    process.env[FLAG_ENV_VAR] = 'true';
+    const prompt = sceneTemplate(makeContext(undefined));
+    expect(prompt).not.toContain(WORLD_DESCRIPTION_HEADER);
+  });
+
+  it('trims a long description at a word boundary rather than rendering it in full', () => {
+    process.env[FLAG_ENV_VAR] = 'true';
+    const longDescription = 'A pressing deadline looms over the town. '.repeat(20);
+    const prompt = sceneTemplate(makeContext(longDescription));
+    expect(prompt).toContain(WORLD_DESCRIPTION_HEADER);
+    expect(prompt).not.toContain(longDescription.trim());
+    expect(prompt).toContain('...');
+  });
+
+  it('explicitly disables with "false" even though the default is off', () => {
+    process.env[FLAG_ENV_VAR] = 'false';
+    const prompt = sceneTemplate(makeContext('The deadline is six weeks away.'));
+    expect(prompt).not.toContain(WORLD_DESCRIPTION_HEADER);
+  });
+});

--- a/src/lib/promptTemplates/templates/narrative/__tests__/worldDescriptionBlock.test.ts
+++ b/src/lib/promptTemplates/templates/narrative/__tests__/worldDescriptionBlock.test.ts
@@ -1,0 +1,27 @@
+import { worldDescriptionBlock } from '../worldDescriptionBlock';
+
+describe('worldDescriptionBlock', () => {
+  it('renders nothing when the description is absent', () => {
+    expect(worldDescriptionBlock(undefined)).toBe('');
+  });
+
+  it('renders nothing when the description is blank', () => {
+    expect(worldDescriptionBlock('   ')).toBe('');
+  });
+
+  it('renders the description under its header when present', () => {
+    const block = worldDescriptionBlock('The council votes in six weeks.');
+    expect(block).toContain(
+      'WORLD DESCRIPTION (established at creation — the pressures this world was built around):'
+    );
+    expect(block).toContain('The council votes in six weeks.');
+  });
+
+  it('trims a long description at a word boundary with an ellipsis', () => {
+    const long = 'A pressing deadline looms over the town. '.repeat(20).trim();
+    const block = worldDescriptionBlock(long);
+    expect(block).not.toContain(long);
+    expect(block).toContain('...');
+    expect(block.length).toBeLessThan(long.length);
+  });
+});

--- a/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
+++ b/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
@@ -1,12 +1,14 @@
 import { PERSPECTIVE_EXAMPLES, shouldIncludeExamples } from '../../examples';
 import { majorEventGuidelines } from './majorEventGuidelines';
 import { worldClockBlock } from './worldClockBlock';
+import { worldDescriptionBlock } from './worldDescriptionBlock';
 import {
   describeNarrativeLength,
   PARAGRAPH_SEPARATOR_INSTRUCTION,
 } from './narrativeLength';
 import type { NarrativeTemplateContext } from './context';
 import { isPacingStale } from '@/lib/narrative/turnsSinceComplication';
+import { isFeatureEnabled } from '@/lib/featureFlags';
 
 /**
  * Puts the player's own sheet in front of the model. Without it the prompt
@@ -48,6 +50,7 @@ ${lines.join('\n')}
 export const sceneTemplate = (context: NarrativeTemplateContext) => {
   const {
     worldName,
+    worldDescription,
     genre,
     tone,
     narrativeContext,
@@ -114,12 +117,16 @@ ${npcRoster.map((npc: { id: string; name: string; description?: string }) => `- 
     : '';
 
   const backgroundSection = formatPlayerBackground(playerCharacterBackground);
+  // EXPERIMENT (#1865), unmeasured — see worldDescriptionBlock for why.
+  const worldDescriptionSection = isFeatureEnabled('WORLD_DESCRIPTION_IN_SCENE')
+    ? worldDescriptionBlock(worldDescription)
+    : '';
 
   const baseContent = `Continue the ${genre} narrative for "${worldName}" with a new ${segmentType} segment.
 
 World: ${worldName}
 Tone: ${tone}${characterSkillContext ? characterSkillContext : ''}${enhancedCharacterContext ? enhancedCharacterContext : ''}
-${backgroundSection}
+${worldDescriptionSection}${backgroundSection}
 STORY SO FAR:
 ${recentContent}
 

--- a/src/lib/promptTemplates/templates/narrative/worldDescriptionBlock.ts
+++ b/src/lib/promptTemplates/templates/narrative/worldDescriptionBlock.ts
@@ -1,0 +1,31 @@
+import { truncate } from '@/lib/utils';
+
+/**
+ * The world's own founding description, carried into the per-turn scene
+ * prompt. initialSceneTemplate already renders it in full, once, for the
+ * opening scene — by turn 20 that context is gone unless lore extraction
+ * happened to capture it, so anything the description states but the story
+ * never narrates (a deadline, a standing threat) is lost. This is that same
+ * text, reaching every turn instead of just the first.
+ *
+ * Unlike the opening scene, this block pays its cost every turn, so it is
+ * trimmed to WORLD_DESCRIPTION_CHAR_LIMIT (word boundary, "...") rather than
+ * rendered in full — a description can run to whatever length its author
+ * wrote, with no upstream cap.
+ *
+ * Rendered only when the WORLD_DESCRIPTION_IN_SCENE flag is on (see
+ * sceneTemplate.ts). EXPERIMENT (#1865): whether this changes play at all is
+ * unmeasured — see narraitor-prompt-template-governance/eval-logs/
+ * 1865-world-description-in-scene.md.
+ */
+const WORLD_DESCRIPTION_CHAR_LIMIT = 400;
+
+export const worldDescriptionBlock = (worldDescription?: string): string => {
+  const trimmed = worldDescription?.trim();
+  if (!trimmed) return '';
+
+  return `
+WORLD DESCRIPTION (established at creation — the pressures this world was built around):
+${truncate(trimmed, WORLD_DESCRIPTION_CHAR_LIMIT)}
+`;
+};


### PR DESCRIPTION
## Description
`sceneTemplate.ts` never renders `worldDescription`, even though it's already on the template context (`world.description`, set in `buildNarrativeContext`) and `initialSceneTemplate.ts` already renders it for the opening scene. So by turn 20, the model has forgotten whatever pressure the world's description set up (Harrowgate's council vote in six weeks, say) unless lore extraction happened to capture it — and extraction only fires on generated text, so anything the description states but the story never narrates is lost.

This adds a `WORLD DESCRIPTION` block to the per-turn scene prompt, trimmed to 400 characters at a word boundary (`truncate`, the same helper `inventoryContextBuilder.ts` already uses), gated behind a new `WORLD_DESCRIPTION_IN_SCENE` flag that defaults **off**.

**This is an experiment, not a fix.** Whether it changes play at all is the open question the issue names, and it costs roughly 100 extra input tokens on every turn once it's on. This PR wires the mechanism and gates it; it does not claim the mechanism works.

## Related Issue
Closes #1865

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A — internal prompt-template experiment behind a flag, not a user-facing story.

## Flow Diagrams
N/A

## Component Development
N/A — no UI change, no new component.
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes
- New flag `WORLD_DESCRIPTION_IN_SCENE` (`src/lib/featureFlags.ts`, env var `NEXT_PUBLIC_FEATURE_WORLD_DESCRIPTION_IN_SCENE`), default `false`, same on/off convention as `WORLD_COST` — turns on only for the exact string `"true"`.
- New `worldDescriptionBlock.ts` (`src/lib/promptTemplates/templates/narrative/`) renders the description under a `WORLD DESCRIPTION` header, trimmed to 400 chars at a word boundary with `truncate` from `src/lib/utils`. `sceneTemplate.ts` calls it only when the flag is on; off, the prompt is byte-for-byte what it was before this PR.
- The trim exists because `initialSceneTemplate.ts` pays the description's full cost once, at the opening scene, but this block would pay it every turn for the rest of the session against a free-text field with no upstream length cap. 400 chars (~100 tokens) is a reasonable default, not a measured one.
- **The issue's own acceptance criterion is an eval verdict** ("run the eval... record the eval log... ship, hold, or retire on the evidence"), and this lane can't run that eval — it needs a live multi-turn Gemini session against a real provider key, which this worktree has no path to. The eval-log entry (`.claude/skills/narraitor-prompt-template-governance/eval-logs/1865-world-description-in-scene.md`) says **UNMEASURED** in plain terms: the mechanism is wired and unit-tested, but nothing here shows it changes play, for better or worse. Jack may prefer to leave #1865 open until that playtest runs rather than close it off this PR.

## Screenshots
N/A — no UI change.

## Visual Baseline Changes
None.

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed (not run — no dependency changes)
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm test` — the new suites are `src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.worldDescription.test.ts`, `worldDescriptionBlock.test.ts`, and the added case in `src/lib/__tests__/featureFlags.test.ts`.
2. With the flag unset (default), call `sceneTemplate(context)` and confirm the output has no `WORLD DESCRIPTION` section — it's unchanged from before this PR.
3. Set `NEXT_PUBLIC_FEATURE_WORLD_DESCRIPTION_IN_SCENE=true` and confirm the section appears, carrying `world.description` trimmed to 400 characters.
4. This PR does not include a live playtest — see Implementation Notes.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required) — eval-log entry added
- [x] No new warnings generated
- [x] Accessibility considerations addressed — N/A, no UI change
