### PR TITLE
refactor(character): narrow character signatures for portraits and skill checks (#1951)

### DIFF
--- a/src/app/api/generate-portrait/__tests__/route.test.ts
+++ b/src/app/api/generate-portrait/__tests__/route.test.ts
@@ -5,6 +5,9 @@
 jest.mock('@/lib/ai/geminiImageGenerator', () => ({
   generateImageWithGemini: jest.fn(),
 }));
+jest.mock('@/lib/ai/portraitGenerator', () => ({
+  buildPortraitPrompt: jest.fn(),
+}));
 jest.mock('@/lib/utils/logger', () => {
   return jest.fn().mockImplementation(() => ({
     debug: jest.fn(),
@@ -16,8 +19,10 @@ jest.mock('@/lib/utils/logger', () => {
 import { NextRequest } from 'next/server';
 import { POST } from '../route';
 import { generateImageWithGemini } from '@/lib/ai/geminiImageGenerator';
+import { buildPortraitPrompt } from '@/lib/ai/portraitGenerator';
 
 const mockGenerate = generateImageWithGemini as jest.MockedFunction<typeof generateImageWithGemini>;
+const mockBuildPortraitPrompt = buildPortraitPrompt as jest.MockedFunction<typeof buildPortraitPrompt>;
 
 // The direct-prompt input format skips the AI-assisted prompt builder, which
 // keeps these tests on the generate-and-fall-back path they're about.
@@ -92,5 +97,51 @@ describe('/api/generate-portrait', () => {
     expect(response.status).toBe(200);
     expect(data.portrait.url).toContain('api.dicebear.com/7.x/avataaars/svg');
     expect(data.portrait.prompt).toContain('rate limited');
+  });
+
+  it('uses recognizable source material fallback when prompt generation fails for a known figure', async () => {
+    mockBuildPortraitPrompt.mockRejectedValue(new Error('AI detection failed'));
+
+    const response = await POST(
+      makeRequest({
+        character: {
+          name: 'Sherlock Holmes',
+          background: {
+            physicalDescription: 'tall with a deerstalker hat',
+            isKnownFigure: true,
+          },
+        },
+        world: { genre: 'mystery' },
+        promptOnly: true,
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.prompt).toContain(
+      'This should be recognizable as Sherlock Holmes from the source material.'
+    );
+  });
+
+  it('uses original character fallback when prompt generation fails for a non-known figure', async () => {
+    mockBuildPortraitPrompt.mockRejectedValue(new Error('AI detection failed'));
+
+    const response = await POST(
+      makeRequest({
+        character: {
+          name: 'Original Hero',
+          background: {
+            physicalDescription: 'armored warrior',
+            isKnownFigure: false,
+          },
+        },
+        world: { genre: 'fantasy' },
+        promptOnly: true,
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.prompt).toContain('This is an original character.');
   });
 });

--- a/src/app/api/generate-portrait/route.ts
+++ b/src/app/api/generate-portrait/route.ts
@@ -2,7 +2,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import Logger from '@/lib/utils/logger';
-import { Character } from '@/types/character.types';
+import { PortraitSubject } from '@/types/character.types';
 import { World } from '@/types/world.types';
 import { truncate, getTimestamp } from '@/lib/utils';
 import { resolveGeneratedImageUrl } from '@/lib/api/imageGenerationHelpers';
@@ -17,7 +17,6 @@ async function buildPortraitPrompt(
   characterName: string,
   physicalDescription: string,
   worldGenre: string,
-  isKnownFigure?: boolean,
   apiKey?: string | null
 ): Promise<string> {
   try {
@@ -41,46 +40,22 @@ async function buildPortraitPrompt(
     logger.debug('generate-portrait API', 'Creating AI client and generator');
     const aiClient = createDefaultGeminiClient(apiKey);
 
-    // Create a minimal character object for detection
-    const mockCharacter: Character = {
-      id: 'detection-temp',
-      name: characterName,
-      description: '',
-      worldId: 'temp',
-      background: {
-        physicalDescription: physicalDescription,
-        history: '',
-        personality: '',
-        goals: [],
-        fears: [],
-        relationships: [],
-      },
-      attributes: [],
-      skills: [],
-      derivedStats: [],
-      inventory: {
-        characterId: 'detection-temp',
-        items: [],
-        capacity: 100,
-        categories: [],
-        itemOrder: [],
-      },
-      status: {
-        conditions: [],
-      },
-      createdAt: getTimestamp(),
-      updatedAt: getTimestamp(),
-    };
-
     logger.debug(
       'generate-portrait API',
       'Calling buildPortraitPrompt directly to avoid image generation'
     );
 
     // Call buildPortraitPrompt directly to avoid the image generation requirement
-    const prompt = await buildPortraitPromptFn(aiClient, mockCharacter, {
-      worldGenre: worldGenre,
-    });
+    const prompt = await buildPortraitPromptFn(
+      aiClient,
+      {
+        name: characterName,
+        background: { physicalDescription },
+      },
+      {
+        worldGenre: worldGenre,
+      }
+    );
 
     logger.debug(
       'generate-portrait API',
@@ -96,7 +71,7 @@ async function buildPortraitPrompt(
     );
 
     // Fallback to basic prompt if AI detection fails
-    return `Create a professional portrait of ${characterName}, ${physicalDescription}. ${isKnownFigure ? `This should be recognizable as ${characterName} from the source material.` : 'This is an original character.'} Style: realistic portrait, professional lighting, clear facial features, suitable for a character profile. Setting genre: ${worldGenre}.`;
+    return `Create a professional portrait of ${characterName}, ${physicalDescription}. This is an original character. Style: realistic portrait, professional lighting, clear facial features, suitable for a character profile. Setting genre: ${worldGenre}.`;
   }
 }
 
@@ -116,7 +91,7 @@ export async function POST(request: NextRequest) {
 
     // Handle different input formats
     let prompt: string;
-    let character: Character | undefined;
+    let character: PortraitSubject | undefined;
     let world: World | undefined;
     const apiKey = resolveApiKey(request);
 
@@ -145,13 +120,11 @@ export async function POST(request: NextRequest) {
         const physicalDesc =
           customDescription || character?.background?.physicalDescription || '';
         const worldGenre = world?.genre || 'modern';
-        const isKnownFigure = character?.background?.isKnownFigure;
 
         const prompt = await buildPortraitPrompt(
           characterName,
           physicalDesc,
           worldGenre,
-          isKnownFigure,
           apiKey
         );
 
@@ -167,13 +140,11 @@ export async function POST(request: NextRequest) {
           character?.background?.physicalDescription ||
           'No specific appearance described';
         const worldGenre = world?.genre || 'fantasy';
-        const isKnownFigure = character?.background?.isKnownFigure;
 
         prompt = await buildPortraitPrompt(
           characterName,
           physicalDesc,
           worldGenre,
-          isKnownFigure,
           apiKey
         );
       }

--- a/src/app/api/generate-portrait/route.ts
+++ b/src/app/api/generate-portrait/route.ts
@@ -17,6 +17,7 @@ async function buildPortraitPrompt(
   characterName: string,
   physicalDescription: string,
   worldGenre: string,
+  isKnownFigure?: boolean,
   apiKey?: string | null
 ): Promise<string> {
   try {
@@ -71,7 +72,7 @@ async function buildPortraitPrompt(
     );
 
     // Fallback to basic prompt if AI detection fails
-    return `Create a professional portrait of ${characterName}, ${physicalDescription}. This is an original character. Style: realistic portrait, professional lighting, clear facial features, suitable for a character profile. Setting genre: ${worldGenre}.`;
+    return `Create a professional portrait of ${characterName}, ${physicalDescription}. ${isKnownFigure ? `This should be recognizable as ${characterName} from the source material.` : 'This is an original character.'} Style: realistic portrait, professional lighting, clear facial features, suitable for a character profile. Setting genre: ${worldGenre}.`;
   }
 }
 
@@ -120,11 +121,13 @@ export async function POST(request: NextRequest) {
         const physicalDesc =
           customDescription || character?.background?.physicalDescription || '';
         const worldGenre = world?.genre || 'modern';
+        const isKnownFigure = character?.background?.isKnownFigure;
 
         const prompt = await buildPortraitPrompt(
           characterName,
           physicalDesc,
           worldGenre,
+          isKnownFigure,
           apiKey
         );
 
@@ -140,11 +143,13 @@ export async function POST(request: NextRequest) {
           character?.background?.physicalDescription ||
           'No specific appearance described';
         const worldGenre = world?.genre || 'fantasy';
+        const isKnownFigure = character?.background?.isKnownFigure;
 
         prompt = await buildPortraitPrompt(
           characterName,
           physicalDesc,
           worldGenre,
+          isKnownFigure,
           apiKey
         );
       }

--- a/src/components/CharacterCreationWizard/steps/PortraitStep.tsx
+++ b/src/components/CharacterCreationWizard/steps/PortraitStep.tsx
@@ -4,7 +4,7 @@ import React, { useRef, useState } from 'react';
 import { CheckCircle } from 'lucide-react';
 import { CharacterPortrait } from '@/components/CharacterPortrait';
 import { GeneratedImage } from '@/types/common.types';
-import { Character } from '@/types/character.types';
+import { PortraitSubject } from '@/types/character.types';
 import { World } from '@/types/world.types';
 import { LoadingState } from '@/components/ui/LoadingState';
 import { PortraitCustomizationSection } from '@/components/shared';
@@ -13,7 +13,6 @@ import {
   ImageUploadPicker,
   PresetAvatarPicker,
 } from '@/components/CharacterPortrait';
-import { getTimestamp } from '@/lib/utils';
 import { usePortraitGeneration } from '@/lib/hooks/usePortraitGeneration';
 
 interface CharacterFormData {
@@ -103,24 +102,8 @@ export function PortraitStep({
   const handleGeneratePortrait = async () => {
     const epoch = sourceEpochRef.current;
 
-    const characterForGeneration: Character = {
-      id: 'temp',
+    const characterForGeneration: PortraitSubject = {
       name: data.characterData.name,
-      description: '',
-      worldId: data.worldId,
-      attributes: data.characterData.attributes.map((attr) => ({
-        attributeId: attr.attributeId,
-        value: attr.value,
-      })),
-      skills: data.characterData.skills
-        .filter((skill) => skill.isSelected)
-        .map((skill) => ({
-          skillId: skill.skillId,
-          level: skill.level,
-          experience: 0,
-          isActive: true,
-        })),
-      derivedStats: [],
       background: {
         history:
           data.characterData.background.history +
@@ -129,20 +112,7 @@ export function PortraitStep({
         physicalDescription:
           localPhysicalDescription ||
           data.characterData.background.physicalDescription,
-        goals: data.characterData.background.goals,
-        fears: [],
-        relationships: [],
       },
-      inventory: {
-        items: [],
-        capacity: 100,
-        categories: [],
-        characterId: 'temp',
-        itemOrder: [],
-      },
-      status: { conditions: [] },
-      createdAt: getTimestamp(),
-      updatedAt: getTimestamp(),
     };
 
     try {

--- a/src/components/CharacterEditor/CharacterEditor.tsx
+++ b/src/components/CharacterEditor/CharacterEditor.tsx
@@ -128,7 +128,7 @@ const CharacterEditor: React.FC<CharacterEditorProps> = ({ characterId }) => {
     setPortraitError(null); // Clear previous portrait errors
     try {
       const { portrait } = await generatePortrait({
-        character: { ...editingCharacter, id: characterId },
+        character: editingCharacter,
         world: world,
         customDescription: customDescription,
       });

--- a/src/components/Narrative/__tests__/NarrativeController.skillCheck.integration.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeController.skillCheck.integration.test.tsx
@@ -10,14 +10,14 @@
  * skill checks would fail even when the character had the required skill.
  */
 
-import { evaluateSkillCheck } from '@/utils/skillCheckEvaluator';
+import {
+  evaluateSkillCheck,
+  type SkillCheckSubject,
+} from '@/utils/skillCheckEvaluator';
 import { WorldSkill } from '@/types/world.types';
-import { Character } from '@/types/character.types';
-import { EntityID } from '@/types/common.types';
 
 describe('Skill Check Integration - ID-based Flow', () => {
   const mockStealthSkillId = 'stealth-skill';
-  const mockCharacterId = 'test-character' as EntityID;
 
   const mockWorldSkills: WorldSkill[] = [
     {
@@ -34,21 +34,7 @@ describe('Skill Check Integration - ID-based Flow', () => {
     },
   ];
 
-  const mockCharacter: Character = {
-    id: mockCharacterId,
-    name: 'Test Hero',
-    worldId: 'test-world',
-    description: 'A skilled hero',
-    background: {
-      history: 'A skilled adventurer',
-      personality: 'Cautious and observant',
-      goals: ['Master the art of stealth'],
-      fears: [],
-      relationships: [],
-    },
-    status: {
-      conditions: [],
-    },
+  const mockCharacter: SkillCheckSubject = {
     attributes: [
       {
         attributeId: 'dexterity',
@@ -59,20 +45,8 @@ describe('Skill Check Integration - ID-based Flow', () => {
       {
         skillId: mockStealthSkillId,
         level: 5,
-        experience: 0,
-        isActive: true,
       },
     ],
-    derivedStats: [],
-    inventory: {
-      characterId: mockCharacterId,
-      items: [],
-      capacity: 10,
-      categories: [],
-      itemOrder: [],
-    },
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
   };
 
   it('evaluates skill check using skill ID directly', () => {

--- a/src/components/devtools/TestDataGeneratorSection/TestDataGeneratorSection.tsx
+++ b/src/components/devtools/TestDataGeneratorSection/TestDataGeneratorSection.tsx
@@ -294,48 +294,13 @@ export const TestDataGeneratorSection: React.FC = () => {
           if (storeCharacter) {
             const { portrait } = await generatePortrait({
               character: {
-                id: storeCharacter.id,
                 name: storeCharacter.name,
-                worldId: storeCharacter.worldId,
                 background: {
                   history: storeCharacter.background.history,
                   personality: storeCharacter.background.personality,
                   physicalDescription:
                     storeCharacter.background.physicalDescription || '',
-                  goals: storeCharacter.background.goals,
-                  fears: storeCharacter.background.fears,
-                  relationships: [],
                 },
-                attributes: storeCharacter.attributes.map(
-                  (attr: { id: string; name: string; baseValue: number }) => ({
-                    attributeId:
-                      currentWorld.attributes.find(
-                        (wa) => wa.name === attr.name
-                      )?.id || attr.id,
-                    value: attr.baseValue,
-                  })
-                ),
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                skills: storeCharacter.skills.map((skill: any) => ({
-                  skillId:
-                    currentWorld.skills.find((ws) => ws.name === skill.name)
-                      ?.id || skill.id,
-                  level: skill.level,
-                  experience: 0,
-                  isActive: true,
-                })),
-                inventory: {
-                  characterId: storeCharacter.id,
-                  items: [],
-                  capacity: 100,
-                  categories: [],
-                },
-                status: {
-                  conditions: storeCharacter.status.conditions,
-                  location: currentWorld.name,
-                },
-                createdAt: storeCharacter.createdAt,
-                updatedAt: storeCharacter.updatedAt,
               },
               world: currentWorld,
             });

--- a/src/lib/ai/__tests__/portraitGenerator.test.ts
+++ b/src/lib/ai/__tests__/portraitGenerator.test.ts
@@ -1,9 +1,8 @@
 // src/lib/ai/__tests__/portraitGenerator.test.ts
 
 import { buildPortraitPrompt } from '../portraitGenerator';
-import { Character } from '../../../types/character.types';
+import { PortraitSubject } from '../../../types/character.types';
 import { AIClient } from '../types';
-import { getTimestamp } from '@/lib/utils/timestamp';
 
 // Mock the AI client
 const mockAIClient: AIClient = {
@@ -12,7 +11,7 @@ const mockAIClient: AIClient = {
 };
 
 describe('portraitGenerator', () => {
-  let mockCharacter: Character;
+  let mockCharacter: PortraitSubject;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -66,38 +65,13 @@ describe('portraitGenerator', () => {
     );
 
     mockCharacter = {
-      id: 'char-1',
       name: 'Elara Moonshadow',
-      worldId: 'world-1',
-      description:
-        'A mysterious elven mage with silver hair and piercing blue eyes',
-      attributes: [
-        { attributeId: 'strength', value: 8 },
-        { attributeId: 'intelligence', value: 15 },
-      ],
-      skills: [
-        { skillId: 'magic', level: 10, experience: 100, isActive: true },
-      ],
-      derivedStats: [],
       background: {
         history: 'A skilled mage from the northern kingdoms',
         personality: 'Wise and mysterious',
         physicalDescription:
           'Tall elf with long silver hair and piercing blue eyes',
-        goals: ['Master ancient magic'],
-        fears: ['Losing control of power'],
-        relationships: [],
       },
-      inventory: {
-        items: [],
-        capacity: 100,
-        categories: [],
-        characterId: 'char-1',
-        itemOrder: [],
-      },
-      status: { conditions: [] },
-      createdAt: getTimestamp(),
-      updatedAt: getTimestamp(),
     };
   });
 

--- a/src/lib/ai/portraitGenerator.ts
+++ b/src/lib/ai/portraitGenerator.ts
@@ -1,6 +1,4 @@
-// src/lib/ai/portraitGenerator.ts
-
-import { Character } from '../../types/character.types';
+import { PortraitSubject } from '../../types/character.types';
 import { AIClient } from './types';
 import { truncate, safeTrim } from '@/lib/utils';
 import { normalizeText, NORM_NAME, NORM_DESC } from '@/lib/utils/textNormalization';
@@ -181,7 +179,7 @@ async function enhancePhysicalDiversity(
  */
 export async function buildPortraitPrompt(
   aiClient: AIClient,
-  character: Character,
+  character: PortraitSubject,
   options: PortraitGenerationOptions = {}
 ): Promise<string> {
   // If no detection options provided, run AI detection

--- a/src/lib/api/generatePortrait.ts
+++ b/src/lib/api/generatePortrait.ts
@@ -1,8 +1,9 @@
 import type { GeneratedImage } from '@/types/common.types';
+import type { PortraitSubject } from '@/types/character.types';
 import { aiFetch } from '@/lib/ai/aiFetch';
 
 export interface PortraitRequest {
-  character?: unknown;
+  character?: PortraitSubject;
   world?: unknown;
   customDescription?: string;
   prompt?: string;

--- a/src/lib/narrative/__tests__/evaluateDecisionSkillChecks.test.ts
+++ b/src/lib/narrative/__tests__/evaluateDecisionSkillChecks.test.ts
@@ -96,4 +96,20 @@ describe('evaluateDecisionSkillChecks', () => {
     expect(result.skillCheckTags).toEqual(['skill-critical-failure:skill-1', 'skill-roll:1']);
     expect(result.decisionOutcome).toBe('critical-failure');
   });
+
+  it('translates store character skills to roll results with matching skillLevel', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.5); // d20 -> 11
+
+    const character = buildCharacter(); // cs-1 has worldSkillId: 'skill-1' and level: 3
+
+    const result = evaluateDecisionSkillChecks({
+      selectedOption: optionWithSkill(),
+      character,
+      world: buildWorld([worldSkill('skill-1', 'Stealth')]),
+    });
+
+    expect(result.rollResults).toHaveLength(1);
+    expect(result.rollResults[0].skillLevel).toBe(3);
+    expect(result.rollResults[0].skillId).toBe('skill-1');
+  });
 });

--- a/src/lib/narrative/evaluateDecisionSkillChecks.ts
+++ b/src/lib/narrative/evaluateDecisionSkillChecks.ts
@@ -4,9 +4,11 @@
 // NarrativeController.generateNextSegment as a pure (no React state) unit;
 // the only side effect is the injected onSkillCheckPerformed callback.
 
-import { evaluateSkillCheck } from '@/utils/skillCheckEvaluator';
+import {
+  evaluateSkillCheck,
+  type SkillCheckSubject,
+} from '@/utils/skillCheckEvaluator';
 import { logger } from '@/lib/utils/logger';
-import type { Character as UtilCharacter } from '@/types/character.types';
 import type { Character as StoreCharacter } from '@/state/characterStore';
 import type { World } from '@/types/world.types';
 import type {
@@ -29,41 +31,16 @@ export interface DecisionSkillCheckResult {
   decisionOutcome?: DecisionOutcome;
 }
 
-// Adapt the store's character shape to the skill-check evaluator's expected format.
-function adaptStoreCharacterToUtil(character: StoreCharacter): UtilCharacter {
+function toSkillCheckSubject(character: StoreCharacter): SkillCheckSubject {
   return {
-    id: character.id,
-    name: character.name,
-    description: character.description,
-    worldId: character.worldId,
     skills: character.skills.map((skill) => ({
       skillId: skill.worldSkillId || skill.id,
       level: skill.level,
-      experience: 0,
-      isActive: true,
     })),
     attributes: character.attributes.map((attr) => ({
       attributeId: attr.worldAttributeId || attr.id,
       value: attr.modifiedValue || attr.baseValue,
     })),
-    derivedStats: [],
-    background: {
-      history: character.background?.history || '',
-      personality: character.background?.personality || '',
-      goals: character.background?.goals || [],
-      fears: character.background?.fears || [],
-      relationships: [],
-    },
-    inventory: {
-      characterId: character.inventory.characterId,
-      items: [],
-      capacity: character.inventory.capacity,
-      categories: [],
-      itemOrder: [],
-    },
-    status: character.status,
-    createdAt: character.createdAt,
-    updatedAt: character.updatedAt,
   };
 }
 
@@ -81,6 +58,7 @@ export function evaluateDecisionSkillChecks({
     const skillRequirements = selectedOption.requirements.filter(
       (req) => req.type === 'skill'
     );
+    const subject = toSkillCheckSubject(character);
 
     for (const requirement of skillRequirements) {
       const requiredLevel =
@@ -95,11 +73,9 @@ export function evaluateDecisionSkillChecks({
         difficulty: requiredLevel,
       };
 
-      const adaptedCharacter = adaptStoreCharacterToUtil(character);
-
       try {
         const rollResult = evaluateSkillCheck(
-          adaptedCharacter,
+          subject,
           skillCheck,
           world.skills || []
         );

--- a/src/types/character.types.ts
+++ b/src/types/character.types.ts
@@ -25,7 +25,10 @@ export interface Character extends NamedEntity, TimestampedEntity {
 export interface PortraitSubject {
   name: string;
   background?: Partial<
-    Pick<CharacterBackground, 'physicalDescription' | 'history' | 'personality'>
+    Pick<
+      CharacterBackground,
+      'physicalDescription' | 'history' | 'personality' | 'isKnownFigure'
+    >
   >;
 }
 

--- a/src/types/character.types.ts
+++ b/src/types/character.types.ts
@@ -22,6 +22,13 @@ export interface Character extends NamedEntity, TimestampedEntity {
   portrait?: GeneratedImage;
 }
 
+export interface PortraitSubject {
+  name: string;
+  background?: Partial<
+    Pick<CharacterBackground, 'physicalDescription' | 'history' | 'personality'>
+  >;
+}
+
 /**
  * Represents a character's attribute value
  */

--- a/src/utils/__tests__/skillCheckEvaluator.test.ts
+++ b/src/utils/__tests__/skillCheckEvaluator.test.ts
@@ -13,14 +13,17 @@
  * @author Generated with Claude Code
  */
 
-import { evaluateSkillCheck, rollD20 } from '../skillCheckEvaluator';
 import {
-  Character,
+  evaluateSkillCheck,
+  rollD20,
+  SkillCheck,
+  SkillCheckSubject,
+} from '../skillCheckEvaluator';
+import {
   CharacterSkill,
   CharacterAttribute,
 } from '@/types/character.types';
 import { WorldSkill } from '@/types/world.types';
-import { SkillCheck } from '../skillCheckEvaluator';
 
 /**
  * Mock character attributes for testing various attribute bonus scenarios
@@ -43,9 +46,7 @@ const mockCharacterSkills: CharacterSkill[] = [
 /**
  * Complete mock character with attributes and skills for comprehensive testing
  */
-const mockCharacter: Partial<Character> = {
-  id: 'test-character',
-  name: 'Test Character',
+const mockCharacter: SkillCheckSubject = {
   attributes: mockCharacterAttributes,
   skills: mockCharacterSkills,
 };
@@ -129,7 +130,7 @@ describe('evaluateSkillCheck with d20 rolls', () => {
       };
 
       const result = evaluateSkillCheck(
-        mockCharacter as Character,
+        mockCharacter,
         skillCheck,
         mockWorldSkills
       );
@@ -153,7 +154,7 @@ describe('evaluateSkillCheck with d20 rolls', () => {
       };
 
       const result = evaluateSkillCheck(
-        mockCharacter as Character,
+        mockCharacter,
         skillCheck,
         mockWorldSkills
       );
@@ -172,7 +173,7 @@ describe('evaluateSkillCheck with d20 rolls', () => {
       };
 
       const result = evaluateSkillCheck(
-        mockCharacter as Character,
+        mockCharacter,
         skillCheck,
         mockWorldSkills
       );
@@ -188,7 +189,7 @@ describe('evaluateSkillCheck with d20 rolls', () => {
     it('should auto-succeed on natural 20 even if total < DC', () => {
       (Math.random as jest.Mock).mockReturnValue(0.95); // Returns 20
 
-      const weakCharacter: Partial<Character> = {
+      const weakCharacter: SkillCheckSubject = {
         ...mockCharacter,
         skills: [], // No skills
         attributes: [{ attributeId: 'strength', value: 1 }], // Minimal attribute
@@ -200,7 +201,7 @@ describe('evaluateSkillCheck with d20 rolls', () => {
       };
 
       const result = evaluateSkillCheck(
-        weakCharacter as Character,
+        weakCharacter,
         skillCheck,
         mockWorldSkills
       );
@@ -220,12 +221,10 @@ describe('evaluateSkillCheck with d20 rolls', () => {
     it('should auto-fail on natural 1 even if total >= DC', () => {
       (Math.random as jest.Mock).mockReturnValue(0.0); // Returns 1
 
-      const expertCharacter: Partial<Character> = {
-        ...mockCharacter,
+      const expertCharacter: SkillCheckSubject = {
         skills: [
-          { skillId: 'athletics', level: 20, experience: 0, isActive: true },
+          { skillId: 'athletics', level: 20, isActive: true },
         ],
-        derivedStats: [],
         attributes: [{ attributeId: 'strength', value: 30 }],
       };
 
@@ -235,7 +234,7 @@ describe('evaluateSkillCheck with d20 rolls', () => {
       };
 
       const result = evaluateSkillCheck(
-        expertCharacter as Character,
+        expertCharacter,
         skillCheck,
         mockWorldSkills
       );
@@ -255,7 +254,7 @@ describe('evaluateSkillCheck with d20 rolls', () => {
     it('should allow untrained characters (skill level 0) to attempt', () => {
       (Math.random as jest.Mock).mockReturnValue(0.9); // Returns 19
 
-      const untrainedCharacter: Partial<Character> = {
+      const untrainedCharacter: SkillCheckSubject = {
         ...mockCharacter,
         skills: [], // No athletics skill
       };
@@ -266,7 +265,7 @@ describe('evaluateSkillCheck with d20 rolls', () => {
       };
 
       const result = evaluateSkillCheck(
-        untrainedCharacter as Character,
+        untrainedCharacter,
         skillCheck,
         mockWorldSkills
       );
@@ -286,7 +285,7 @@ describe('evaluateSkillCheck with d20 rolls', () => {
       };
 
       const result = evaluateSkillCheck(
-        mockCharacter as Character,
+        mockCharacter,
         skillCheck,
         mockWorldSkills
       );
@@ -307,7 +306,7 @@ describe('evaluateSkillCheck with d20 rolls', () => {
       };
 
       const result = evaluateSkillCheck(
-        mockCharacter as Character,
+        mockCharacter,
         skillCheck,
         mockWorldSkills
       );
@@ -329,7 +328,7 @@ describe('evaluateSkillCheck with d20 rolls', () => {
       };
 
       const result = evaluateSkillCheck(
-        mockCharacter as Character,
+        mockCharacter,
         skillCheck,
         mockWorldSkills
       );
@@ -349,7 +348,7 @@ describe('evaluateSkillCheck with d20 rolls', () => {
 
       expect(() => {
         evaluateSkillCheck(
-          mockCharacter as Character,
+          mockCharacter,
           skillCheck,
           mockWorldSkills
         );
@@ -367,7 +366,7 @@ describe('evaluateSkillCheck with d20 rolls', () => {
       };
 
       const result = evaluateSkillCheck(
-        mockCharacter as Character,
+        mockCharacter,
         skillCheck,
         mockWorldSkills
       );
@@ -389,7 +388,7 @@ describe('evaluateSkillCheck with d20 rolls', () => {
       };
 
       const result = evaluateSkillCheck(
-        mockCharacter as Character,
+        mockCharacter,
         skillCheck,
         mockWorldSkills
       );
@@ -402,6 +401,56 @@ describe('evaluateSkillCheck with d20 rolls', () => {
       expect(result.success).toBe(false); // 9 < 20
       expect(result.isCriticalSuccess).toBe(false);
       expect(result.isCriticalFailure).toBe(false);
+    });
+  });
+
+  describe('skill active status', () => {
+    it('should exclude skills marked with isActive: false (treating as skill level 0)', () => {
+      (Math.random as jest.Mock).mockReturnValue(0.5); // Returns 11
+
+      const characterWithInactiveSkill: SkillCheckSubject = {
+        attributes: mockCharacterAttributes,
+        skills: [
+          { skillId: 'athletics', level: 8, isActive: false },
+        ],
+      };
+
+      const skillCheck: SkillCheck = {
+        skillId: 'athletics',
+        difficulty: 5,
+      };
+
+      const result = evaluateSkillCheck(
+        characterWithInactiveSkill,
+        skillCheck,
+        mockWorldSkills
+      );
+
+      expect(result.skillLevel).toBe(0);
+    });
+
+    it('should use skills when isActive is absent (defaults to active)', () => {
+      (Math.random as jest.Mock).mockReturnValue(0.5); // Returns 11
+
+      const characterWithAbsentIsActive: SkillCheckSubject = {
+        attributes: mockCharacterAttributes,
+        skills: [
+          { skillId: 'athletics', level: 8 },
+        ],
+      };
+
+      const skillCheck: SkillCheck = {
+        skillId: 'athletics',
+        difficulty: 5,
+      };
+
+      const result = evaluateSkillCheck(
+        characterWithAbsentIsActive,
+        skillCheck,
+        mockWorldSkills
+      );
+
+      expect(result.skillLevel).toBe(8);
     });
   });
 });

--- a/src/utils/skillCheckEvaluator.ts
+++ b/src/utils/skillCheckEvaluator.ts
@@ -1,6 +1,6 @@
 // Probabilistic d20-based skill check evaluation used by the narrative system.
 
-import { Character } from '@/types/character.types';
+import { CharacterSkill, CharacterAttribute } from '@/types/character.types';
 import { WorldSkill } from '@/types/world.types';
 import { SkillCheckRoll } from '@/types/narrative.types';
 
@@ -20,8 +20,13 @@ export interface SkillCheck {
   difficulty: number;
 }
 
+export interface SkillCheckSubject {
+  skills: (Pick<CharacterSkill, 'skillId' | 'level'> & { isActive?: boolean })[];
+  attributes: Pick<CharacterAttribute, 'attributeId' | 'value'>[];
+}
+
 export function evaluateSkillCheck(
-  character: Character,
+  character: SkillCheckSubject,
   skillCheck: SkillCheck,
   worldSkills: WorldSkill[]
 ): SkillCheckRoll {
@@ -51,7 +56,7 @@ export function evaluateSkillCheck(
 
   // Untrained (skill level 0) is allowed: anyone can attempt.
   const characterSkill = character.skills.find(skill =>
-    skill.skillId === worldSkill.id && skill.isActive
+    skill.skillId === worldSkill.id && skill.isActive !== false
   );
   const skillLevel = characterSkill?.level || 0;
 


### PR DESCRIPTION
## Description
Two core functions (`buildPortraitPrompt` and `evaluateSkillCheck`) were demanding a full `Character` entity when they only read a handful of fields. That forced callers across the wizard, devtools, and narrative engine to fabricate synthetic character objects with throwaway dummy data.

This PR introduces two narrow `Pick`-derived subject types (`PortraitSubject` and `SkillCheckSubject`), narrows the function parameters and `PortraitRequest.character`, deletes ~120 lines of synthetic character mocking, and cleans up the skill check adapter.

## Related Issue
Closes #1951

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A (code health refactor)

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes
- `PortraitSubject` picks `physicalDescription`, `history`, and `personality` from `CharacterBackground`.
- `SkillCheckSubject` picks `skillId` and `level` from `CharacterSkill` (with optional `isActive`) and `attributeId` and `value` from `CharacterAttribute`.
- `evaluateSkillCheck`'s active filter now checks `skill.isActive !== false` rather than `skill.isActive`, allowing the adapter and callers without an `isActive` property to default to active without inventing fake values.
- `adaptStoreCharacterToUtil` is collapsed into `toSkillCheckSubject` (pure key translation) and hoisted out of the requirement loop.
- Route behavior is strictly preserved — only `name` and `physicalDescription` continue to be forwarded to the prompt builder.

## Screenshots
N/A

## Visual Baseline Changes
None

## Code Review Summary (if applicable)
Clean type checking, linting, and knip passes across the repo.

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
Run targeted tests:
```bash
npm test -- src/utils/__tests__/skillCheckEvaluator.test.ts src/lib/narrative/__tests__ src/lib/ai/__tests__/portraitGenerator.test.ts src/app/api/generate-portrait src/components/CharacterCreationWizard
```

Run full suite:
```bash
npm test
npm run type-check
npm run lint
npm run knip
```

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed