### PR TITLE
Fix reverse-order sort in extractRecentNarrative (#1974)

### DIFF
--- a/src/lib/ai/__tests__/endingGenerator.sort.test.ts
+++ b/src/lib/ai/__tests__/endingGenerator.sort.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Tests for extractRecentNarrative sort order and formatting
+ */
+
+import { extractRecentNarrative } from '../endingGenerator';
+import type { NarrativeSegment } from '../../../types/narrative.types';
+import { getTimestamp } from '../../utils/timestamp';
+
+describe('extractRecentNarrative', () => {
+  it('returns the 10 most recent segments in chronological order and formats dialogue', () => {
+    const baseTime = new Date('2026-01-01T12:00:00Z').getTime();
+
+    // Build 12 segments with staggered timestamps (seg-1 is oldest, seg-12 is newest)
+    const segments: NarrativeSegment[] = Array.from({ length: 12 }, (_, i) => {
+      const index = i + 1;
+      const isDialogue = index === 6;
+      return {
+        id: `seg-${index}`,
+        content: isDialogue ? `Hello from segment ${index}` : `Segment ${index} content`,
+        type: isDialogue ? 'dialogue' : 'action',
+        sessionId: 'session-789',
+        worldId: 'world-123',
+        metadata: { tags: [], mood: 'neutral' },
+        timestamp: new Date(baseTime + index * 60000),
+        createdAt: getTimestamp(),
+        updatedAt: getTimestamp(),
+      };
+    });
+
+    const result = extractRecentNarrative(segments);
+
+    expect(result).toHaveLength(10);
+
+    // The two earliest segments (seg-1 and seg-2) should be dropped
+    expect(result).not.toContain('Segment 1 content');
+    expect(result).not.toContain('Segment 2 content');
+
+    // The 10 most recent segments should survive in chronological (oldest-first) order
+    expect(result[0]).toBe('Segment 3 content');
+    expect(result[1]).toBe('Segment 4 content');
+    expect(result[2]).toBe('Segment 5 content');
+    expect(result[3]).toBe('Dialogue: Hello from segment 6');
+    expect(result[4]).toBe('Segment 7 content');
+    expect(result[5]).toBe('Segment 8 content');
+    expect(result[6]).toBe('Segment 9 content');
+    expect(result[7]).toBe('Segment 10 content');
+    expect(result[8]).toBe('Segment 11 content');
+    expect(result[9]).toBe('Segment 12 content');
+  });
+});

--- a/src/lib/ai/endingGenerator.ts
+++ b/src/lib/ai/endingGenerator.ts
@@ -14,10 +14,10 @@ import type {
 import type { JournalEntry } from '../../types/journal.types';
 import type { ProviderCredential } from './providers/types';
 
-function extractRecentNarrative(segments: NarrativeSegment[]): string[] {
+export function extractRecentNarrative(segments: NarrativeSegment[]): string[] {
   const recentSegments = segments
-    .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
-    .slice(0, 10);
+    .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
+    .slice(-10);
 
   return recentSegments.map(segment => {
     const prefix = segment.type === 'dialogue' ? 'Dialogue: ' : '';


### PR DESCRIPTION
## Description
extractRecentNarrative in endingGenerator was sorting narrative segments newest-first (b - a) and taking the first 10 items. Upstream callers already deliver segments in chronological order, and the prompt frames "Recent narrative events:" as sequential history. This caused the model to see the story's final beat at the top and the oldest beat at the bottom.

This flips the sort to ascending order (a - b) and takes the last 10 segments (slice(-10)), matching the upstream contract and the prompt's natural reading direction.

## Related Issue
Closes #1974

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
N/A

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes
Exported `extractRecentNarrative` from `src/lib/ai/endingGenerator.ts` so it can be tested directly without mocking the full Gemini client pipeline.

## Screenshots
N/A

## Visual Baseline Changes
None

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. Run `npm test -- src/lib/ai/__tests__/endingGenerator.sort.test.ts` to verify chronological sorting and dialogue formatting.
2. Run `npm test -- src/lib/ai/__tests__/endingGenerator` to verify existing ending generator test suites pass.
3. Run `npm run type-check` and `npm run lint`.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed
