### PR TITLE
Strip issue citations and redundant comments from the weekly sweep (#1952)

### DIFF
--- a/src/components/GameSession/hooks/useActiveGameSessionActions.ts
+++ b/src/components/GameSession/hooks/useActiveGameSessionActions.ts
@@ -89,7 +89,7 @@ export const useActiveGameSessionActions = ({
     setLocalSelectedChoiceId(choiceId);
     setShouldTriggerGeneration(true); // Trigger narrative generation
 
-    // Create decision journal entry (Issue #174)
+    // Create decision journal entry
     if (currentDecision && characterId) {
       createDecisionJournalEntry(currentDecision, choiceId, false);
     }
@@ -123,7 +123,7 @@ export const useActiveGameSessionActions = ({
     // Handle custom player input
     const customChoiceId = generateUniqueId('custom');
 
-    // Create decision journal entry for custom choice (Issue #174)
+    // Create decision journal entry for custom choice
     if (currentDecision && characterId) {
       createDecisionJournalEntry(currentDecision, customText, true);
     }
@@ -135,7 +135,7 @@ export const useActiveGameSessionActions = ({
     setIsGenerating(true);
     setIsGeneratingChoices(true);
 
-    // Phase 1 (Issue #918): infer skill checks for the typed action so custom
+    // Phase 1: infer skill checks for the typed action so custom
     // actions get the same d20 treatment as predefined choices. The resulting
     // requirements are attached to the option below; NarrativeController then
     // rolls them via its existing skill-check evaluation.
@@ -217,7 +217,7 @@ export const useActiveGameSessionActions = ({
       selectedOptionId: decision.selectedOptionId,
       decisionWeight: decision.decisionWeight,
       contextSummary: decision.contextSummary,
-      // Dev-mode only (#1829 round 6) - dropped here, same as the store
+      // Dev-mode only - this was dropped here, same as the store
       // call site in usePlayerChoices.ts, before a codex review caught it.
       debugInfo: decision.debugInfo,
     };

--- a/src/components/GameSession/hooks/useGameSessionState.ts
+++ b/src/components/GameSession/hooks/useGameSessionState.ts
@@ -80,7 +80,7 @@ export const useGameSessionState = ({
   // Scope each store subscription to the slice this hook actually uses, so the
   // game session doesn't re-render on every unrelated store write during play.
   // Session state itself is consumed via the dedicated subscription below; here
-  // we only need its (stable) action methods (issue #1358).
+  // we only need its (stable) action methods.
   const actualWorldState = useWorldStore(
     useShallow((state) => ({ worlds: state.worlds }))
   );
@@ -161,7 +161,6 @@ export const useGameSessionState = ({
     }
   }, [worldId, currentCharacterId, isClient, actualCharacterState, logger, worldCharacters]); // Dependencies to prevent stale closures
   
-  // Handle retry
   const handleRetry = useCallback(() => {
     setError(null);
     setSessionState(prev => ({ ...prev, error: null }));
@@ -175,7 +174,6 @@ export const useGameSessionState = ({
     }
   }, [sessionCharacterId, worldId, onSessionStart, actualSessionState, logger]);
 
-  // Handle dismiss error
   const handleDismissError = () => {
     setError(null);
     setSessionState(prev => ({ ...prev, error: null }));
@@ -226,7 +224,6 @@ export const useGameSessionState = ({
   };
 
 
-  // Handle end session
   const handleEndSession = () => {
     actualSessionState.endSession?.();
     setSessionState(prev => ({ ...prev, status: 'ended' }));
@@ -246,7 +243,7 @@ export const useGameSessionState = ({
     // If store already has an active session that matches our requirements, don't
     // re-initialize — but re-arm the crash-recovery marker. A clean refresh clears
     // it on pagehide, and this remount path skips initializeSession/resumeSavedSession,
-    // so without this a crash before the next save would leave no marker (issue #221).
+    // so without this a crash before the next save would leave no marker.
     if (!disableAutoResume &&
         currentStoreState.status === 'active' &&
         currentStoreState.worldId === worldId &&

--- a/src/components/Narrative/NarrativeHistoryManager.tsx
+++ b/src/components/Narrative/NarrativeHistoryManager.tsx
@@ -14,7 +14,7 @@ interface NarrativeHistoryManagerProps {
   disableInitialAutoScroll?: boolean;
   /**
    * True while a NarrativeController elsewhere in the tree is actively
-   * generating the next turn (issue #1476). This component only displays
+   * generating the next turn. This component only displays
    * persisted segments, so it has no generation state of its own — a
    * composer that hides its own NarrativeController's history (the live play
    * surface does, via ActiveGameSessionNarrativeColumn) passes its
@@ -38,7 +38,6 @@ export const NarrativeHistoryManager: React.FC<NarrativeHistoryManagerProps> = (
   // We define error state but don't currently use setError - this is for future error handling
   const [error] = useState<string | null>(null);
   
-  // Get segments from the store
   const getSegments = useNarrativeStore(state => state.getSessionSegments);
   
   // Subscribe to narrative store updates
@@ -69,7 +68,7 @@ export const NarrativeHistoryManager: React.FC<NarrativeHistoryManagerProps> = (
     // changes, instead of on every narrative-store write. Segments stream in
     // token-by-token during play (each a store write), and addSegment replaces
     // sessionSegments[sessionId] with a new array, so a reference check catches
-    // every add/remove for this session (issue #1358).
+    // every add/remove for this session.
     let prevSegmentIds = useNarrativeStore.getState().sessionSegments[sessionId];
     const unsubscribe = useNarrativeStore.subscribe((state) => {
       const nextSegmentIds = state.sessionSegments[sessionId];
@@ -164,7 +163,7 @@ export const NarrativeHistoryManager: React.FC<NarrativeHistoryManagerProps> = (
         // Only show segments when they've stabilized
         segments={stabilized ? segments : []}
         // Always show loading animation until stabilized, regardless of whether we have segments —
-        // also true while a sibling NarrativeController generates the next turn (issue #1476).
+        // also true while a sibling NarrativeController generates the next turn.
         isLoading={isLoading || !stabilized || isGenerating}
         streamingContent={streamingContent}
         // Segments withheld pre-stabilization are historical, not newly generated —

--- a/src/components/devtools/DevToolsContext/DevToolsContext.tsx
+++ b/src/components/devtools/DevToolsContext/DevToolsContext.tsx
@@ -29,9 +29,6 @@ interface DevToolsContextType {
   updateSetting: <K extends keyof DevToolsSettings>(key: K, value: DevToolsSettings[K]) => void;
 }
 
-/**
- * Default context values
- */
 const defaultContext: DevToolsContextType = {
   isOpen: false,
   toggleDevTools: () => {
@@ -46,9 +43,6 @@ const defaultContext: DevToolsContextType = {
   updateSetting: () => {}
 };
 
-/**
- * DevTools Context
- */
 const DevToolsContext = createContext<DevToolsContextType>(defaultContext);
 
 /**
@@ -107,7 +101,6 @@ export const DevToolsProvider = ({
     setSectionVisibilityState(newVisibility);
   };
 
-  // Check if a section is visible
   const checkSectionVisible = (sectionId: string) => {
     return isSectionVisible(sectionId, sectionVisibility);
   };
@@ -144,7 +137,4 @@ export const DevToolsProvider = ({
   );
 };
 
-/**
- * Hook to use DevTools context
- */
 export const useDevTools = () => useContext(DevToolsContext);

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -9,8 +9,8 @@
  * in the browser.
  */
 const FEATURE_FLAG_DEFAULTS = {
-  // Client-side typewriter reveal over an already-complete response (#1695).
-  // Real token streaming from /api/narrative/generate (issue #1476) now
+  // Client-side typewriter reveal over an already-complete response.
+  // Real token streaming from /api/narrative/generate now
   // covers the same "text should arrive progressively" goal for the live
   // play surface, so this defaults off — playing both back to back would
   // double the reveal instead of speeding it up. Kept as an opt-in fallback
@@ -29,13 +29,13 @@ const FEATURE_FLAG_DEFAULTS = {
   // narraitor-prompt-template-governance/eval-logs/1882-world-cost.md measures it.
   WORLD_COST: false,
   // Renders the world's own founding description in the per-turn scene
-  // prompt (#1865), not just the opening scene. Experiment, not a fix: it
+  // prompt, not just the opening scene. Experiment, not a fix: it
   // might carry the world's pressures further into the session, or it might
   // do nothing but cost tokens every turn. Off until a playtest measures it —
   // see narraitor-prompt-template-governance/eval-logs/1865-world-description-in-scene.md.
   WORLD_DESCRIPTION_IN_SCENE: false,
-  // Guards against the engine backfilling a conversation that never happened
-  // (#1857). The player naming a prior private exchange with a rostered NPC
+  // Guards against the engine backfilling a conversation that never happened.
+  // The player naming a prior private exchange with a rostered NPC
   // turns co-presence already on the segments into an assertable fact, which
   // reaches the contract, the deterministic detector, and the lore extractor.
   // On by default: the whole path is gated on a rare turn, and off means a

--- a/src/lib/promptTemplates/templates/narrative/choiceTypeTemplates.ts
+++ b/src/lib/promptTemplates/templates/narrative/choiceTypeTemplates.ts
@@ -37,7 +37,7 @@ const ALIGNMENT_DEFINITIONS: Record<'NEUTRAL' | 'CHAOTIC' | 'LAWFUL', string> = 
 
 /**
  * The glossary orders in rotation. Excludes LAWFUL/NEUTRAL/CHAOTIC (the
- * canonical running order #1877 removed from the numbered slots) and any
+ * canonical running order removed from the numbered slots) and any
  * order ending in CHAOTIC (the slot-3 tell round 5 found still holding at
  * 83% even with the order shuffled) - the two shapes the alignment-spread
  * tests forbid.
@@ -54,9 +54,9 @@ const ALIGNMENT_GLOSSARY_ORDERS: Array<Array<'NEUTRAL' | 'CHAOTIC' | 'LAWFUL'>> 
  *
  * The mix of alignments is chosen per scene rather than mandated. Removing the
  * quota was not enough on its own: the model kept returning lawful, neutral,
- * chaotic in that order because the prompt itself taught the pattern. #1877
- * moved the mix decision earlier and took the glossary out of slot order, but
- * a FIXED reordering is still a pattern - round 5 (#1829) measured 70% one
+ * chaotic in that order because the prompt itself taught the pattern. Moving
+ * the mix decision earlier and taking the glossary out of slot order wasn't
+ * enough either - a FIXED reordering is still a pattern - round 5 measured 70% one
  * dominant order and 83-87% slot-predicts-tag against a single static
  * glossary. So the glossary's own listing order now rotates per turn (see
  * ALIGNMENT_GLOSSARY_ORDERS below) instead of landing on one order and
@@ -100,7 +100,7 @@ ${worldSkills.map(skill => `- ${skill.name}: ${skill.description}`).join('\n')}`
 
   const protagonistInfo = protagonistGuidance(playerCharacterName);
 
-  // Round 5 (#1829) measured slot-predicts-tag at 87%/70%/83% even after the
+  // Round 5 measured slot-predicts-tag at 87%/70%/83% even after the
   // glossary stopped running in slot order: a FIXED glossary order is still a
   // pattern to learn against, just one call removed from the numbered slots.
   // Rotate which of the four permitted orders (no LAWFUL-NEUTRAL-CHAOTIC, none

--- a/src/lib/test-utils/testDataFactory.ts
+++ b/src/lib/test-utils/testDataFactory.ts
@@ -39,9 +39,6 @@ export function createMockWorld(overrides: Partial<World> = {}): World {
   };
 }
 
-/**
- * Creates a mock WorldAttribute object
- */
 export function createMockWorldAttribute(
   overrides: Partial<WorldAttribute> = {}
 ): WorldAttribute {
@@ -58,9 +55,6 @@ export function createMockWorldAttribute(
   };
 }
 
-/**
- * Creates a mock WorldSkill object
- */
 export function createMockWorldSkill(
   overrides: Partial<WorldSkill> = {}
 ): WorldSkill {
@@ -136,9 +130,6 @@ export function createMockCharacter(
   };
 }
 
-/**
- * Creates a mock NarrativeSegment object
- */
 export function createMockNarrativeSegment(
   overrides: Partial<NarrativeSegment> = {}
 ): NarrativeSegment {
@@ -161,9 +152,6 @@ export function createMockNarrativeSegment(
   };
 }
 
-/**
- * Creates a mock JournalEntry object
- */
 export function createMockJournalEntry(
   overrides: Partial<JournalEntry> = {}
 ): JournalEntry {
@@ -188,9 +176,6 @@ export function createMockJournalEntry(
   };
 }
 
-/**
- * Creates a mock InventoryItem object
- */
 export function createMockInventoryItem(
   overrides: Partial<InventoryItem> = {}
 ): InventoryItem {

--- a/src/state/__tests__/integration/narrativeStore.playerDecisionTracker.testHelpers.ts
+++ b/src/state/__tests__/integration/narrativeStore.playerDecisionTracker.testHelpers.ts
@@ -25,9 +25,6 @@ export const createTestTracker = () => new PlayerDecisionTracker({
   maxTotalDecisions: 100
 });
 
-/**
- * Resets the narrative store to initial state
- */
 export const resetNarrativeStore = () => {
   useNarrativeStore.setState({
     segments: {},
@@ -97,9 +94,6 @@ export const createMarketplaceSegment = (sessionId: string, worldId: string): Se
   timestamp: new Date()
 });
 
-/**
- * Creates a merchant encounter segment
- */
 export const createMerchantEncounterSegment = (sessionId: string, worldId: string, characterId: string): SegmentInput => ({
   worldId,
   content: 'A distressed merchant approaches you, wringing his hands nervously.',
@@ -113,9 +107,6 @@ export const createMerchantEncounterSegment = (sessionId: string, worldId: strin
   timestamp: new Date()
 });
 
-/**
- * Creates a merchant plea segment
- */
 export const createMerchantPleaSegment = (sessionId: string, worldId: string, characterId: string): SegmentInput => ({
   worldId,
   content: '"Please, adventurer! Bandits stole my entire shipment on the road from Millhaven!"',
@@ -171,9 +162,6 @@ export const createMerchantHelpOptions = (): DecisionOption[] => [
   }
 ];
 
-/**
- * Creates bandit camp decision options
- */
 export const createBanditCampOptions = (): DecisionOption[] => [
   { id: 'sneak-stealth', text: 'Sneak in quietly and recover the goods without fighting' },
   { id: 'negotiate-bandits', text: 'Approach openly and try to negotiate the return of the goods' },
@@ -181,9 +169,6 @@ export const createBanditCampOptions = (): DecisionOption[] => [
   { id: 'retreat-plan', text: 'Retreat and come back with town guards for backup' }
 ];
 
-/**
- * Records a decision in the tracker with standard parameters
- */
 export const recordDecisionInTracker = (
   tracker: PlayerDecisionTracker,
   prompt: string,

--- a/src/state/__tests__/persistence/persistenceIntegration.test.ts
+++ b/src/state/__tests__/persistence/persistenceIntegration.test.ts
@@ -42,7 +42,6 @@ jest.unmock('../../characterStore');
 import { useWorldStore } from '../../worldStore';
 import { useCharacterStore } from '../../characterStore';
 
-// Mock indexedDB
 const mockIndexedDB = {
   deleteDatabase: jest.fn(),
   open: jest.fn(),
@@ -56,7 +55,6 @@ describe('Persistence Integration - MVP', () => {
   };
 
   beforeEach(() => {
-    // Clear all mocks
     jest.clearAllMocks();
 
     // Get the mock storage
@@ -75,7 +73,6 @@ describe('Persistence Integration - MVP', () => {
     useWorldStore.getState().reset();
     useCharacterStore.getState().reset();
 
-    // Mock global indexedDB
     (global as unknown as { indexedDB?: typeof mockIndexedDB }).indexedDB =
       mockIndexedDB;
   });
@@ -87,7 +84,6 @@ describe('Persistence Integration - MVP', () => {
 
   describe('basic persistence functionality', () => {
     test('should persist character store data', async () => {
-      // Use Jest's fake timers
       jest.useFakeTimers();
 
       // Clear the mock after initialization
@@ -140,13 +136,11 @@ describe('Persistence Integration - MVP', () => {
     }, 10000);
 
     test('should maintain data relationships between stores', async () => {
-      // Use Jest's fake timers
       jest.useFakeTimers();
 
       // Clear the mock after initialization
       mockStorage.setItem.mockClear();
 
-      // Create a world
       const worldId = useWorldStore.getState().createWorld({
         name: 'Reference World',
         description: 'A test world for persistence testing',
@@ -247,7 +241,6 @@ describe('Persistence Integration - MVP', () => {
     });
 
     test('should handle persistence errors gracefully', async () => {
-      // Use Jest's fake timers
       jest.useFakeTimers();
 
       // Simulate persistence errors

--- a/src/state/navigationStore.ts
+++ b/src/state/navigationStore.ts
@@ -74,9 +74,6 @@ const sessionStorageHelpers = {
   },
 };
 
-/**
- * Local storage helpers for persistent preferences
- */
 const localStorageHelpers = {
   setFlowState: (flowState: string | null): void => {
     if (!isStorageAvailable()) return;
@@ -135,7 +132,6 @@ export interface NavigationState {
   // Navigation history (recent pages)
   history: NavigationHistoryEntry[];
   
-  // Navigation preferences
   preferences: NavigationPreferences;
   
   // Modal/dialog states
@@ -156,7 +152,6 @@ export interface NavigationState {
   clearHistory: () => void;
   removeFromHistory: (path: string) => void;
   
-  // Preferences
   updatePreferences: (updates: Partial<NavigationPreferences>) => void;
   setSidebarCollapsed: (collapsed: boolean) => void;
   
@@ -164,7 +159,6 @@ export interface NavigationState {
   setModalState: (modalId: string, isOpen: boolean) => void;
   closeAllModals: () => void;
   
-  // Flow state
   setCurrentFlowStep: (step: NavigationState['currentFlowStep']) => void;
   
   // Breadcrumb management
@@ -181,9 +175,6 @@ export interface NavigationState {
   hasVisited: (path: string) => boolean;
 }
 
-/**
- * Default navigation preferences
- */
 const defaultPreferences: NavigationPreferences = {
   sidebarCollapsed: false,
   breadcrumbsEnabled: true,

--- a/src/utils/__tests__/skillCheckEvaluator.test.ts
+++ b/src/utils/__tests__/skillCheckEvaluator.test.ts
@@ -22,10 +22,6 @@ import {
 import { WorldSkill } from '@/types/world.types';
 import { SkillCheck } from '../skillCheckEvaluator';
 
-// ============================================================================
-// TEST DATA SETUP
-// ============================================================================
-
 /**
  * Mock character attributes for testing various attribute bonus scenarios
  */
@@ -95,10 +91,6 @@ const mockWorldSkills: WorldSkill[] = [
     maxValue: 20,
   },
 ];
-
-// ============================================================================
-// TEST SUITES
-// ============================================================================
 
 describe('rollD20', () => {
   it('should return a number between 1 and 20', () => {


### PR DESCRIPTION
## Description
Applies the findings from #1952 (the automated weekly comment sweep): strips bare issue-number citations from comments, drops comments that just restate the line below them, removes two section-divider banners, and collapses redundant one-line JSDoc where the function name already says what the comment says. No code or behavior changes - this is comment text only.

## Related Issue
Closes #1952

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

Not quite any of the above - it's a comment-only cleanup with zero behavior change. Closest fit is refactoring, left unchecked since nothing about the code itself changed.

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

N/A for new code - there is none. Existing tests for every touched file still pass (see Testing Instructions).

## User Stories Addressed
None - this is a technical-debt cleanup, not a feature.

## Flow Diagrams
Not applicable.

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

Not applicable - no component behavior or markup changed, only comments.

## Implementation Notes
Ran the repo's `node scripts/audit-comments.mjs --json` before and after: Tier 1 findings went 299 -> 263, Tier 2 went 85 -> 70 (issue #1952 has the full breakdown). I also re-read every one of the 14 "archaeological" hits the script flagged and left all of them alone - they turned out to be live constraints wearing history as a costume (`shouldExposeStoreOnWindow.ts`, `resolveApiKey.ts`, `geminiClient.ts`, `sessionStore.ts`) or a regression test's actual reason for existing (`markSessionEnded.test.ts` and seven others). None of those are touched here.

A couple of citations sat inside otherwise load-bearing prose explaining prompt-rotation experiments (`choiceTypeTemplates.ts`, `featureFlags.ts`) - stripped the ticket numbers there too but kept every sentence of the reasoning, per the project's own no-ticket-numbers-in-comments convention.

Four commits, one per cleanup category, each independently revertable:
- Strip issue-number citations from comments - git blame already has them
- Drop redundant comments that restate the code below them
- Remove section-divider banners from skillCheckEvaluator tests
- Collapse redundant one-line JSDoc in test factory helpers

## Screenshots
Not applicable - no UI change.

## Visual Baseline Changes
None. This PR doesn't touch `tests/visual/**-snapshots/**`.

## Code Review Summary (if applicable)
Not applicable - not an automated implementation.

## Chrome DevTools MCP Verification Summary (if applicable)
Not applicable - no browser-observable change.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit not applicable to a comment-only change; not run.

## Testing Instructions
1. `npm run lint` - 0 errors (pre-existing `no-explicit-any` warnings elsewhere, untouched by this PR).
2. `npm run type-check` - clean.
3. `npm test -- <every file this PR touches>` - 10 suites, 42 tests, all green.
4. `git diff develop..chore/comment-sweep-1952 --stat` - 11 files, 19 insertions / 87 deletions, comment lines only.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed

Documentation and accessibility items not applicable - no docs or UI affected by a comment-only change.
