### PR TITLE
Introduce TurnResolver to settle core session state before the next Decision (#1983)

### DIFF
--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -512,18 +512,14 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
       setError(null);
       resetStreamingPreview();
 
-      // Race AI generation against a timeout so a slow response falls back
-      // instead of hanging. The abort signal propagates through the resolver
-      // to the underlying generator call.
+      // The abort signal propagates through the resolver to the underlying
+      // generator call. Only the provider round-trip is timed; reconciliation
+      // (store writes + world-cost extraction) runs unraced so a slow
+      // reconciliation doesn't trigger a duplicate fallback segment.
       const generationAbort = new AbortController();
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        generationTimeoutId = setTimeout(() => {
-          generationAbort.abort();
-          reject(
-            new Error(`Initial generation timed out after ${AI_GENERATION_TIMEOUT_MS}ms`)
-          );
-        }, AI_GENERATION_TIMEOUT_MS);
-      });
+      generationTimeoutId = setTimeout(() => {
+        generationAbort.abort();
+      }, AI_GENERATION_TIMEOUT_MS);
 
       const initialCommand: InitialTurnCommand = {
         sessionId,
@@ -534,10 +530,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
         onChunk: handleStreamChunk,
       };
 
-      const turnResult = await Promise.race([
-        resolveInitialTurn(initialCommand, narrativeGenerator),
-        timeoutPromise,
-      ]);
+      const turnResult = await resolveInitialTurn(initialCommand, narrativeGenerator);
 
       // Skip if component unmounted during async operation
       if (!mountedRef.current) {
@@ -553,6 +546,13 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
         setSegments(currentSegments);
         setIsLoading(false);
         return;
+      }
+
+      if (turnResult.reconciliationErrors.length > 0) {
+        logger.warn(
+          '[NarrativeController] Initial turn reconciliation partial:',
+          turnResult.reconciliationErrors.map((e) => e.step)
+        );
       }
 
       const gatedSegment = turnResult.segment;
@@ -576,10 +576,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
         generatePlayerChoices();
       }
     } catch {
-      // Error generating initial narrative (timeout, network, etc.)
-      // The resolver may have already committed a segment before the
-      // timeout race rejected. Check the store before inserting a
-      // fallback to avoid duplicates.
+      // Error generating initial narrative (timeout, abort, network, etc.).
       try {
         const alreadyCommitted = getSessionSegments(sessionId);
         if (alreadyCommitted.length > 0) {
@@ -716,17 +713,13 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
       const pacingEscalationRequested =
         !hasWorldClock && isPacingStale(computeTurnsSinceComplication(segments));
 
-      // Race AI generation against a timeout so a slow response falls back
-      // instead of hanging.
+      // The abort signal times out the provider round-trip; reconciliation
+      // runs unraced so a slow side-effect pass doesn't trigger a spurious
+      // error + Retry while the segment was already committed.
       const segmentAbort = new AbortController();
-      const segmentTimeoutPromise = new Promise<never>((_, reject) => {
-        segmentTimeoutId = setTimeout(() => {
-          segmentAbort.abort();
-          reject(
-            new Error(`Segment generation timed out after ${AI_GENERATION_TIMEOUT_MS}ms`)
-          );
-        }, AI_GENERATION_TIMEOUT_MS);
-      });
+      segmentTimeoutId = setTimeout(() => {
+        segmentAbort.abort();
+      }, AI_GENERATION_TIMEOUT_MS);
 
       const command: TurnCommand = {
         sessionId,
@@ -754,14 +747,18 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
         onChunk: handleStreamChunk,
       };
 
-      const turnResult = await Promise.race([
-        resolveTurn(command, narrativeGenerator),
-        segmentTimeoutPromise,
-      ]);
+      const turnResult = await resolveTurn(command, narrativeGenerator);
 
       // Skip if component unmounted during async operation
       if (!mountedRef.current) {
         return;
+      }
+
+      if (turnResult.reconciliationErrors.length > 0) {
+        logger.warn(
+          '[NarrativeController] Turn reconciliation partial:',
+          turnResult.reconciliationErrors.map((e) => e.step)
+        );
       }
 
       const gatedSegment = turnResult.segment;

--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -576,42 +576,53 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
         generatePlayerChoices();
       }
     } catch {
-      // Error generating initial narrative — create a graceful fallback segment
+      // Error generating initial narrative (timeout, network, etc.)
+      // The resolver may have already committed a segment before the
+      // timeout race rejected. Check the store before inserting a
+      // fallback to avoid duplicates.
       try {
-        const now = new Date();
-        const segmentId = `seg-${worldId}-fallback-${Date.now()}`;
-        const fallbackSegment: NarrativeSegment = {
-          id: segmentId,
-          content:
-            'The adventure begins. You find yourself at the edge of a new journey. What will you do next?',
-          type: 'scene',
-          characterIds: [],
-          metadata: {
-            characterIds: [],
-            location: 'Starting Location',
-            tags: ['intro', 'fallback'],
-          },
-          sessionId,
-          worldId,
-          timestamp: now,
-          createdAt: now.toISOString(),
-          updatedAt: now.toISOString(),
-        };
-
-        // Add locally and to the store to unblock the UI
-        const gatedFallback = storeSegmentAndTakeGated(fallbackSegment);
-        setSegments((prev) => [...prev, gatedFallback]);
-
-        // Notify parent so it can progress to choices skeleton + generation
-        if (onNarrativeGenerated) {
-          onNarrativeGenerated(gatedFallback);
-        }
-
-        // Kick off choice generation (will provide AI or fallback choices)
-        if (generateChoices && !isSessionEndingSegment(gatedFallback)) {
-          setTimeout(() => {
+        const alreadyCommitted = getSessionSegments(sessionId);
+        if (alreadyCommitted.length > 0) {
+          // The resolver finished generation but reconciliation pushed
+          // past the timeout. Adopt the committed segment instead.
+          setSegments(alreadyCommitted);
+          if (onNarrativeGenerated) {
+            onNarrativeGenerated(alreadyCommitted[0]);
+          }
+          if (generateChoices && !isSessionEndingSegment(alreadyCommitted[0])) {
             generatePlayerChoices();
-          }, 500);
+          }
+        } else {
+          const now = new Date();
+          const segmentId = `seg-${worldId}-fallback-${Date.now()}`;
+          const fallbackSegment: NarrativeSegment = {
+            id: segmentId,
+            content:
+              'The adventure begins. You find yourself at the edge of a new journey. What will you do next?',
+            type: 'scene',
+            characterIds: [],
+            metadata: {
+              characterIds: [],
+              location: 'Starting Location',
+              tags: ['intro', 'fallback'],
+            },
+            sessionId,
+            worldId,
+            timestamp: now,
+            createdAt: now.toISOString(),
+            updatedAt: now.toISOString(),
+          };
+
+          const gatedFallback = storeSegmentAndTakeGated(fallbackSegment);
+          setSegments((prev) => [...prev, gatedFallback]);
+
+          if (onNarrativeGenerated) {
+            onNarrativeGenerated(gatedFallback);
+          }
+
+          if (generateChoices && !isSessionEndingSegment(gatedFallback)) {
+            generatePlayerChoices();
+          }
         }
       } catch (error) {
         // Surface the original error if fallback insert also fails

--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -32,10 +32,23 @@ import { useCharacterStore } from '@/state/characterStore';
 import { useWorldStore } from '@/state/worldStore';
 import { useNPCStore } from '@/state/npcStore';
 import { resolveTurn, resolveInitialTurn } from '@/lib/narrative/turnResolver';
-import type { TurnCommand, InitialTurnCommand } from '@/types/turnResolver.types';
+import type {
+  TurnCommand,
+  InitialTurnCommand,
+  TurnResult,
+} from '@/types/turnResolver.types';
+import type { NarrativeError } from '@/lib/narrative/narrativeErrors';
 
 
 const EMPTY_NPC_IDS: string[] = [];
+const PARTIAL_RECONCILIATION_ERROR: NarrativeError = {
+  title: 'The story paused',
+  message: 'The story advanced, but some session changes did not finish.',
+  suggestion: 'Stop here rather than making another choice.',
+  retryable: false,
+  retryLabel: 'Continue the story',
+  severity: 'error',
+};
 
 interface NarrativeControllerProps {
   worldId: string;
@@ -231,6 +244,22 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
     onChoicesGenerated,
     onError: setError,
   });
+
+  const confirmTurnSettled = useCallback(
+    (turnResult: TurnResult, context: string): boolean => {
+      if (turnResult.status === 'settled') {
+        return true;
+      }
+
+      logger.warn(
+        `[NarrativeController] ${context} reconciliation partial:`,
+        turnResult.reconciliationErrors.map((error) => error.step)
+      );
+      setGenerationError(PARTIAL_RECONCILIATION_ERROR);
+      return false;
+    },
+    [setGenerationError]
+  );
 
   // Initialize component state on mount
   useEffect(() => {
@@ -548,12 +577,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
         return;
       }
 
-      if (turnResult.reconciliationErrors.length > 0) {
-        logger.warn(
-          '[NarrativeController] Initial turn reconciliation partial:',
-          turnResult.reconciliationErrors.map((e) => e.step)
-        );
-      }
+      const isTurnSettled = confirmTurnSettled(turnResult, 'Initial turn');
 
       const gatedSegment = turnResult.segment;
 
@@ -572,7 +596,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
       // Generate choices if enabled - skip when this segment already ends
       // the session. The resolver has already settled all core state, so
       // choice generation reads the post-turn revision.
-      if (generateChoices && !turnResult.isEnding) {
+      if (generateChoices && isTurnSettled && !turnResult.isEnding) {
         generatePlayerChoices();
       }
     } catch {
@@ -580,15 +604,13 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
       try {
         const alreadyCommitted = getSessionSegments(sessionId);
         if (alreadyCommitted.length > 0) {
-          // The resolver finished generation but reconciliation pushed
-          // past the timeout. Adopt the committed segment instead.
+          // A post-commit failure cannot safely retry generation or advance
+          // to another Decision because the stored Turn may be partial.
           setSegments(alreadyCommitted);
           if (onNarrativeGenerated) {
             onNarrativeGenerated(alreadyCommitted[0]);
           }
-          if (generateChoices && !isSessionEndingSegment(alreadyCommitted[0])) {
-            generatePlayerChoices();
-          }
+          setGenerationError(PARTIAL_RECONCILIATION_ERROR);
         } else {
           const now = new Date();
           const segmentId = `seg-${worldId}-fallback-${Date.now()}`;
@@ -754,12 +776,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
         return;
       }
 
-      if (turnResult.reconciliationErrors.length > 0) {
-        logger.warn(
-          '[NarrativeController] Turn reconciliation partial:',
-          turnResult.reconciliationErrors.map((e) => e.step)
-        );
-      }
+      const isTurnSettled = confirmTurnSettled(turnResult, 'Turn');
 
       const gatedSegment = turnResult.segment;
 
@@ -784,6 +801,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
         isFatalCriticalFailure && Boolean(onEndingSuggested);
       if (
         generateChoices &&
+        isTurnSettled &&
         !turnResult.isEnding &&
         !criticalFailureEndsSession
       ) {

--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -24,16 +24,15 @@ import {
 } from '@/lib/narrative/evaluateDecisionSkillChecks';
 import { computeTurnsSinceComplication, isPacingStale } from '@/lib/narrative/turnsSinceComplication';
 import { isFatalCadenceOffCooldown } from '@/lib/narrative/fatalDecisionCadence';
-import { buildWorldClockPromptContext, countWorldClockTurns } from '@/lib/narrative/worldClock';
 import { isFeatureEnabled } from '@/lib/featureFlags';
-import { mergeTurnTags } from '@/lib/narrative/turnTags';
 import { logger } from '@/lib/utils/logger';
 import { AI_GENERATION_TIMEOUT_MS } from '@/lib/constants/timeouts';
 import { isPlaywrightEnv } from '@/lib/utils/isPlaywrightEnv';
 import { useCharacterStore } from '@/state/characterStore';
 import { useWorldStore } from '@/state/worldStore';
 import { useNPCStore } from '@/state/npcStore';
-import { useWorldThreadStore } from '@/state/worldThreadStore';
+import { resolveTurn, resolveInitialTurn } from '@/lib/narrative/turnResolver';
+import type { TurnCommand, InitialTurnCommand } from '@/types/turnResolver.types';
 
 
 const EMPTY_NPC_IDS: string[] = [];
@@ -513,10 +512,9 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
       setError(null);
       resetStreamingPreview();
 
-      // Race AI generation against a timeout so a slow response falls back instead of hanging.
-      // Losing the race must also ABORT the generation: without the signal,
-      // the abandoned request keeps running (and spending) until aiFetch's
-      // ceiling, then mutates lore/inventory/NPC state when it settles.
+      // Race AI generation against a timeout so a slow response falls back
+      // instead of hanging. The abort signal propagates through the resolver
+      // to the underlying generator call.
       const generationAbort = new AbortController();
       const timeoutPromise = new Promise<never>((_, reject) => {
         generationTimeoutId = setTimeout(() => {
@@ -526,13 +524,18 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
           );
         }, AI_GENERATION_TIMEOUT_MS);
       });
-      const result = await Promise.race([
-        narrativeGenerator.generateInitialScene(
-          worldId,
-          characterId ? [characterId] : [],
-          sessionId,
-          { signal: generationAbort.signal, onChunk: handleStreamChunk }
-        ),
+
+      const initialCommand: InitialTurnCommand = {
+        sessionId,
+        worldId,
+        characterId: characterId ?? '',
+        generateChoices: generateChoices ?? true,
+        signal: generationAbort.signal,
+        onChunk: handleStreamChunk,
+      };
+
+      const turnResult = await Promise.race([
+        resolveInitialTurn(initialCommand, narrativeGenerator),
         timeoutPromise,
       ]);
 
@@ -545,27 +548,14 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
       const currentSegments = getSessionSegments(sessionId);
       const nowHasSegments = currentSegments.length > 0;
 
-      if (nowHasSegments) {
+      // If segments appeared from another source, just adopt them
+      if (nowHasSegments && !currentSegments.some(s => s.id === turnResult.segment.id)) {
+        setSegments(currentSegments);
         setIsLoading(false);
         return;
       }
 
-      const segmentId = `seg-${worldId}-${Date.now()}`;
-      const now = new Date();
-      const newSegment: NarrativeSegment = {
-        id: segmentId,
-        content: result.content,
-        type: result.segmentType,
-        characterIds: result.metadata.characterIds || [],
-        metadata: result.metadata,
-        sessionId, // Explicitly set sessionId
-        worldId, // Explicitly set worldId
-        timestamp: now,
-        createdAt: now.toISOString(),
-        updatedAt: now.toISOString(),
-      };
-
-      const gatedSegment = storeSegmentAndTakeGated(newSegment);
+      const gatedSegment = turnResult.segment;
 
       // Add to local state
       setSegments((prev) => [...prev, gatedSegment]);
@@ -579,12 +569,11 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
       // choice generation below doesn't wait on.
       void checkForEndingIndicators(gatedSegment);
 
-      // Generate choices if enabled - skip when this segment already ends the session
-      if (generateChoices && !isSessionEndingSegment(gatedSegment)) {
-        // Start generating AI choices immediately without showing fallback choices first
-        setTimeout(() => {
-          generatePlayerChoices();
-        }, 500); // Reduced timeout since we're not showing immediate choices
+      // Generate choices if enabled - skip when this segment already ends
+      // the session. The resolver has already settled all core state, so
+      // choice generation reads the post-turn revision.
+      if (generateChoices && !turnResult.isEnding) {
+        generatePlayerChoices();
       }
     } catch {
       // Error generating initial narrative — create a graceful fallback segment
@@ -655,34 +644,6 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
 
     let segmentTimeoutId: ReturnType<typeof setTimeout> | undefined;
     try {
-      // Use recent segments for context (last 3 segments for efficiency)
-      const recentSegments = segments.slice(-3);
-      // Streak tracked over the whole session, not just the trimmed context
-      // window above — a quiet stretch spans more than 3 segments.
-      const turnsSinceComplication = computeTurnsSinceComplication(segments);
-      // The turn the prompt names must match the one the store stamps after
-      // this segment lands (sessionSegments length after add), and the local
-      // segments state can lag the store, so read the store count directly.
-      const currentTurn =
-        countWorldClockTurns(useNarrativeStore.getState().getSessionSegments(sessionId)) + 1;
-      const worldClock = isFeatureEnabled('WORLD_CLOCK')
-        ? buildWorldClockPromptContext(
-            useWorldThreadStore
-              .getState()
-              .getAll()
-              .filter((thread) => thread.sessionId === sessionId),
-            currentTurn
-          )
-        : undefined;
-      // The scene prompt only carries the rising-tension block above this
-      // threshold, and the complication it asks for arrives with no dice roll
-      // behind it. Stamping the ask onto the segment is what lets the streak
-      // reset; without it the guidance would repeat on every following turn.
-      // With the world clock on, the template does not render that block, so
-      // the stamp stays off too and flag-off behavior is exactly the guard's.
-      const pacingEscalationRequested =
-        !worldClock && isPacingStale(turnsSinceComplication);
-
       // Get the actual choice text from the narrative store
       const decisions = useNarrativeStore
         .getState()
@@ -699,9 +660,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
         );
         if (option) {
           selectedOption = option;
-          // Extract decision weight from the decision
           decisionWeight = decision.decisionWeight;
-          // For custom input, use the customText, otherwise use the regular text
           choiceText =
             option.isCustomInput && option.customText
               ? option.customText
@@ -713,10 +672,6 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
 
       // Evaluate skill requirements (rolls, tags, outcome, per-roll toasts, and
       // the parent onSkillCheckPerformed notification are handled in the helper)
-      // Read characters/worlds at call time via getState() rather than
-      // subscribing — they're only needed here inside this async handler, so a
-      // store subscription would re-render the controller on every character/
-      // world write for no benefit.
       const character = characterId
         ? useCharacterStore.getState().characters[characterId]
         : undefined;
@@ -730,16 +685,8 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
         });
 
       // Fatal outcome check: a critical decision only ends the run on a true
-      // critical-failure roll (natural 1). An ordinary missed roll is a
-      // survivable setback the AI narrates (and can still escalate via the
-      // fatal-outcome tag the extraction stamps), so one unlucky-but-ordinary
-      // roll does not end the story.
-      //
-      // Critical weight is model-assigned and unbudgeted, so a tense genre can
-      // mark every turn pivotal and turn that natural 1 into a per-turn death
-      // roll. The cadence guard is what budgets it: only a decision off
-      // cooldown may be fatal, and taking that permission is what spends it,
-      // whichever way the dice then fall.
+      // critical-failure roll (natural 1). The cadence guard budgets it: only
+      // a decision off cooldown may be fatal.
       const fatalRiskAllowed =
         decisionWeight === 'critical' && isFatalCadenceOffCooldown(segments);
       const isFatalCriticalFailure =
@@ -752,31 +699,14 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
         );
       }
 
-      // Combine existing tags with skill check tags
-      const existingTags =
-        recentSegments[recentSegments.length - 1]?.metadata?.tags || [];
-      const currentTags = mergeTurnTags(existingTags, skillCheckTags);
+      // Pacing stamp: the resolver builds worldClock from the store but needs
+      // the escalation flag from the controller's pacing evaluation.
+      const hasWorldClock = isFeatureEnabled('WORLD_CLOCK');
+      const pacingEscalationRequested =
+        !hasWorldClock && isPacingStale(computeTurnsSinceComplication(segments));
 
-      // Build skill check context for the AI
-      let skillCheckContext = '';
-      if (rollResults.length > 0) {
-        const skillResultDescriptions = rollResults.map((r) => {
-          if (r.isCriticalSuccess) {
-            return `${r.skillName}: CRITICAL SUCCESS (natural 20)`;
-          } else if (r.isCriticalFailure) {
-            return `${r.skillName}: CRITICAL FAILURE (natural 1)`;
-          } else if (r.success) {
-            return `${r.skillName}: SUCCESS (rolled ${r.total} vs DC ${r.dc})`;
-          } else {
-            return `${r.skillName}: FAILURE (rolled ${r.total} vs DC ${r.dc})`;
-          }
-        });
-        skillCheckContext = ` [Skill checks: ${skillResultDescriptions.join(', ')}]`;
-      }
-
-      // Same contract as the initial-scene race: losing the race aborts the
-      // generation at the fetch layer instead of orphaning it until aiFetch's
-      // ceiling fires.
+      // Race AI generation against a timeout so a slow response falls back
+      // instead of hanging.
       const segmentAbort = new AbortController();
       const segmentTimeoutPromise = new Promise<never>((_, reject) => {
         segmentTimeoutId = setTimeout(() => {
@@ -786,39 +716,35 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
           );
         }, AI_GENERATION_TIMEOUT_MS);
       });
-      const result = await Promise.race([
-        narrativeGenerator.generateSegment(
-          {
-            worldId,
-            sessionId,
-            characterIds: characterId ? [characterId] : [],
-            narrativeContext: {
-              worldId,
-              currentSceneId: `scene-${Date.now()}`,
-              characterIds: characterId ? [characterId] : [],
-              previousSegments: recentSegments,
-              currentTags,
-              sessionId,
-              recentSegments,
-              turnsSinceComplication,
-              worldClock,
-              currentSituation: `Player chose: "${choiceText}"${skillCheckContext}`,
-            },
-            generationParameters: {
-              includedTopics: [choiceText],
-              // No desiredLength: the template scales the beat off decisionWeight
-              // so weighty moments get more room than routine ones.
-              decisionWeight,
-              // Critical decisions with critical failures should have tragic tone
-              desiredTone:
-                decisionWeight === 'critical' &&
-                rollResults.some((r) => r.isCriticalFailure)
-                  ? 'tragic'
-                  : undefined,
-            },
-          },
-          { signal: segmentAbort.signal, onChunk: handleStreamChunk }
-        ),
+
+      const command: TurnCommand = {
+        sessionId,
+        worldId,
+        characterId: characterId ?? '',
+        choiceId: triggeringChoiceId,
+        choiceText,
+        isCustomInput,
+        skillCheckResults: rollResults,
+        skillCheckTags,
+        decisionOutcome,
+        decisionWeight,
+        pacingEscalationRequested,
+        fatalRiskAllowed,
+        isFatalCriticalFailure,
+        generationParams: {
+          includedTopics: [choiceText],
+          desiredTone:
+            decisionWeight === 'critical' &&
+            rollResults.some((r) => r.isCriticalFailure)
+              ? 'tragic'
+              : undefined,
+        },
+        signal: segmentAbort.signal,
+        onChunk: handleStreamChunk,
+      };
+
+      const turnResult = await Promise.race([
+        resolveTurn(command, narrativeGenerator),
         segmentTimeoutPromise,
       ]);
 
@@ -827,29 +753,7 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
         return;
       }
 
-      const segmentId = `seg-${worldId}-${triggeringChoiceId}-${Date.now()}`;
-      const now = new Date();
-      const newSegment: NarrativeSegment = {
-        id: segmentId,
-        content: result.content,
-        type: result.segmentType,
-        characterIds: result.metadata.characterIds || [],
-        metadata: {
-          ...result.metadata,
-          // Merge skill check tags into metadata
-          tags: [...(result.metadata.tags || []), ...skillCheckTags],
-          decisionOutcome,
-          pacingEscalationRequested,
-          fatalRiskAllowed,
-        },
-        sessionId, // Explicitly set sessionId
-        worldId, // Explicitly set worldId
-        timestamp: now,
-        createdAt: now.toISOString(),
-        updatedAt: now.toISOString(),
-      };
-
-      const gatedSegment = storeSegmentAndTakeGated(newSegment);
+      const gatedSegment = turnResult.segment;
 
       // Add to local state
       setSegments((prev) => [...prev, gatedSegment]);
@@ -866,28 +770,16 @@ export const NarrativeController: React.FC<NarrativeControllerProps> = ({
       // Generate choices if enabled - skip when the session is ending
       // (fatal/ending segment or a fatal critical-decision failure).
       // A fatal critical failure only ends the session when an ending handler
-      // is wired: suggestEnding() is a no-op without onEndingSuggested. Without
-      // a handler, keep generating choices so a standalone controller (harness,
-      // story, embedder) can still move forward instead of stalling with no
-      // ending and no choices.
+      // is wired. The resolver has already settled all core state, so choice
+      // generation reads the post-turn revision — no setTimeout needed.
       const criticalFailureEndsSession =
         isFatalCriticalFailure && Boolean(onEndingSuggested);
       if (
         generateChoices &&
-        !isSessionEndingSegment(gatedSegment) &&
+        !turnResult.isEnding &&
         !criticalFailureEndsSession
       ) {
-        if (isCustomInput) {
-          // Generate choices after a longer delay to ensure custom input is fully processed
-          setTimeout(() => {
-            generatePlayerChoices();
-          }, 2000); // Longer delay after custom input
-        } else {
-          // Start generating AI choices immediately without showing fallback choices first
-          setTimeout(() => {
-            generatePlayerChoices();
-          }, 500); // Normal timeout for predefined choices
-        }
+        generatePlayerChoices();
       }
     } catch (err) {
       // Error generating narrative. Classify the failure (transient network/

--- a/src/components/Narrative/__tests__/NarrativeController.contentGate.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeController.contentGate.test.tsx
@@ -37,6 +37,7 @@ const RAW_GENERATED_CONTENT = [
 ].join('\n');
 
 const mockGenerateInitialScene = jest.fn();
+const mockGeneratePlayerChoices = jest.fn();
 
 jest.mock('@/lib/ai/defaultGeminiClient', () => ({
   createDefaultGeminiClient: jest.fn(() => ({ generateContent: jest.fn() })),
@@ -46,7 +47,7 @@ jest.mock('@/lib/ai/narrativeGenerator', () => ({
   NarrativeGenerator: jest.fn().mockImplementation(() => ({
     generateInitialScene: mockGenerateInitialScene,
     generateSegment: jest.fn(),
-    generatePlayerChoices: jest.fn(),
+    generatePlayerChoices: mockGeneratePlayerChoices,
   })),
 }));
 
@@ -113,6 +114,7 @@ describe('NarrativeController - the rendered passage is gated', () => {
         updatedAt: new Date().toISOString(),
       },
       snapshot: { sessionId: 'test-session' },
+      status: 'settled',
       isFatal: false,
       isEnding: false,
       reconciliationErrors: [],
@@ -167,5 +169,37 @@ describe('NarrativeController - the rendered passage is gated', () => {
 
     expect(onNarrativeGenerated).toHaveBeenCalledTimes(1);
     expect(onNarrativeGenerated.mock.calls[0][0].content).toBe(PROSE);
+  });
+
+  it('blocks the first Decision when initial reconciliation is partial', async () => {
+    const { resolveInitialTurn } = jest.requireMock('@/lib/narrative/turnResolver');
+    (resolveInitialTurn as jest.Mock).mockResolvedValueOnce({
+      segment: {
+        id: 'seg-partial',
+        content: PROSE,
+        type: 'scene',
+        sessionId: 'test-session',
+        worldId: 'test-world',
+        characterIds: [],
+        metadata: { characterIds: [], tags: [], location: 'Harrowgate' },
+        timestamp: new Date(),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      snapshot: { sessionId: 'test-session' },
+      status: 'partial',
+      isFatal: false,
+      isEnding: false,
+      reconciliationErrors: [
+        { step: 'worldStateThreads', error: new Error('thread update failed') },
+      ],
+    });
+
+    await renderController(jest.fn());
+
+    expect(mockGeneratePlayerChoices).not.toHaveBeenCalled();
+    expect(useNarrativeStore.getState().generationError).toEqual(
+      expect.objectContaining({ retryable: false })
+    );
   });
 });

--- a/src/components/Narrative/__tests__/NarrativeController.contentGate.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeController.contentGate.test.tsx
@@ -115,6 +115,7 @@ describe('NarrativeController - the rendered passage is gated', () => {
       snapshot: { sessionId: 'test-session' },
       isFatal: false,
       isEnding: false,
+      reconciliationErrors: [],
     });
 
     mockZustandStore(

--- a/src/components/Narrative/__tests__/NarrativeController.contentGate.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeController.contentGate.test.tsx
@@ -61,6 +61,12 @@ jest.mock('../useEndingDetection', () => ({
   useEndingDetection: () => ({ checkForEndingIndicators: jest.fn() }),
 }));
 
+jest.mock('@/lib/narrative/turnResolver', () => ({
+  resolveTurn: jest.fn(),
+  resolveInitialTurn: jest.fn(),
+  readSnapshot: jest.fn(),
+}));
+
 jest.mock('@/state/characterStore', () => ({ useCharacterStore: jest.fn() }));
 jest.mock('@/state/worldStore', () => ({ useWorldStore: jest.fn() }));
 jest.mock('@/state/npcStore', () => ({ useNPCStore: jest.fn() }));
@@ -88,6 +94,27 @@ describe('NarrativeController - the rendered passage is gated', () => {
       content: RAW_GENERATED_CONTENT,
       segmentType: 'scene',
       metadata: { characterIds: [], tags: [], location: 'Harrowgate' },
+    });
+
+    // The resolver gates the content via addSegment internally. The controller
+    // receives the gated result from TurnResult.segment.
+    const { resolveInitialTurn } = jest.requireMock('@/lib/narrative/turnResolver');
+    (resolveInitialTurn as jest.Mock).mockResolvedValue({
+      segment: {
+        id: 'seg-resolved',
+        content: PROSE,
+        type: 'scene',
+        sessionId: 'test-session',
+        worldId: 'test-world',
+        characterIds: [],
+        metadata: { characterIds: [], tags: [], location: 'Harrowgate' },
+        timestamp: new Date(),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      snapshot: { sessionId: 'test-session' },
+      isFatal: false,
+      isEnding: false,
     });
 
     mockZustandStore(

--- a/src/components/Narrative/__tests__/NarrativeController.fatalCadence.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeController.fatalCadence.test.tsx
@@ -197,6 +197,7 @@ describe('NarrativeController - fatal cadence on pivotal decisions', () => {
         updatedAt: new Date().toISOString(),
       },
       snapshot: { sessionId: 'test-session' },
+      status: 'settled',
       isFatal: false,
       isEnding: false,
       reconciliationErrors: [],

--- a/src/components/Narrative/__tests__/NarrativeController.fatalCadence.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeController.fatalCadence.test.tsx
@@ -199,6 +199,7 @@ describe('NarrativeController - fatal cadence on pivotal decisions', () => {
       snapshot: { sessionId: 'test-session' },
       isFatal: false,
       isEnding: false,
+      reconciliationErrors: [],
     });
   });
 

--- a/src/components/Narrative/__tests__/NarrativeController.fatalCadence.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeController.fatalCadence.test.tsx
@@ -47,6 +47,14 @@ jest.mock('@/state/narrativeStore', () => ({ useNarrativeStore: jest.fn() }));
 jest.mock('@/state/characterStore', () => ({ useCharacterStore: jest.fn() }));
 jest.mock('@/state/worldStore', () => ({ useWorldStore: jest.fn() }));
 jest.mock('@/state/npcStore', () => ({ useNPCStore: jest.fn() }));
+
+const mockResolveTurn = jest.fn();
+jest.mock('@/lib/narrative/turnResolver', () => ({
+  resolveTurn: (...args: unknown[]) => mockResolveTurn(...args),
+  resolveInitialTurn: jest.fn(),
+  readSnapshot: jest.fn(),
+}));
+
 jest.mock('../NarrativeHistory', () => ({
   NarrativeHistory: () => <div data-testid="narrative-history" />,
 }));
@@ -175,6 +183,23 @@ describe('NarrativeController - fatal cadence on pivotal decisions', () => {
       segmentType: 'scene',
       metadata: { characterIds: [], tags: [] },
     });
+    mockResolveTurn.mockResolvedValue({
+      segment: {
+        id: 'seg-resolved',
+        content: 'The door gives way.',
+        type: 'scene',
+        sessionId: 'test-session',
+        worldId: 'test-world',
+        characterIds: [],
+        metadata: { characterIds: [], tags: [] },
+        timestamp: new Date(),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      snapshot: { sessionId: 'test-session' },
+      isFatal: false,
+      isEnding: false,
+    });
   });
 
   it('does not end the run on a natural 1 while the fatal cadence is on cooldown', async () => {
@@ -192,19 +217,19 @@ describe('NarrativeController - fatal cadence on pivotal decisions', () => {
     expect(onEndingSuggested.mock.calls[0][0]).toMatch(/^fatal:/);
   });
 
-  it('records the spent fatal risk on the segment so the next pivotal turn is spaced out', async () => {
+  it('records the spent fatal risk on the command so the resolver stamps it', async () => {
     await playCriticalTurn(quietTurns(FATAL_DECISION_COOLDOWN_TURNS), jest.fn());
 
-    expect(mockAddSegment).toHaveBeenCalled();
-    const stored = mockAddSegment.mock.calls[0][1];
-    expect(stored.metadata.fatalRiskAllowed).toBe(true);
+    expect(mockResolveTurn).toHaveBeenCalled();
+    const command = mockResolveTurn.mock.calls[0][0];
+    expect(command.fatalRiskAllowed).toBe(true);
   });
 
   it('leaves the marker off a turn whose pivotal decision could not be fatal', async () => {
     await playCriticalTurn(quietTurns(3), jest.fn());
 
-    expect(mockAddSegment).toHaveBeenCalled();
-    const stored = mockAddSegment.mock.calls[0][1];
-    expect(stored.metadata.fatalRiskAllowed).toBe(false);
+    expect(mockResolveTurn).toHaveBeenCalled();
+    const command = mockResolveTurn.mock.calls[0][0];
+    expect(command.fatalRiskAllowed).toBe(false);
   });
 });

--- a/src/components/Narrative/__tests__/NarrativeController.generationError.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeController.generationError.test.tsx
@@ -25,6 +25,7 @@ import { ToastProvider } from '@/components/ui/toast/toaster';
 import type { NarrativeStore } from '@/state/narrativeStore.types';
 
 const mockGenerateSegment = jest.fn();
+const mockGeneratePlayerChoices = jest.fn();
 
 jest.mock('@/lib/ai/defaultGeminiClient', () => ({
   createDefaultGeminiClient: jest.fn(() => ({
@@ -36,7 +37,7 @@ jest.mock('@/lib/ai/narrativeGenerator', () => ({
   NarrativeGenerator: jest.fn().mockImplementation(() => ({
     generateInitialScene: jest.fn(),
     generateSegment: mockGenerateSegment,
-    generatePlayerChoices: jest.fn().mockResolvedValue({
+    generatePlayerChoices: mockGeneratePlayerChoices.mockResolvedValue({
       id: 'decision-1',
       prompt: 'What do you do?',
       options: [],
@@ -169,6 +170,7 @@ describe('NarrativeController — generation error capture (#1478)', () => {
         updatedAt: new Date().toISOString(),
       },
       snapshot: { sessionId: 'test-session' },
+      status: 'settled',
       isFatal: false,
       isEnding: false,
       reconciliationErrors: [],
@@ -189,5 +191,46 @@ describe('NarrativeController — generation error capture (#1478)', () => {
     // The error is cleared at the start of every attempt and never set on success.
     expect(narrativeStoreMock.clearGenerationError).toHaveBeenCalled();
     expect(narrativeStoreMock.setGenerationError).not.toHaveBeenCalled();
+  });
+
+  it('blocks choice generation when the committed turn is only partial', async () => {
+    mockResolveTurn.mockResolvedValue({
+      segment: {
+        id: 'seg-partial',
+        content: 'The path bends north.',
+        type: 'scene',
+        sessionId: 'test-session',
+        worldId: 'test-world',
+        characterIds: [],
+        metadata: { characterIds: [], tags: [], location: 'North Path' },
+        timestamp: new Date(),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      snapshot: { sessionId: 'test-session' },
+      status: 'partial',
+      isFatal: false,
+      isEnding: false,
+      reconciliationErrors: [
+        { step: 'worldClock', error: new Error('clock failed') },
+      ],
+    });
+
+    renderWithToast(
+      <NarrativeController
+        worldId="test-world"
+        sessionId="test-session"
+        triggerGeneration={true}
+        generateChoices={true}
+        choiceId="choice-1"
+      />
+    );
+
+    await flush();
+
+    expect(mockGeneratePlayerChoices).not.toHaveBeenCalled();
+    expect(narrativeStoreMock.setGenerationError).toHaveBeenCalledWith(
+      expect.objectContaining({ retryable: false })
+    );
   });
 });

--- a/src/components/Narrative/__tests__/NarrativeController.generationError.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeController.generationError.test.tsx
@@ -171,6 +171,7 @@ describe('NarrativeController — generation error capture (#1478)', () => {
       snapshot: { sessionId: 'test-session' },
       isFatal: false,
       isEnding: false,
+      reconciliationErrors: [],
     });
 
     renderWithToast(

--- a/src/components/Narrative/__tests__/NarrativeController.generationError.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeController.generationError.test.tsx
@@ -52,6 +52,13 @@ jest.mock('@/state/characterStore', () => ({ useCharacterStore: jest.fn() }));
 jest.mock('@/state/worldStore', () => ({ useWorldStore: jest.fn() }));
 jest.mock('@/state/npcStore', () => ({ useNPCStore: jest.fn() }));
 
+const mockResolveTurn = jest.fn();
+jest.mock('@/lib/narrative/turnResolver', () => ({
+  resolveTurn: (...args: unknown[]) => mockResolveTurn(...args),
+  resolveInitialTurn: jest.fn(),
+  readSnapshot: jest.fn(),
+}));
+
 jest.mock('../NarrativeHistory', () => ({
   NarrativeHistory: () => <div data-testid="narrative-history" />,
 }));
@@ -128,7 +135,7 @@ describe('NarrativeController — generation error capture (#1478)', () => {
   });
 
   it('captures a classified, retryable error when the segment call rejects', async () => {
-    mockGenerateSegment.mockRejectedValue(new Error('network request failed'));
+    mockResolveTurn.mockRejectedValue(new Error('network request failed'));
 
     renderWithToast(
       <NarrativeController
@@ -148,10 +155,22 @@ describe('NarrativeController — generation error capture (#1478)', () => {
   });
 
   it('does not leave an error behind when the segment call resolves', async () => {
-    mockGenerateSegment.mockResolvedValue({
-      content: 'The path bends north.',
-      segmentType: 'scene',
-      metadata: { characterIds: [], tags: [], location: 'North Path' },
+    mockResolveTurn.mockResolvedValue({
+      segment: {
+        id: 'seg-resolved',
+        content: 'The path bends north.',
+        type: 'scene',
+        sessionId: 'test-session',
+        worldId: 'test-world',
+        characterIds: [],
+        metadata: { characterIds: [], tags: [], location: 'North Path' },
+        timestamp: new Date(),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      snapshot: { sessionId: 'test-session' },
+      isFatal: false,
+      isEnding: false,
     });
 
     renderWithToast(
@@ -169,6 +188,5 @@ describe('NarrativeController — generation error capture (#1478)', () => {
     // The error is cleared at the start of every attempt and never set on success.
     expect(narrativeStoreMock.clearGenerationError).toHaveBeenCalled();
     expect(narrativeStoreMock.setGenerationError).not.toHaveBeenCalled();
-    expect(narrativeStoreMock.addSegment).toHaveBeenCalled();
   });
 });

--- a/src/components/Narrative/__tests__/NarrativeController.timeout.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeController.timeout.test.tsx
@@ -155,8 +155,15 @@ describe('NarrativeController — per-choice segment timeout (#1429)', () => {
   });
 
   it('surfaces error state after timeout when resolveTurn hangs', async () => {
-    // Never-resolving promise simulates a hung resolver
-    mockResolveTurn.mockReturnValue(new Promise(() => {}));
+    // The mock rejects on abort — matching the real resolver's behavior
+    // where an aborted generator throws through the resolver chain.
+    mockResolveTurn.mockImplementation((command: { signal?: AbortSignal }) =>
+      new Promise((_, reject) => {
+        command.signal?.addEventListener('abort', () => {
+          reject(new Error('The operation was aborted'));
+        });
+      })
+    );
 
     renderWithToast(
       <NarrativeController
@@ -168,7 +175,7 @@ describe('NarrativeController — per-choice segment timeout (#1429)', () => {
       />
     );
 
-    // Advance past AI_GENERATION_TIMEOUT_MS so the race rejects
+    // Advance past AI_GENERATION_TIMEOUT_MS so the abort signal fires
     await act(async () => {
       jest.advanceTimersByTime(AI_GENERATION_TIMEOUT_MS + 100);
     });
@@ -182,10 +189,10 @@ describe('NarrativeController — per-choice segment timeout (#1429)', () => {
     expect(screen.queryByTestId('loading-indicator')).toBeNull();
   });
 
-  it('aborts the losing generation when the race times out', async () => {
-    // Losing the race must cancel the request itself, not just abandon the
-    // promise — otherwise the fetch lives on until aiFetch's outer ceiling
-    // (a zombie that wastes spend and mutates stores when it settles).
+  it('aborts the generation via signal when the timeout fires', async () => {
+    // The timeout fires abort() on the signal, which the real resolver
+    // propagates to the fetch layer. The mock ignores it (never resolves)
+    // to verify the signal itself was aborted.
     mockResolveTurn.mockReturnValue(new Promise(() => {}));
 
     renderWithToast(

--- a/src/components/Narrative/__tests__/NarrativeController.timeout.test.tsx
+++ b/src/components/Narrative/__tests__/NarrativeController.timeout.test.tsx
@@ -62,6 +62,13 @@ jest.mock('@/state/npcStore', () => ({
   useNPCStore: jest.fn(),
 }));
 
+const mockResolveTurn = jest.fn();
+jest.mock('@/lib/narrative/turnResolver', () => ({
+  resolveTurn: (...args: unknown[]) => mockResolveTurn(...args),
+  resolveInitialTurn: jest.fn(),
+  readSnapshot: jest.fn(),
+}));
+
 jest.mock('../NarrativeHistory', () => ({
   NarrativeHistory: ({
     isLoading,
@@ -147,9 +154,9 @@ describe('NarrativeController — per-choice segment timeout (#1429)', () => {
     jest.useRealTimers();
   });
 
-  it('surfaces error state after timeout when generateSegment hangs', async () => {
-    // Never-resolving promise simulates a hung AI call
-    mockGenerateSegment.mockReturnValue(new Promise(() => {}));
+  it('surfaces error state after timeout when resolveTurn hangs', async () => {
+    // Never-resolving promise simulates a hung resolver
+    mockResolveTurn.mockReturnValue(new Promise(() => {}));
 
     renderWithToast(
       <NarrativeController
@@ -179,7 +186,7 @@ describe('NarrativeController — per-choice segment timeout (#1429)', () => {
     // Losing the race must cancel the request itself, not just abandon the
     // promise — otherwise the fetch lives on until aiFetch's outer ceiling
     // (a zombie that wastes spend and mutates stores when it settles).
-    mockGenerateSegment.mockReturnValue(new Promise(() => {}));
+    mockResolveTurn.mockReturnValue(new Promise(() => {}));
 
     renderWithToast(
       <NarrativeController
@@ -195,17 +202,15 @@ describe('NarrativeController — per-choice segment timeout (#1429)', () => {
       await Promise.resolve();
     });
 
-    expect(mockGenerateSegment).toHaveBeenCalledTimes(1);
-    const options = mockGenerateSegment.mock.calls[0][1] as
-      | { signal?: AbortSignal }
-      | undefined;
-    expect(options?.signal).toBeInstanceOf(AbortSignal);
-    expect(options?.signal?.aborted).toBe(false);
+    expect(mockResolveTurn).toHaveBeenCalledTimes(1);
+    const command = mockResolveTurn.mock.calls[0][0] as { signal?: AbortSignal };
+    expect(command?.signal).toBeInstanceOf(AbortSignal);
+    expect(command?.signal?.aborted).toBe(false);
 
     await act(async () => {
       jest.advanceTimersByTime(AI_GENERATION_TIMEOUT_MS + 100);
     });
 
-    expect(options?.signal?.aborted).toBe(true);
+    expect(command?.signal?.aborted).toBe(true);
   });
 });

--- a/src/lib/ai/narrativeGenerator.ts
+++ b/src/lib/ai/narrativeGenerator.ts
@@ -452,54 +452,6 @@ export class NarrativeGenerator {
       throwIfAborted(options?.signal);
       recordRequestCalibration(fullyEnhancedPrompt, response);
 
-      // Deferred off the per-turn path, same as generateSegment above.
-      if (response.content) {
-        if (process.env.NODE_ENV !== 'production') {
-          logger.info('[NarrativeGenerator] EXTRACTION: Initial scene', {
-            worldId,
-            sessionId,
-            contentLength: response.content.length,
-          });
-        }
-
-        const existingLoreContext = getLoreContextForPrompt(worldId, sessionId, {
-          recordUsage: false,
-        });
-        void extractStructuredLore(response.content, existingLoreContext, {
-          playerCharacterName: playerCharacter?.name,
-        })
-          .then(async (structuredLore) => {
-            const { useLoreStore } = await import('@/state/loreStore');
-            const { addStructuredLore } = useLoreStore.getState();
-            addStructuredLore(structuredLore, worldId, sessionId);
-
-            if (process.env.NODE_ENV !== 'production') {
-              logger.info(
-                '[NarrativeGenerator] Extracted and stored lore from initial scene:',
-                {
-                  worldId,
-                  sessionId,
-                  factCount:
-                    structuredLore.characters.length +
-                    structuredLore.locations.length +
-                    structuredLore.events.length +
-                    structuredLore.rules.length,
-                  characters: structuredLore.characters.map((c) => c.name),
-                  locations: structuredLore.locations.map((l) => l.name),
-                  events: structuredLore.events.length,
-                  rules: structuredLore.rules.length,
-                }
-              );
-            }
-          })
-          .catch((error) => {
-            logger.error(
-              '[NarrativeGenerator] Failed to extract lore from initial scene:',
-              error
-            );
-          });
-      }
-
       // The opening segment is the one turn with no earlier place to carry forward.
       let result = await formatNarrativeResponse(
         response,
@@ -541,10 +493,59 @@ export class NarrativeGenerator {
         logger.warn('Failed to record lore mentions:', error);
       }
 
-      // Resolver guard: skip item processing and NPC sync when the resolver
-      // drives this call (it awaits those itself).
+      // Resolver guard: skip lore extraction, item processing, and NPC
+      // sync when the resolver drives this call (it handles those itself).
       if (isResolverManaged(options)) {
         return result;
+      }
+
+      // Lore extraction runs on the final (possibly corrected) prose, after
+      // the resolver guard, so resolver-driven calls don't double-extract.
+      if (result.content) {
+        if (process.env.NODE_ENV !== 'production') {
+          logger.info('[NarrativeGenerator] EXTRACTION: Initial scene', {
+            worldId,
+            sessionId,
+            contentLength: result.content.length,
+          });
+        }
+
+        const existingLoreContext = getLoreContextForPrompt(worldId, sessionId, {
+          recordUsage: false,
+        });
+        void extractStructuredLore(result.content, existingLoreContext, {
+          playerCharacterName: playerCharacter?.name,
+        })
+          .then(async (structuredLore) => {
+            const { useLoreStore } = await import('@/state/loreStore');
+            const { addStructuredLore } = useLoreStore.getState();
+            addStructuredLore(structuredLore, worldId, sessionId);
+
+            if (process.env.NODE_ENV !== 'production') {
+              logger.info(
+                '[NarrativeGenerator] Extracted and stored lore from initial scene:',
+                {
+                  worldId,
+                  sessionId,
+                  factCount:
+                    structuredLore.characters.length +
+                    structuredLore.locations.length +
+                    structuredLore.events.length +
+                    structuredLore.rules.length,
+                  characters: structuredLore.characters.map((c) => c.name),
+                  locations: structuredLore.locations.map((l) => l.name),
+                  events: structuredLore.events.length,
+                  rules: structuredLore.rules.length,
+                }
+              );
+            }
+          })
+          .catch((error) => {
+            logger.error(
+              '[NarrativeGenerator] Failed to extract lore from initial scene:',
+              error
+            );
+          });
       }
 
       if (result.metadata.itemsAcquired && result.metadata.itemsAcquired.length > 0) {

--- a/src/lib/ai/narrativeGenerator.ts
+++ b/src/lib/ai/narrativeGenerator.ts
@@ -56,7 +56,7 @@ import {
   collectContinuityTopicsFromStores,
   enhancePromptWithContinuityExpectations,
 } from './narrativeGenerator.continuity';
-import { isResolverActive } from '@/lib/narrative/resolverGuard';
+import { isResolverManaged } from '@/lib/narrative/resolverGuard';
 import {
   buildKnownNameTokens,
   enhancePromptWithPhraseVariety,
@@ -94,7 +94,7 @@ export class NarrativeGenerator {
    */
   async generateSegment(
     request: NarrativeGenerationRequest,
-    options?: { signal?: AbortSignal; onChunk?: (delta: string) => void }
+    options?: { signal?: AbortSignal; onChunk?: (delta: string) => void; resolverManaged?: boolean }
   ): Promise<NarrativeGenerationResult> {
     try {
       const world = this.getWorld(request.worldId);
@@ -201,10 +201,11 @@ export class NarrativeGenerator {
       // acquisition/loss, NPC sync) in case the caller aborted mid-pipeline.
       throwIfAborted(options?.signal);
 
-      // When the TurnResolver drives this session, it handles all post-
-      // generation side effects (lore, inventory, NPC sync) itself, so skip
-      // the fire-and-forget tails here to avoid duplicate writers.
-      if (request.sessionId && isResolverActive(request.sessionId)) {
+      // When the TurnResolver drives this call, it handles inventory, NPC
+      // sync, and lore extraction itself, so skip the fire-and-forget tails
+      // here to avoid duplicate writers. Only this specific call is
+      // suppressed; concurrent calls from other paths run normally.
+      if (isResolverManaged(options)) {
         return result;
       }
 
@@ -368,6 +369,7 @@ export class NarrativeGenerator {
       generationParameters?: GenerationParameters;
       signal?: AbortSignal;
       onChunk?: (delta: string) => void;
+      resolverManaged?: boolean;
     }
   ): Promise<NarrativeGenerationResult> {
     try {
@@ -540,8 +542,8 @@ export class NarrativeGenerator {
       }
 
       // Resolver guard: skip item processing and NPC sync when the resolver
-      // drives this session (it awaits those itself).
-      if (sessionId && isResolverActive(sessionId)) {
+      // drives this call (it awaits those itself).
+      if (isResolverManaged(options)) {
         return result;
       }
 

--- a/src/lib/ai/narrativeGenerator.ts
+++ b/src/lib/ai/narrativeGenerator.ts
@@ -56,6 +56,7 @@ import {
   collectContinuityTopicsFromStores,
   enhancePromptWithContinuityExpectations,
 } from './narrativeGenerator.continuity';
+import { isResolverActive } from '@/lib/narrative/resolverGuard';
 import {
   buildKnownNameTokens,
   enhancePromptWithPhraseVariety,
@@ -199,6 +200,13 @@ export class NarrativeGenerator {
       // Re-check before the store-mutating tail (lore extraction, item
       // acquisition/loss, NPC sync) in case the caller aborted mid-pipeline.
       throwIfAborted(options?.signal);
+
+      // When the TurnResolver drives this session, it handles all post-
+      // generation side effects (lore, inventory, NPC sync) itself, so skip
+      // the fire-and-forget tails here to avoid duplicate writers.
+      if (request.sessionId && isResolverActive(request.sessionId)) {
+        return result;
+      }
 
       // Lore extraction runs on the final (possibly corrected) prose so a
       // contradicted draft never pollutes the lore store. Deferred off the
@@ -529,6 +537,12 @@ export class NarrativeGenerator {
         checkAndRecordLoreMentions(worldId, sessionId, result.content ?? '', 'narrative');
       } catch (error) {
         logger.warn('Failed to record lore mentions:', error);
+      }
+
+      // Resolver guard: skip item processing and NPC sync when the resolver
+      // drives this session (it awaits those itself).
+      if (sessionId && isResolverActive(sessionId)) {
+        return result;
       }
 
       if (result.metadata.itemsAcquired && result.metadata.itemsAcquired.length > 0) {

--- a/src/lib/narrative/__tests__/applyWorldClockUpdates.test.ts
+++ b/src/lib/narrative/__tests__/applyWorldClockUpdates.test.ts
@@ -61,6 +61,23 @@ describe('applyWorldClockUpdates', () => {
     expect(useWorldThreadStore.getState().hasSessionLedger('session-1')).toBe(false);
   });
 
+  it('reports a fail-open extraction error to an awaited caller', async () => {
+    mockIsFeatureEnabled.mockReturnValue(true);
+    const extractionError = new Error('clock extraction failed');
+    const onError = jest.fn();
+    processSpy.mockRejectedValueOnce(extractionError);
+
+    const note = await applyWorldClockUpdates({
+      segment: segment(worldId),
+      sessionId: 'session-1',
+      currentTurn: 1,
+      onError,
+    });
+
+    expect(note).toBeUndefined();
+    expect(onError).toHaveBeenCalledWith(extractionError);
+  });
+
   it('with the flag on, seeds an unseeded session from the world prose and applies the result', async () => {
     mockIsFeatureEnabled.mockReturnValue(true);
     processSpy.mockResolvedValue({

--- a/src/lib/narrative/__tests__/itemAcquisitionProcessor.test.ts
+++ b/src/lib/narrative/__tests__/itemAcquisitionProcessor.test.ts
@@ -425,13 +425,20 @@ describe('itemAcquisitionProcessor', () => {
         .mockImplementationOnce(() => {
           throw new Error('Failed to add item');
         });
+      const onError = jest.fn();
 
-      await processAcquiredItems(items, 'character-123', 'session-456');
+      await processAcquiredItems(
+        items,
+        'character-123',
+        'session-456',
+        onError
+      );
 
       // Both categorizations should have been attempted
       expect(mockCategorize).toHaveBeenCalledTimes(2);
       // Both additions should have been attempted
       expect(mockAddItem).toHaveBeenCalledTimes(2);
+      expect(onError).toHaveBeenCalledWith(expect.any(Error));
     });
 
     it('splits multi-quantity equipment into individual items', async () => {

--- a/src/lib/narrative/__tests__/itemLossProcessor.test.ts
+++ b/src/lib/narrative/__tests__/itemLossProcessor.test.ts
@@ -239,10 +239,17 @@ describe('itemLossProcessor', () => {
         .mockImplementationOnce((_characterId, _itemId, _qty) => {
           // Success for the second item
         });
+      const onError = jest.fn();
 
-      await processLostItems(items, 'character-123', 'session-456');
+      await processLostItems(
+        items,
+        'character-123',
+        'session-456',
+        onError
+      );
 
       expect(mockRemoveItem).toHaveBeenCalledTimes(2);
+      expect(onError).toHaveBeenCalledWith(expect.any(Error));
     });
   });
 });

--- a/src/lib/narrative/__tests__/turnResolver.test.ts
+++ b/src/lib/narrative/__tests__/turnResolver.test.ts
@@ -59,6 +59,10 @@ jest.mock('@/lib/narrative/narrativeContentGate', () => ({
   applyNarrativeContentGate: jest.fn((content: string) => content),
 }));
 
+jest.mock('../turnTags', () => ({
+  mergeTurnTags: jest.fn((_prev: string[], current: string[]) => current),
+}));
+
 jest.mock('../isSessionEndingSegment', () => ({
   isSessionEndingSegment: jest.fn(() => false),
 }));

--- a/src/lib/narrative/__tests__/turnResolver.test.ts
+++ b/src/lib/narrative/__tests__/turnResolver.test.ts
@@ -1,0 +1,462 @@
+import { resolveTurn, resolveInitialTurn } from '../turnResolver';
+import { isResolverActive, markResolverActive, markResolverInactive } from '../resolverGuard';
+import { assembleSessionSnapshot } from '../sessionSnapshotAssembler';
+import { useNarrativeStore } from '@/state/narrativeStore';
+import { useSessionStore } from '@/state/sessionStore';
+import { useCharacterStore } from '@/state/characterStore';
+import { useInventoryStore } from '@/state/inventoryStore';
+import { useWorldThreadStore } from '@/state/worldThreadStore';
+import type { NarrativeGenerationResult } from '@/types/narrative.types';
+import type { TurnCommand } from '@/types/turnResolver.types';
+import type { NarrativeGenerator } from '@/lib/ai/narrativeGenerator';
+
+jest.mock('@/lib/featureFlags', () => ({
+  isFeatureEnabled: jest.fn(() => false),
+}));
+
+jest.mock('../applyWorldClockUpdates', () => ({
+  applyWorldClockUpdates: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('../applyWorldStateThreadUpdates', () => ({
+  applyWorldStateThreadUpdates: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../itemAcquisitionProcessor', () => ({
+  processAcquiredItems: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../itemLossProcessor', () => ({
+  processLostItems: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/lib/ai/narrativeGenerator.npc', () => ({
+  syncNpcMetadata: jest.fn(),
+}));
+
+jest.mock('../worldClock', () => ({
+  countWorldClockTurns: jest.fn((segments: unknown[]) => segments.length),
+  buildWorldClockPromptContext: jest.fn(),
+}));
+
+jest.mock('../turnsSinceComplication', () => ({
+  computeTurnsSinceComplication: jest.fn(() => 0),
+}));
+
+jest.mock('../itemLossInference', () => ({
+  inferItemsLostFromNarrative: jest.fn(() => []),
+}));
+
+jest.mock('@/lib/ai/loreContextHelper', () => ({
+  getLoreContextForPrompt: jest.fn(() => ''),
+}));
+
+jest.mock('@/lib/analytics/trackFunnelStep', () => ({
+  trackFunnelStep: jest.fn(),
+}));
+
+jest.mock('@/lib/narrative/narrativeContentGate', () => ({
+  applyNarrativeContentGate: jest.fn((content: string) => content),
+}));
+
+jest.mock('../isSessionEndingSegment', () => ({
+  isSessionEndingSegment: jest.fn(() => false),
+}));
+
+const { applyWorldClockUpdates } = jest.requireMock('../applyWorldClockUpdates');
+const { applyWorldStateThreadUpdates } = jest.requireMock('../applyWorldStateThreadUpdates');
+const { processAcquiredItems } = jest.requireMock('../itemAcquisitionProcessor');
+const { processLostItems } = jest.requireMock('../itemLossProcessor');
+const { syncNpcMetadata } = jest.requireMock('@/lib/ai/narrativeGenerator.npc');
+
+function makeGenerationResult(overrides: Partial<NarrativeGenerationResult> = {}): NarrativeGenerationResult {
+  return {
+    content: 'The road stretches ahead under a gray sky.',
+    segmentType: 'scene',
+    metadata: {
+      characterIds: [],
+      tags: [],
+      location: 'The road',
+      ...overrides.metadata,
+    },
+    ...overrides,
+  };
+}
+
+function makeMockGenerator(result?: NarrativeGenerationResult): NarrativeGenerator {
+  const genResult = result ?? makeGenerationResult();
+  return {
+    generateSegment: jest.fn().mockResolvedValue(genResult),
+    generateInitialScene: jest.fn().mockResolvedValue(genResult),
+  } as unknown as NarrativeGenerator;
+}
+
+function makeCommand(overrides: Partial<TurnCommand> = {}): TurnCommand {
+  return {
+    sessionId: 'session-1',
+    worldId: 'world-1',
+    characterId: 'char-1',
+    choiceId: 'choice-1',
+    choiceText: 'Head north',
+    isCustomInput: false,
+    skillCheckResults: [],
+    skillCheckTags: [],
+    pacingEscalationRequested: false,
+    fatalRiskAllowed: false,
+    isFatalCriticalFailure: false,
+    ...overrides,
+  };
+}
+
+function seedStores() {
+  useSessionStore.setState({
+    id: 'session-1',
+    worldId: 'world-1',
+    characterId: 'char-1',
+    status: 'active',
+  } as never);
+
+  useCharacterStore.setState({
+    characters: {
+      'char-1': {
+        id: 'char-1',
+        name: 'Test Character',
+        description: 'A test character',
+        worldId: 'world-1',
+        attributes: [],
+        skills: [],
+        level: 1,
+        status: { conditions: [] },
+        background: '',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    },
+  } as never);
+
+  useNarrativeStore.setState({
+    segments: {},
+    sessionSegments: {},
+    decisions: {},
+    sessionDecisions: {},
+    endedSessions: {},
+  } as never);
+
+  useInventoryStore.setState({
+    items: {},
+    characterInventories: {},
+  } as never);
+
+  useWorldThreadStore.setState({
+    threads: {},
+    sessionThreads: {},
+    seedAttempts: {},
+  } as never);
+}
+
+describe('TurnResolver', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    seedStores();
+  });
+
+  describe('resolveTurn', () => {
+    it('commits a segment and returns a settled result', async () => {
+      const generator = makeMockGenerator();
+      const command = makeCommand();
+
+      const result = await resolveTurn(command, generator);
+
+      expect(result.segment).toBeDefined();
+      expect(result.segment.content).toBe('The road stretches ahead under a gray sky.');
+      expect(result.segment.sessionId).toBe('session-1');
+      expect(result.snapshot).toBeDefined();
+      expect(result.snapshot.sessionId).toBe('session-1');
+    });
+
+    it('awaits world clock updates instead of fire-and-forget', async () => {
+      const generator = makeMockGenerator();
+      const command = makeCommand();
+
+      await resolveTurn(command, generator);
+
+      expect(applyWorldClockUpdates).toHaveBeenCalledTimes(1);
+      expect(applyWorldClockUpdates).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: 'session-1',
+        })
+      );
+    });
+
+    it('awaits world state thread updates instead of fire-and-forget', async () => {
+      const generator = makeMockGenerator();
+      const command = makeCommand();
+
+      await resolveTurn(command, generator);
+
+      expect(applyWorldStateThreadUpdates).toHaveBeenCalledTimes(1);
+    });
+
+    it('processes acquired items synchronously in the turn pipeline', async () => {
+      const result = makeGenerationResult({
+        metadata: {
+          characterIds: [],
+          tags: [],
+          itemsAcquired: [{ name: 'Iron sword' }],
+        },
+      });
+      const generator = makeMockGenerator(result);
+      const command = makeCommand();
+
+      await resolveTurn(command, generator);
+
+      expect(processAcquiredItems).toHaveBeenCalledWith(
+        [{ name: 'Iron sword' }],
+        'char-1',
+        'session-1'
+      );
+    });
+
+    it('processes lost items synchronously in the turn pipeline', async () => {
+      const result = makeGenerationResult({
+        metadata: {
+          characterIds: [],
+          tags: [],
+          itemsLost: [{ name: 'Old key' }],
+        },
+      });
+      const generator = makeMockGenerator(result);
+      const command = makeCommand();
+
+      await resolveTurn(command, generator);
+
+      expect(processLostItems).toHaveBeenCalledWith(
+        [{ name: 'Old key' }],
+        'char-1',
+        'session-1'
+      );
+    });
+
+    it('calls syncNpcMetadata', async () => {
+      const result = makeGenerationResult({
+        metadata: {
+          characterIds: [],
+          tags: [],
+          characters: [{ id: 'npc-1', name: 'Guard', role: 'guard' }],
+        },
+      });
+      const generator = makeMockGenerator(result);
+      const command = makeCommand();
+
+      await resolveTurn(command, generator);
+
+      expect(syncNpcMetadata).toHaveBeenCalledWith(
+        'world-1',
+        expect.arrayContaining([expect.objectContaining({ name: 'Guard' })])
+      );
+    });
+
+    it('stamps fatal-outcome tag from world cost reconciliation', async () => {
+      (applyWorldClockUpdates as jest.Mock).mockResolvedValueOnce({
+        worldCost: { fatal: true, entries: [] },
+      });
+
+      const generator = makeMockGenerator();
+      const command = makeCommand();
+
+      const result = await resolveTurn(command, generator);
+
+      expect(result.isFatal).toBe(true);
+      expect(result.isEnding).toBe(true);
+    });
+
+    it('marks isFatal from a critical failure command', async () => {
+      const generator = makeMockGenerator();
+      const command = makeCommand({ isFatalCriticalFailure: true });
+
+      const result = await resolveTurn(command, generator);
+
+      expect(result.isFatal).toBe(true);
+    });
+
+    it('post-turn snapshot reflects the committed segment', async () => {
+      const generator = makeMockGenerator();
+      const command = makeCommand();
+
+      const result = await resolveTurn(command, generator);
+
+      expect(result.snapshot.turnIndex).toBeGreaterThan(0);
+      const storedSegments = useNarrativeStore.getState().getSessionSegments('session-1');
+      expect(storedSegments.length).toBe(1);
+    });
+  });
+
+  describe('turn serialization', () => {
+    it('serializes concurrent turns for the same session', async () => {
+      const callOrder: string[] = [];
+
+      const slowGenerator = {
+        generateSegment: jest.fn().mockImplementation(async () => {
+          callOrder.push('gen-start');
+          await new Promise((r) => setTimeout(r, 50));
+          callOrder.push('gen-end');
+          return makeGenerationResult();
+        }),
+        generateInitialScene: jest.fn(),
+      } as unknown as NarrativeGenerator;
+
+      const command1 = makeCommand({ choiceId: 'choice-1' });
+      const command2 = makeCommand({ choiceId: 'choice-2' });
+
+      const [result1, result2] = await Promise.all([
+        resolveTurn(command1, slowGenerator),
+        resolveTurn(command2, slowGenerator),
+      ]);
+
+      // Both should succeed
+      expect(result1.segment).toBeDefined();
+      expect(result2.segment).toBeDefined();
+
+      // The generator should have been called twice sequentially
+      expect(slowGenerator.generateSegment).toHaveBeenCalledTimes(2);
+
+      // Verify sequential execution: gen-start, gen-end, gen-start, gen-end
+      expect(callOrder).toEqual(['gen-start', 'gen-end', 'gen-start', 'gen-end']);
+    });
+  });
+
+  describe('resolver guard', () => {
+    it('marks session active during turn resolution', async () => {
+      let wasActive = false;
+      const generator = {
+        generateSegment: jest.fn().mockImplementation(async () => {
+          wasActive = isResolverActive('session-1');
+          return makeGenerationResult();
+        }),
+        generateInitialScene: jest.fn(),
+      } as unknown as NarrativeGenerator;
+
+      await resolveTurn(makeCommand(), generator);
+
+      expect(wasActive).toBe(true);
+      // After resolution, guard should be cleared
+      expect(isResolverActive('session-1')).toBe(false);
+    });
+
+    it('clears the guard even on error', async () => {
+      const generator = {
+        generateSegment: jest.fn().mockRejectedValue(new Error('AI failed')),
+        generateInitialScene: jest.fn(),
+      } as unknown as NarrativeGenerator;
+
+      await expect(resolveTurn(makeCommand(), generator)).rejects.toThrow('AI failed');
+      expect(isResolverActive('session-1')).toBe(false);
+    });
+  });
+
+  describe('abort handling', () => {
+    it('propagates abort signal to the generator', async () => {
+      const abortController = new AbortController();
+      abortController.abort();
+
+      const generator = {
+        generateSegment: jest.fn().mockRejectedValue(new Error('aborted')),
+        generateInitialScene: jest.fn(),
+      } as unknown as NarrativeGenerator;
+
+      const command = makeCommand({ signal: abortController.signal });
+
+      await expect(resolveTurn(command, generator)).rejects.toThrow();
+
+      // No segment should be committed
+      const segments = useNarrativeStore.getState().getSessionSegments('session-1');
+      expect(segments.length).toBe(0);
+    });
+  });
+
+  describe('resolveInitialTurn', () => {
+    it('commits the first segment and returns a settled result', async () => {
+      const generator = makeMockGenerator();
+
+      const result = await resolveInitialTurn(
+        {
+          sessionId: 'session-1',
+          worldId: 'world-1',
+          characterId: 'char-1',
+          generateChoices: true,
+        },
+        generator
+      );
+
+      expect(result.segment).toBeDefined();
+      expect(result.segment.content).toBe('The road stretches ahead under a gray sky.');
+      expect(generator.generateInitialScene).toHaveBeenCalledTimes(1);
+      expect(applyWorldClockUpdates).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe('resolverGuard', () => {
+  afterEach(() => {
+    markResolverInactive('test-session');
+  });
+
+  it('starts inactive', () => {
+    expect(isResolverActive('test-session')).toBe(false);
+  });
+
+  it('marks active and inactive', () => {
+    markResolverActive('test-session');
+    expect(isResolverActive('test-session')).toBe(true);
+
+    markResolverInactive('test-session');
+    expect(isResolverActive('test-session')).toBe(false);
+  });
+
+  it('scopes to session IDs', () => {
+    markResolverActive('session-a');
+    expect(isResolverActive('session-a')).toBe(true);
+    expect(isResolverActive('session-b')).toBe(false);
+    markResolverInactive('session-a');
+  });
+});
+
+describe('sessionSnapshotAssembler', () => {
+  beforeEach(() => {
+    seedStores();
+  });
+
+  it('assembles a frozen snapshot from current store state', () => {
+    const snapshot = assembleSessionSnapshot('session-1');
+
+    expect(snapshot.sessionId).toBe('session-1');
+    expect(snapshot.worldId).toBe('world-1');
+    expect(snapshot.characterId).toBe('char-1');
+    expect(Object.isFrozen(snapshot.segments)).toBe(true);
+    expect(Object.isFrozen(snapshot.decisions)).toBe(true);
+    expect(Object.isFrozen(snapshot.inventory)).toBe(true);
+  });
+
+  it('reads character conditions', () => {
+    useCharacterStore.setState({
+      characters: {
+        'char-1': {
+          id: 'char-1',
+          name: 'Test',
+          description: '',
+          worldId: 'world-1',
+          attributes: [],
+          skills: [],
+          level: 1,
+          status: { conditions: ['poisoned', 'exhausted'] },
+          background: '',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      },
+    } as never);
+
+    const snapshot = assembleSessionSnapshot('session-1');
+    expect(snapshot.conditions).toEqual(['poisoned', 'exhausted']);
+  });
+});

--- a/src/lib/narrative/__tests__/turnResolver.test.ts
+++ b/src/lib/narrative/__tests__/turnResolver.test.ts
@@ -194,11 +194,44 @@ describe('TurnResolver', () => {
 
       const result = await resolveTurn(command, generator);
 
+      expect(result.status).toBe('settled');
       expect(result.segment).toBeDefined();
       expect(result.segment.content).toBe('The road stretches ahead under a gray sky.');
       expect(result.segment.sessionId).toBe('session-1');
       expect(result.snapshot).toBeDefined();
       expect(result.snapshot.sessionId).toBe('session-1');
+    });
+
+    it('rejects before commit when an abort-ignoring generator is cancelled', async () => {
+      const abortController = new AbortController();
+      const generator = makeMockGenerator();
+      (generator.generateSegment as jest.Mock).mockReturnValue(
+        new Promise(() => {})
+      );
+
+      const turnPromise = resolveTurn(
+        makeCommand({
+          sessionId: 'session-abort',
+          signal: abortController.signal,
+        }),
+        generator
+      );
+      await Promise.resolve();
+      expect(generator.generateSegment).toHaveBeenCalledTimes(1);
+
+      abortController.abort();
+      const result = await Promise.race([
+        turnPromise.then(
+          () => 'resolved',
+          (error) => error
+        ),
+        new Promise((resolve) => setTimeout(() => resolve('still-pending'), 0)),
+      ]);
+
+      expect(result).toMatchObject({ name: 'AbortError' });
+      expect(
+        useNarrativeStore.getState().getSessionSegments('session-abort')
+      ).toHaveLength(0);
     });
 
     it('blocks until world clock updates resolve', async () => {
@@ -261,7 +294,8 @@ describe('TurnResolver', () => {
       expect(processAcquiredItems).toHaveBeenCalledWith(
         [{ name: 'Iron sword' }],
         'char-1',
-        'session-1'
+        'session-1',
+        expect.any(Function)
       );
     });
 
@@ -281,7 +315,8 @@ describe('TurnResolver', () => {
       expect(processLostItems).toHaveBeenCalledWith(
         [{ name: 'Old key' }],
         'char-1',
-        'session-1'
+        'session-1',
+        expect.any(Function)
       );
     });
 
@@ -342,7 +377,7 @@ describe('TurnResolver', () => {
       expect(storedSegments.length).toBe(1);
     });
 
-    it('captures reconciliation errors without aborting the turn', async () => {
+    it('returns an explicit partial result when reconciliation fails', async () => {
       (applyWorldClockUpdates as jest.Mock).mockRejectedValueOnce(
         new Error('clock extraction failed')
       );
@@ -350,9 +385,26 @@ describe('TurnResolver', () => {
       const generator = makeMockGenerator();
       const result = await resolveTurn(makeCommand(), generator);
 
+      expect(result.status).toBe('partial');
       expect(result.segment).toBeDefined();
       expect(result.reconciliationErrors).toHaveLength(1);
       expect(result.reconciliationErrors[0].step).toBe('worldClock');
+    });
+
+    it('captures reconciliation failures reported by fail-open helpers', async () => {
+      (applyWorldClockUpdates as jest.Mock).mockImplementationOnce(
+        ({ onError }: { onError: (error: unknown) => void }) => {
+          onError(new Error('clock helper failed internally'));
+          return Promise.resolve(undefined);
+        }
+      );
+
+      const result = await resolveTurn(makeCommand(), makeMockGenerator());
+
+      expect(result.status).toBe('partial');
+      expect(result.reconciliationErrors).toEqual([
+        expect.objectContaining({ step: 'worldClock' }),
+      ]);
     });
 
     it('fires lore extraction as fire-and-forget', async () => {
@@ -535,6 +587,7 @@ describe('TurnResolver', () => {
         generator
       );
 
+      expect(result.status).toBe('partial');
       expect(result.reconciliationErrors).toHaveLength(1);
       expect(result.reconciliationErrors[0].step).toBe('worldStateThreads');
     });

--- a/src/lib/narrative/__tests__/turnResolver.test.ts
+++ b/src/lib/narrative/__tests__/turnResolver.test.ts
@@ -361,6 +361,39 @@ describe('TurnResolver', () => {
 
       expect(extractStructuredLore).toHaveBeenCalledTimes(1);
     });
+
+    it('passes playerCharacterName to lore extraction', async () => {
+      const generator = makeMockGenerator();
+      await resolveTurn(makeCommand(), generator);
+
+      expect(extractStructuredLore).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.objectContaining({ playerCharacterName: 'Test Character' })
+      );
+    });
+
+    it('passes authoritative characterId to reconciliation, not the session singleton', async () => {
+      // Point the session singleton at a different character
+      useSessionStore.setState({
+        id: 'session-1',
+        worldId: 'world-1',
+        characterId: 'other-char',
+        status: 'active',
+      } as never);
+
+      const generator = makeMockGenerator();
+      await resolveTurn(makeCommand({ characterId: 'char-1' }), generator);
+
+      // applyWorldClockUpdates should receive the command's characterId,
+      // not the session singleton's 'other-char'
+      expect(applyWorldClockUpdates).toHaveBeenCalledWith(
+        expect.objectContaining({ playerCharacterId: 'char-1' })
+      );
+      expect(applyWorldStateThreadUpdates).toHaveBeenCalledWith(
+        expect.objectContaining({ characterId: 'char-1' })
+      );
+    });
   });
 
   describe('turn serialization', () => {

--- a/src/lib/narrative/__tests__/turnResolver.test.ts
+++ b/src/lib/narrative/__tests__/turnResolver.test.ts
@@ -1,5 +1,5 @@
 import { resolveTurn, resolveInitialTurn } from '../turnResolver';
-import { isResolverActive, markResolverActive, markResolverInactive } from '../resolverGuard';
+import { isResolverManaged } from '../resolverGuard';
 import { assembleSessionSnapshot } from '../sessionSnapshotAssembler';
 import { useNarrativeStore } from '@/state/narrativeStore';
 import { useSessionStore } from '@/state/sessionStore';
@@ -49,6 +49,7 @@ jest.mock('../itemLossInference', () => ({
 
 jest.mock('@/lib/ai/loreContextHelper', () => ({
   getLoreContextForPrompt: jest.fn(() => ''),
+  checkAndRecordLoreMentions: jest.fn(),
 }));
 
 jest.mock('@/lib/analytics/trackFunnelStep', () => ({
@@ -67,11 +68,22 @@ jest.mock('../isSessionEndingSegment', () => ({
   isSessionEndingSegment: jest.fn(() => false),
 }));
 
+jest.mock('@/lib/ai/structuredLoreExtractor', () => ({
+  extractStructuredLore: jest.fn().mockResolvedValue({
+    characters: [], locations: [], events: [], rules: [],
+  }),
+}));
+
+jest.mock('@/lib/ai/narrativeGenerator.continuity', () => ({
+  collectContinuityTopicsFromStores: jest.fn(() => []),
+}));
+
 const { applyWorldClockUpdates } = jest.requireMock('../applyWorldClockUpdates');
 const { applyWorldStateThreadUpdates } = jest.requireMock('../applyWorldStateThreadUpdates');
 const { processAcquiredItems } = jest.requireMock('../itemAcquisitionProcessor');
 const { processLostItems } = jest.requireMock('../itemLossProcessor');
 const { syncNpcMetadata } = jest.requireMock('@/lib/ai/narrativeGenerator.npc');
+const { extractStructuredLore } = jest.requireMock('@/lib/ai/structuredLoreExtractor');
 
 function makeGenerationResult(overrides: Partial<NarrativeGenerationResult> = {}): NarrativeGenerationResult {
   return {
@@ -158,6 +170,17 @@ function seedStores() {
   } as never);
 }
 
+/** Returns a { promise, resolve, reject } triple for test control. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe('TurnResolver', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -178,27 +201,48 @@ describe('TurnResolver', () => {
       expect(result.snapshot.sessionId).toBe('session-1');
     });
 
-    it('awaits world clock updates instead of fire-and-forget', async () => {
+    it('blocks until world clock updates resolve', async () => {
+      const clockDeferred = deferred<null>();
+      (applyWorldClockUpdates as jest.Mock).mockReturnValue(clockDeferred.promise);
+
       const generator = makeMockGenerator();
       const command = makeCommand();
+      const turnPromise = resolveTurn(command, generator);
 
-      await resolveTurn(command, generator);
-
+      // Flush microtasks so generation and segment commit complete,
+      // but reconciliation is still pending.
+      await new Promise((r) => setTimeout(r, 0));
       expect(applyWorldClockUpdates).toHaveBeenCalledTimes(1);
-      expect(applyWorldClockUpdates).toHaveBeenCalledWith(
-        expect.objectContaining({
-          sessionId: 'session-1',
-        })
-      );
+
+      // The resolver should still be pending because the clock update
+      // hasn't resolved. If it were void-fired, turnPromise would
+      // already have settled.
+      let settled = false;
+      turnPromise.then(() => { settled = true; });
+      await new Promise((r) => setTimeout(r, 0));
+      expect(settled).toBe(false);
+
+      // Now resolve the deferred and verify the resolver completes.
+      clockDeferred.resolve(null);
+      const result = await turnPromise;
+      expect(result.segment).toBeDefined();
     });
 
-    it('awaits world state thread updates instead of fire-and-forget', async () => {
+    it('blocks until world state thread updates resolve', async () => {
+      const threadDeferred = deferred<void>();
+      (applyWorldStateThreadUpdates as jest.Mock).mockReturnValue(threadDeferred.promise);
+
       const generator = makeMockGenerator();
-      const command = makeCommand();
+      const turnPromise = resolveTurn(makeCommand(), generator);
 
-      await resolveTurn(command, generator);
+      await new Promise((r) => setTimeout(r, 0));
+      let settled = false;
+      turnPromise.then(() => { settled = true; });
+      await new Promise((r) => setTimeout(r, 0));
+      expect(settled).toBe(false);
 
-      expect(applyWorldStateThreadUpdates).toHaveBeenCalledTimes(1);
+      threadDeferred.resolve();
+      await turnPromise;
     });
 
     it('processes acquired items synchronously in the turn pipeline', async () => {
@@ -271,16 +315,20 @@ describe('TurnResolver', () => {
       const result = await resolveTurn(command, generator);
 
       expect(result.isFatal).toBe(true);
-      expect(result.isEnding).toBe(true);
     });
 
-    it('marks isFatal from a critical failure command', async () => {
+    it('marks isFatal from a critical failure command without setting isEnding', async () => {
       const generator = makeMockGenerator();
       const command = makeCommand({ isFatalCriticalFailure: true });
 
       const result = await resolveTurn(command, generator);
 
+      // isFatal is true because the command says so, but isEnding stays
+      // false because the segment itself doesn't carry ending tags.
+      // The controller decides what to do with isFatal based on its own
+      // handler availability.
       expect(result.isFatal).toBe(true);
+      expect(result.isEnding).toBe(false);
     });
 
     it('post-turn snapshot reflects the committed segment', async () => {
@@ -292,6 +340,26 @@ describe('TurnResolver', () => {
       expect(result.snapshot.turnIndex).toBeGreaterThan(0);
       const storedSegments = useNarrativeStore.getState().getSessionSegments('session-1');
       expect(storedSegments.length).toBe(1);
+    });
+
+    it('captures reconciliation errors without aborting the turn', async () => {
+      (applyWorldClockUpdates as jest.Mock).mockRejectedValueOnce(
+        new Error('clock extraction failed')
+      );
+
+      const generator = makeMockGenerator();
+      const result = await resolveTurn(makeCommand(), generator);
+
+      expect(result.segment).toBeDefined();
+      expect(result.reconciliationErrors).toHaveLength(1);
+      expect(result.reconciliationErrors[0].step).toBe('worldClock');
+    });
+
+    it('fires lore extraction as fire-and-forget', async () => {
+      const generator = makeMockGenerator();
+      await resolveTurn(makeCommand(), generator);
+
+      expect(extractStructuredLore).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -329,32 +397,24 @@ describe('TurnResolver', () => {
     });
   });
 
-  describe('resolver guard', () => {
-    it('marks session active during turn resolution', async () => {
-      let wasActive = false;
-      const generator = {
-        generateSegment: jest.fn().mockImplementation(async () => {
-          wasActive = isResolverActive('session-1');
-          return makeGenerationResult();
-        }),
-        generateInitialScene: jest.fn(),
-      } as unknown as NarrativeGenerator;
-
+  describe('resolverManaged guard', () => {
+    it('passes resolverManaged to the generator call', async () => {
+      const generator = makeMockGenerator();
       await resolveTurn(makeCommand(), generator);
 
-      expect(wasActive).toBe(true);
-      // After resolution, guard should be cleared
-      expect(isResolverActive('session-1')).toBe(false);
+      const genCall = (generator.generateSegment as jest.Mock).mock.calls[0];
+      expect(genCall[1]).toEqual(
+        expect.objectContaining({ resolverManaged: true })
+      );
     });
 
-    it('clears the guard even on error', async () => {
-      const generator = {
-        generateSegment: jest.fn().mockRejectedValue(new Error('AI failed')),
-        generateInitialScene: jest.fn(),
-      } as unknown as NarrativeGenerator;
-
-      await expect(resolveTurn(makeCommand(), generator)).rejects.toThrow('AI failed');
-      expect(isResolverActive('session-1')).toBe(false);
+    it('is call-scoped, not session-scoped', () => {
+      // The guard is now a pure function check on the options object.
+      // No session-wide state to leak.
+      expect(isResolverManaged({ resolverManaged: true })).toBe(true);
+      expect(isResolverManaged({ resolverManaged: false })).toBe(false);
+      expect(isResolverManaged(undefined)).toBe(false);
+      expect(isResolverManaged({})).toBe(false);
     });
   });
 
@@ -397,31 +457,66 @@ describe('TurnResolver', () => {
       expect(generator.generateInitialScene).toHaveBeenCalledTimes(1);
       expect(applyWorldClockUpdates).toHaveBeenCalledTimes(1);
     });
+
+    it('skips generation when a segment already exists in the store', async () => {
+      // Simulate another instance having committed a segment
+      useNarrativeStore.getState().addSegment('session-1', {
+        content: 'Previously committed.',
+        type: 'scene',
+        characterIds: [],
+        metadata: { characterIds: [], tags: [] },
+        worldId: 'world-1',
+        timestamp: new Date(),
+        updatedAt: new Date().toISOString(),
+      });
+
+      const generator = makeMockGenerator();
+      const result = await resolveInitialTurn(
+        {
+          sessionId: 'session-1',
+          worldId: 'world-1',
+          characterId: 'char-1',
+          generateChoices: true,
+        },
+        generator
+      );
+
+      // Should adopt the existing segment, not generate a new one
+      expect(generator.generateInitialScene).not.toHaveBeenCalled();
+      expect(result.segment.content).toBe('Previously committed.');
+    });
+
+    it('returns reconciliation errors when present', async () => {
+      (applyWorldStateThreadUpdates as jest.Mock).mockRejectedValueOnce(
+        new Error('thread extraction failed')
+      );
+
+      const generator = makeMockGenerator();
+      const result = await resolveInitialTurn(
+        {
+          sessionId: 'session-1',
+          worldId: 'world-1',
+          characterId: 'char-1',
+          generateChoices: true,
+        },
+        generator
+      );
+
+      expect(result.reconciliationErrors).toHaveLength(1);
+      expect(result.reconciliationErrors[0].step).toBe('worldStateThreads');
+    });
   });
 });
 
-describe('resolverGuard', () => {
-  afterEach(() => {
-    markResolverInactive('test-session');
+describe('resolverManaged guard', () => {
+  it('returns true only when explicitly set', () => {
+    expect(isResolverManaged({ resolverManaged: true })).toBe(true);
   });
 
-  it('starts inactive', () => {
-    expect(isResolverActive('test-session')).toBe(false);
-  });
-
-  it('marks active and inactive', () => {
-    markResolverActive('test-session');
-    expect(isResolverActive('test-session')).toBe(true);
-
-    markResolverInactive('test-session');
-    expect(isResolverActive('test-session')).toBe(false);
-  });
-
-  it('scopes to session IDs', () => {
-    markResolverActive('session-a');
-    expect(isResolverActive('session-a')).toBe(true);
-    expect(isResolverActive('session-b')).toBe(false);
-    markResolverInactive('session-a');
+  it('returns false for all other inputs', () => {
+    expect(isResolverManaged(undefined)).toBe(false);
+    expect(isResolverManaged({})).toBe(false);
+    expect(isResolverManaged({ resolverManaged: false })).toBe(false);
   });
 });
 
@@ -439,6 +534,31 @@ describe('sessionSnapshotAssembler', () => {
     expect(Object.isFrozen(snapshot.segments)).toBe(true);
     expect(Object.isFrozen(snapshot.decisions)).toBe(true);
     expect(Object.isFrozen(snapshot.inventory)).toBe(true);
+  });
+
+  it('uses authoritative IDs from the command, not the session singleton', () => {
+    // Point the session singleton at a different world/character
+    useSessionStore.setState({
+      id: 'session-1',
+      worldId: 'other-world',
+      characterId: 'other-char',
+      status: 'active',
+    } as never);
+
+    const snapshot = assembleSessionSnapshot('session-1', {
+      worldId: 'world-1',
+      characterId: 'char-1',
+    });
+
+    expect(snapshot.worldId).toBe('world-1');
+    expect(snapshot.characterId).toBe('char-1');
+  });
+
+  it('falls back to session singleton when IDs are not passed', () => {
+    const snapshot = assembleSessionSnapshot('session-1');
+
+    expect(snapshot.worldId).toBe('world-1');
+    expect(snapshot.characterId).toBe('char-1');
   });
 
   it('reads character conditions', () => {

--- a/src/lib/narrative/applyWorldClockUpdates.ts
+++ b/src/lib/narrative/applyWorldClockUpdates.ts
@@ -26,6 +26,8 @@ export interface ApplyWorldClockUpdatesParams {
   playerCharacterId?: EntityID;
   /** 1-based index of this segment in the session, read after it was added. */
   currentTurn: number;
+  /** Reports a fail-open extraction so an awaited caller can mark the Turn partial. */
+  onError?: (error: unknown) => void;
 }
 
 /** What the one extraction call reconciled this turn; each member stamps its own metadata field. */
@@ -77,6 +79,7 @@ async function reconcileSegment({
   characterId,
   playerCharacterId,
   currentTurn,
+  onError,
 }: ApplyWorldClockUpdatesParams): Promise<ReconciledSegmentNotes | undefined> {
   const goalStore = useGoalStore.getState();
   const clockOn = isFeatureEnabled('WORLD_CLOCK') && isWorldClockTurnSegment(segment);
@@ -119,6 +122,7 @@ async function reconcileSegment({
     return notes.worldClock || notes.worldCost ? notes : undefined;
   } catch (error) {
     logger.warn('[WorldClock] Ledger reconciliation failed', { sessionId, error });
+    onError?.(error);
     return undefined;
   }
 }

--- a/src/lib/narrative/applyWorldStateThreadUpdates.ts
+++ b/src/lib/narrative/applyWorldStateThreadUpdates.ts
@@ -24,6 +24,8 @@ export interface ApplyWorldStateThreadUpdatesParams {
   /** When set, used as the authoritative character instead of reading the
    *  session singleton. Prevents stale reads after a session switch. */
   characterId?: EntityID;
+  /** Reports a fail-open update so an awaited caller can mark the Turn partial. */
+  onError?: (error: unknown) => void;
 }
 
 export async function applyWorldStateThreadUpdates({
@@ -33,6 +35,7 @@ export async function applyWorldStateThreadUpdates({
   sessionId,
   isFirstSegment,
   characterId: authoritativeCharacterId,
+  onError,
 }: ApplyWorldStateThreadUpdatesParams): Promise<void> {
   try {
     if (!characterStoreModule) {
@@ -234,5 +237,6 @@ export async function applyWorldStateThreadUpdates({
       error: error instanceof Error ? error.message : 'Unknown error',
       sessionId,
     });
+    onError?.(error);
   }
 }

--- a/src/lib/narrative/applyWorldStateThreadUpdates.ts
+++ b/src/lib/narrative/applyWorldStateThreadUpdates.ts
@@ -21,6 +21,9 @@ export interface ApplyWorldStateThreadUpdatesParams {
   finalMetadata: NarrativeMetadata;
   sessionId: EntityID;
   isFirstSegment: boolean;
+  /** When set, used as the authoritative character instead of reading the
+   *  session singleton. Prevents stale reads after a session switch. */
+  characterId?: EntityID;
 }
 
 export async function applyWorldStateThreadUpdates({
@@ -29,6 +32,7 @@ export async function applyWorldStateThreadUpdates({
   finalMetadata,
   sessionId,
   isFirstSegment,
+  characterId: authoritativeCharacterId,
 }: ApplyWorldStateThreadUpdatesParams): Promise<void> {
   try {
     if (!characterStoreModule) {
@@ -52,6 +56,7 @@ export async function applyWorldStateThreadUpdates({
     }
 
     const activeCharacterId =
+      authoritativeCharacterId ??
       sessionStore.characterId ??
       originalSegmentData.characterIds?.[0] ??
       finalMetadata.characterIds?.[0] ??

--- a/src/lib/narrative/itemAcquisitionProcessor.ts
+++ b/src/lib/narrative/itemAcquisitionProcessor.ts
@@ -45,11 +45,13 @@ const processingQueue = new Map<EntityID, Promise<void>>();
  * @param items - Array of item metadata from AI narrative generation
  * @param characterId - ID of the character acquiring the items
  * @param sessionId - ID of the current game session
+ * @param onError - Reports fail-open item errors to an awaited caller
  */
 export async function processAcquiredItems(
   items: AcquiredItemMetadata[],
   characterId: EntityID,
-  sessionId: EntityID
+  sessionId: EntityID,
+  onError?: (error: unknown) => void
 ): Promise<void> {
   if (!items || items.length === 0) {
     return;
@@ -119,11 +121,18 @@ export async function processAcquiredItems(
         } catch (err) {
           // Log error but continue processing remaining items
           logger.error(`Failed to add item "${item.name}" to inventory:`, err);
+          onError?.(err);
         }
       }
     },
-    (err) => logger.error('Previous item acquisition run failed', err),
-    (err) => logger.error('processAcquiredItems encountered an unexpected error', err)
+    (err) => {
+      logger.error('Previous item acquisition run failed', err);
+      onError?.(err);
+    },
+    (err) => {
+      logger.error('processAcquiredItems encountered an unexpected error', err);
+      onError?.(err);
+    }
   );
 }
 

--- a/src/lib/narrative/itemLossProcessor.ts
+++ b/src/lib/narrative/itemLossProcessor.ts
@@ -37,11 +37,13 @@ const processingQueue = new Map<EntityID, Promise<void>>();
  * @param items - Array of item loss metadata from AI narrative generation
  * @param characterId - ID of the character losing the items
  * @param sessionId - ID of the current game session
+ * @param onError - Reports fail-open item errors to an awaited caller
  */
 export async function processLostItems(
   items: LostItemMetadata[],
   characterId: EntityID,
-  sessionId: EntityID
+  sessionId: EntityID,
+  onError?: (error: unknown) => void
 ): Promise<void> {
   if (!items || items.length === 0) {
     return;
@@ -101,11 +103,18 @@ export async function processLostItems(
           await delayBetweenItems(i, preparedItems.length);
         } catch (err) {
           logger.error(`Failed to remove item "${item.name}" from inventory:`, err);
+          onError?.(err);
         }
       }
     },
-    (err) => logger.error('Previous item loss run failed', err),
-    (err) => logger.error('processLostItems encountered an unexpected error', err)
+    (err) => {
+      logger.error('Previous item loss run failed', err);
+      onError?.(err);
+    },
+    (err) => {
+      logger.error('processLostItems encountered an unexpected error', err);
+      onError?.(err);
+    }
   );
 }
 
@@ -192,4 +201,3 @@ async function createJournalEntryForLoss(
     });
   }
 }
-

--- a/src/lib/narrative/resolverGuard.ts
+++ b/src/lib/narrative/resolverGuard.ts
@@ -1,29 +1,21 @@
 // src/lib/narrative/resolverGuard.ts
 
-import type { EntityID } from '@/types/common.types';
+/**
+ * Call-scoped flag that prevents duplicate writers during the TurnResolver
+ * migration. When the resolver drives a generation + commit cycle, it
+ * passes `resolverManaged: true` in the options so the generator and
+ * addSegment skip their own fire-and-forget side-effect tails. Only the
+ * specific call from the resolver is suppressed; concurrent calls from
+ * other paths (item-use, bootstrap) run their own tails normally.
+ *
+ * This replaces the previous session-wide guard, which blocked ALL writes
+ * to a session while any resolver was active.
+ */
 
 /**
- * Session-scoped guard that prevents duplicate writers during the
- * TurnResolver migration. When a session is resolver-active, the old
- * fire-and-forget tails in narrativeGenerator.generateSegment() and
- * narrativeStore.addSegment() skip their side effects because the
- * resolver handles those itself.
- *
- * Three-phase deployment:
- * 1. Guard lands, nothing calls markResolverActive - zero behavior change.
- * 2. Resolver wired, marks sessions active on entry - old path is dead.
- * 3. Stable, guard checks removed, fire-and-forget tails deleted.
+ * Check whether a generation or commit call should skip its side-effect
+ * tails because the TurnResolver is handling them.
  */
-const activeSessions = new Set<EntityID>();
-
-export function markResolverActive(sessionId: EntityID): void {
-  activeSessions.add(sessionId);
-}
-
-export function markResolverInactive(sessionId: EntityID): void {
-  activeSessions.delete(sessionId);
-}
-
-export function isResolverActive(sessionId: EntityID): boolean {
-  return activeSessions.has(sessionId);
+export function isResolverManaged(options?: { resolverManaged?: boolean }): boolean {
+  return options?.resolverManaged === true;
 }

--- a/src/lib/narrative/resolverGuard.ts
+++ b/src/lib/narrative/resolverGuard.ts
@@ -1,0 +1,29 @@
+// src/lib/narrative/resolverGuard.ts
+
+import type { EntityID } from '@/types/common.types';
+
+/**
+ * Session-scoped guard that prevents duplicate writers during the
+ * TurnResolver migration. When a session is resolver-active, the old
+ * fire-and-forget tails in narrativeGenerator.generateSegment() and
+ * narrativeStore.addSegment() skip their side effects because the
+ * resolver handles those itself.
+ *
+ * Three-phase deployment:
+ * 1. Guard lands, nothing calls markResolverActive - zero behavior change.
+ * 2. Resolver wired, marks sessions active on entry - old path is dead.
+ * 3. Stable, guard checks removed, fire-and-forget tails deleted.
+ */
+const activeSessions = new Set<EntityID>();
+
+export function markResolverActive(sessionId: EntityID): void {
+  activeSessions.add(sessionId);
+}
+
+export function markResolverInactive(sessionId: EntityID): void {
+  activeSessions.delete(sessionId);
+}
+
+export function isResolverActive(sessionId: EntityID): boolean {
+  return activeSessions.has(sessionId);
+}

--- a/src/lib/narrative/sessionSnapshotAssembler.ts
+++ b/src/lib/narrative/sessionSnapshotAssembler.ts
@@ -1,0 +1,73 @@
+// src/lib/narrative/sessionSnapshotAssembler.ts
+
+import type { EntityID } from '@/types/common.types';
+import type { SessionSnapshot } from '@/types/turnResolver.types';
+import { useNarrativeStore } from '@/state/narrativeStore';
+import { useCharacterStore } from '@/state/characterStore';
+import { useInventoryStore } from '@/state/inventoryStore';
+import { useWorldThreadStore } from '@/state/worldThreadStore';
+import { useWorldStore } from '@/state/worldStore';
+import { useNPCStore } from '@/state/npcStore';
+import { useSessionStore } from '@/state/sessionStore';
+import { getLoreContextForPrompt } from '@/lib/ai/loreContextHelper';
+import { countWorldClockTurns } from '@/lib/narrative/worldClock';
+
+/**
+ * Reads every session-relevant store once at call time and returns a frozen,
+ * read-only snapshot. No subscriptions, no side effects. Modeled after the
+ * existing decisionSnapshot.ts and buildContinuityContractFromStores()
+ * patterns.
+ *
+ * Prompt projections and post-turn assertions consume this instead of
+ * scattered getState() calls, which eliminates the race window where one
+ * store has been updated but another hasn't.
+ */
+export function assembleSessionSnapshot(sessionId: EntityID): SessionSnapshot {
+  const narrativeState = useNarrativeStore.getState();
+  const characterState = useCharacterStore.getState();
+  const inventoryState = useInventoryStore.getState();
+  const worldThreadState = useWorldThreadStore.getState();
+  const worldState = useWorldStore.getState();
+  const npcState = useNPCStore.getState();
+  const sessionState = useSessionStore.getState();
+
+  const worldId = sessionState.worldId ?? '';
+  const characterId = sessionState.characterId ?? '';
+
+  const allSegments = narrativeState.getSessionSegments(sessionId);
+  const turnIndex = countWorldClockTurns(allSegments);
+
+  const character = characterState.characters[characterId];
+  const conditions = character?.status?.conditions ?? [];
+
+  const inventory = inventoryState.getCharacterItems(characterId);
+
+  const worldThreads = worldThreadState
+    .getAll()
+    .filter((thread) => thread.sessionId === sessionId);
+
+  const ws = worldState.getWorldState(worldId);
+
+  const loreContext = getLoreContextForPrompt(worldId, sessionId);
+
+  const npcs = npcState.getNPCsByWorld(worldId);
+
+  const snapshot: SessionSnapshot = {
+    sessionId,
+    worldId,
+    characterId,
+    turnIndex,
+    segments: Object.freeze([...allSegments]) as readonly typeof allSegments[number][],
+    decisions: Object.freeze([...narrativeState.getSessionDecisions(sessionId)]),
+    character: Object.freeze({ ...character }) as Readonly<typeof character>,
+    inventory: Object.freeze([...inventory]),
+    worldThreads: Object.freeze([...worldThreads]),
+    worldState: ws ? Object.freeze({ ...ws }) : undefined,
+    loreContext,
+    npcs: Object.freeze([...npcs]),
+    conditions: Object.freeze([...conditions]),
+    endedSessions: Object.freeze({ ...narrativeState.endedSessions }),
+  };
+
+  return snapshot;
+}

--- a/src/lib/narrative/sessionSnapshotAssembler.ts
+++ b/src/lib/narrative/sessionSnapshotAssembler.ts
@@ -21,8 +21,15 @@ import { countWorldClockTurns } from '@/lib/narrative/worldClock';
  * Prompt projections and post-turn assertions consume this instead of
  * scattered getState() calls, which eliminates the race window where one
  * store has been updated but another hasn't.
+ *
+ * Pass authoritative worldId/characterId from the command so the snapshot
+ * is always bound to the requested session, not whichever session happens
+ * to be active in the singleton store.
  */
-export function assembleSessionSnapshot(sessionId: EntityID): SessionSnapshot {
+export function assembleSessionSnapshot(
+  sessionId: EntityID,
+  ids?: { worldId: EntityID; characterId: EntityID }
+): SessionSnapshot {
   const narrativeState = useNarrativeStore.getState();
   const characterState = useCharacterStore.getState();
   const inventoryState = useInventoryStore.getState();
@@ -31,8 +38,8 @@ export function assembleSessionSnapshot(sessionId: EntityID): SessionSnapshot {
   const npcState = useNPCStore.getState();
   const sessionState = useSessionStore.getState();
 
-  const worldId = sessionState.worldId ?? '';
-  const characterId = sessionState.characterId ?? '';
+  const worldId = ids?.worldId ?? sessionState.worldId ?? '';
+  const characterId = ids?.characterId ?? sessionState.characterId ?? '';
 
   const allSegments = narrativeState.getSessionSegments(sessionId);
   const turnIndex = countWorldClockTurns(allSegments);

--- a/src/lib/narrative/turnResolver.ts
+++ b/src/lib/narrative/turnResolver.ts
@@ -30,6 +30,7 @@ import {
 } from '@/lib/narrative/resolverGuard';
 import { logger } from '@/lib/utils/logger';
 import { inferItemsLostFromNarrative } from '@/lib/narrative/itemLossInference';
+import { mergeTurnTags } from '@/lib/narrative/turnTags';
 import { useInventoryStore } from '@/state/inventoryStore';
 
 /**
@@ -154,7 +155,10 @@ async function resolveTurnInner(
           currentSceneId: `scene-${Date.now()}`,
           characterIds: characterId ? [characterId] : [],
           previousSegments: [...recentSegments],
-          currentTags: command.skillCheckTags,
+          currentTags: mergeTurnTags(
+            recentSegments[recentSegments.length - 1]?.metadata?.tags ?? [],
+            command.skillCheckTags
+          ),
           sessionId,
           recentSegments: [...recentSegments],
           turnsSinceComplication,

--- a/src/lib/narrative/turnResolver.ts
+++ b/src/lib/narrative/turnResolver.ts
@@ -11,7 +11,7 @@ import type {
 import type { NarrativeGenerator } from '@/lib/ai/narrativeGenerator';
 import type { ReconciledSegmentNotes } from '@/lib/narrative/applyWorldClockUpdates';
 import { useNarrativeStore } from '@/state/narrativeStore';
-import { useSessionStore } from '@/state/sessionStore';
+import { useCharacterStore } from '@/state/characterStore';
 import { applyWorldClockUpdates } from '@/lib/narrative/applyWorldClockUpdates';
 import { applyWorldStateThreadUpdates } from '@/lib/narrative/applyWorldStateThreadUpdates';
 import { processAcquiredItems } from '@/lib/narrative/itemAcquisitionProcessor';
@@ -240,7 +240,11 @@ async function resolveTurnInner(
   // Fire lore extraction as fire-and-forget. It doesn't block the turn
   // but still runs so facts introduced in this turn's prose are
   // available to later prompts.
-  fireLoreExtraction(result, { worldId, sessionId, characterIds: characterId ? [characterId] : [] });
+  fireLoreExtraction(
+    result,
+    { worldId, sessionId, characterIds: characterId ? [characterId] : [] },
+    preTurnSnapshot.character?.name
+  );
 
   // Read the settled segment after reconciliation may have stamped tags
   const settledSegment =
@@ -338,7 +342,13 @@ async function resolveInitialTurnInner(
 
   syncNpcMetadata(worldId, result.metadata.characters);
 
-  fireLoreExtraction(result, { worldId, sessionId, characterIds: characterId ? [characterId] : [] });
+  const playerCharacterName =
+    useCharacterStore.getState().characters[characterId]?.name;
+  fireLoreExtraction(
+    result,
+    { worldId, sessionId, characterIds: characterId ? [characterId] : [] },
+    playerCharacterName
+  );
 
   const settledSegment =
     useNarrativeStore.getState().segments[storedSegmentId] ?? storedSegment;
@@ -387,7 +397,6 @@ async function reconcileCoreSideEffects({
   // 1. World clock: goals, thread extraction, world cost, fatal tag
   const allSegments = useNarrativeStore.getState().getSessionSegments(sessionId);
   const currentTurn = countWorldClockTurns(allSegments);
-  const session = useSessionStore.getState();
   let notes: ReconciledSegmentNotes | null = null;
 
   try {
@@ -395,8 +404,7 @@ async function reconcileCoreSideEffects({
       segment,
       sessionId,
       characterId: metadata.characterIds?.[0],
-      playerCharacterId:
-        session.id === sessionId ? session.characterId ?? undefined : undefined,
+      playerCharacterId: characterId,
       currentTurn,
     });
 
@@ -435,6 +443,7 @@ async function reconcileCoreSideEffects({
       finalMetadata: segment.metadata,
       sessionId,
       isFirstSegment,
+      characterId,
     });
   } catch (error) {
     logger.warn('[TurnResolver] World state thread update failed:', error);
@@ -470,7 +479,8 @@ async function reconcileCoreSideEffects({
  */
 function fireLoreExtraction(
   result: { content: string; metadata: { continuity?: { remainingIssues?: Array<{ type: string; entity: string }> } } },
-  request: { worldId: EntityID; sessionId: EntityID; characterIds: string[] }
+  request: { worldId: EntityID; sessionId: EntityID; characterIds: string[] },
+  playerCharacterName?: string
 ): void {
   if (!result.content) return;
 
@@ -486,6 +496,7 @@ function fireLoreExtraction(
 
   void extractStructuredLore(result.content, existingLoreContext, {
     continuityTopics: collectContinuityTopicsFromStores(request),
+    playerCharacterName,
     ...(unattestedSpeakers.length > 0 ? { unattestedSpeakers } : {}),
   })
     .then(async (structuredLore) => {

--- a/src/lib/narrative/turnResolver.ts
+++ b/src/lib/narrative/turnResolver.ts
@@ -1,0 +1,433 @@
+// src/lib/narrative/turnResolver.ts
+
+import type { EntityID } from '@/types/common.types';
+import type { NarrativeSegment } from '@/types/narrative.types';
+import type {
+  TurnCommand,
+  InitialTurnCommand,
+  TurnResult,
+  SessionSnapshot,
+} from '@/types/turnResolver.types';
+import type { NarrativeGenerator } from '@/lib/ai/narrativeGenerator';
+import type { ReconciledSegmentNotes } from '@/lib/narrative/applyWorldClockUpdates';
+import { useNarrativeStore } from '@/state/narrativeStore';
+import { useSessionStore } from '@/state/sessionStore';
+import { applyWorldClockUpdates } from '@/lib/narrative/applyWorldClockUpdates';
+import { applyWorldStateThreadUpdates } from '@/lib/narrative/applyWorldStateThreadUpdates';
+import { processAcquiredItems } from '@/lib/narrative/itemAcquisitionProcessor';
+import { processLostItems } from '@/lib/narrative/itemLossProcessor';
+import { syncNpcMetadata } from '@/lib/ai/narrativeGenerator.npc';
+import { isSessionEndingSegment } from '@/lib/narrative/isSessionEndingSegment';
+import { countWorldClockTurns } from '@/lib/narrative/worldClock';
+import { buildWorldClockPromptContext } from '@/lib/narrative/worldClock';
+import { isFeatureEnabled } from '@/lib/featureFlags';
+import { computeTurnsSinceComplication } from '@/lib/narrative/turnsSinceComplication';
+import { useWorldThreadStore } from '@/state/worldThreadStore';
+import { assembleSessionSnapshot } from '@/lib/narrative/sessionSnapshotAssembler';
+import {
+  markResolverActive,
+  markResolverInactive,
+} from '@/lib/narrative/resolverGuard';
+import { logger } from '@/lib/utils/logger';
+import { inferItemsLostFromNarrative } from '@/lib/narrative/itemLossInference';
+import { useInventoryStore } from '@/state/inventoryStore';
+
+/**
+ * Per-session lock so concurrent resolveTurn calls execute sequentially.
+ * Modeled after chainBySession in applyWorldClockUpdates.ts.
+ */
+const turnLockBySession = new Map<EntityID, Promise<unknown>>();
+
+function withTurnLock<T>(
+  sessionId: EntityID,
+  fn: () => Promise<T>
+): Promise<T> {
+  const prev = turnLockBySession.get(sessionId) ?? Promise.resolve();
+  const next = prev.then(fn, fn);
+  turnLockBySession.set(sessionId, next);
+  // Clean up the reference once the chain settles, but only if nothing
+  // new appended while this link was running. The .catch suppresses the
+  // dangling rejection on the cleanup branch — the caller's own await
+  // handles the real error.
+  const cleanup = next.finally(() => {
+    if (turnLockBySession.get(sessionId) === next) {
+      turnLockBySession.delete(sessionId);
+    }
+  });
+  cleanup.catch(() => {});
+  return next;
+}
+
+/**
+ * Read-only session snapshot, for prompt projections or DevTools.
+ */
+export function readSnapshot(sessionId: EntityID): SessionSnapshot {
+  return assembleSessionSnapshot(sessionId);
+}
+
+/**
+ * Advance the story by one Turn. Handles everything between "the player
+ * picked a choice" and "the next Decision can safely read state":
+ *
+ * 1. Acquire per-session lock
+ * 2. Mark the session resolver-active (generator/addSegment skip side effects)
+ * 3. Call the generator (prompt building + Gemini call)
+ * 4. Build and commit the NarrativeSegment
+ * 5. Await core reconciliation (world clock, world state threads, inventory)
+ * 6. Stamp fatal-outcome tags from reconciliation
+ * 7. Assemble post-turn snapshot
+ * 8. Release lock
+ * 9. Fire-and-forget background work (lore extraction handled by generator
+ *    outside the guard, if needed in the future)
+ */
+export function resolveTurn(
+  command: TurnCommand,
+  generator: NarrativeGenerator
+): Promise<TurnResult> {
+  return withTurnLock(command.sessionId, () =>
+    resolveTurnInner(command, generator)
+  );
+}
+
+/**
+ * First turn of a session - generates the initial scene. Same settlement
+ * guarantees as resolveTurn.
+ */
+export function resolveInitialTurn(
+  command: InitialTurnCommand,
+  generator: NarrativeGenerator
+): Promise<TurnResult> {
+  return withTurnLock(command.sessionId, () =>
+    resolveInitialTurnInner(command, generator)
+  );
+}
+
+// -- Internal implementation --------------------------------------------------
+
+async function resolveTurnInner(
+  command: TurnCommand,
+  generator: NarrativeGenerator
+): Promise<TurnResult> {
+  const { sessionId, worldId, characterId } = command;
+
+  markResolverActive(sessionId);
+  try {
+    // Pre-turn snapshot for prompt context
+    const preTurnSnapshot = assembleSessionSnapshot(sessionId);
+    const recentSegments = preTurnSnapshot.segments.slice(-3);
+    const turnsSinceComplication = computeTurnsSinceComplication(
+      [...preTurnSnapshot.segments]
+    );
+    const currentTurn = preTurnSnapshot.turnIndex + 1;
+
+    const worldClock = isFeatureEnabled('WORLD_CLOCK')
+      ? buildWorldClockPromptContext(
+          useWorldThreadStore
+            .getState()
+            .getAll()
+            .filter((thread) => thread.sessionId === sessionId),
+          currentTurn
+        )
+      : undefined;
+
+    // Build skill check context string for the AI prompt
+    let skillCheckContext = '';
+    if (command.skillCheckResults.length > 0) {
+      const descriptions = command.skillCheckResults.map((r) => {
+        if (r.isCriticalSuccess) return `${r.skillName}: CRITICAL SUCCESS (natural 20)`;
+        if (r.isCriticalFailure) return `${r.skillName}: CRITICAL FAILURE (natural 1)`;
+        if (r.success) return `${r.skillName}: SUCCESS (rolled ${r.total} vs DC ${r.dc})`;
+        return `${r.skillName}: FAILURE (rolled ${r.total} vs DC ${r.dc})`;
+      });
+      skillCheckContext = ` [Skill checks: ${descriptions.join(', ')}]`;
+    }
+
+    // Call the generator - with the resolver active, it returns the result
+    // without running its own fire-and-forget side effects.
+    const result = await generator.generateSegment(
+      {
+        worldId,
+        sessionId,
+        characterIds: characterId ? [characterId] : [],
+        narrativeContext: {
+          worldId,
+          currentSceneId: `scene-${Date.now()}`,
+          characterIds: characterId ? [characterId] : [],
+          previousSegments: [...recentSegments],
+          currentTags: command.skillCheckTags,
+          sessionId,
+          recentSegments: [...recentSegments],
+          turnsSinceComplication,
+          worldClock,
+          currentSituation: `Player chose: "${command.choiceText}"${skillCheckContext}`,
+        },
+        generationParameters: {
+          includedTopics: command.generationParams?.includedTopics ?? [command.choiceText],
+          decisionWeight: command.decisionWeight,
+          desiredTone: command.generationParams?.desiredTone,
+        },
+      },
+      { signal: command.signal, onChunk: command.onChunk }
+    );
+
+    // Infer item losses from the narrative text when the AI didn't tag them
+    let metadata = { ...result.metadata };
+    if (
+      (!metadata.itemsLost || metadata.itemsLost.length === 0) &&
+      result.content
+    ) {
+      const characterInventory = useInventoryStore
+        .getState()
+        .getCharacterItems(characterId);
+      const inferredLosses = inferItemsLostFromNarrative(
+        result.content,
+        characterInventory
+      );
+      if (inferredLosses.length > 0) {
+        metadata = { ...metadata, itemsLost: inferredLosses };
+      }
+    }
+
+    // Build the segment (this construction was in NarrativeController lines 830-850)
+    const segmentId = `seg-${worldId}-${command.choiceId}-${Date.now()}`;
+    const now = new Date();
+    const newSegment: NarrativeSegment = {
+      id: segmentId,
+      content: result.content,
+      type: result.segmentType,
+      characterIds: metadata.characterIds || [],
+      metadata: {
+        ...metadata,
+        tags: [...(metadata.tags || []), ...command.skillCheckTags],
+        decisionOutcome: command.decisionOutcome,
+        pacingEscalationRequested: command.pacingEscalationRequested,
+        fatalRiskAllowed: command.fatalRiskAllowed,
+      },
+      sessionId,
+      worldId,
+      timestamp: now,
+      createdAt: now.toISOString(),
+      updatedAt: now.toISOString(),
+    };
+
+    // Commit the segment to the narrative store. With the resolver guard
+    // active, addSegment does the synchronous write and skips its own
+    // fire-and-forget tails.
+    const storedSegmentId = useNarrativeStore.getState().addSegment(sessionId, {
+      content: newSegment.content,
+      type: newSegment.type,
+      characterIds: newSegment.characterIds || [],
+      metadata: newSegment.metadata,
+      worldId: newSegment.worldId,
+      updatedAt: newSegment.updatedAt,
+      timestamp: newSegment.timestamp,
+    });
+
+    // Read back the gated version (addSegment runs content dedup/sanitization)
+    const storedSegment =
+      useNarrativeStore.getState().segments[storedSegmentId] ?? newSegment;
+
+    // -- Core reconciliation: awaited, not fire-and-forget --
+
+    const reconciledNotes = await reconcileCoreSideEffects({
+      segment: storedSegment,
+      segmentId: storedSegmentId,
+      sessionId,
+      characterId,
+      metadata,
+      isFirstSegment: false,
+    });
+
+    // Synchronous NPC sync (already not fire-and-forget)
+    syncNpcMetadata(worldId, result.metadata.characters);
+
+    // Read the settled segment after reconciliation may have stamped tags
+    const settledSegment =
+      useNarrativeStore.getState().segments[storedSegmentId] ?? storedSegment;
+
+    // Post-turn snapshot: the settled revision
+    const postTurnSnapshot = assembleSessionSnapshot(sessionId);
+
+    const isFatal =
+      command.isFatalCriticalFailure ||
+      settledSegment.metadata?.tags?.includes('fatal-outcome') === true;
+    const isEnding = isSessionEndingSegment(settledSegment) || isFatal;
+
+    return {
+      segment: settledSegment,
+      snapshot: postTurnSnapshot,
+      isFatal,
+      isEnding,
+      reconciledNotes: reconciledNotes ?? undefined,
+    };
+  } finally {
+    markResolverInactive(sessionId);
+  }
+}
+
+async function resolveInitialTurnInner(
+  command: InitialTurnCommand,
+  generator: NarrativeGenerator
+): Promise<TurnResult> {
+  const { sessionId, worldId, characterId } = command;
+
+  markResolverActive(sessionId);
+  try {
+    const result = await generator.generateInitialScene(
+      worldId,
+      characterId ? [characterId] : [],
+      sessionId,
+      { signal: command.signal, onChunk: command.onChunk }
+    );
+
+    const segmentId = `seg-${worldId}-${Date.now()}`;
+    const now = new Date();
+    const newSegment: NarrativeSegment = {
+      id: segmentId,
+      content: result.content,
+      type: result.segmentType,
+      characterIds: result.metadata.characterIds || [],
+      metadata: result.metadata,
+      sessionId,
+      worldId,
+      timestamp: now,
+      createdAt: now.toISOString(),
+      updatedAt: now.toISOString(),
+    };
+
+    const storedSegmentId = useNarrativeStore.getState().addSegment(sessionId, {
+      content: newSegment.content,
+      type: newSegment.type,
+      characterIds: newSegment.characterIds || [],
+      metadata: newSegment.metadata,
+      worldId: newSegment.worldId,
+      updatedAt: newSegment.updatedAt,
+      timestamp: newSegment.timestamp,
+    });
+
+    const storedSegment =
+      useNarrativeStore.getState().segments[storedSegmentId] ?? newSegment;
+
+    const reconciledNotes = await reconcileCoreSideEffects({
+      segment: storedSegment,
+      segmentId: storedSegmentId,
+      sessionId,
+      characterId,
+      metadata: result.metadata,
+      isFirstSegment: true,
+    });
+
+    syncNpcMetadata(worldId, result.metadata.characters);
+
+    const settledSegment =
+      useNarrativeStore.getState().segments[storedSegmentId] ?? storedSegment;
+
+    const postTurnSnapshot = assembleSessionSnapshot(sessionId);
+
+    return {
+      segment: settledSegment,
+      snapshot: postTurnSnapshot,
+      isFatal: false,
+      isEnding: isSessionEndingSegment(settledSegment),
+      reconciledNotes: reconciledNotes ?? undefined,
+    };
+  } finally {
+    markResolverInactive(sessionId);
+  }
+}
+
+/**
+ * The core side effects that MUST complete before the next Decision reads
+ * state. Each was previously fire-and-forget; the resolver awaits them.
+ */
+interface ReconcileParams {
+  segment: NarrativeSegment;
+  segmentId: EntityID;
+  sessionId: EntityID;
+  characterId: EntityID;
+  metadata: NarrativeSegment['metadata'];
+  isFirstSegment: boolean;
+}
+
+async function reconcileCoreSideEffects({
+  segment,
+  segmentId,
+  sessionId,
+  characterId,
+  metadata,
+  isFirstSegment,
+}: ReconcileParams): Promise<ReconciledSegmentNotes | null> {
+  // 1. World clock: goals, thread extraction, world cost, fatal tag
+  const allSegments = useNarrativeStore.getState().getSessionSegments(sessionId);
+  const currentTurn = countWorldClockTurns(allSegments);
+  const session = useSessionStore.getState();
+  let notes: ReconciledSegmentNotes | null = null;
+
+  try {
+    const result = await applyWorldClockUpdates({
+      segment,
+      sessionId,
+      characterId: metadata.characterIds?.[0],
+      playerCharacterId:
+        session.id === sessionId ? session.characterId ?? undefined : undefined,
+      currentTurn,
+    });
+
+    if (result) {
+      notes = result;
+      const current = useNarrativeStore.getState().segments[segmentId];
+      if (current) {
+        const currentTags = current.metadata?.tags ?? [];
+        const tags =
+          result.worldCost?.fatal && !currentTags.includes('fatal-outcome')
+            ? [...currentTags, 'fatal-outcome']
+            : currentTags;
+        useNarrativeStore.getState().updateSegment(segmentId, {
+          metadata: { ...current.metadata, ...result, tags },
+        });
+      }
+    }
+  } catch (error) {
+    logger.warn('[TurnResolver] World clock reconciliation failed:', error);
+  }
+
+  // 2. World state threads: player threads, relationships, major events
+  try {
+    await applyWorldStateThreadUpdates({
+      newSegment: segment,
+      originalSegmentData: {
+        content: segment.content,
+        type: segment.type,
+        characterIds: segment.characterIds,
+        metadata: segment.metadata,
+        worldId: segment.worldId,
+        timestamp: segment.timestamp,
+        updatedAt: segment.updatedAt ?? new Date().toISOString(),
+      },
+      finalMetadata: segment.metadata,
+      sessionId,
+      isFirstSegment,
+    });
+  } catch (error) {
+    logger.warn('[TurnResolver] World state thread update failed:', error);
+  }
+
+  // 3. Inventory mutations
+  try {
+    if (metadata.itemsAcquired && metadata.itemsAcquired.length > 0) {
+      await processAcquiredItems(metadata.itemsAcquired, characterId, sessionId);
+    }
+  } catch (error) {
+    logger.warn('[TurnResolver] Item acquisition failed:', error);
+  }
+
+  try {
+    if (metadata.itemsLost && metadata.itemsLost.length > 0) {
+      await processLostItems(metadata.itemsLost, characterId, sessionId);
+    }
+  } catch (error) {
+    logger.warn('[TurnResolver] Item loss processing failed:', error);
+  }
+
+  return notes;
+}

--- a/src/lib/narrative/turnResolver.ts
+++ b/src/lib/narrative/turnResolver.ts
@@ -58,6 +58,53 @@ function withTurnLock<T>(
   return next;
 }
 
+function getAbortError(signal: AbortSignal): Error {
+  if (signal.reason instanceof Error) {
+    return signal.reason;
+  }
+
+  const error = new Error('The operation was aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+/**
+ * Makes cancellation authoritative at the pre-commit generation seam even
+ * when a downstream provider or formatter ignores the signal itself.
+ */
+function awaitGeneration<T>(
+  startGeneration: () => Promise<T>,
+  signal?: AbortSignal
+): Promise<T> {
+  if (signal?.aborted) {
+    return Promise.reject(getAbortError(signal));
+  }
+
+  const generation = startGeneration();
+  if (!signal) {
+    return generation;
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    const handleAbort = () => {
+      signal.removeEventListener('abort', handleAbort);
+      reject(getAbortError(signal));
+    };
+
+    signal.addEventListener('abort', handleAbort, { once: true });
+    generation.then(
+      (result) => {
+        signal.removeEventListener('abort', handleAbort);
+        resolve(result);
+      },
+      (error) => {
+        signal.removeEventListener('abort', handleAbort);
+        reject(error);
+      }
+    );
+  });
+}
+
 /**
  * Advance the story by one Turn. Handles everything between "the player
  * picked a choice" and "the next Decision can safely read state":
@@ -134,33 +181,36 @@ async function resolveTurnInner(
 
   // Call the generator with resolverManaged so it skips its own
   // fire-and-forget side effects (lore, inventory, NPC sync).
-  const result = await generator.generateSegment(
-    {
-      worldId,
-      sessionId,
-      characterIds: characterId ? [characterId] : [],
-      narrativeContext: {
+  const result = await awaitGeneration(
+    () => generator.generateSegment(
+      {
         worldId,
-        currentSceneId: `scene-${Date.now()}`,
-        characterIds: characterId ? [characterId] : [],
-        previousSegments: [...recentSegments],
-        currentTags: mergeTurnTags(
-          recentSegments[recentSegments.length - 1]?.metadata?.tags ?? [],
-          command.skillCheckTags
-        ),
         sessionId,
-        recentSegments: [...recentSegments],
-        turnsSinceComplication,
-        worldClock,
-        currentSituation: `Player chose: "${command.choiceText}"${skillCheckContext}`,
+        characterIds: characterId ? [characterId] : [],
+        narrativeContext: {
+          worldId,
+          currentSceneId: `scene-${Date.now()}`,
+          characterIds: characterId ? [characterId] : [],
+          previousSegments: [...recentSegments],
+          currentTags: mergeTurnTags(
+            recentSegments[recentSegments.length - 1]?.metadata?.tags ?? [],
+            command.skillCheckTags
+          ),
+          sessionId,
+          recentSegments: [...recentSegments],
+          turnsSinceComplication,
+          worldClock,
+          currentSituation: `Player chose: "${command.choiceText}"${skillCheckContext}`,
+        },
+        generationParameters: {
+          includedTopics: command.generationParams?.includedTopics ?? [command.choiceText],
+          decisionWeight: command.decisionWeight,
+          desiredTone: command.generationParams?.desiredTone,
+        },
       },
-      generationParameters: {
-        includedTopics: command.generationParams?.includedTopics ?? [command.choiceText],
-        decisionWeight: command.decisionWeight,
-        desiredTone: command.generationParams?.desiredTone,
-      },
-    },
-    { signal: command.signal, onChunk: command.onChunk, resolverManaged: true }
+      { signal: command.signal, onChunk: command.onChunk, resolverManaged: true }
+    ),
+    command.signal
   );
 
   // Infer item losses from the narrative text when the AI didn't tag them
@@ -263,6 +313,7 @@ async function resolveTurnInner(
 
   return {
     segment: settledSegment,
+    status: errors.length === 0 ? 'settled' : 'partial',
     snapshot: postTurnSnapshot,
     isFatal,
     isEnding,
@@ -285,6 +336,7 @@ async function resolveInitialTurnInner(
     const existing = existingSegments[0];
     return {
       segment: existing,
+      status: 'settled',
       snapshot: assembleSessionSnapshot(sessionId, ids),
       isFatal: false,
       isEnding: isSessionEndingSegment(existing),
@@ -292,11 +344,14 @@ async function resolveInitialTurnInner(
     };
   }
 
-  const result = await generator.generateInitialScene(
-    worldId,
-    characterId ? [characterId] : [],
-    sessionId,
-    { signal: command.signal, onChunk: command.onChunk, resolverManaged: true }
+  const result = await awaitGeneration(
+    () => generator.generateInitialScene(
+      worldId,
+      characterId ? [characterId] : [],
+      sessionId,
+      { signal: command.signal, onChunk: command.onChunk, resolverManaged: true }
+    ),
+    command.signal
   );
 
   const segmentId = `seg-${worldId}-${Date.now()}`;
@@ -357,6 +412,7 @@ async function resolveInitialTurnInner(
 
   return {
     segment: settledSegment,
+    status: errors.length === 0 ? 'settled' : 'partial',
     snapshot: postTurnSnapshot,
     isFatal: false,
     isEnding: isSessionEndingSegment(settledSegment),
@@ -393,6 +449,14 @@ async function reconcileCoreSideEffects({
   isFirstSegment,
 }: ReconcileParams): Promise<ReconcileResult> {
   const errors: ReconciliationError[] = [];
+  const recordError = (
+    step: ReconciliationError['step'],
+    message: string,
+    error: unknown
+  ) => {
+    logger.warn(message, error);
+    errors.push({ step, error });
+  };
 
   // 1. World clock: goals, thread extraction, world cost, fatal tag
   const allSegments = useNarrativeStore.getState().getSessionSegments(sessionId);
@@ -406,6 +470,12 @@ async function reconcileCoreSideEffects({
       characterId: metadata.characterIds?.[0],
       playerCharacterId: characterId,
       currentTurn,
+      onError: (error) =>
+        recordError(
+          'worldClock',
+          '[TurnResolver] World clock reconciliation failed:',
+          error
+        ),
     });
 
     if (result) {
@@ -423,8 +493,11 @@ async function reconcileCoreSideEffects({
       }
     }
   } catch (error) {
-    logger.warn('[TurnResolver] World clock reconciliation failed:', error);
-    errors.push({ step: 'worldClock', error });
+    recordError(
+      'worldClock',
+      '[TurnResolver] World clock reconciliation failed:',
+      error
+    );
   }
 
   // 2. World state threads: player threads, relationships, major events
@@ -444,29 +517,64 @@ async function reconcileCoreSideEffects({
       sessionId,
       isFirstSegment,
       characterId,
+      onError: (error) =>
+        recordError(
+          'worldStateThreads',
+          '[TurnResolver] World state thread update failed:',
+          error
+        ),
     });
   } catch (error) {
-    logger.warn('[TurnResolver] World state thread update failed:', error);
-    errors.push({ step: 'worldStateThreads', error });
+    recordError(
+      'worldStateThreads',
+      '[TurnResolver] World state thread update failed:',
+      error
+    );
   }
 
   // 3. Inventory mutations
   try {
     if (metadata.itemsAcquired && metadata.itemsAcquired.length > 0) {
-      await processAcquiredItems(metadata.itemsAcquired, characterId, sessionId);
+      await processAcquiredItems(
+        metadata.itemsAcquired,
+        characterId,
+        sessionId,
+        (error) =>
+          recordError(
+            'itemAcquisition',
+            '[TurnResolver] Item acquisition failed:',
+            error
+          )
+      );
     }
   } catch (error) {
-    logger.warn('[TurnResolver] Item acquisition failed:', error);
-    errors.push({ step: 'itemAcquisition', error });
+    recordError(
+      'itemAcquisition',
+      '[TurnResolver] Item acquisition failed:',
+      error
+    );
   }
 
   try {
     if (metadata.itemsLost && metadata.itemsLost.length > 0) {
-      await processLostItems(metadata.itemsLost, characterId, sessionId);
+      await processLostItems(
+        metadata.itemsLost,
+        characterId,
+        sessionId,
+        (error) =>
+          recordError(
+            'itemLoss',
+            '[TurnResolver] Item loss processing failed:',
+            error
+          )
+      );
     }
   } catch (error) {
-    logger.warn('[TurnResolver] Item loss processing failed:', error);
-    errors.push({ step: 'itemLoss', error });
+    recordError(
+      'itemLoss',
+      '[TurnResolver] Item loss processing failed:',
+      error
+    );
   }
 
   return { notes, errors };

--- a/src/lib/narrative/turnResolver.ts
+++ b/src/lib/narrative/turnResolver.ts
@@ -6,7 +6,7 @@ import type {
   TurnCommand,
   InitialTurnCommand,
   TurnResult,
-  SessionSnapshot,
+  ReconciliationError,
 } from '@/types/turnResolver.types';
 import type { NarrativeGenerator } from '@/lib/ai/narrativeGenerator';
 import type { ReconciledSegmentNotes } from '@/lib/narrative/applyWorldClockUpdates';
@@ -24,10 +24,9 @@ import { isFeatureEnabled } from '@/lib/featureFlags';
 import { computeTurnsSinceComplication } from '@/lib/narrative/turnsSinceComplication';
 import { useWorldThreadStore } from '@/state/worldThreadStore';
 import { assembleSessionSnapshot } from '@/lib/narrative/sessionSnapshotAssembler';
-import {
-  markResolverActive,
-  markResolverInactive,
-} from '@/lib/narrative/resolverGuard';
+import { extractStructuredLore } from '@/lib/ai/structuredLoreExtractor';
+import { getLoreContextForPrompt } from '@/lib/ai/loreContextHelper';
+import { collectContinuityTopicsFromStores } from '@/lib/ai/narrativeGenerator.continuity';
 import { logger } from '@/lib/utils/logger';
 import { inferItemsLostFromNarrative } from '@/lib/narrative/itemLossInference';
 import { mergeTurnTags } from '@/lib/narrative/turnTags';
@@ -48,7 +47,7 @@ function withTurnLock<T>(
   turnLockBySession.set(sessionId, next);
   // Clean up the reference once the chain settles, but only if nothing
   // new appended while this link was running. The .catch suppresses the
-  // dangling rejection on the cleanup branch — the caller's own await
+  // dangling rejection on the cleanup branch -- the caller's own await
   // handles the real error.
   const cleanup = next.finally(() => {
     if (turnLockBySession.get(sessionId) === next) {
@@ -60,26 +59,17 @@ function withTurnLock<T>(
 }
 
 /**
- * Read-only session snapshot, for prompt projections or DevTools.
- */
-export function readSnapshot(sessionId: EntityID): SessionSnapshot {
-  return assembleSessionSnapshot(sessionId);
-}
-
-/**
  * Advance the story by one Turn. Handles everything between "the player
  * picked a choice" and "the next Decision can safely read state":
  *
  * 1. Acquire per-session lock
- * 2. Mark the session resolver-active (generator/addSegment skip side effects)
- * 3. Call the generator (prompt building + Gemini call)
- * 4. Build and commit the NarrativeSegment
- * 5. Await core reconciliation (world clock, world state threads, inventory)
- * 6. Stamp fatal-outcome tags from reconciliation
+ * 2. Call the generator with resolverManaged flag (skips its side effects)
+ * 3. Build and commit the NarrativeSegment
+ * 4. Await core reconciliation (world clock, world state threads, inventory)
+ * 5. Stamp fatal-outcome tags from reconciliation
+ * 6. Fire lore extraction (fire-and-forget, not blocking)
  * 7. Assemble post-turn snapshot
  * 8. Release lock
- * 9. Fire-and-forget background work (lore extraction handled by generator
- *    outside the guard, if needed in the future)
  */
 export function resolveTurn(
   command: TurnCommand,
@@ -110,114 +100,114 @@ async function resolveTurnInner(
   generator: NarrativeGenerator
 ): Promise<TurnResult> {
   const { sessionId, worldId, characterId } = command;
+  const ids = { worldId, characterId };
 
-  markResolverActive(sessionId);
-  try {
-    // Pre-turn snapshot for prompt context
-    const preTurnSnapshot = assembleSessionSnapshot(sessionId);
-    const recentSegments = preTurnSnapshot.segments.slice(-3);
-    const turnsSinceComplication = computeTurnsSinceComplication(
-      [...preTurnSnapshot.segments]
-    );
-    const currentTurn = preTurnSnapshot.turnIndex + 1;
+  // Pre-turn snapshot for prompt context
+  const preTurnSnapshot = assembleSessionSnapshot(sessionId, ids);
+  const recentSegments = preTurnSnapshot.segments.slice(-3);
+  const turnsSinceComplication = computeTurnsSinceComplication(
+    [...preTurnSnapshot.segments]
+  );
+  const currentTurn = preTurnSnapshot.turnIndex + 1;
 
-    const worldClock = isFeatureEnabled('WORLD_CLOCK')
-      ? buildWorldClockPromptContext(
-          useWorldThreadStore
-            .getState()
-            .getAll()
-            .filter((thread) => thread.sessionId === sessionId),
-          currentTurn
-        )
-      : undefined;
+  const worldClock = isFeatureEnabled('WORLD_CLOCK')
+    ? buildWorldClockPromptContext(
+        useWorldThreadStore
+          .getState()
+          .getAll()
+          .filter((thread) => thread.sessionId === sessionId),
+        currentTurn
+      )
+    : undefined;
 
-    // Build skill check context string for the AI prompt
-    let skillCheckContext = '';
-    if (command.skillCheckResults.length > 0) {
-      const descriptions = command.skillCheckResults.map((r) => {
-        if (r.isCriticalSuccess) return `${r.skillName}: CRITICAL SUCCESS (natural 20)`;
-        if (r.isCriticalFailure) return `${r.skillName}: CRITICAL FAILURE (natural 1)`;
-        if (r.success) return `${r.skillName}: SUCCESS (rolled ${r.total} vs DC ${r.dc})`;
-        return `${r.skillName}: FAILURE (rolled ${r.total} vs DC ${r.dc})`;
-      });
-      skillCheckContext = ` [Skill checks: ${descriptions.join(', ')}]`;
-    }
+  // Build skill check context string for the AI prompt
+  let skillCheckContext = '';
+  if (command.skillCheckResults.length > 0) {
+    const descriptions = command.skillCheckResults.map((r) => {
+      if (r.isCriticalSuccess) return `${r.skillName}: CRITICAL SUCCESS (natural 20)`;
+      if (r.isCriticalFailure) return `${r.skillName}: CRITICAL FAILURE (natural 1)`;
+      if (r.success) return `${r.skillName}: SUCCESS (rolled ${r.total} vs DC ${r.dc})`;
+      return `${r.skillName}: FAILURE (rolled ${r.total} vs DC ${r.dc})`;
+    });
+    skillCheckContext = ` [Skill checks: ${descriptions.join(', ')}]`;
+  }
 
-    // Call the generator - with the resolver active, it returns the result
-    // without running its own fire-and-forget side effects.
-    const result = await generator.generateSegment(
-      {
-        worldId,
-        sessionId,
-        characterIds: characterId ? [characterId] : [],
-        narrativeContext: {
-          worldId,
-          currentSceneId: `scene-${Date.now()}`,
-          characterIds: characterId ? [characterId] : [],
-          previousSegments: [...recentSegments],
-          currentTags: mergeTurnTags(
-            recentSegments[recentSegments.length - 1]?.metadata?.tags ?? [],
-            command.skillCheckTags
-          ),
-          sessionId,
-          recentSegments: [...recentSegments],
-          turnsSinceComplication,
-          worldClock,
-          currentSituation: `Player chose: "${command.choiceText}"${skillCheckContext}`,
-        },
-        generationParameters: {
-          includedTopics: command.generationParams?.includedTopics ?? [command.choiceText],
-          decisionWeight: command.decisionWeight,
-          desiredTone: command.generationParams?.desiredTone,
-        },
-      },
-      { signal: command.signal, onChunk: command.onChunk }
-    );
-
-    // Infer item losses from the narrative text when the AI didn't tag them
-    let metadata = { ...result.metadata };
-    if (
-      (!metadata.itemsLost || metadata.itemsLost.length === 0) &&
-      result.content
-    ) {
-      const characterInventory = useInventoryStore
-        .getState()
-        .getCharacterItems(characterId);
-      const inferredLosses = inferItemsLostFromNarrative(
-        result.content,
-        characterInventory
-      );
-      if (inferredLosses.length > 0) {
-        metadata = { ...metadata, itemsLost: inferredLosses };
-      }
-    }
-
-    // Build the segment (this construction was in NarrativeController lines 830-850)
-    const segmentId = `seg-${worldId}-${command.choiceId}-${Date.now()}`;
-    const now = new Date();
-    const newSegment: NarrativeSegment = {
-      id: segmentId,
-      content: result.content,
-      type: result.segmentType,
-      characterIds: metadata.characterIds || [],
-      metadata: {
-        ...metadata,
-        tags: [...(metadata.tags || []), ...command.skillCheckTags],
-        decisionOutcome: command.decisionOutcome,
-        pacingEscalationRequested: command.pacingEscalationRequested,
-        fatalRiskAllowed: command.fatalRiskAllowed,
-      },
-      sessionId,
+  // Call the generator with resolverManaged so it skips its own
+  // fire-and-forget side effects (lore, inventory, NPC sync).
+  const result = await generator.generateSegment(
+    {
       worldId,
-      timestamp: now,
-      createdAt: now.toISOString(),
-      updatedAt: now.toISOString(),
-    };
+      sessionId,
+      characterIds: characterId ? [characterId] : [],
+      narrativeContext: {
+        worldId,
+        currentSceneId: `scene-${Date.now()}`,
+        characterIds: characterId ? [characterId] : [],
+        previousSegments: [...recentSegments],
+        currentTags: mergeTurnTags(
+          recentSegments[recentSegments.length - 1]?.metadata?.tags ?? [],
+          command.skillCheckTags
+        ),
+        sessionId,
+        recentSegments: [...recentSegments],
+        turnsSinceComplication,
+        worldClock,
+        currentSituation: `Player chose: "${command.choiceText}"${skillCheckContext}`,
+      },
+      generationParameters: {
+        includedTopics: command.generationParams?.includedTopics ?? [command.choiceText],
+        decisionWeight: command.decisionWeight,
+        desiredTone: command.generationParams?.desiredTone,
+      },
+    },
+    { signal: command.signal, onChunk: command.onChunk, resolverManaged: true }
+  );
 
-    // Commit the segment to the narrative store. With the resolver guard
-    // active, addSegment does the synchronous write and skips its own
-    // fire-and-forget tails.
-    const storedSegmentId = useNarrativeStore.getState().addSegment(sessionId, {
+  // Infer item losses from the narrative text when the AI didn't tag them
+  let metadata = { ...result.metadata };
+  if (
+    (!metadata.itemsLost || metadata.itemsLost.length === 0) &&
+    result.content
+  ) {
+    const characterInventory = useInventoryStore
+      .getState()
+      .getCharacterItems(characterId);
+    const inferredLosses = inferItemsLostFromNarrative(
+      result.content,
+      characterInventory
+    );
+    if (inferredLosses.length > 0) {
+      metadata = { ...metadata, itemsLost: inferredLosses };
+    }
+  }
+
+  // Build the segment
+  const segmentId = `seg-${worldId}-${command.choiceId}-${Date.now()}`;
+  const now = new Date();
+  const newSegment: NarrativeSegment = {
+    id: segmentId,
+    content: result.content,
+    type: result.segmentType,
+    characterIds: metadata.characterIds || [],
+    metadata: {
+      ...metadata,
+      tags: [...(metadata.tags || []), ...command.skillCheckTags],
+      decisionOutcome: command.decisionOutcome,
+      pacingEscalationRequested: command.pacingEscalationRequested,
+      fatalRiskAllowed: command.fatalRiskAllowed,
+    },
+    sessionId,
+    worldId,
+    timestamp: now,
+    createdAt: now.toISOString(),
+    updatedAt: now.toISOString(),
+  };
+
+  // Commit the segment. The resolverManaged flag tells addSegment to skip
+  // its own fire-and-forget tails; the resolver handles those below.
+  const storedSegmentId = useNarrativeStore.getState().addSegment(
+    sessionId,
+    {
       content: newSegment.content,
       type: newSegment.type,
       characterIds: newSegment.characterIds || [],
@@ -225,48 +215,56 @@ async function resolveTurnInner(
       worldId: newSegment.worldId,
       updatedAt: newSegment.updatedAt,
       timestamp: newSegment.timestamp,
-    });
+    },
+    { resolverManaged: true }
+  );
 
-    // Read back the gated version (addSegment runs content dedup/sanitization)
-    const storedSegment =
-      useNarrativeStore.getState().segments[storedSegmentId] ?? newSegment;
+  // Read back the gated version (addSegment runs content dedup/sanitization)
+  const storedSegment =
+    useNarrativeStore.getState().segments[storedSegmentId] ?? newSegment;
 
-    // -- Core reconciliation: awaited, not fire-and-forget --
+  // -- Core reconciliation: awaited, not fire-and-forget --
 
-    const reconciledNotes = await reconcileCoreSideEffects({
-      segment: storedSegment,
-      segmentId: storedSegmentId,
-      sessionId,
-      characterId,
-      metadata,
-      isFirstSegment: false,
-    });
+  const { notes, errors } = await reconcileCoreSideEffects({
+    segment: storedSegment,
+    segmentId: storedSegmentId,
+    sessionId,
+    characterId,
+    metadata,
+    isFirstSegment: false,
+  });
 
-    // Synchronous NPC sync (already not fire-and-forget)
-    syncNpcMetadata(worldId, result.metadata.characters);
+  // Synchronous NPC sync (already not fire-and-forget)
+  syncNpcMetadata(worldId, result.metadata.characters);
 
-    // Read the settled segment after reconciliation may have stamped tags
-    const settledSegment =
-      useNarrativeStore.getState().segments[storedSegmentId] ?? storedSegment;
+  // Fire lore extraction as fire-and-forget. It doesn't block the turn
+  // but still runs so facts introduced in this turn's prose are
+  // available to later prompts.
+  fireLoreExtraction(result, { worldId, sessionId, characterIds: characterId ? [characterId] : [] });
 
-    // Post-turn snapshot: the settled revision
-    const postTurnSnapshot = assembleSessionSnapshot(sessionId);
+  // Read the settled segment after reconciliation may have stamped tags
+  const settledSegment =
+    useNarrativeStore.getState().segments[storedSegmentId] ?? storedSegment;
 
-    const isFatal =
-      command.isFatalCriticalFailure ||
-      settledSegment.metadata?.tags?.includes('fatal-outcome') === true;
-    const isEnding = isSessionEndingSegment(settledSegment) || isFatal;
+  // Post-turn snapshot: the settled revision
+  const postTurnSnapshot = assembleSessionSnapshot(sessionId, ids);
 
-    return {
-      segment: settledSegment,
-      snapshot: postTurnSnapshot,
-      isFatal,
-      isEnding,
-      reconciledNotes: reconciledNotes ?? undefined,
-    };
-  } finally {
-    markResolverInactive(sessionId);
-  }
+  // isFatal reports whether a fatal outcome was detected, but does NOT
+  // fold into isEnding unconditionally. The controller decides what to
+  // do with a fatal flag based on its own handler availability.
+  const isFatal =
+    command.isFatalCriticalFailure ||
+    settledSegment.metadata?.tags?.includes('fatal-outcome') === true;
+  const isEnding = isSessionEndingSegment(settledSegment);
+
+  return {
+    segment: settledSegment,
+    snapshot: postTurnSnapshot,
+    isFatal,
+    isEnding,
+    reconciledNotes: notes ?? undefined,
+    reconciliationErrors: errors,
+  };
 }
 
 async function resolveInitialTurnInner(
@@ -274,32 +272,47 @@ async function resolveInitialTurnInner(
   generator: NarrativeGenerator
 ): Promise<TurnResult> {
   const { sessionId, worldId, characterId } = command;
+  const ids = { worldId, characterId };
 
-  markResolverActive(sessionId);
-  try {
-    const result = await generator.generateInitialScene(
-      worldId,
-      characterId ? [characterId] : [],
-      sessionId,
-      { signal: command.signal, onChunk: command.onChunk }
-    );
-
-    const segmentId = `seg-${worldId}-${Date.now()}`;
-    const now = new Date();
-    const newSegment: NarrativeSegment = {
-      id: segmentId,
-      content: result.content,
-      type: result.segmentType,
-      characterIds: result.metadata.characterIds || [],
-      metadata: result.metadata,
-      sessionId,
-      worldId,
-      timestamp: now,
-      createdAt: now.toISOString(),
-      updatedAt: now.toISOString(),
+  // Recheck inside the lock: if another instance already committed an
+  // opening segment while this request was queued, skip generation.
+  const existingSegments = useNarrativeStore.getState().getSessionSegments(sessionId);
+  if (existingSegments.length > 0) {
+    const existing = existingSegments[0];
+    return {
+      segment: existing,
+      snapshot: assembleSessionSnapshot(sessionId, ids),
+      isFatal: false,
+      isEnding: isSessionEndingSegment(existing),
+      reconciliationErrors: [],
     };
+  }
 
-    const storedSegmentId = useNarrativeStore.getState().addSegment(sessionId, {
+  const result = await generator.generateInitialScene(
+    worldId,
+    characterId ? [characterId] : [],
+    sessionId,
+    { signal: command.signal, onChunk: command.onChunk, resolverManaged: true }
+  );
+
+  const segmentId = `seg-${worldId}-${Date.now()}`;
+  const now = new Date();
+  const newSegment: NarrativeSegment = {
+    id: segmentId,
+    content: result.content,
+    type: result.segmentType,
+    characterIds: result.metadata.characterIds || [],
+    metadata: result.metadata,
+    sessionId,
+    worldId,
+    timestamp: now,
+    createdAt: now.toISOString(),
+    updatedAt: now.toISOString(),
+  };
+
+  const storedSegmentId = useNarrativeStore.getState().addSegment(
+    sessionId,
+    {
       content: newSegment.content,
       type: newSegment.type,
       characterIds: newSegment.characterIds || [],
@@ -307,42 +320,45 @@ async function resolveInitialTurnInner(
       worldId: newSegment.worldId,
       updatedAt: newSegment.updatedAt,
       timestamp: newSegment.timestamp,
-    });
+    },
+    { resolverManaged: true }
+  );
 
-    const storedSegment =
-      useNarrativeStore.getState().segments[storedSegmentId] ?? newSegment;
+  const storedSegment =
+    useNarrativeStore.getState().segments[storedSegmentId] ?? newSegment;
 
-    const reconciledNotes = await reconcileCoreSideEffects({
-      segment: storedSegment,
-      segmentId: storedSegmentId,
-      sessionId,
-      characterId,
-      metadata: result.metadata,
-      isFirstSegment: true,
-    });
+  const { notes, errors } = await reconcileCoreSideEffects({
+    segment: storedSegment,
+    segmentId: storedSegmentId,
+    sessionId,
+    characterId,
+    metadata: result.metadata,
+    isFirstSegment: true,
+  });
 
-    syncNpcMetadata(worldId, result.metadata.characters);
+  syncNpcMetadata(worldId, result.metadata.characters);
 
-    const settledSegment =
-      useNarrativeStore.getState().segments[storedSegmentId] ?? storedSegment;
+  fireLoreExtraction(result, { worldId, sessionId, characterIds: characterId ? [characterId] : [] });
 
-    const postTurnSnapshot = assembleSessionSnapshot(sessionId);
+  const settledSegment =
+    useNarrativeStore.getState().segments[storedSegmentId] ?? storedSegment;
 
-    return {
-      segment: settledSegment,
-      snapshot: postTurnSnapshot,
-      isFatal: false,
-      isEnding: isSessionEndingSegment(settledSegment),
-      reconciledNotes: reconciledNotes ?? undefined,
-    };
-  } finally {
-    markResolverInactive(sessionId);
-  }
+  const postTurnSnapshot = assembleSessionSnapshot(sessionId, ids);
+
+  return {
+    segment: settledSegment,
+    snapshot: postTurnSnapshot,
+    isFatal: false,
+    isEnding: isSessionEndingSegment(settledSegment),
+    reconciledNotes: notes ?? undefined,
+    reconciliationErrors: errors,
+  };
 }
 
 /**
  * The core side effects that MUST complete before the next Decision reads
  * state. Each was previously fire-and-forget; the resolver awaits them.
+ * Errors are captured per-step rather than aborting the whole turn.
  */
 interface ReconcileParams {
   segment: NarrativeSegment;
@@ -353,6 +369,11 @@ interface ReconcileParams {
   isFirstSegment: boolean;
 }
 
+interface ReconcileResult {
+  notes: ReconciledSegmentNotes | null;
+  errors: ReconciliationError[];
+}
+
 async function reconcileCoreSideEffects({
   segment,
   segmentId,
@@ -360,7 +381,9 @@ async function reconcileCoreSideEffects({
   characterId,
   metadata,
   isFirstSegment,
-}: ReconcileParams): Promise<ReconciledSegmentNotes | null> {
+}: ReconcileParams): Promise<ReconcileResult> {
+  const errors: ReconciliationError[] = [];
+
   // 1. World clock: goals, thread extraction, world cost, fatal tag
   const allSegments = useNarrativeStore.getState().getSessionSegments(sessionId);
   const currentTurn = countWorldClockTurns(allSegments);
@@ -393,6 +416,7 @@ async function reconcileCoreSideEffects({
     }
   } catch (error) {
     logger.warn('[TurnResolver] World clock reconciliation failed:', error);
+    errors.push({ step: 'worldClock', error });
   }
 
   // 2. World state threads: player threads, relationships, major events
@@ -414,6 +438,7 @@ async function reconcileCoreSideEffects({
     });
   } catch (error) {
     logger.warn('[TurnResolver] World state thread update failed:', error);
+    errors.push({ step: 'worldStateThreads', error });
   }
 
   // 3. Inventory mutations
@@ -423,6 +448,7 @@ async function reconcileCoreSideEffects({
     }
   } catch (error) {
     logger.warn('[TurnResolver] Item acquisition failed:', error);
+    errors.push({ step: 'itemAcquisition', error });
   }
 
   try {
@@ -431,7 +457,43 @@ async function reconcileCoreSideEffects({
     }
   } catch (error) {
     logger.warn('[TurnResolver] Item loss processing failed:', error);
+    errors.push({ step: 'itemLoss', error });
   }
 
-  return notes;
+  return { notes, errors };
+}
+
+/**
+ * Fire lore extraction as fire-and-forget. The turn doesn't block on it,
+ * but it still runs so facts introduced in this segment's prose are
+ * available to later prompts and continuity checks.
+ */
+function fireLoreExtraction(
+  result: { content: string; metadata: { continuity?: { remainingIssues?: Array<{ type: string; entity: string }> } } },
+  request: { worldId: EntityID; sessionId: EntityID; characterIds: string[] }
+): void {
+  if (!result.content) return;
+
+  const existingLoreContext = getLoreContextForPrompt(request.worldId, request.sessionId, {
+    recordUsage: false,
+  });
+
+  const unattestedSpeakers = (
+    result.metadata.continuity?.remainingIssues ?? []
+  )
+    .filter((issue) => issue.type === 'invented-exchange')
+    .map((issue) => issue.entity);
+
+  void extractStructuredLore(result.content, existingLoreContext, {
+    continuityTopics: collectContinuityTopicsFromStores(request),
+    ...(unattestedSpeakers.length > 0 ? { unattestedSpeakers } : {}),
+  })
+    .then(async (structuredLore) => {
+      const { useLoreStore } = await import('@/state/loreStore');
+      const { addStructuredLore } = useLoreStore.getState();
+      addStructuredLore(structuredLore, request.worldId, request.sessionId);
+    })
+    .catch((error) => {
+      logger.warn('[TurnResolver] Lore extraction failed:', error);
+    });
 }

--- a/src/state/narrativeStore.segments.ts
+++ b/src/state/narrativeStore.segments.ts
@@ -10,6 +10,7 @@ import { countWorldClockTurns } from '../lib/narrative/worldClock';
 import { formatDecisionText } from '../lib/narrative/formatDecisionText';
 import { useSessionStore } from './sessionStore';
 import { trackFunnelStep } from '@/lib/analytics/trackFunnelStep';
+import { isResolverActive } from '@/lib/narrative/resolverGuard';
 import type { NarrativeStoreSet, NarrativeStoreGet } from './narrativeStore.types';
 
 const normalizeLocationKey = (value: string): string =>
@@ -168,6 +169,12 @@ export const createNarrativeSegmentActions = (
       useSessionStore.getState().updateSavedSessionNarrativeCount(sessionId, sessionSegments.length);
     } catch (error) {
       logger.error('[NarrativeStore]', 'Failed to update session narrative count:', error);
+    }
+
+    // When the TurnResolver drives this session, it awaits these operations
+    // itself, so skip the fire-and-forget tails to avoid duplicate writers.
+    if (isResolverActive(sessionId)) {
+      return segmentId;
     }
 
     // One post-segment extraction call covers goals and the world clock's

--- a/src/state/narrativeStore.segments.ts
+++ b/src/state/narrativeStore.segments.ts
@@ -10,7 +10,7 @@ import { countWorldClockTurns } from '../lib/narrative/worldClock';
 import { formatDecisionText } from '../lib/narrative/formatDecisionText';
 import { useSessionStore } from './sessionStore';
 import { trackFunnelStep } from '@/lib/analytics/trackFunnelStep';
-import { isResolverActive } from '@/lib/narrative/resolverGuard';
+import { isResolverManaged } from '@/lib/narrative/resolverGuard';
 import type { NarrativeStoreSet, NarrativeStoreGet } from './narrativeStore.types';
 
 const normalizeLocationKey = (value: string): string =>
@@ -23,7 +23,7 @@ export const createNarrativeSegmentActions = (
   set: NarrativeStoreSet,
   get: NarrativeStoreGet
 ) => ({
-  addSegment: (sessionId: EntityID, segmentData: Omit<NarrativeSegment, 'id' | 'sessionId' | 'createdAt'>): EntityID => {
+  addSegment: (sessionId: EntityID, segmentData: Omit<NarrativeSegment, 'id' | 'sessionId' | 'createdAt'>, options?: { resolverManaged?: boolean }): EntityID => {
     const normalizedContent = normalizeText(segmentData.content || '', NORM_DESC);
     if (!normalizedContent) {
       throw new Error('Segment content is required');
@@ -171,9 +171,11 @@ export const createNarrativeSegmentActions = (
       logger.error('[NarrativeStore]', 'Failed to update session narrative count:', error);
     }
 
-    // When the TurnResolver drives this session, it awaits these operations
-    // itself, so skip the fire-and-forget tails to avoid duplicate writers.
-    if (isResolverActive(sessionId)) {
+    // When the TurnResolver drives this specific commit, it awaits these
+    // operations itself, so skip the fire-and-forget tails to avoid
+    // duplicate writers. Only this call is suppressed; concurrent commits
+    // from other paths (item-use, bootstrap) run their own tails.
+    if (isResolverManaged(options)) {
       return segmentId;
     }
 

--- a/src/state/narrativeStore.types.ts
+++ b/src/state/narrativeStore.types.ts
@@ -34,7 +34,7 @@ export interface NarrativeStore {
   _hasHydrated: boolean; // Track if persistence has loaded
 
   // Actions
-  addSegment: (sessionId: EntityID, segment: Omit<NarrativeSegment, 'id' | 'sessionId' | 'createdAt'>) => EntityID;
+  addSegment: (sessionId: EntityID, segment: Omit<NarrativeSegment, 'id' | 'sessionId' | 'createdAt'>, options?: { resolverManaged?: boolean }) => EntityID;
   updateSegment: (segmentId: EntityID, updates: Partial<NarrativeSegment>) => void;
   deleteSegment: (segmentId: EntityID) => void;
 

--- a/src/types/turnResolver.types.ts
+++ b/src/types/turnResolver.types.ts
@@ -78,15 +78,19 @@ export interface InitialTurnCommand {
   onChunk?: (chunk: string) => void;
 }
 
+/** The settlement state of a committed Turn. */
+export type TurnSettlementStatus = 'settled' | 'partial';
+
 /**
- * The settled result of one turn. Everything in here has been committed to
- * the stores and is safe to read. The next Decision can consume `snapshot`
- * knowing it reflects this turn's mutations.
+ * The result of one committed Turn. A settled result is safe for the next
+ * Decision to consume; a partial result must keep that Decision blocked.
  */
 export interface TurnResult {
   /** The committed, content-gated segment. */
   segment: NarrativeSegment;
-  /** Post-turn snapshot with all core mutations applied. */
+  /** Whether every core mutation completed successfully. */
+  status: TurnSettlementStatus;
+  /** Post-turn snapshot of the state that was successfully applied. */
   snapshot: SessionSnapshot;
   /** Whether a fatal outcome was detected (from world cost or critical failure). */
   isFatal: boolean;
@@ -98,11 +102,11 @@ export interface TurnResult {
   isEnding: boolean;
   /** The reconciled notes stamped onto the segment's metadata. */
   reconciledNotes?: ReconciledSegmentNotes;
-  /** Errors from core reconciliation steps that were swallowed. Empty when all succeeded. */
+  /** Errors from core reconciliation steps. Empty when `status` is settled. */
   reconciliationErrors: ReconciliationError[];
 }
 
-/** A core reconciliation step that failed but was swallowed to avoid blocking the turn. */
+/** A core reconciliation step that failed while settling the Turn. */
 export interface ReconciliationError {
   step: 'worldClock' | 'worldStateThreads' | 'itemAcquisition' | 'itemLoss';
   error: unknown;

--- a/src/types/turnResolver.types.ts
+++ b/src/types/turnResolver.types.ts
@@ -90,8 +90,20 @@ export interface TurnResult {
   snapshot: SessionSnapshot;
   /** Whether a fatal outcome was detected (from world cost or critical failure). */
   isFatal: boolean;
-  /** Whether the segment type is 'ending' or carries ending tags. */
+  /**
+   * Whether the segment carries ending/fatal tags. The controller decides
+   * what to do with this (call onEndingSuggested, skip choices, etc.)
+   * based on its own handler availability.
+   */
   isEnding: boolean;
   /** The reconciled notes stamped onto the segment's metadata. */
   reconciledNotes?: ReconciledSegmentNotes;
+  /** Errors from core reconciliation steps that were swallowed. Empty when all succeeded. */
+  reconciliationErrors: ReconciliationError[];
+}
+
+/** A core reconciliation step that failed but was swallowed to avoid blocking the turn. */
+export interface ReconciliationError {
+  step: 'worldClock' | 'worldStateThreads' | 'itemAcquisition' | 'itemLoss';
+  error: unknown;
 }

--- a/src/types/turnResolver.types.ts
+++ b/src/types/turnResolver.types.ts
@@ -1,0 +1,97 @@
+// src/types/turnResolver.types.ts
+
+import type { EntityID } from './common.types';
+import type { NarrativeSegment, Decision, DecisionWeight, DecisionOutcome, SkillCheckRoll, EndingTone } from './narrative.types';
+import type { Character } from '@/state/characterStore.types';
+import type { InventoryItem } from './inventory.types';
+import type { WorldThread } from './worldThread.types';
+import type { WorldState } from './world-state.types';
+import type { NPC } from './npc.types';
+import type { ReconciledSegmentNotes } from '@/lib/narrative/applyWorldClockUpdates';
+
+/**
+ * Read-only snapshot of the session state a Turn needs. Assembled once at
+ * call time from all relevant stores, then frozen. Prompt projections and
+ * post-turn assertions consume this instead of scattered getState() calls.
+ */
+export interface SessionSnapshot {
+  readonly sessionId: EntityID;
+  readonly worldId: EntityID;
+  readonly characterId: EntityID;
+  /** 1-based, from sessionSegments.length. */
+  readonly turnIndex: number;
+  /** Recent window for prompt context, not the full history. */
+  readonly segments: readonly NarrativeSegment[];
+  /** All session decisions (needed for decision linking and history). */
+  readonly decisions: readonly Decision[];
+  readonly character: Readonly<Character>;
+  readonly inventory: readonly InventoryItem[];
+  readonly worldThreads: readonly WorldThread[];
+  readonly worldState: Readonly<WorldState> | undefined;
+  /** Pre-formatted lore context for prompt projection. */
+  readonly loreContext: string;
+  readonly npcs: readonly NPC[];
+  /** Flattened from character.status.conditions for quick access. */
+  readonly conditions: readonly string[];
+  readonly endedSessions: Readonly<Record<EntityID, boolean>>;
+}
+
+/**
+ * What the caller hands TurnResolver to advance the story. The resolver
+ * handles everything from here: snapshot, generation, commitment, and
+ * reconciliation.
+ */
+export interface TurnCommand {
+  sessionId: EntityID;
+  worldId: EntityID;
+  characterId: EntityID;
+  choiceId: string;
+  choiceText: string;
+  isCustomInput: boolean;
+  skillCheckResults: SkillCheckRoll[];
+  skillCheckTags: string[];
+  decisionOutcome?: DecisionOutcome;
+  decisionWeight?: DecisionWeight;
+  /** The segment pacing fields the controller computes before the turn. */
+  pacingEscalationRequested: boolean;
+  fatalRiskAllowed: boolean;
+  isFatalCriticalFailure: boolean;
+  generationParams?: {
+    desiredTone?: EndingTone;
+    includedTopics?: string[];
+  };
+  /** Abort signal from the controller's timeout race. */
+  signal?: AbortSignal;
+  /** Streaming chunk callback for progressive rendering. */
+  onChunk?: (chunk: string) => void;
+}
+
+/**
+ * Same shape for the first turn, which has no prior choice.
+ */
+export interface InitialTurnCommand {
+  sessionId: EntityID;
+  worldId: EntityID;
+  characterId: EntityID;
+  generateChoices: boolean;
+  signal?: AbortSignal;
+  onChunk?: (chunk: string) => void;
+}
+
+/**
+ * The settled result of one turn. Everything in here has been committed to
+ * the stores and is safe to read. The next Decision can consume `snapshot`
+ * knowing it reflects this turn's mutations.
+ */
+export interface TurnResult {
+  /** The committed, content-gated segment. */
+  segment: NarrativeSegment;
+  /** Post-turn snapshot with all core mutations applied. */
+  snapshot: SessionSnapshot;
+  /** Whether a fatal outcome was detected (from world cost or critical failure). */
+  isFatal: boolean;
+  /** Whether the segment type is 'ending' or carries ending tags. */
+  isEnding: boolean;
+  /** The reconciled notes stamped onto the segment's metadata. */
+  reconciledNotes?: ReconciledSegmentNotes;
+}


### PR DESCRIPTION
## Description

The turn lifecycle was split across fire-and-forget work in the generator, narrative store, and controller. The next Decision could read stale inventory, world threads, and fatal-outcome state because those mutations had not settled.

This PR introduces `TurnResolver` between the controller and generator. It serializes controller-driven turns per session, commits the generated segment, awaits core reconciliation, and returns the post-turn snapshot before choice generation starts.

The review follow-up makes that contract honest when something goes wrong. Provider cancellation is enforced at the resolver's pre-commit generation seam, even if downstream generation ignores the abort signal. Reconciliation now returns an explicit `settled` or `partial` status, reports failures from helpers that otherwise fail open, and blocks the next Decision when core state is partial.

### Scope and deferrals

This PR covers controller-driven turns: the initial scene and per-choice segments routed through `NarrativeController`.

- Item-use turns still bypass the resolver. #1985 tracks that work.
- Choice generation still rereads live stores instead of consuming `TurnResult.snapshot`. #1986 tracks that work.

Those gaps mean this PR is one bounded part of #1983, not completion of the epic.

## Related Issue

Part of #1983. Follow-up scope is tracked in #1985 and #1986.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The tests hold reconciliation promises pending, exercise the real store boundary, cancel a generator that ignores its signal, and verify that partial results cannot generate choices.

## User Stories Addressed

For controller-driven turns, this establishes causal ordering between segment commitment, core reconciliation, and the next Decision. It also makes partial reconciliation visible instead of presenting an incomplete store revision as settled.

The integrated live matrix and the two deferred paths remain open under #1983, #1985, and #1986.

## Flow Diagrams

Not applicable.

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

Not applicable. The controller's rendered output is unchanged.

## Implementation Notes

The main modules are:

| File | Lines | Purpose |
| --- | ---: | --- |
| `src/types/turnResolver.types.ts` | 113 | Turn commands, settlement status, result, snapshot, and reconciliation error types |
| `src/lib/narrative/turnResolver.ts` | 618 | Generation boundary, per-session lock, commitment, reconciliation, and snapshot assembly |
| `src/lib/narrative/resolverGuard.ts` | 21 | Call-scoped resolver ownership check |
| `src/lib/narrative/sessionSnapshotAssembler.ts` | 80 | Authoritative snapshot assembly across session stores |
| `src/lib/narrative/__tests__/turnResolver.test.ts` | 672 | Resolver integration coverage |

`NarrativeController` delegates initial and normal turn lifecycle work to the resolver. It generates choices only after a `settled` result. A `partial` result leaves the committed prose visible, sets a non-retryable error, and stops before another Decision can read incomplete state.

`applyWorldClockUpdates`, `applyWorldStateThreadUpdates`, `processAcquiredItems`, and `processLostItems` keep their fail-open behavior for existing callers. An optional error callback now lets the resolver record those failures in `TurnResult.reconciliationErrors`.

Lore extraction, item image generation, journal copies, analytics, and DevTools continuity recording remain asynchronous because they do not define the core settled revision.

## Screenshots

Not applicable. There are no visual changes.

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

The follow-up addresses the two remaining in-scope blockers from the latest review:

- The timeout no longer races post-commit reconciliation. Resolver-side cancellation prevents an abort-ignoring generator from committing afterward.
- Core reconciliation failures produce `status: 'partial'`, including failures swallowed inside existing helpers, and both controller paths block choice generation for that result.

The item-use and snapshot-consumption review threads describe valid gaps, but they are intentionally separated into #1985 and #1986.

## Chrome DevTools MCP Verification Summary (if applicable)

Not applicable. This change does not alter rendered UI behavior.

## Quality Checks (if applicable)

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Knip, dependency validation, dependency baseline checks, the full Jest suite, and the production build also pass locally.

## Testing Instructions

Run the focused settlement and controller coverage first:

```bash
npm test -- src/lib/narrative/__tests__/turnResolver.test.ts \
  src/components/Narrative/__tests__/NarrativeController.generationError.test.tsx \
  src/components/Narrative/__tests__/NarrativeController.contentGate.test.tsx
```

Then run the code-quality gates:

```bash
npm run type-check
npm run lint
npm run knip
npm run deps:validate
npm run deps:check
```

The final local verification passed 452 suites and 3,206 tests:

```bash
npm test
NEXT_PUBLIC_SITE_URL=https://narraitor-six.vercel.app npm run build
```

## Checklist

- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

`turnResolver.ts` and its integration test exceed the 300-line guideline. This PR keeps the initial and normal turn paths beside their shared reconciliation contract; splitting them during this review fix would add unrelated restructuring.
