### PR TITLE
Try the JSON path before the flattened reader

### DIFF
--- a/src/lib/ai/__tests__/narrativeGenerator.response.parse.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.response.parse.test.ts
@@ -68,4 +68,24 @@ describe('parseNarrativeResponse debris guard', () => {
 
     expect(parsed.actualContent).toBe(prose);
   });
+
+  it('keeps the whole passage when malformed JSON holds a content marker in its prose', () => {
+    const raw =
+      '{"content":"She squinted at the terminal. content: "redacted" it said, and nothing else. Mira stepped back from the glow.","type":"scene"}';
+    const parsed = parseNarrativeResponse({ content: raw }, 'scene');
+
+    expect(parsed.actualContent).toBe(
+      'She squinted at the terminal. content: "redacted" it said, and nothing else. Mira stepped back from the glow.'
+    );
+  });
+
+  it('keeps the whole passage when a fenced response holds a content marker in its prose', () => {
+    const raw =
+      '```json\n{"content":"The sign read content: "closed" and she turned away down the long wet street."}\n```';
+    const parsed = parseNarrativeResponse({ content: raw }, 'scene');
+
+    expect(parsed.actualContent).toBe(
+      'The sign read content: "closed" and she turned away down the long wet street.'
+    );
+  });
 });

--- a/src/lib/ai/__tests__/narrativeGenerator.response.parse.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.response.parse.test.ts
@@ -88,4 +88,25 @@ describe('parseNarrativeResponse debris guard', () => {
       'The sign read content: "closed" and she turned away down the long wet street.'
     );
   });
+
+  it('reads a flattened dump the model wrapped in a json fence', () => {
+    const raw =
+      '```json\nmetadata.characterIds: [] metadata.mood: tense content: "Panic claws at your throat as the shadow lunges forward." type: action\n```';
+    const parsed = parseNarrativeResponse({ content: raw }, 'scene');
+
+    expect(parsed.actualContent).toBe(
+      'Panic claws at your throat as the shadow lunges forward.'
+    );
+    expect(parsed.segmentType).toBe('action');
+  });
+
+  it('reads a flattened dump the model wrapped in braces', () => {
+    const raw =
+      '{ metadata.mood: tense content: "Panic claws at your throat as the shadow lunges forward." type: action }';
+    const parsed = parseNarrativeResponse({ content: raw }, 'scene');
+
+    expect(parsed.actualContent).toBe(
+      'Panic claws at your throat as the shadow lunges forward.'
+    );
+  });
 });

