### PR TITLE
Match natural NPC name references in unrecorded exchange guard

### DIFF
--- a/src/lib/lore/__tests__/unrecordedExchange.test.ts
+++ b/src/lib/lore/__tests__/unrecordedExchange.test.ts
@@ -65,6 +65,23 @@ describe('detectUnrecordedExchangeClaim', () => {
     expect(claim).toMatchObject({ npcId: 'npc-marla', name: 'Marla Jones' });
   });
 
+  it('ignores incidental name stopwords when resolving a unique NPC', () => {
+    const claim = detectUnrecordedExchangeClaim(
+      'Ask Mira to repeat what she told me privately at the mill.',
+      { 'npc-mira': 'Mira', 'npc-caretaker': 'The Caretaker' }
+    );
+    expect(claim).toMatchObject({ npcId: 'npc-mira', name: 'Mira' });
+  });
+
+  it('does not resolve an NPC from an incidental name stopword alone', () => {
+    expect(
+      detectUnrecordedExchangeClaim(
+        'Ask Mira to repeat what she told me privately at the mill.',
+        { 'npc-caretaker': 'The Caretaker' }
+      )
+    ).toBeNull();
+  });
+
   it('declines when release-smoke phrasing mentions multiple rostered NPCs partially or fully', () => {
     expect(
       detectUnrecordedExchangeClaim(

--- a/src/lib/lore/__tests__/unrecordedExchange.test.ts
+++ b/src/lib/lore/__tests__/unrecordedExchange.test.ts
@@ -56,6 +56,32 @@ describe('detectUnrecordedExchangeClaim', () => {
       )
     ).toBeNull();
   });
+
+  it('resolves a multi-word NPC name by an individual name part when unique', () => {
+    const claim = detectUnrecordedExchangeClaim(
+      'Ask Marla to repeat what she told me privately.',
+      { 'npc-marla': 'Marla Jones' }
+    );
+    expect(claim).toMatchObject({ npcId: 'npc-marla', name: 'Marla Jones' });
+  });
+
+  it('declines when release-smoke phrasing mentions multiple rostered NPCs partially or fully', () => {
+    expect(
+      detectUnrecordedExchangeClaim(
+        'Ask Marla why Coach Barry told me the game was off, just between us.',
+        { 'npc-marla': 'Marla Jones', 'npc-barry': 'Coach Barry' }
+      )
+    ).toBeNull();
+  });
+
+  it('declines when a name part is shared by multiple rostered NPCs', () => {
+    expect(
+      detectUnrecordedExchangeClaim(
+        'Ask Marla to repeat what she told me privately.',
+        { 'npc-marla-1': 'Marla Jones', 'npc-marla-2': 'Marla Singer' }
+      )
+    ).toBeNull();
+  });
 });
 
 describe('countSharedScenes', () => {

--- a/src/lib/lore/unrecordedExchange.ts
+++ b/src/lib/lore/unrecordedExchange.ts
@@ -145,8 +145,10 @@ export function detectUnrecordedExchangeClaim(
 
   const named = Object.entries(npcNames ?? {}).filter(([, name]) => {
     const trimmed = name?.trim();
-    return (
-      !!trimmed && new RegExp(`\\b${escapeRegExp(trimmed)}\\b`, 'i').test(text)
+    if (!trimmed) return false;
+    const terms = [trimmed, ...trimmed.split(/\s+/).filter(Boolean)];
+    return terms.some((term) =>
+      new RegExp(`\\b${escapeRegExp(term)}\\b`, 'i').test(text)
     );
   });
 

--- a/src/lib/lore/unrecordedExchange.ts
+++ b/src/lib/lore/unrecordedExchange.ts
@@ -18,7 +18,7 @@
  */
 
 import type { EntityID } from '../../types/common.types';
-import { escapeRegExp } from './continuityLedger';
+import { MIN_TERM_LENGTH, escapeRegExp } from './continuityLedger';
 
 /**
  * Two tiers, because the single sharpest failure mode here is firing on a
@@ -93,6 +93,7 @@ export interface UnrecordedExchangeClaim {
 }
 
 const MAX_CLAIM_LENGTH = 200;
+const NPC_NAME_PART_STOPWORDS = new Set(['a', 'an', 'and', 'of', 'the']);
 
 /**
  * Counts, per NPC, the narrated scenes shared with the protagonist and whether
@@ -146,7 +147,12 @@ export function detectUnrecordedExchangeClaim(
   const named = Object.entries(npcNames ?? {}).filter(([, name]) => {
     const trimmed = name?.trim();
     if (!trimmed) return false;
-    const terms = [trimmed, ...trimmed.split(/\s+/).filter(Boolean)];
+    const nameParts = trimmed.split(/\s+/).filter(
+      (part) =>
+        part.length >= MIN_TERM_LENGTH &&
+        !NPC_NAME_PART_STOPWORDS.has(part.toLowerCase())
+    );
+    const terms = [trimmed, ...nameParts];
     return terms.some((term) =>
       new RegExp(`\\b${escapeRegExp(term)}\\b`, 'i').test(text)
     );


### PR DESCRIPTION
## Description
When players type actions referencing an NPC by just their first or last name (like typing "Marla" instead of "Marla Jones"), the unrecorded-exchange guard previously missed the reference because it was strictly matching full stored strings. That could let an invented off-page exchange slip by or inadvertently attribute a claim to another mentioned character.

This updates `detectUnrecordedExchangeClaim` to match each rostered NPC against its full stored name and eligible whitespace-delimited name parts with word boundaries. Short parts and common grammar words are ignored so incidental text such as "the mill" can't create a roster match. Matches are counted per NPC so unique references resolve to the canonical stored entity, while any ambiguous multi-NPC reference fails open cleanly.

## Related Issue
Closes #1967

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Failing behavior-first tests were written and verified to fail prior to modifying `detectUnrecordedExchangeClaim`. They cover partial name resolution, smoke-test multi-character phrase rejection, shared first-name ambiguity handling, unique NPC resolution despite an incidental stopword, and rejection of an incidental stopword as the sole NPC match.

## User Stories Addressed
Addresses NPC name reference matching in unrecorded exchange detection so players can naturally refer to characters by distinctive single name parts without breaking continuity guards.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes
- Matches each rostered NPC against its full stored name plus eligible whitespace-delimited parts using case-insensitive regex with word boundaries.
- Reuses `MIN_TERM_LENGTH` and ignores the name-part stopwords `a`, `an`, `and`, `of`, and `the`; natural titles such as `Coach` and `Captain` remain eligible.
- Keeps the full stored name eligible even when it contains a filtered part.
- Uses `terms.some()` per NPC to count matches per character rather than per term.
- Returns `null` if zero or more than one NPC matches to preserve fail-open safety.
- Does not modify historical notes in `RELEASES.md` as they accurately reflect the v1.3 release state.

## Screenshots
N/A

## Visual Baseline Changes
None

## Code Review Summary (if applicable)
The review found that matching every name part let incidental articles such as `the` create false roster hits. This follow-up filters non-distinct parts while keeping full names and natural titles eligible. Public API signatures, types, callers, feature flags, and documentation remain unchanged.

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. Run `npm test -- src/lib/lore/__tests__/unrecordedExchange.test.ts` to verify the targeted unit test suite.
2. Run `npm test` to run the full unit test suite.
3. Run `npm run type-check`, `npm run lint`, and `npm run knip` to verify static analysis.
4. Run `NEXT_PUBLIC_SITE_URL=https://narraitor-six.vercel.app npm run build` to verify the production and Storybook builds.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed
