### PR TITLE
Rewrite mock-only test assertions to check real state

### DIFF
--- a/src/components/Narrative/__tests__/NarrativeController.contextSummaryPersistence.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeController.contextSummaryPersistence.test.tsx
@@ -66,7 +66,16 @@ describe('NarrativeController context summary persistence', () => {
   });
 
   it('persists contextSummary when storing generated decisions', async () => {
-    const addDecision = jest.fn().mockReturnValue('decision-123');
+    // A tiny fake store slice, not just a call-recorder: addDecision writes
+    // into storedDecisions and getSessionDecisions reads it back, so the test
+    // can prove the decision is readable after storing it rather than only
+    // that addDecision was invoked with the right arguments.
+    const storedDecisions: Array<Record<string, unknown>> = [];
+    const addDecision = jest.fn((sessionId: string, decisionData: Record<string, unknown>) => {
+      const id = 'decision-123';
+      storedDecisions.push({ id, sessionId, ...decisionData });
+      return id;
+    });
     const getSessionSegments = jest.fn().mockReturnValue([
       {
         id: 'segment-1',
@@ -78,7 +87,7 @@ describe('NarrativeController context summary persistence', () => {
         timestamp: new Date(),
       },
     ]);
-    const getSessionDecisions = jest.fn().mockReturnValue([]);
+    const getSessionDecisions = jest.fn(() => storedDecisions);
 
     mockZustandStore(
       useNarrativeStore as jest.MockedFunction<typeof useNarrativeStore>,
@@ -134,14 +143,16 @@ describe('NarrativeController context summary persistence', () => {
       expect(addDecision).toHaveBeenCalled();
     });
 
-    expect(addDecision).toHaveBeenCalledWith(
-      'test-session',
-      expect.objectContaining({
-        prompt: 'What do you do?',
-        decisionWeight: 'major',
-        contextSummary: 'A tense standoff unfolds at the crossroads.',
-      })
-    );
+    // Read the decision back through the same getter the store exposes,
+    // rather than inspecting addDecision's call args, so this proves the
+    // decision is actually stored and retrievable.
+    const [stored] = getSessionDecisions();
+    expect(stored).toMatchObject({
+      sessionId: 'test-session',
+      prompt: 'What do you do?',
+      decisionWeight: 'major',
+      contextSummary: 'A tense standoff unfolds at the crossroads.',
+    });
 
     // Post-hydration choice generation should fire exactly once (no double-trigger).
     expect(addDecision).toHaveBeenCalledTimes(1);

--- a/src/components/Narrative/hooks/__tests__/usePlayerChoices.test.ts
+++ b/src/components/Narrative/hooks/__tests__/usePlayerChoices.test.ts
@@ -25,9 +25,18 @@ const aiDecision = {
 };
 
 function setupStore(overrides: Record<string, unknown> = {}) {
-  const addDecision = jest.fn().mockReturnValue('stored-decision-1');
+  // A tiny fake store slice, not just a call-recorder: addDecision writes into
+  // storedDecisions and getSessionDecisions reads it back, so a test can prove
+  // a decision is readable after storing it rather than only that addDecision
+  // was invoked with the right arguments.
+  const storedDecisions: Array<Record<string, unknown>> = [];
+  const addDecision = jest.fn((sessionId: string, decisionData: Record<string, unknown>) => {
+    const id = 'stored-decision-1';
+    storedDecisions.push({ id, sessionId, ...decisionData });
+    return id;
+  });
   const getSessionSegments = jest.fn().mockReturnValue([baseSegment]);
-  const getSessionDecisions = jest.fn().mockReturnValue([]);
+  const getSessionDecisions = jest.fn(() => storedDecisions);
   mockZustandStore(
     useNarrativeStore as jest.MockedFunction<typeof useNarrativeStore>,
     createMockNarrativeStore({
@@ -85,7 +94,7 @@ describe('usePlayerChoices', () => {
   });
 
   it('generates AI choices, persists the decision, and notifies the parent', async () => {
-    const { addDecision } = setupStore();
+    const { getSessionDecisions } = setupStore();
     const { result, aiGenerate, onChoicesGenerated } = renderPlayerChoices();
 
     await act(async () => {
@@ -93,14 +102,17 @@ describe('usePlayerChoices', () => {
     });
 
     expect(aiGenerate).toHaveBeenCalledWith('w1', expect.any(Object), ['c1']);
-    expect(addDecision).toHaveBeenCalledWith(
-      's1',
-      expect.objectContaining({
-        prompt: 'What do you do?',
-        decisionWeight: 'major',
-        contextSummary: 'A fork in the road.',
-      })
-    );
+
+    // Read the decision back through the same getter the store exposes,
+    // rather than inspecting addDecision's call args, so this proves the
+    // decision is actually stored and retrievable.
+    const [stored] = getSessionDecisions();
+    expect(stored).toMatchObject({
+      sessionId: 's1',
+      prompt: 'What do you do?',
+      decisionWeight: 'major',
+      contextSummary: 'A fork in the road.',
+    });
     expect(onChoicesGenerated).toHaveBeenCalledTimes(1);
   });
 

--- a/src/hooks/__tests__/useAutoSave.test.ts
+++ b/src/hooks/__tests__/useAutoSave.test.ts
@@ -163,15 +163,17 @@ describe('useAutoSave', () => {
     expect(result.current.isRunning).toBe(true);
   });
 
-  it('should carry the player-choice reason through to the save service', async () => {
+  it('forwards the triggerSave reason to the save service', async () => {
     const { result } = renderHook(() => useAutoSave());
 
     await act(async () => {
       await result.current.triggerSave('player-choice');
     });
 
-    // The reason is the point: the service debounces or skips on it, so a save
-    // that arrives under the wrong reason behaves differently downstream.
+    // This only proves the hook wires the reason string through unchanged.
+    // Whether a given reason actually debounces or skips is the save
+    // service's own behavior, exercised against the real service (not
+    // mocked) in autoSaveService.test.ts.
     expect(mockAutoSaveService.triggerSave).toHaveBeenCalledWith('player-choice');
     expect(mockSessionStore.updateAutoSaveStatus).toHaveBeenCalledWith('saving');
   });

--- a/src/lib/ai/__tests__/narrativeGenerator.skillContext.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.skillContext.test.ts
@@ -194,13 +194,17 @@ describe('NarrativeGenerator - Skill Context Integration', () => {
     // The segment resolved even though lore extraction is still pending.
     expect(addStructuredLore).not.toHaveBeenCalled();
 
-    resolveLoreExtraction({ characters: [], locations: [], events: [], rules: [] });
+    const resolvedLore = { characters: [], locations: [], events: [], rules: [] };
+    resolveLoreExtraction(resolvedLore);
     // Flush the microtask queue so the deferred .then() chain (which
     // includes an `await import(...)`) has a chance to run.
     await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(addStructuredLore).toHaveBeenCalled();
+    // Check the actual payload reaches the store, not just that some call
+    // happened — a call with the wrong world/session/lore shape should still
+    // fail this.
+    expect(addStructuredLore).toHaveBeenCalledWith(resolvedLore, 'skill-world', 'session-1');
   });
 });

--- a/src/lib/storage/__tests__/indexedDBAdapter.crud.test.ts
+++ b/src/lib/storage/__tests__/indexedDBAdapter.crud.test.ts
@@ -91,24 +91,30 @@ describe('IndexedDBAdapter - CRUD Operations', () => {
   describe('setItem', () => {
     test('should store value with key', async () => {
       const testData = { name: 'Test World' };
-      const mockRequest = createMockRequest();
+      // A tiny in-memory backing map, not just call-recorders: put writes into
+      // it and get reads back from it, so the test can prove the value round
+      // trips rather than only that put was called with the right shape.
+      const backing = new Map<string, unknown>();
       const mockStore = createMockStore();
-      mockStore.put.mockReturnValue(mockRequest);
+      mockStore.put.mockImplementation((record: { id: string; value: unknown }) => {
+        backing.set(record.id, record.value);
+        return createMockRequest();
+      });
+      mockStore.get.mockImplementation((key: string) =>
+        createMockRequest(backing.has(key) ? { value: backing.get(key) } : undefined)
+      );
 
       setupMockTransaction(mockDB, mockStore);
 
       const setPromise = adapter.setItem('test-key', JSON.stringify(testData));
-      triggerSuccess(mockRequest);
-
+      triggerSuccess(mockStore.put.mock.results[0].value);
       await setPromise;
 
-      expect(mockStore.put).toHaveBeenCalledWith(
-        {
-          id: 'test-key',
-          value: testData
-        },
-        'test-key'
-      );
+      const getPromise = adapter.getItem('test-key');
+      triggerSuccess(mockStore.get.mock.results[0].value);
+      const result = await getPromise;
+
+      expect(result).toBe(JSON.stringify(testData));
     });
 
     test('should overwrite existing value', async () => {
@@ -173,18 +179,30 @@ describe('IndexedDBAdapter - CRUD Operations', () => {
 
   describe('removeItem', () => {
     test('should remove stored value by key', async () => {
-      const mockRequest = createMockRequest();
+      // Seed the backing map so removal has something real to remove, then
+      // read it back afterward to prove the key is actually gone rather than
+      // only that delete was called with it.
+      const backing = new Map<string, unknown>([['test-key', { name: 'Test World' }]]);
       const mockStore = createMockStore();
-      mockStore.delete.mockReturnValue(mockRequest);
+      mockStore.delete.mockImplementation((key: string) => {
+        backing.delete(key);
+        return createMockRequest();
+      });
+      mockStore.get.mockImplementation((key: string) =>
+        createMockRequest(backing.has(key) ? { value: backing.get(key) } : undefined)
+      );
 
       setupMockTransaction(mockDB, mockStore);
 
       const removePromise = adapter.removeItem('test-key');
-      triggerSuccess(mockRequest);
-
+      triggerSuccess(mockStore.delete.mock.results[0].value);
       await removePromise;
 
-      expect(mockStore.delete).toHaveBeenCalledWith('test-key');
+      const getPromise = adapter.getItem('test-key');
+      triggerSuccess(mockStore.get.mock.results[0].value);
+      const result = await getPromise;
+
+      expect(result).toBeNull();
     });
 
     test('should handle removal of non-existent key', async () => {

--- a/src/lib/storage/__tests__/indexedDBAdapter.initialization.test.ts
+++ b/src/lib/storage/__tests__/indexedDBAdapter.initialization.test.ts
@@ -2,7 +2,10 @@ import { IndexedDBAdapter } from '../indexedDBAdapter';
 import {
   createMockDB,
   createMockIDB,
-  createMockRequest
+  createMockRequest,
+  createMockStore,
+  setupMockTransaction,
+  triggerSuccess
 } from './indexedDBAdapter.testHelpers';
 
 describe('IndexedDBAdapter - Initialization', () => {
@@ -68,6 +71,12 @@ describe('IndexedDBAdapter - Initialization', () => {
         if (mockTransaction.oncomplete) {
           mockTransaction.oncomplete();
         }
+        // Real IndexedDB fires the open request's onsuccess once the upgrade
+        // transaction completes — without it, the adapter never gets a db
+        // handle, which the round-trip check below would otherwise catch.
+        if (mockRequest.onsuccess) {
+          mockRequest.onsuccess({ target: { result: mockDB } } as unknown as Event);
+        }
       }, 0);
 
       return mockRequest;
@@ -76,6 +85,16 @@ describe('IndexedDBAdapter - Initialization', () => {
     await adapter.initialize();
 
     expect(mockDB.createObjectStore).toHaveBeenCalledWith('narraitor-store');
+
+    // A schema-only check would still pass if the newly created store were
+    // unusable — prove the adapter can actually read/write through it.
+    const mockStore = createMockStore();
+    mockStore.put.mockImplementation(() => createMockRequest());
+    setupMockTransaction(mockDB, mockStore);
+
+    const setPromise = adapter.setItem('smoke-key', JSON.stringify({ ok: true }));
+    triggerSuccess(mockStore.put.mock.results[0].value);
+    await expect(setPromise).resolves.toBeUndefined();
   });
 
   test('should handle database upgrade scenarios', async () => {

--- a/src/state/__tests__/narrativeStore.decisionTracking.integration.test.ts
+++ b/src/state/__tests__/narrativeStore.decisionTracking.integration.test.ts
@@ -1,32 +1,18 @@
 /**
  * Integration tests for Issue #142: PlayerDecisionTracker integration with narrativeStore.selectDecisionOption()
- * 
+ *
  * These tests verify that when players make choices through narrativeStore.selectDecisionOption(),
  * the decisions are automatically tracked by PlayerDecisionTracker for personalization.
- * 
- * Focus: Integration behavior, not implementation details
+ *
+ * Focus: Integration behavior, not implementation details — exercises the real
+ * playerDecisionTracker singleton rather than mocking it, so a case actually
+ * proves tracking happened instead of only that a function was called.
  */
 
 import { useNarrativeStore } from '../narrativeStore';
 import { getTimestamp } from '@/lib/utils/timestamp';
 import { playerDecisionTracker } from '../../lib/ai/playerDecisionTracker';
 import { DecisionOption } from '../../types/narrative.types';
-
-// Mock the PlayerDecisionTracker to control its behavior in tests
-jest.mock('../../lib/ai/playerDecisionTracker', () => ({
-  playerDecisionTracker: {
-    recordDecision: jest.fn(),
-    getSessionDecisions: jest.fn(() => []),
-    clearDecisions: jest.fn(),
-    analyzeChoicePatterns: jest.fn(() => ({
-      dominantChoiceTypes: [],
-      choiceDistribution: {},
-      patternStrength: 0
-    }))
-  }
-}));
-
-const mockPlayerDecisionTracker = playerDecisionTracker as jest.Mocked<typeof playerDecisionTracker>;
 
 // Test helpers
 const TEST_SESSION = 'session-123';
@@ -64,7 +50,7 @@ describe('NarrativeStore - PlayerDecisionTracker Integration (Issue #142)', () =
       loading: false,
       error: null
     });
-    jest.clearAllMocks();
+    playerDecisionTracker.clearDecisions();
   });
 
   describe('Core Integration Behavior', () => {
@@ -86,18 +72,16 @@ describe('NarrativeStore - PlayerDecisionTracker Integration (Issue #142)', () =
 
       useNarrativeStore.getState().selectDecisionOption(decisionId, 'help-option', TEST_CHARACTER);
 
-      expect(mockPlayerDecisionTracker.recordDecision).toHaveBeenCalledTimes(1);
-      expect(mockPlayerDecisionTracker.recordDecision).toHaveBeenCalledWith(
-        'You encounter a wounded traveler on the road. What do you do?',
-        'Help the traveler with healing supplies',
-        'diplomatic',
-        TEST_SESSION,
-        TEST_WORLD,
-        expect.objectContaining({
-          situation: expect.any(String),
-          location: 'Forest Road'
-        })
-      );
+      const tracked = playerDecisionTracker.getSessionDecisions(TEST_SESSION);
+      expect(tracked).toHaveLength(1);
+      expect(tracked[0]).toMatchObject({
+        prompt: 'You encounter a wounded traveler on the road. What do you do?',
+        choiceText: 'Help the traveler with healing supplies',
+        choiceType: 'diplomatic',
+        sessionId: TEST_SESSION,
+        worldId: TEST_WORLD
+      });
+      expect(tracked[0].context).toMatchObject({ location: 'Forest Road' });
     });
 
     it('should correctly infer choice types from decision options', () => {
@@ -116,12 +100,11 @@ describe('NarrativeStore - PlayerDecisionTracker Integration (Issue #142)', () =
 
         useNarrativeStore.getState().selectDecisionOption(decisionId, `opt-${i}`, TEST_CHARACTER);
 
-        expect(mockPlayerDecisionTracker.recordDecision).toHaveBeenCalledWith(
-          prompt, text, type, TEST_SESSION, expect.any(String), expect.any(Object)
-        );
+        const [latest] = playerDecisionTracker.getSessionDecisions(TEST_SESSION);
+        expect(latest).toMatchObject({ prompt, choiceText: text, choiceType: type });
       });
 
-      expect(mockPlayerDecisionTracker.recordDecision).toHaveBeenCalledTimes(testCases.length);
+      expect(playerDecisionTracker.getSessionDecisions(TEST_SESSION)).toHaveLength(testCases.length);
     });
 
     it('should extract relevant context from game session', () => {
@@ -147,22 +130,21 @@ describe('NarrativeStore - PlayerDecisionTracker Integration (Issue #142)', () =
 
       useNarrativeStore.getState().selectDecisionOption(decisionId, 'help-merchant', TEST_CHARACTER);
 
-      expect(mockPlayerDecisionTracker.recordDecision).toHaveBeenCalledWith(
-        expect.any(String), expect.any(String), expect.any(String), TEST_SESSION, expect.any(String),
-        expect.objectContaining({
-          location: 'Rivertown Marketplace',
-          situation: expect.stringContaining('merchant'),
-          charactersPresent: expect.arrayContaining(['merchant-npc'])
-        })
-      );
+      const [tracked] = playerDecisionTracker.getSessionDecisions(TEST_SESSION);
+      expect(tracked.context).toMatchObject({
+        location: 'Rivertown Marketplace',
+        situation: expect.stringContaining('merchant')
+      });
+      expect(tracked.context?.charactersPresent).toEqual(expect.arrayContaining(['merchant-npc']));
     });
   });
 
   describe('Error Handling and Edge Cases', () => {
     it('should handle tracking failures gracefully without breaking game flow', () => {
-      mockPlayerDecisionTracker.recordDecision.mockImplementation(() => {
-        throw new Error('Tracking system temporarily unavailable');
-      });
+      const recordDecisionSpy = jest.spyOn(playerDecisionTracker, 'recordDecision')
+        .mockImplementationOnce(() => {
+          throw new Error('Tracking system temporarily unavailable');
+        });
 
       const decisionId = createTestDecision(TEST_SESSION, 'Choose your path', [
         { id: 'left-path', text: 'Take the left path' },
@@ -179,6 +161,8 @@ describe('NarrativeStore - PlayerDecisionTracker Integration (Issue #142)', () =
       expect(decisions[decisionId].characterId).toBe(TEST_CHARACTER);
       expect(decisions[decisionId].selectedAt).toBeInstanceOf(Date);
       expect(error).toBeNull();
+
+      recordDecisionSpy.mockRestore();
     });
 
     it('should handle decisions without character IDs appropriately', () => {
@@ -189,7 +173,7 @@ describe('NarrativeStore - PlayerDecisionTracker Integration (Issue #142)', () =
 
       useNarrativeStore.getState().selectDecisionOption(decisionId, 'answer-honestly');
 
-      expect(mockPlayerDecisionTracker.recordDecision).toHaveBeenCalledTimes(0);
+      expect(playerDecisionTracker.getSessionDecisions(TEST_SESSION)).toHaveLength(0);
 
       const decision = useNarrativeStore.getState().decisions[decisionId];
       expect(decision.selectedOptionId).toBe('answer-honestly');
@@ -204,10 +188,10 @@ describe('NarrativeStore - PlayerDecisionTracker Integration (Issue #142)', () =
 
       useNarrativeStore.getState().selectDecisionOption(decisionId, 'look-around', TEST_CHARACTER);
 
-      expect(mockPlayerDecisionTracker.recordDecision).toHaveBeenCalledTimes(1);
-      const [, , , calledSessionId, calledWorldId] = mockPlayerDecisionTracker.recordDecision.mock.calls[0];
-      expect(calledSessionId).toBe(TEST_SESSION);
-      expect(calledWorldId).toBeDefined();
+      const [tracked] = playerDecisionTracker.getSessionDecisions(TEST_SESSION);
+      expect(tracked).toBeDefined();
+      expect(tracked.sessionId).toBe(TEST_SESSION);
+      expect(tracked.worldId).toBeDefined();
     });
   });
 
@@ -224,18 +208,15 @@ describe('NarrativeStore - PlayerDecisionTracker Integration (Issue #142)', () =
         useNarrativeStore.getState().selectDecisionOption(decisionId, `diplomatic-${i}`, TEST_CHARACTER);
       });
 
-      expect(mockPlayerDecisionTracker.recordDecision).toHaveBeenCalledTimes(3);
-
       sessions.forEach((sessionId, i) => {
-        expect(mockPlayerDecisionTracker.recordDecision).toHaveBeenNthCalledWith(
-          i + 1,
-          expect.stringContaining(`Session ${i + 1}`),
-          'Try to find a peaceful solution',
-          'diplomatic',
-          sessionId,
-          expect.any(String),
-          expect.any(Object)
-        );
+        const tracked = playerDecisionTracker.getSessionDecisions(sessionId);
+        expect(tracked).toHaveLength(1);
+        expect(tracked[0]).toMatchObject({
+          prompt: expect.stringContaining(`Session ${i + 1}`),
+          choiceText: 'Try to find a peaceful solution',
+          choiceType: 'diplomatic',
+          sessionId
+        });
       });
     });
 
@@ -256,16 +237,16 @@ describe('NarrativeStore - PlayerDecisionTracker Integration (Issue #142)', () =
 
         useNarrativeStore.getState().selectDecisionOption(decisionId, `lawful-${i}`, TEST_CHARACTER);
 
-        expect(mockPlayerDecisionTracker.recordDecision).toHaveBeenNthCalledWith(
-          i + 1,
-          expect.any(String),
-          choiceText,
-          'diplomatic',
-          TEST_SESSION,
-          expect.any(String),
-          expect.any(Object)
-        );
+        // recordDecision sanitizes stored text by stripping `<>'"&` — match
+        // what actually lands, not the pre-sanitized source string.
+        const [latest] = playerDecisionTracker.getSessionDecisions(TEST_SESSION);
+        expect(latest).toMatchObject({
+          choiceText: choiceText.replace(/[<>'"&]/g, ''),
+          choiceType: 'diplomatic'
+        });
       });
+
+      expect(playerDecisionTracker.getSessionDecisions(TEST_SESSION)).toHaveLength(lawfulVariations.length);
     });
   });
 });


### PR DESCRIPTION
## Description
Rewrites the 8 mock-only test cases the weekly test sweep flagged in [#1954](https://github.com/jerseycheese/Narraitor/issues/1954) — each one only checked that a mock function was called, while its name promised persistence or tracking. Every case now reads back real state (a real store, a real singleton, or a stateful mock backing a round trip) instead of inspecting a setter's call args.

Two of the rewrites turned up real bugs in the test fixtures themselves, not just weak assertions:
- `narrativeStore.decisionTracking.integration.test.ts` — one exact-string assertion broke against the real `playerDecisionTracker`, because `recordDecision` sanitizes quote characters before storing. Fixed the expectation to match the actual (correct) sanitized value.
- `indexedDBAdapter.initialization.test.ts` — the mocked `open` request never fired `onsuccess` after the upgrade transaction completed, so `IndexedDBAdapter`'s db handle was never actually set. Real IndexedDB fires both; the mock only fired one. Fixed the mock to match the real event sequence.

## Related Issue
Closes #1954

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
Not applicable — this is a test-quality fix, not a feature change.

## Flow Diagrams
Not applicable.

## Component Development
Not applicable — no UI changes.

## Implementation Notes
Per file, worst-first as filed in the issue:

- `src/state/__tests__/narrativeStore.decisionTracking.integration.test.ts` (5 cases) — dropped the `jest.mock` for `playerDecisionTracker` entirely and exercised the real singleton, reading `getSessionDecisions(sessionId)` back after each `selectDecisionOption` call instead of inspecting the mock's call args.
- `src/components/Narrative/__tests__/NarrativeController.contextSummaryPersistence.test.tsx` and `src/components/Narrative/hooks/__tests__/usePlayerChoices.test.ts` — kept the project's usual store-mocking pattern (`mockZustandStore`/`createMockNarrativeStore`), but gave the mocked `addDecision`/`getSessionDecisions` pair a small backing array so the decision is read back through the getter, proving it's actually retrievable rather than only that the setter was invoked with the right shape.
- `src/lib/ai/__tests__/narrativeGenerator.skillContext.test.ts` — the lore-extraction race test now checks the actual lore payload, `worldId`, and `sessionId` reaching `addStructuredLore`, not just that it was called at all.
- `src/lib/storage/__tests__/indexedDBAdapter.crud.test.ts` — `setItem`/`removeItem` cases now back the mocked object store with an in-memory `Map`, so a `setItem` proves out via a following `getItem`, and a `removeItem` proves the key is actually gone.
- `src/lib/storage/__tests__/indexedDBAdapter.initialization.test.ts` — added a smoke `setItem` after the object-store-creation case, using the same stateful-mock technique. That's what surfaced the missing `onsuccess` call described above.
- `src/hooks/__tests__/useAutoSave.test.ts` — this one case's real behavior (does `player-choice` actually debounce differently downstream) is already honestly covered by `autoSaveService.test.ts` against the real service. Renamed the case to say what it actually checks (the hook forwards the reason string) instead of re-testing debounce logic a second time.

## Screenshots
Not applicable.

## Visual Baseline Changes
None.

## Code Review Summary (if applicable)
Not applicable — no automated implementation pipeline used.

## Chrome DevTools MCP Verification Summary (if applicable)
Not applicable — no browser-observable change; all edits are Jest test files.

## Quality Checks
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed — not run; no dependency or security-relevant change here
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `npm test` — full suite: 450 suites / 3137 tests passed.
2. `npm run type-check` — clean.
3. `npm run lint` — 0 errors (pre-existing warnings elsewhere untouched by this PR).
4. To confirm a specific rewrite: `npm test -- <path from Implementation Notes>`.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required) — not applicable, no docs reference these test internals
- [x] No new warnings generated
- [ ] Accessibility considerations addressed — not applicable, test-only change
