### PR TITLE
Remove trivial negative-reference tests over dead CSS, docs, and config

### DIFF
--- a/__tests__/storybook-config.test.js
+++ b/__tests__/storybook-config.test.js
@@ -11,10 +11,6 @@ describe('.storybook/main.cjs', () => {
     expect(fs.existsSync(nextConfigPath)).toBe(true);
   });
 
-  it('does not glob for story formats the repo has none of', () => {
-    expect(storybookConfig.stories).not.toContain('../src/stories/**/*.mdx');
-  });
-
   it('swaps the 11 MB Gemini tokenizer for the browser stub', async () => {
     const config = await storybookConfig.webpackFinal({ resolve: { alias: {} } });
 

--- a/src/app/__tests__/app-shell.css.test.ts
+++ b/src/app/__tests__/app-shell.css.test.ts
@@ -86,14 +86,4 @@ describe('app-shell.css static checks', () => {
     }
   });
 
-  it('does not carry the dead three-design-system theme-menu-* rules (#1583)', () => {
-    expect(appShellCss).not.toMatch(/\.theme-menu-item-text/);
-    expect(appShellCss).not.toMatch(/\.theme-menu-mode/);
-    expect(appShellCss).not.toMatch(/\.theme-menu \.header-dropdown-menu\s*\{\s*width:\s*15rem/);
-  });
-
-  it('does not carry the retired workshop shell (#1655)', () => {
-    expect(appShellCss).not.toMatch(/\.workshop-(sidebar|context-header|workspace)/);
-    expect(appShellCss).not.toMatch(/\.app-surface-workshop/);
-  });
 });

--- a/src/app/__tests__/layout.metadata.test.ts
+++ b/src/app/__tests__/layout.metadata.test.ts
@@ -6,16 +6,11 @@ import path from 'path';
  *
  * Read as source rather than imported: layout.tsx pulls in next/font/google and
  * the whole provider stack, which is a lot of mocking to assert an object
- * literal. What's worth pinning is the regression — the description that leads
- * with "using AI", which #1421 rejected on the landing page.
+ * literal.
  */
 const layoutSource = fs.readFileSync(path.join(__dirname, '../layout.tsx'), 'utf-8');
 
 describe('root layout metadata', () => {
-  it('has dropped the retired "using AI" description', () => {
-    expect(layoutSource).not.toMatch(/A narrative-driven RPG framework using AI/);
-  });
-
   it('declares the share metadata the public launch needs', () => {
     expect(layoutSource).toMatch(/metadataBase:\s*new URL\(getSiteUrl\(\)\)/);
     expect(layoutSource).toMatch(/template:\s*'%s — Narraitor'/);

--- a/src/components/ai/__tests__/provider-config.css.test.ts
+++ b/src/components/ai/__tests__/provider-config.css.test.ts
@@ -24,6 +24,6 @@ describe('provider settings width', () => {
   it('caps the providers page from the token rather than a literal width', () => {
     const rule = ruleFor(providerConfigCss, '.component-providers-page');
     expect(rule).toMatch(/max-width:\s*var\(--page-width-form\)/);
-    expect(providerConfigCss).not.toMatch(/max-width:\s*\d+(\.\d+)?(rem|px)/);
+    expect(rule).not.toMatch(/max-width:\s*\d+(\.\d+)?(rem|px)/);
   });
 });


### PR DESCRIPTION
## Description
A test-reaper pass over the pattern from #1935: a test reads source, CSS, or config and only asserts that a retired string, selector, key, or literal is gone, with no behavior-level assertion underneath. That's a stale-reference check wearing a Jest wrapper, not coverage.

The named starting point - `scripts/__tests__/playtest-world-specs.test.js` from #1932 - turned out to already be gone. That PR's second commit ("Drop trivial playtest world spec guard") removed it before merge, so it nets to zero in the squashed commit on `develop` and there was nothing left to delete.

Deleted (pure negative reference guards, no positive invariant underneath):
- `src/app/__tests__/layout.metadata.test.ts` - dropped the case asserting layout.tsx no longer says "using AI" (#1421). The sibling case asserting the real metadata shape stays and still catches a regression (verified by breaking it locally).
- `src/app/__tests__/app-shell.css.test.ts` - dropped two cases asserting dead `theme-menu-*` CSS (#1583, three-skin era) and the retired workshop shell selectors (#1655) are absent from the stylesheet.
- `__tests__/storybook-config.test.js` - dropped the case asserting Storybook's `stories` glob doesn't include an MDX pattern the repo never used.

Rewritten, not deleted:
- `src/components/ai/__tests__/provider-config.css.test.ts` - the case was checking two things at once: the providers page rule uses `var(--page-width-form)` (real invariant, kept), and *no line anywhere in the whole file* has a literal max-width (a blanket file-wide scan standing in for a much narrower claim). Scoped the negative assertion down to the same rule under test, so it now guards against that specific rule carrying a hardcoded fallback alongside the token - a real regression, not archaeology.

Audited more broadly per the acceptance criteria: every test file reading real source/CSS/config via `fs.readFileSync` (7 files total, including the four above), plus every test name containing "no longer," "removed," "retired," "dead," or "dropped" across `src`, `__tests__`, and `scripts`. Everything else that matched was either a reusable policy check (the DS3 type-scale migration guard, the bare-`var()` custom-property guard - both scan the whole tree for a class of bug, not a one-off), a real behavior/game-state assertion that happened to share vocabulary ("item no longer appears," "dead entity," "dropped item" - inventory and lore domain terms, not code archaeology), or a real persistence-migration test (`sessionStore.tutorial.test.ts` asserts a migration function actually clears a field on real input, not that a string is gone from source). Those are left untouched - noted below.

Left intentionally unchanged, because the negative assertion still catches a real regression:
- `src/app/__tests__/app-shell.css.test.ts` - the "Section" placeholder guard (#1577) and the bare-bullet-eyebrow guard. Per #1577's own definition of done, the SECTION eyebrow bug hit four separate stylesheet sites from a copy-paste pattern; the DoD explicitly asks for it "frozen as an assertion" so it can't drift back on any of the four. That's a real regression guard, not proof a retired feature is gone.
- `src/lib/theme/themes/__tests__/typeScaleMigration.test.ts` and `undefinedCustomProperties.test.ts` - both are reusable policy checks (no re-introduced literal font-size once a token exists; no bare `var()` reference with no definition site) that scan all of `src/`, not one-off checks against a single retired string.
- `src/state/__tests__/sessionStore.tutorial.test.ts` - the v2->v3 migration test runs the real `migrate()` function against real input and asserts the output state, which is functional behavior coverage, not source archaeology.

Before/after: 444 test suites / 3085 cases -> 444 test suites / 3081 cases (4 cases deleted, 1 rewritten in place).

## Related Issue
Closes #1935

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

N/A on "new code is tested" - this PR removes and narrows tests, it doesn't add product code. Coverage is maintained in the sense that matters: every deletion was verified to have no positive invariant underneath, and the one rewrite was verified with a deliberate-break check (see Testing Instructions).

## User Stories Addressed
N/A - test-suite maintenance, not a user-facing change.

## Flow Diagrams
N/A.

## Component Development
N/A - no component changes.

## Implementation Notes
Two commits, split deliberately per the `test-reaper` skill: one for the three pure deletions, one for the provider-config rewrite. A rewrite needs the reviewer to actually read the diff; a deletion doesn't, and mixing them makes both harder to review.

## Screenshots
N/A - no UI changes.

## Visual Baseline Changes
None - this PR doesn't touch `tests/visual/**`.

## Code Review Summary (if applicable)
N/A.

## Chrome DevTools MCP Verification Summary (if applicable)
N/A - no browser verification needed for test-file changes.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit N/A - no dependency or production-code changes.

## Testing Instructions
1. `npm test` - 444 suites / 3081 tests pass (down from 3085 before this change).
2. `npm run type-check` - clean.
3. `npm run lint` - 0 errors (126 pre-existing `no-explicit-any` warnings in Playwright helper files, unrelated to this change).
4. `npm run knip` - clean; none of the deletions orphaned an import, helper, or fixture.
5. Deliberate-break check on every survivor per `test-reaper`: broke the `layout.tsx` template string and confirmed `layout.metadata.test.ts`'s remaining case fails; added a literal `max-width` alongside the token in `provider-config.css` and confirmed the rewritten `provider-config.css.test.ts` case fails. Both reverted before commit.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed

"Comments added" and "Accessibility considerations" N/A - this is a test-deletion/rewrite pass, no new logic or UI to comment on or check for accessibility.
