### PR TITLE
Parse flattened dotted-key metadata dumps and trim gate survivors (#1965)

### DIFF
--- a/src/lib/ai/__tests__/narrativeGenerator.response.parse.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.response.parse.test.ts
@@ -44,4 +44,28 @@ describe('parseNarrativeResponse debris guard', () => {
     expect(parsed.actualContent).toBe('You flee.');
   });
 
+  it('recovers prose from a flattened dotted-key dump', () => {
+    const raw =
+      'metadata.characterIds: [] metadata.speakerId: null metadata.location: "Ruins" metadata.mood: "grim" metadata.majorEvent: "The fall" content: "Panic claws at your throat as the shadow lunges forward. Your blade rises too late, and the iron edge finds its mark." type: action';
+    const parsed = parseNarrativeResponse({ content: raw }, 'scene');
+
+    expect(parsed.actualContent).toBe(
+      'Panic claws at your throat as the shadow lunges forward. Your blade rises too late, and the iron edge finds its mark.'
+    );
+  });
+
+  it('takes the segment type from trailing unquoted type in a flattened dump', () => {
+    const raw =
+      'metadata.characterIds: [] content: "Panic claws at your throat as the shadow lunges forward." type: action';
+    const parsed = parseNarrativeResponse({ content: raw }, 'scene');
+
+    expect(parsed.segmentType).toBe('action');
+  });
+
+  it('leaves ordinary prose containing colons untouched', () => {
+    const prose = 'She read the label aloud: content: three grams of powder.';
+    const parsed = parseNarrativeResponse({ content: prose }, 'scene');
+
+    expect(parsed.actualContent).toBe(prose);
+  });
 });

--- a/src/lib/ai/narrativeGenerator.response.parse.ts
+++ b/src/lib/ai/narrativeGenerator.response.parse.ts
@@ -79,7 +79,6 @@ export const parseNarrativeResponse = (
   const flattened = extractFlattenedFields(actualContent);
   if (flattened) {
     actualContent = flattened.content;
-    contentFromClosedField = true;
     if (flattened.type) segmentType = flattened.type;
   } else if (
     actualContent.includes('```json') ||

--- a/src/lib/ai/narrativeGenerator.response.parse.ts
+++ b/src/lib/ai/narrativeGenerator.response.parse.ts
@@ -12,6 +12,14 @@ import { stripMarkdownFences, extractJsonObject } from './parseJSON';
  */
 const MIN_RECOVERED_PASSAGE_LENGTH = 20;
 
+const VALID_SEGMENT_TYPES = [
+  'scene',
+  'dialogue',
+  'action',
+  'transition',
+  'ending',
+];
+
 /**
  * Recognises what's left when a response never carried a usable content field -
  * a bare brace, an unclosed object, a fragment cut off mid-sentence. Only
@@ -28,6 +36,38 @@ const isJsonDebris = (text: string): boolean => {
   );
 };
 
+/**
+ * The shape a response takes when it answers with the schema's keys but not its
+ * JSON: dotted metadata paths and an unquoted content key. The quoted-key
+ * extraction below cannot see it, so without this the whole dump ships as prose.
+ */
+const FLATTENED_FIELD_PATTERN =
+  /(?:^|\s)(?:metadata\.\w+\s*[:=]|content\s*[:=]\s*")/;
+
+const extractFlattenedFields = (
+  raw: string
+): { content: string; type?: string } | null => {
+  if (!FLATTENED_FIELD_PATTERN.test(raw)) return null;
+
+  const contentMatch = raw.match(/(?:^|[\s,])["']?content["']?\s*[:=]\s*"/i);
+  if (!contentMatch) return null;
+
+  const afterMarker = raw.slice(contentMatch.index! + contentMatch[0].length);
+  const lastQuoteIndex = afterMarker.lastIndexOf('"');
+  if (lastQuoteIndex === -1) return null;
+
+  const content = afterMarker.slice(0, lastQuoteIndex);
+  if (isJsonDebris(content)) return null;
+
+  const trailing = afterMarker.slice(lastQuoteIndex + 1);
+  const typeMatch = trailing.match(/(?:^|\s)type\s*[:=]\s*["']?(\w+)["']?/i);
+  const rawType = typeMatch ? typeMatch[1].toLowerCase() : undefined;
+  const type =
+    rawType && VALID_SEGMENT_TYPES.includes(rawType) ? rawType : undefined;
+
+  return { content, type };
+};
+
 export const parseNarrativeResponse = (
   response: { content?: string },
   segmentType: string
@@ -36,7 +76,12 @@ export const parseNarrativeResponse = (
   let extractedMetadata: NarrativeExtractedMetadata = {};
   let contentFromClosedField = false;
 
-  if (
+  const flattened = extractFlattenedFields(actualContent);
+  if (flattened) {
+    actualContent = flattened.content;
+    contentFromClosedField = true;
+    if (flattened.type) segmentType = flattened.type;
+  } else if (
     actualContent.includes('```json') ||
     actualContent.startsWith('{') ||
     actualContent.includes('"content":')
@@ -72,12 +117,7 @@ export const parseNarrativeResponse = (
           actualContent = parsed.content;
           contentFromClosedField = true;
         }
-        if (
-          parsed.type &&
-          ['scene', 'dialogue', 'action', 'transition', 'ending'].includes(
-            parsed.type
-          )
-        ) {
+        if (parsed.type && VALID_SEGMENT_TYPES.includes(parsed.type)) {
           segmentType = parsed.type;
         }
         if (parsed.metadata) {

--- a/src/lib/narrative/__tests__/narrativeContentGate.test.ts
+++ b/src/lib/narrative/__tests__/narrativeContentGate.test.ts
@@ -161,8 +161,9 @@ describe('stripNonNarrativeBlocks', () => {
   it('leaves ordinary prose containing colons and metadata keywords untouched', () => {
     const line1 = 'She read the label aloud: content: three grams of powder.';
     const line2 = 'He hesitated. Type: unknown, the screen said.';
-    const line3 = 'The metadata of the archive meant nothing to her now.';
-    const content = `${line1}\n\n${line2}\n\n${line3}`;
+    const line3 = 'The medical display flashed her blood type: O';
+    const line4 = 'The metadata of the archive meant nothing to her now.';
+    const content = `${line1}\n\n${line2}\n\n${line3}\n\n${line4}`;
 
     expect(stripNonNarrativeBlocks(content)).toBe(content);
   });

--- a/src/lib/narrative/__tests__/narrativeContentGate.test.ts
+++ b/src/lib/narrative/__tests__/narrativeContentGate.test.ts
@@ -128,6 +128,44 @@ describe('stripNonNarrativeBlocks', () => {
 
     expect(stripNonNarrativeBlocks(content)).toBe(`${PROSE}\n${MORE_PROSE}`);
   });
+
+  it('removes a standalone dotted-metadata block', () => {
+    const content = [
+      PROSE,
+      '',
+      'metadata.characterIds: [] metadata.speakerId: null',
+      'metadata.mood: "tense"',
+      '',
+      MORE_PROSE,
+    ].join('\n');
+
+    expect(stripNonNarrativeBlocks(content)).toBe(`${PROSE}\n\n${MORE_PROSE}`);
+  });
+
+  it('keeps prose when a block begins with a dotted-metadata run', () => {
+    const content = [
+      `metadata.characterIds: [] metadata.speakerId: null content: "${PROSE}" type: action`,
+      '',
+      MORE_PROSE,
+    ].join('\n');
+
+    expect(stripNonNarrativeBlocks(content)).toBe(`${PROSE}\n\n${MORE_PROSE}`);
+  });
+
+  it('trims a trailing bare type fragment from the end of a paragraph', () => {
+    const content = `${PROSE}" type: action`;
+
+    expect(stripNonNarrativeBlocks(content)).toBe(PROSE);
+  });
+
+  it('leaves ordinary prose containing colons and metadata keywords untouched', () => {
+    const line1 = 'She read the label aloud: content: three grams of powder.';
+    const line2 = 'He hesitated. Type: unknown, the screen said.';
+    const line3 = 'The metadata of the archive meant nothing to her now.';
+    const content = `${line1}\n\n${line2}\n\n${line3}`;
+
+    expect(stripNonNarrativeBlocks(content)).toBe(content);
+  });
 });
 
 describe('dedupeAgainstRecent', () => {

--- a/src/lib/narrative/narrativeContentGate.ts
+++ b/src/lib/narrative/narrativeContentGate.ts
@@ -38,7 +38,7 @@ const CONTAINER_TAG_PATTERN =
 const BOOKKEEPING_LABEL_PATTERN =
   /^(?:world\s+(?:clock|state)|player\s+status|character\s+status|current\s+(?:status|goals?|conditions?|threats?|threads?)|status|outstanding\s+goals?|goals?|objectives?|open\s+threads?|threads?|threats?|conditions?|inventory|ledger|cost|clock|time|storyteller['’]?s?\s+note|narrator['’]?s?\s+note|gm\s+note|metadata|summary)\b/i;
 
-const METADATA_LEAD_PATTERN = /^(?:\*\*)?["']?metadata["']?(?:\*\*)?\s*[:=]/i;
+const METADATA_LEAD_PATTERN = /^(?:\*\*)?["']?metadata(?:\.\w+)?["']?(?:\*\*)?\s*[:=]/i;
 
 const LIST_ITEM_PATTERN = /^(?:[-*+•]|\d+[.)])\s+/;
 
@@ -57,6 +57,43 @@ const SCAFFOLDING_LINE_PATTERNS: RegExp[] = [
   /^\**\s*world\s+clock\b[^.!?]*:?\s*\**$/i,
   /^\[?\s*overdue\b[^\]]*\]?$/i,
 ];
+
+const DOTTED_METADATA_LEAD_PATTERN = /^(?:\*\*)?["']?metadata\.\w+/i;
+const CONTENT_MARKER_PATTERN = /(?:^|[\s,])["']?content["']?\s*[:=]/i;
+const METADATA_MARKER_PATTERN = /(?:metadata\.\w+|content|type)\s*[:=]\s*/gi;
+const SENTENCE_END_PATTERN = /[.!?]["']?\s/;
+const TRAILING_METADATA_SUFFIX_PATTERN =
+  /\s*["']?\s*(?:(?:type|metadata\.\w+)\s*[:=]\s*[^\s.!?]+\s*)+$/i;
+
+const trimDottedMetadataPrefix = (block: string): string => {
+  if (
+    !DOTTED_METADATA_LEAD_PATTERN.test(block.trim()) ||
+    !CONTENT_MARKER_PATTERN.test(block)
+  ) {
+    return block;
+  }
+
+  const matches = Array.from(block.matchAll(METADATA_MARKER_PATTERN));
+  if (matches.length === 0) return block;
+
+  let lastMarker = matches[0];
+  for (let i = 1; i < matches.length; i++) {
+    const nextMarker = matches[i];
+    const gap = block.slice(
+      lastMarker.index + lastMarker[0].length,
+      nextMarker.index
+    );
+    if (SENTENCE_END_PATTERN.test(gap)) break;
+    lastMarker = nextMarker;
+  }
+
+  const cutIndex = lastMarker.index + lastMarker[0].length;
+  const remaining = block.slice(cutIndex);
+  return remaining.replace(/^["']/, '').trimStart();
+};
+
+const trimTrailingMetadataSuffix = (block: string): string =>
+  block.replace(TRAILING_METADATA_SUFFIX_PATTERN, '').trimEnd();
 
 const splitParagraphs = (text: string): string[] =>
   text
@@ -140,7 +177,10 @@ export const stripNonNarrativeBlocks = (content: string): string => {
 
   return withoutScaffolding
     .split(/\n{2,}/)
+    .map(trimDottedMetadataPrefix)
     .filter((block) => !isBookkeepingBlock(block))
+    .map(trimTrailingMetadataSuffix)
+    .filter(Boolean)
     .join('\n\n')
     .replace(/\n{3,}/g, '\n\n')
     .trim();

--- a/src/lib/narrative/narrativeContentGate.ts
+++ b/src/lib/narrative/narrativeContentGate.ts
@@ -63,7 +63,7 @@ const CONTENT_MARKER_PATTERN = /(?:^|[\s,])["']?content["']?\s*[:=]/i;
 const METADATA_MARKER_PATTERN = /(?:metadata\.\w+|content|type)\s*[:=]\s*/gi;
 const SENTENCE_END_PATTERN = /[.!?]["']?\s/;
 const TRAILING_METADATA_SUFFIX_PATTERN =
-  /\s*["']?\s*(?:type|metadata\.\w+)\s*[:=]\s*[^\s.!?]+(?:\s+(?:type|metadata\.\w+)\s*[:=]\s*[^\s.!?]+)*\s*$/i;
+  /\s*["']?\s*(?:type\s*[:=]\s*(?:scene|dialogue|action|transition|ending)|metadata\.\w+\s*[:=]\s*[^\s.!?]+)(?:\s+(?:type\s*[:=]\s*(?:scene|dialogue|action|transition|ending)|metadata\.\w+\s*[:=]\s*[^\s.!?]+))*\s*$/i;
 
 const trimDottedMetadataPrefix = (block: string): string => {
   if (

--- a/src/lib/narrative/narrativeContentGate.ts
+++ b/src/lib/narrative/narrativeContentGate.ts
@@ -63,7 +63,7 @@ const CONTENT_MARKER_PATTERN = /(?:^|[\s,])["']?content["']?\s*[:=]/i;
 const METADATA_MARKER_PATTERN = /(?:metadata\.\w+|content|type)\s*[:=]\s*/gi;
 const SENTENCE_END_PATTERN = /[.!?]["']?\s/;
 const TRAILING_METADATA_SUFFIX_PATTERN =
-  /\s*["']?\s*(?:(?:type|metadata\.\w+)\s*[:=]\s*[^\s.!?]+\s*)+$/i;
+  /\s*["']?\s*(?:type|metadata\.\w+)\s*[:=]\s*[^\s.!?]+(?:\s+(?:type|metadata\.\w+)\s*[:=]\s*[^\s.!?]+)*\s*$/i;
 
 const trimDottedMetadataPrefix = (block: string): string => {
   if (


### PR DESCRIPTION
## Description
This fixes #1965 where Gemini answered with a flattened `key: value` dump using dotted, unquoted keys rather than JSON, causing the raw metadata dump to ship to the DOM as prose.

The fix introduces a two-layer defense:
1. An early extraction step in `parseNarrativeResponse` that recovers the prose passage and trailing segment type from dotted-key dumps before falling back to existing metadata defaults.
2. A widened metadata pattern and prefix/suffix trim pipeline in `narrativeContentGate` to prevent glued metadata dumps or trailing `type: action` fragments from slipping through if parsing misses them.

Regarding the issue body's note that either fix alone would have caught this: measured against the recorded turn 30 response, that's not quite true for the gate layer on its own. Splitting the raw response on blank lines puts the dotted dump in block 0 with the first prose paragraph ("Panic claws at your throat..."). A block-level reject would drop that entire opening paragraph, and the trailing `" type: action` in block 2 would still leak to the player. The parser is the primary fix, while the gate provides prefix/suffix trims for defense in depth.

## Related Issue
Closes #1965

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
As a player, when the AI generates a response using flattened dotted keys instead of JSON, I should read clean narrative prose rather than raw system metadata and action labels.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified
N/A - Non-UI text parsing and gating logic.

## Implementation Notes
- Parser: Added `FLATTENED_FIELD_PATTERN` and `extractFlattenedFields` in `src/lib/ai/narrativeGenerator.response.parse.ts` to extract `content` and optional `type`. Unused dotted metadata fields (`metadata.mood`, etc.) are dropped so `formatNarrativeResponse` populates them from fallback location/mood logic.
- Content Gate: Widened `METADATA_LEAD_PATTERN` to `/^(?:\*\*)?["\x27]?metadata(?:\.\w+)?["\x27]?(?:\*\*)?\s*[:=]/i`, added `trimDottedMetadataPrefix` and `trimTrailingMetadataSuffix`, and ordered the pipeline as `split -> prefix trim -> reject bookkeeping -> suffix trim -> drop empties -> join`.

## Screenshots
N/A

## Visual Baseline Changes
None

## Code Review Summary (if applicable)
Local unit test coverage was added first for both parser extraction and content gate trims, confirming test failures prior to fix implementation. Full test suite, TypeScript type checks, and ESLint checks pass cleanly.

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. Run targeted unit tests:
   ```bash
   npm test -- src/lib/ai/__tests__/narrativeGenerator.response.parse.test.ts src/lib/narrative/__tests__/narrativeContentGate.test.ts src/state/__tests__/narrativeStore.contentGate.test.ts src/components/Narrative/__tests__/NarrativeController.contentGate.test.tsx
   ```
2. Run full test suite and quality checks:
   ```bash
   npm test && npm run type-check && npm run lint
   ```

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed