### PR TITLE
Make CLAUDE.md the canon agent instructions, and commit the parallel-lane skill

### DIFF
--- a/.claude/skills/narraitor-parallel-lane-orchestration/SKILL.md
+++ b/.claude/skills/narraitor-parallel-lane-orchestration/SKILL.md
@@ -43,7 +43,9 @@ wrong and score the body.
 ## 4. Batch selection
 
 Run the `prioritize-issues` skill for the ranking, then subtract everything that cannot safely
-run right now:
+run right now. That skill is user-level, not committed here — where it isn't available (a fresh
+clone, a cloud session), the repo ships `.claude/agents/issue-prioritizer.md`, which does the
+same ranking job:
 
 - **Already in motion.** Any issue with an open PR, or an existing worktree/branch matching its
   number. A pre-existing worktree is not proof of abandonment — ask before touching it.
@@ -63,8 +65,9 @@ Lanes start faster and cleaner when the orchestrator does this work up front rat
 each lane do it:
 
 ```bash
+REPO=$(git rev-parse --show-toplevel)   # never hardcode a home path; this file is public
 git worktree add -b claude/issue-<n> \
-  /Users/jackhaas/Projects/personal/narraitor/.claude/worktrees/issue-<n> origin/develop
+  "$REPO/.claude/worktrees/issue-<n>" origin/develop
 git -C <worktree> branch --unset-upstream    # else a bare git push targets develop
 ( cd <worktree> && npm ci )                  # node_modules is per-worktree
 ```
@@ -126,7 +129,8 @@ one what changed and what proves it works. Do not merge anything — leave them 
 for me. [Or: merge each on green with `gh pr merge --squash --delete-branch`, then run the
 `post-merge` skill for each.]
 