--- a/src/lib/ai/narrativeGenerator.response.parse.ts
+++ b/src/lib/ai/narrativeGenerator.response.parse.ts
@@ -76,15 +76,21 @@ export const parseNarrativeResponse = (
   let extractedMetadata: NarrativeExtractedMetadata = {};
   let contentFromClosedField = false;
 
-  const flattened = extractFlattenedFields(actualContent);
+  // A response that already looks like JSON goes down the JSON path even when
+  // it is malformed, because prose can legitimately contain the flattened
+  // shape's marker - a character reading a config file, a screen quoted inside
+  // the scene. Reaching for the flattened reader first would cut such a passage
+  // at its own prose and ship the object's tail along with it.
+  const looksLikeJson =
+    actualContent.includes('```json') ||
+    actualContent.startsWith('{') ||
+    actualContent.includes('"content":');
+  const flattened = looksLikeJson ? null : extractFlattenedFields(actualContent);
+
   if (flattened) {
     actualContent = flattened.content;
     if (flattened.type) segmentType = flattened.type;
-  } else if (
-    actualContent.includes('```json') ||
-    actualContent.startsWith('{') ||
-    actualContent.includes('"content":')
-  ) {
+  } else if (looksLikeJson) {
     try {
       const stripped = stripMarkdownFences(actualContent);
       const jsonStr = extractJsonObject(stripped);

--- a/src/lib/ai/narrativeGenerator.response.parse.ts
+++ b/src/lib/ai/narrativeGenerator.response.parse.ts
@@ -76,21 +76,12 @@ export const parseNarrativeResponse = (
   let extractedMetadata: NarrativeExtractedMetadata = {};
   let contentFromClosedField = false;
 
-  // A response that already looks like JSON goes down the JSON path even when
-  // it is malformed, because prose can legitimately contain the flattened
-  // shape's marker - a character reading a config file, a screen quoted inside
-  // the scene. Reaching for the flattened reader first would cut such a passage
-  // at its own prose and ship the object's tail along with it.
   const looksLikeJson =
     actualContent.includes('```json') ||
     actualContent.startsWith('{') ||
     actualContent.includes('"content":');
-  const flattened = looksLikeJson ? null : extractFlattenedFields(actualContent);
 
-  if (flattened) {
-    actualContent = flattened.content;
-    if (flattened.type) segmentType = flattened.type;
-  } else if (looksLikeJson) {
+  if (looksLikeJson) {
     try {
       const stripped = stripMarkdownFences(actualContent);
       const jsonStr = extractJsonObject(stripped);
@@ -281,13 +272,28 @@ export const parseNarrativeResponse = (
         // Fallback extraction failed - use default content
       }
     }
+  }
 
-    // When no path found a closed content field the raw text is still sitting
-    // there. Failing here hands the turn to the existing retry and
-    // fallback-segment handling instead of shipping a one-character passage.
-    if (!contentFromClosedField && isJsonDebris(actualContent)) {
-      throw new Error('Service error: malformed API response');
+  // The flattened reader runs after the JSON path rather than ahead of it.
+  // Prose carries the flattened shape's marker often enough - a character
+  // reading a config file, a screen quoted inside the scene - that going first
+  // would cut a malformed object's passage at its own prose and ship the
+  // object's tail with it. Running second still catches a dotted-key dump the
+  // JSON recovery could not read, fenced or braced.
+  if (!contentFromClosedField) {
+    const flattened = extractFlattenedFields(actualContent);
+    if (flattened) {
+      actualContent = flattened.content;
+      contentFromClosedField = true;
+      if (flattened.type) segmentType = flattened.type;
     }
+  }
+
+  // When no path found a closed content field the raw text is still sitting
+  // there. Failing here hands the turn to the existing retry and
+  // fallback-segment handling instead of shipping a one-character passage.
+  if (looksLikeJson && !contentFromClosedField && isJsonDebris(actualContent)) {
+    throw new Error('Service error: malformed API response');
   }
 
   return {


### PR DESCRIPTION
## Description
Follow-up to #1970, caught in review after it merged. That PR put the new flattened dotted-key reader ahead of the JSON branch in `parseNarrativeResponse`, so it ran on every response before the JSON path got a look. Prose carries the flattened shape's marker often enough - a character reading a config file, a screen quoted inside the scene - and when a malformed JSON response contains one, the flattened reader cut the passage at that marker and shipped the object's tail to the player.

The fix makes the flattened reader a fallback: the JSON path runs first, and the flattened reader runs only when that path came back without a closed content field. Both orderings are wrong on their own, which is what the second commit here corrects - see Implementation Notes.

Measured on four inputs, before and after #1970 and at the head of this branch:

| input | before #1970 | after #1970 | this PR |
| :--- | :--- | :--- | :--- |
| malformed JSON, prose contains `content: "` | full passage | `redacted" it said, and nothing else. Mira stepped back from the glow.","type":"scene"` | full passage |
| fenced, same shape | full passage | `closed" and she turned away down the long wet street.` | full passage |
| dotted-key dump in a `json` fence | raw dump | passage recovered | passage recovered |
| dotted-key dump in braces | raw dump | passage recovered | passage recovered |

Properly escaped JSON was never affected by any of this, so rows one and two only bite the malformed responses this file exists to salvage - the same failure class #1965 is about.

## Related Issue
Follow-up to #1970 / #1965. No separate issue filed - this is a regression in unreleased work on `develop`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Four regression tests, each confirmed red against the baseline it pins and green at head:

| tests | red against |
| :--- | :--- |
| the two prose-marker cases | `develop` (#1970 as merged) |
| the two dotted-dump cases | the first commit on this branch |

Nothing else in the file moved in either run.

## User Stories Addressed
As a player, when the AI answers with malformed JSON whose prose happens to mention a content key, I should still read the whole passage rather than a fragment with raw JSON stuck to the end - and when it answers with a dotted-key dump inside a fence, I should read the passage rather than the dump.

## Flow Diagrams
Not applicable.

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

Not applicable - text parsing, no UI surface.

## Implementation Notes
`src/lib/ai/narrativeGenerator.response.parse.ts`. The first commit hoisted the three JSON entry conditions into a `looksLikeJson` const and gated `extractFlattenedFields` behind it. Codex flagged that as too blunt and was right: a dotted-key dump wrapped in a `json` fence or a pair of braces satisfies `looksLikeJson`, so the reader never ran, the JSON recovery regexes could not match an unquoted `content:` key, and the raw dump shipped - the #1965 bug reintroduced from the other side. The braced variant threw instead.

The second commit moves the reader out of the branch entirely and runs it after, gated on `!contentFromClosedField`. The JSON path keeps first refusal on anything it can read; anything it cannot falls through to the flattened reader regardless of fencing.

That also sets `contentFromClosedField` in the flattened path, which puts it behind the existing debris guard. It had been sitting outside it - harmless while the guard lived inside the `else if` body, but a trap once the guard moved out, which this commit does.

Two smaller review findings are left alone, neither a regression:

- In the gate, `trimDottedMetadataPrefix` runs before the bookkeeping filter, so a pure-machine block carrying a `content:` key trims to its bare value and survives - `metadata.mood: tense content: stuff` ships `stuff`. `develop` shipped the whole dump before, so this is not worse.
- `TRAILING_METADATA_SUFFIX_PATTERN` is end-anchored, which `dropMetaCommentaryTrailer` in `narrativeGenerator.response.normalize.ts` deliberately avoids and explains in a comment. Inconsistent rather than broken.

## Screenshots
Not applicable.

## Visual Baseline Changes
None.

## Code Review Summary (if applicable)
This PR is the output of reviewing #1970, and its second commit is the output of Codex reviewing this one. Both regressions were found by running the same inputs through each branch rather than by reading the diff, which is why the tables carry measured strings.

## Chrome DevTools MCP Verification Summary (if applicable)
Not applicable.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit not run locally; CI covers it.

## Testing Instructions
1. Run the parser and content-gate suites:
   ```bash
   npm test -- src/lib/ai/__tests__/narrativeGenerator.response.parse.test.ts src/lib/narrative/__tests__/narrativeContentGate.test.ts src/state/__tests__/narrativeStore.contentGate.test.ts src/components/Narrative/__tests__/NarrativeController.contentGate.test.tsx
   ```
2. To see either regression, swap `src/lib/ai/narrativeGenerator.response.parse.ts` for the `develop` copy or the first commit's copy and re-run - two tests fail each time, and they are different two.
3. Full gate:
   ```bash
   npm run test:ci && npm run type-check && npm run lint
   ```
   Locally: 449 suites / 3153 tests pass, type-check exit 0, lint exit 0 (127 pre-existing warnings, no errors).

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

No docs affected - the change is internal to the response parser.