-Pick the batch with the `prioritize-issues` skill, then subtract what can't run right now:
+Pick the batch with the `prioritize-issues` skill (or the committed `issue-prioritizer` agent,
+if that skill isn't installed), then subtract what can't run right now:
 anything with an open PR or an existing worktree or branch for its number, anything the body
 says is blocked or held, and anything whose likely file set collides with another candidate's.
 Read bodies before scoring — the labels went on in one retroactive pass and some of them are
@@ -163,7 +167,8 @@ didn't, and what you need from me — plain sentences, no working shorthand.
 
 ## 9. Related
 
-- `prioritize-issues` — the ranking half of batch selection.
+- `prioritize-issues` — the ranking half of batch selection. User-level, not committed.
+- `issue-prioritizer` agent — the committed fallback for the same ranking.
 - `worktree-enhanced` — single-lane worktree setup.
 - `post-merge` — after a lane's PR merges.
 - `narraitor-change-control` — the evidence bar a lane's "done" claim has to clear.

--- a/.claude/skills/narraitor-parallel-lane-orchestration/SKILL.md
+++ b/.claude/skills/narraitor-parallel-lane-orchestration/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: narraitor-parallel-lane-orchestration
+description: Run a batch of Narraitor issues as parallel worktree lanes, with a Fable orchestrator picking the batch and delegating each issue to a subagent whose model matches the issue's model-power label. Use when asked to "work the top N issues in parallel", "fan out the backlog", "kick off a parallel batch", "orchestrate lanes", or when planning a multi-issue push that should run concurrently rather than serially. Covers batch selection, collision avoidance against work already in motion, model tiering, and the lane failure modes that have actually bitten this repo.
+---
+
+# Parallel lane orchestration (Fable orchestrator, tiered lane agents)
+
+## 1. What this is
+
+One Fable-model session acts as orchestrator. It picks N issues off the backlog, pre-builds a
+git worktree per issue, and spawns one Agent-tool subagent per lane — each lane's model chosen
+from that issue's `model-power:*` label, so cheap work runs cheap. The orchestrator never
+implements; it selects, partitions, dispatches, unblocks, and reports.
+
+The mechanism that works here is the **in-harness Agent tool**, not `claude -p` children
+(host-held OAuth 401s) and not a paste-block of terminal commands.
+
+## 2. When to use
+
+- "Work the next N most important issues in parallel."
+- A backlog push where serial execution would waste hours of wall clock.
+- Any time a batch is big enough that batch *selection* is itself a real decision.
+
+Do not use for a single issue (`ship-issue` / `tdd-implement` are cheaper), or when the batch
+would all touch the same file (see collision rules — that batch is serial by nature).
+
+## 3. Model tiering
+
+`model-power:*` is the delegation axis (`complexity:*` is time/scope, not reasoning difficulty).
+Definitions live in `.github/labels.md`.
+
+| Label | Lane model |
+|---|---|
+| `model-power:light` | `haiku` |
+| `model-power:standard` | `sonnet` |
+| `model-power:advanced` | `opus` |
+| `model-power:frontier` | keep out of the batch, or run it in the orchestrator session |
+
+An unlabeled issue is not automatically `standard` — read the body and assign a tier, saying so.
+The labels were applied in a single retroactive pass, so treat a tier that fights the body as
+wrong and score the body.
+
+## 4. Batch selection
+
+Run the `prioritize-issues` skill for the ranking, then subtract everything that cannot safely
+run right now:
+
+- **Already in motion.** Any issue with an open PR, or an existing worktree/branch matching its
+  number. A pre-existing worktree is not proof of abandonment — ask before touching it.
+- **Explicitly held.** A draft PR on a HOLD, an issue whose body says it lands with or after
+  another PR, an issue waiting on a spending or design decision.
+- **Collision.** Predict each candidate's file set. Intersect the sets pairwise. Overlapping
+  candidates either get one named sole owner for the shared file (the other is told in writing
+  not to touch it) or one of them drops out of the batch. Shared prompt templates
+  (`sceneTemplate.ts` and friends) and shared CSS are the repeat offenders.
+
+All-lanes-mergeable proves nothing about collisions: three lanes once trial-merged clean against
+`develop` and the conflict only appeared after the first merge landed.
+
+## 5. Lane setup the orchestrator owns
+
+Lanes start faster and cleaner when the orchestrator does this work up front rather than making
+each lane do it:
+
+```bash
+git worktree add -b claude/issue-<n> \
+  /Users/jackhaas/Projects/personal/narraitor/.claude/worktrees/issue-<n> origin/develop
+git -C <worktree> branch --unset-upstream    # else a bare git push targets develop
+( cd <worktree> && npm ci )                  # node_modules is per-worktree
+```
+
+Do **not** run `install-worktree-port.sh` — it modifies tracked files (`scripts/dev.sh`,
+`scripts/kill-port.sh`) and drops an untracked `scripts/worktree-port.cjs`, so every lane starts
+dirty and a lane reaching for `git add -A` sweeps them into its PR.
+
+Hand each lane its absolute worktree path.
+
+## 6. The traps that have actually cost time here
+
+- **Lanes stall on `Monitor`.** A subagent that uses `Monitor` to watch CI ends its turn waiting
+  for a notification that wakes only the orchestrator. Every lane prompt must carry the blocking
+  poll snippet and the explicit "do not use Monitor" clause, from the first prompt — a corrective
+  message later works but costs a stall-detect round trip per lane, and lanes relapse.
+- **`gh pr checks` shows only the newest run per name.** `no checks reported` means pending, not
+  failing. Never `gh pr edit` a PR body while CI is in flight — it fires a second run whose
+  skipped jobs own the display.
+- **Squash merges break ancestry.** Verify a merge by content
+  (`git show origin/develop:<file> | grep <symbol>`), not `git merge-base --is-ancestor`.
+- **A lane can die after pushing but before reporting.** Check the worktree's `git log` and the
+  PR head against the remote before concluding a dead lane left work undone.
+- **Dead lanes resume.** `SendMessage` to the agent id picks up the existing transcript. Restart
+  only if the transcript is gone.
+- **`API Error: 529` kills a lane at launch, leaving nothing behind.** Verify the worktree is
+  clean, then retry. If a round of retries plus a backoff all fail, say so plainly and fall back
+  to serial — do not let "all PRs green" imply the requested parallelism happened.
+- **Codex review triage earns its keep.** After each PR goes green, read
+  `gh api repos/{owner}/{repo}/pulls/<n>/comments`. Verify the finding yourself before relaying
+  it, and check the comment's `original_commit_id` against the PR's `headRefOid` — a lane may
+  already have fixed it.
+- **`main` is release-only.** PRs target `develop`. Nothing automated goes near `main`.
+
+## 7. Evidence bar for lane completion
+
+A lane is done when its PR is open against `develop` with the full gate green
+(`npm test`, `npm run type-check`, `npm run lint`, plus `lint:css` if it touched CSS), its body
+rendered from `.github/PULL_REQUEST_TEMPLATE.md` with every heading kept, and any Codex findings
+answered. "Merged" is a separate authorization — the batch prompt says which.
+
+The orchestrator reports settled results, never file dumps.
+
+## 8. The kickoff prompt
+
+Paste this into a Fable session at the repo root, with `{N}` filled in and the merge policy
+chosen. It states the destination and the boundaries rather than a step plan — Fable's output
+quality drops when a prompt enumerates steps it can derive.
+
+---
+
+I'm running a parallel backlog push on Narraitor and I want you orchestrating it rather than
+implementing any of it. The point is throughput: {N} issues moving at once, each worked by the
+cheapest model that can actually do it, with none of them stepping on each other.
+
+Where this ends: {N} issues each have a PR open against `develop` with the full quality gate
+green and a body rendered from `.github/PULL_REQUEST_TEMPLATE.md`, and you can tell me for each
+one what changed and what proves it works. Do not merge anything — leave them open and green
+for me. [Or: merge each on green with `gh pr merge --squash --delete-branch`, then run the
+`post-merge` skill for each.]
+
+Pick the batch with the `prioritize-issues` skill, then subtract what can't run right now:
+anything with an open PR or an existing worktree or branch for its number, anything the body
+says is blocked or held, and anything whose likely file set collides with another candidate's.
+Read bodies before scoring — the labels went on in one retroactive pass and some of them are
+wrong now. Tell me the batch and your collision reasoning before you spawn anything; if you
+can't find {N} that are genuinely parallel-safe, hand me a smaller batch and say why rather
+than forcing it.
+
+Choose each lane's model from that issue's `model-power:*` label: light runs on haiku, standard
+on sonnet, advanced on opus. Keep frontier issues out of the batch. Where a label fights the
+body, trust the body and say you overrode it.
+
+Set the lanes up yourself before dispatching — a worktree per issue off `origin/develop` under
+`.claude/worktrees/`, upstream unset, `npm ci` done — and hand each lane its absolute path. Skip
+`install-worktree-port.sh` entirely; it dirties the tree with files that belong to no issue.
+Read the `narraitor-parallel-lane-orchestration` skill for the rest of what has bitten this repo
+before, and treat its trap list as constraints on the lane prompts you write, especially the
+CI-polling one — a lane that reaches for the Monitor tool will sit there forever.
+
+Where a lane's work touches a file another lane needs, name one owner in writing and tell the
+other to leave it alone. Where two candidates can't be separated that way, drop one.
+
+Run the lanes asynchronously and keep working while they go — check in on them, unblock them,
+relay verified review findings, and intervene when one drifts. Don't block on the slowest.
+Before you tell me a lane succeeded, point at the tool result that proves it: a green gate, a
+`gh pr checks` bucket, a diff. If something failed, say so with the output. If a lane dies, look
+at its worktree and its PR head before assuming its work is gone, and resume it rather than
+restarting it.
+
+I'm not watching this in real time, so don't ask me whether to proceed on things that follow
+from this brief. When you're done, write me a summary I can read cold: what shipped, what
+didn't, and what you need from me — plain sentences, no working shorthand.
+
+---
+
+## 9. Related
+
+- `prioritize-issues` — the ranking half of batch selection.
+- `worktree-enhanced` — single-lane worktree setup.
+- `post-merge` — after a lane's PR merges.
+- `narraitor-change-control` — the evidence bar a lane's "done" claim has to clear.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,99 +1,197 @@
 # CLAUDE.md — Narraitor
 
-Narraitor is an AI-driven narrative RPG framework. You build a world (its theme, attributes, skills, and tone), create characters in it, and play through a generated, choice-driven story with a tracked inventory and journal. It's a single-player web app — there's no backend database; player data lives in the browser (IndexedDB via Zustand persistence), and AI generation runs through the player's own provider key.
+Canonical instructions for coding agents in this repo. `AGENTS.md` is gitignored here, so
+this tracked file is the single canon — edit it, not a copy.
+
+Narraitor is an AI-driven narrative RPG framework. You build a world (its theme, attributes,
+skills, and tone), create characters in it, and play through a generated, choice-driven story
+with a tracked inventory and journal. Single-player web app: no backend database, player data
+lives in the browser (IndexedDB via Zustand persistence), and AI generation runs through the
+player's own provider key.
 
 ## Stack
 
-- **Next.js 15** (App Router) + **React 19**, TypeScript.
-- **Zustand 5** for state — one store per domain under `src/state/` (`characterStore`, `inventoryStore`, `journalStore`, `worldStore`, etc.), persisted to IndexedDB.
-- **Plain CSS + design tokens** for styling: `var(--token)` values plus `clsx` for conditional classes. There is **no Tailwind** (it was removed) — don't add utility classes or reintroduce `cva`/`cn()`.
-- AI generation goes through `src/lib/ai/` (Google Gemini via `@google/genai`), keyed by the player's own provider key rather than a server-held key.
+- **Next.js 15** (App Router) + **React 19**, TypeScript strict. Node >= 20, npm.
+- **Zustand 5** — one store per domain under `src/state/` (`characterStore`, `inventoryStore`,
+  `journalStore`, `worldStore`, ...), persisted to IndexedDB via `persistence.ts`.
+- **Plain CSS + design tokens** — `var(--token)` plus `clsx`. **No Tailwind** (removed in the
+  design-system migration); no `cn()`, no `cva`, no `tailwind-merge`.
+- AI generation through `src/lib/ai/` (Google Gemini via `@google/genai`), keyed by the
+  player's own provider key rather than a server-held key.
+- Secrets in `.env.local`. Never commit them.
 
 ## Run it
 
 ```bash
-npm run dev          # scripts/dev.sh — port 3000 in the main checkout; worktrees auto-select their own port
+npm run dev          # scripts/dev.sh — port 3000 in the main checkout; worktrees auto-select
 npm run storybook    # port 6006
 npm run kill         # emergency: pkill -f 'next dev'
 ```
 
-- Check whether a dev server is already running before starting one (`lsof -iTCP:3000`). rcv-simulator-va's main checkout also defaults to 3000 — don't run both at once.
-- Verify: `curl -s localhost:3000 | head -1` returns HTML; Storybook responds at http://localhost:6006.
+Check whether a dev server is already running before starting one (`lsof -iTCP:3000`).
+rcv-simulator-va's main checkout also defaults to 3000 — don't run both at once.
+Verify: `curl -s localhost:3000 | head -1` returns HTML; Storybook responds on 6006.
 
 ## The quality gate
 
-Run before any commit — CI runs these separately and the production build enforces lint and types anyway:
+Run before any commit — CI runs these separately and the production build enforces lint
+and types anyway:
 
 ```bash
-npm test                   # Jest unit/integration suite
+npm test                   # Jest unit/integration
 npm run type-check         # tsc --noEmit
-npm run lint               # ESLint (Next + test/script globs)
+npm run lint               # ESLint (Next + test/script globs, JSX/markup hygiene)
 npm run lint:css           # Stylelint over **/*.css — run after ANY .css edit
 ```
 
+Targeted runs: `npm test -- <path>` for one file, `npm test -- -t "name"` for one case.
+
+Other gates, by what you touched:
+
+- `npm run knip` (unused files/exports/deps) and `npm run audit:css` (unused selectors) — CI gates.
+- `npm run lint:layout-usage` — enforces non-self-closing `PageLayout`.
+- `npm run lint:ds-canon` — design-system canon check.
+- **Structural changes** (imports crossing domains): `npm run deps:validate`, dependency-cruiser
+  against the known-violations baseline. `deps:validate:strict` shows everything; re-baseline
+  only deliberately with `deps:baseline`. `npm run deps:check` is the other half of the ratchet —
+  it fails when a baseline entry no longer reproduces, so fixing a violation means re-baselining.
+- **Visual work:** `npm run test:visual` (Playwright, chromium). Specs seed their own state via
+  `seedTestData(page)`, so there's no separate seed step. Update snapshots deliberately with
+  `test:visual:update`; prune orphans with `test:visual:prune`. User-facing specs should cover
+  light and dark, or carry an inline reason and tracking issue for a single-scheme exception.
+- `npm run test:e2e:critical` — Playwright critical path.
 - `npm run build` — production build (includes a Storybook build step).
-- Structural changes (imports crossing domains): `npm run deps:validate`, dependency-cruiser against the known-violations baseline (`deps:validate:strict` shows everything; re-baseline only deliberately with `deps:baseline`). `npm run deps:check` is the other half of the ratchet: it fails when a baseline entry no longer reproduces, so fixing a violation means re-baselining.
-- Visual work: `npm run test:visual` (Playwright, chromium). Update snapshots deliberately with `test:visual:update`; prune orphans with `test:visual:prune`.
-- If local jest runs out of memory, `npm run test:ci` exists for that (4GB Node heap).
+- If local Jest runs out of memory, `npm run test:ci` exists for that (4GB Node heap).
 
 ## Layout
 
-`src/` is domain-driven:
-
-- `app/` — Next.js routes (App Router).
-- `components/` — React components, organized by domain.
-- `state/` — Zustand stores (the source of truth for app data): world, character, narrative, lore, inventory, npc, journal, goal, navigation, session, plus `persistence.ts` (IndexedDB).
-- `lib/` — non-UI logic: `ai/`, `api/`, `theme/` (design tokens), `generators/`, `devtools/`, feature flags.
-- `services/`, `hooks/`, `utils/`, `types/`, `styles/`, `stories/` (Storybook).
+`src/` is domain-driven: `app/` (routes + API routes), `components/` (by domain, or `ui/`
+for generic), `state/` (Zustand stores — the source of truth for app data, plus
+`persistence.ts`), `lib/` (non-UI: `ai/`, `api/`, `theme/`, `generators/`, `devtools/`,
+`utils/logger`), then `services/`, `hooks/`, `utils/`, `types/`, `styles/`, `stories/`.
 
 ## Conventions
 
-- **Target the `develop` branch** for PRs, not `main`. `main` is release-only; `develop` is the rolling integration branch.
-- KISS by default, in implementation and in tests — MVP-level tests, not exhaustive coverage. Never rig a test to pass.
-- Style with design tokens, not hardcoded values. Stylelint enforces it: no hex, no named colors, no rgb/rgba in product CSS (theme files have scoped overrides). Avoid `!important`.
-- Put an identifying class attribute on components.
-- Look for an existing pattern/utility before adding a new one. One canon version per file — no `simple`/`enhanced` variants.
-- One design system: DS3 ("Mechanical Manuscript"). ADR-013 (PR #1526) collapsed the old three-system setup into DS3 and supersedes ADR-011 — the design system isn't switchable anymore, only light/dark is. Storybook (`npm run storybook`) is still the single canon surface (ADR-012, unaffected — it just renders the one theme now); the old `/dev/design-system*` living style guide stays retired. DESIGN.md is the map, though its type-scale numbers are still DS1's, pending the bolder-DS3 rewrite in #1543.
-- State: CRUD-style store methods; cross-store events via `storeEvents`/`StoreEventTypes`; static imports only (`eval(require())` was eradicated in #1206). Wizard step state goes through sessionStorage (`generated-world-data`); theme prefs through localStorage.
-- Current house style: no wrapper services (ExportService was removed on purpose), use `clsx` directly, extract hooks/helpers before things get clever.
-- Issue work runs the standard global pipeline: analyze-issue, then tdd-implement, then post-merge.
+### General
 
-## Local skills and agents — use them
+- **Target `develop` for PRs, never `main`.** `main` holds tagged releases only — never push
+  to it, never target PRs at it, never do automated work against it. It moves only when the
+  maintainer fast-forwards it to a release. If anything looks like it's about to push to
+  `main` or open a PR against it, stop; that's the maintainer's release flow.
+- Absolute imports with the `@/` alias. Group: React/Next -> external -> internal components
+  -> utils/hooks -> types -> styles.
+- Prettier: 2 spaces, single quotes, trailing commas. Avoid `any`.
+- KISS by default, in implementation and in tests — MVP-level tests, not exhaustive coverage.
+  Never rig a test to pass.
+- Look for an existing pattern or utility before adding a new one. One canon version per file —
+  no `simple` / `enhanced` variants.
+- No wrapper services (ExportService was removed on purpose). Use `clsx` directly. Extract
+  hooks and helpers before things get clever.
+- Issue work runs the standard global pipeline: `analyze-issue`, then `tdd-implement`, then
+  `post-merge`.
 
-Committed under `.claude/` and shipped with the repo:
+### Components
 
-- `narraitor-architecture` skill — invoke BEFORE writing new components, stores, API routes, or planning a feature. Domain boundaries, naming, state patterns, AI integration conventions.
-- `narraitor-pattern-alignment-skill` — run AFTER any code change touching src/, before committing.
-- `style-port` skill — the only sanctioned way to port reference/demo inline styles into production CSS (rigid 6-phase process, token-based, no `!important`).
-- `review` skill — PR review flow: fetch the latest remote diff, run lint + tests, verdict.
-- Agents: design-system-enforcer, format-check, issue-prioritizer, pr-merge-issue-updater, test-fix.
+- `src/components/<Domain>/<ComponentName>.tsx`. PascalCase components, camelCase hooks.
+- Functional only: `export const Component = () => { ... }`. Props interface named
+  `ComponentNameProps`, exported.
+- Default to Server Components; add `'use client'` only for state, effects, or event listeners.
+- Put an identifying class attribute on every component.
+- New components get a Storybook story under `src/stories/` — that's the only glob in
+  `.storybook/main.cjs`, so stories do NOT live beside their components.
 
-## Running in Claude Code cloud
+### State
 
-Cloud sessions clone this repo fresh, so the `SessionStart` hook in `.claude/settings.json` runs `scripts/install_pkgs.sh` to `npm ci` on startup. Unit tests, type-check, lint, and build all work on the Linux cloud VM.
+- `create<StoreInterface>()(...)` in `src/state/`. CRUD-style store methods. `persist`
+  middleware for state that survives reloads.
+- Cross-store events via `storeEvents` / `StoreEventTypes`. Static imports only.
+- Wizard step state goes through sessionStorage (`generated-world-data`); theme prefs
+  through localStorage.
 
-**Don't run the visual-regression or E2E suites in cloud** (`test:visual`, `test:e2e:*`) — the Playwright baselines are macOS-only and will fail on pixel diffs against a Linux runner. Those belong on a local Mac or the macOS CI job.
+### Styling
 
-## Automation directives
+- **One design system: DS3 ("Mechanical Manuscript"), and it is not switchable** — only
+  light/dark is. Components stay theme-blind: no `theme === 'dsN'` branching in JSX; tokens
+  carry the variation, defined per theme in `src/lib/theme/themes/`. The old
+  `/dev/design-system*` showcase routes were deleted and stay deleted.
+- **NEVER** hardcode hex, named colors, or rgb/rgba in product CSS — use `var(--token-name)`.
+  Stylelint fails the build on it. Theme files have scoped overrides. Avoid `!important`.
+- Semantic class names (`badge badge-success`), composed with
+  `clsx('base', condition && 'conditional', className)`.
+- **Storybook is the single canon visual surface** — when production drifts from Storybook,
+  production is wrong. `00-Foundation/Design System Showcase` is the foundation story. The
+  toolbar has a light/dark switcher; verify any visual change in both before merging.
+- `DESIGN.md` is the AI-readable map of tokens, components, and the don'ts list. Treat it as
+  authoritative, but note it flags its own stale DS1-era type-scale values inline.
 
-Slash commands in this repo may carry directives at the top of the file:
+### AI integration
 
-```
-# AUTO-APPROVE: ALL
-# AUTO-ACCEPT-EDITS: ALL
-```
+- Lives in `src/lib/ai/`, SDK `@google/genai`.
+- **NEVER** expose API keys or AI calls on the client. All AI interactions happen in Server
+  Actions or API routes.
 
-For truly automatic execution, select "Yes, and don't ask again this session" on the first prompt. Helper scripts are pre-approved in `.claude/settings.local.json` (machine-local, not committed).
+### Error handling
+
+- `createStoreError` for store errors. The internal `Logger` (`@/lib/utils/logger`) for logging.
+- `ErrorBlock` to surface errors to users.
+
+## Workflow
+
+Read the related files before writing — don't guess types or props. Run
+`npm test -- <relevant_file>` immediately after a logic change, not just at the end.
+New logic gets a unit test in `__tests__/` or a co-located `*.test.tsx`, deterministic,
+with network calls and AI responses mocked. JSDoc on exported functions and complex
+components.
+
+### Pull requests
+
+- **Always render the body from `.github/PULL_REQUEST_TEMPLATE.md`.** Read it first.
+- Keep every template heading in the submitted body. Fill non-applicable sections with
+  "Not applicable." or a short explanation — don't delete them.
+- This applies to PRs created through the GitHub connector or API too: pass a body generated
+  from the template, don't rely on connector defaults or shorter skill summaries.
+- Check only the boxes actually verified in this workflow, and note any skipped checks.
 
 ## Known failure modes
 
-- Port 3000 taken → an orphan `next dev` or rcv-simulator-va's main checkout.
-- Stylelint color failures → a raw color landed outside a theme file; route it through tokens.
-- deps:validate failures → fix the boundary violation, or (rarely, deliberately) re-baseline.
-- deps:check failures → a violation got fixed but its baseline entry is still there; run `deps:baseline` and commit the smaller file.
+- Port 3000 taken -> an orphan `next dev` or rcv-simulator-va's main checkout.
+- Stylelint color failures -> a raw color landed outside a theme file; route it through tokens.
+- `deps:validate` failures -> fix the boundary violation, or (rarely, deliberately) re-baseline.
+- `deps:check` failures -> a violation got fixed but its baseline entry is still there; run
+  `deps:baseline` and commit the smaller file.
 
 ## Pointers
 
-- README.md — product overview.
-- CONTEXT.md — the domain vocabulary (world, turn, decision, provider, etc.) referenced by several local skills.
-- DESIGN.md, ADR-013 (PR #1526, supersedes ADR-011), and ADR-012 (#1484) — the single-design-system decision and the Storybook-as-canon surface.
+README.md (product overview), RELEASES.md (one section per version), CONTEXT.md (domain
+vocabulary — world, turn, decision, provider — referenced by several local skills),
+DESIGN.md (design-system map), `public_docs/architecture/` (ADRs),
+`public_docs/development/release-process.md`.
+
+## Claude Code specifics
+
+Everything above applies to any coding agent. These bits apply only to Claude Code.
+
+### Local skills and agents
+
+`.claude/skills/` and `.claude/agents/` ship with this repo and self-describe — invoke them
+by name, don't wait to be asked. Two that carry the strongest "run me" contract:
+`narraitor-architecture` before writing new components, stores, or API routes, and
+`narraitor-pattern-alignment-skill` after any change under `src/`, before committing.
+`.claude/skills/` is the full list; don't enumerate it here, it rots.
+
+### Running in Claude Code cloud
+
+Cloud sessions clone this repo fresh, so the `SessionStart` hook in `.claude/settings.json`
+runs `scripts/install_pkgs.sh` to `npm ci` on startup. Unit tests, type-check, lint, and
+build all work on the Linux cloud VM.
+
+**Don't run the visual-regression or E2E suites in cloud** (`test:visual`, `test:e2e:*`) —
+the Playwright baselines are macOS-only and will fail on pixel diffs against a Linux runner.
+Those belong on a local Mac or the macOS CI job.
+
+### Automation directives
+
+Slash commands here may carry `# AUTO-APPROVE: ALL` / `# AUTO-ACCEPT-EDITS: ALL` at the top
+of the file. For truly automatic execution, pick "Yes, and don't ask again this session" on
+the first prompt. Helper scripts are pre-approved in `.claude/settings.local.json`
+(machine-local, not committed).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,8 +127,14 @@ for generic), `state/` (Zustand stores — the source of truth for app data, plu
 ### AI integration
 
 - Lives in `src/lib/ai/`, SDK `@google/genai`.
-- **NEVER** expose API keys or AI calls on the client. All AI interactions happen in Server
-  Actions or API routes.
+- **NEVER** call a provider directly from the browser. Every AI interaction goes through a
+  Server Action or an API route.
+- The player's provider key is browser-owned by design — `providerStore` holds it encrypted,
+  `aiFetch` decrypts it and passes it to the route in an `x-provider-api-key` header. That's
+  the BYO-key architecture working as intended; don't redesign it around a server-held key
+  store, which doesn't exist here.
+- Server-owned secrets are the opposite case: anything in `.env.local` stays server-side and
+  never reaches the client.
 
 ### Error handling
 


### PR DESCRIPTION
## Description

`CLAUDE.md` had drifted into being a partial copy of the gitignored `AGENTS.md`, which meant the tracked file was missing half the quality gate and none of the per-domain conventions. This makes the tracked file the single canon and says so in the opening lines, so there's no ambiguity about which one to edit.

The rewrite adds the gates that were never documented (`knip`, `audit:css`, `lint:layout-usage`, `lint:ds-canon`, `test:e2e:critical`), breaks Conventions into Components / State / Styling / AI integration / Error handling, and hardens the branch rule from "target `develop`" into an explicit stop condition — never push to `main`, never target a PR at it, stop if something looks like it's about to.

It also stops listing local skills by name. That list rots the moment a skill is added, which is exactly what this PR's second file demonstrates: `narraitor-parallel-lane-orchestration` was written weeks ago and left untracked, so no worktree ever inherited it and `/narraitor-parallel-lane-orchestration` resolved as an unknown command. The new text points at `.claude/skills/` as the list instead, and the skill is now committed so that pointer is true.

## Related Issue

Not applicable — housekeeping found while debugging why the slash command didn't resolve.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

Not applicable. No runtime code changes — this is a tracked markdown file and an agent skill definition. Nothing under `src/` is touched, so there's nothing to drive from a test.

- [ ] Tests written before implementation
- [ ] All new code is tested
- [ ] All tests pass locally
- [ ] Test coverage maintained or improved

## User Stories Addressed

Not applicable — no user-facing behavior changes.

## Flow Diagrams

Not applicable.

## Component Development

Not applicable — no components touched.

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes

Both files were sitting uncommitted in the main checkout, and the `CLAUDE.md` edit existed a second time, byte-identical, in a Codex worktree. The two copies were diffed against each other before committing to confirm neither had diverged; the duplicate has since been discarded.

The `main`-branch language is deliberately stronger than a convention. It's phrased as a stop condition because an agent reading "target `develop` for PRs" can still rationalize a direct push during cleanup, and `main` moves only when the maintainer fast-forwards it to a release.

## Screenshots

Not applicable.

## Visual Baseline Changes

None. This PR doesn't touch `tests/visual/**-snapshots/**`.

## Code Review Summary (if applicable)

Not applicable.

## Chrome DevTools MCP Verification Summary (if applicable)

Not applicable.

## Quality Checks (if applicable)

No linters or type-checks were run, and none apply — the diff is two markdown files, outside every configured lint glob.

- [ ] Linting passed
- [ ] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

Verification here is that the skill actually resolves, which the old state failed:

1. Check out this branch in a fresh worktree.
2. Confirm `.claude/skills/narraitor-parallel-lane-orchestration/SKILL.md` is present — before this PR it existed only in the main checkout, untracked.
3. Start a Claude Code session in that worktree and run `/narraitor-parallel-lane-orchestration`. It should resolve rather than returning "Unknown command".
4. Read `CLAUDE.md` and confirm the documented gate commands match `package.json` scripts.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed — not applicable, markdown only
