### PR TITLE
Route item-use turns through TurnResolver

### DIFF
--- a/public_docs/features/game-mechanics.md
+++ b/public_docs/features/game-mechanics.md
@@ -264,16 +264,17 @@ When testing, try out different decision weights (minor, major, critical), all t
 
 Item usage ties inventory items into the narrative flow. When a player uses an item, the system handles inventory updates, generates appropriate narrative describing what happens, and creates journal entries for significant moments.
 
-The significance categorization matters because not every item usage deserves AI-generated narrative and a journal entry. Quest items, equipment, documents, and valuables get the full treatment - narrative generation, journal entries, the whole package. Consumables and miscellaneous items just get basic inventory updates. This prevents journal spam from using health potions while keeping important story moments tracked.
+Every item use gets a narrative turn. Significance controls journal creation: quest items, equipment, documents, and valuables create entries, while consumables and miscellaneous items don't. This prevents journal spam from using health potions while keeping important story moments tracked.
 
 ### How It Works
 
 When a player uses an item, the system:
 
-1. Updates inventory counts (decrements stackable items or marks equipment as used)
-2. Generates narrative describing the usage through the AI
-3. Creates a journal entry for significant items only
-4. Tracks remaining quantities in the narrative so players know what they have left
+1. Revalidates the world, character, item ownership, and quantity inside the session's turn lock
+2. Consumes the item once, then generates and commits an item-specific narrative segment
+3. Reconciles world-clock, world-state, and other reported item losses before continuing
+4. Replaces the current choices only after the turn fully settles and doesn't end the session
+5. Creates a journal entry for significant items after the turn lock is released
 
 The AI understands context around stackable items. If you use one health potion from a stack of five, the narrative will mention you still have four left. Use your last potion and it'll emphasize that you're out. This keeps players informed about their resources through the story itself instead of requiring constant inventory checking.
 
@@ -283,11 +284,12 @@ The AI understands context around stackable items. If you use one health potion 
 import { processItemUsage } from '@/lib/inventory/itemUsageService';
 
 // Use an item during gameplay
-const result = await processItemUsage(
+const result = await processItemUsage({
+  worldId,
   characterId,
   itemId,
-  sessionId // optional - uses current session if not provided
-);
+  sessionId,
+});
 
 // Check the result
 if (result.success) {

--- a/src/components/GameSession/ActiveGameSession.tsx
+++ b/src/components/GameSession/ActiveGameSession.tsx
@@ -586,7 +586,11 @@ const ActiveGameSession: React.FC<ActiveGameSessionProps> = ({
             <CharacterDrawerContent character={character} />
           )}
           {activeDrawer === 'inventory' && characterId && (
-            <InventoryDrawerContent characterId={characterId} />
+            <InventoryDrawerContent
+              characterId={characterId}
+              worldId={worldId}
+              sessionId={sessionId}
+            />
           )}
           {activeDrawer === 'story-summary' && (
             <StorySummaryDrawerContent

--- a/src/components/GameSession/ActiveGameSessionControls.tsx
+++ b/src/components/GameSession/ActiveGameSessionControls.tsx
@@ -61,7 +61,11 @@ const ActiveGameSessionControls: React.FC<ActiveGameSessionControlsProps> = ({
           data-testid="inventory-collapsible"
         >
           <CollapsibleSection title="Inventory" initialCollapsed>
-            <InventoryList characterId={characterId} />
+            <InventoryList
+              characterId={characterId}
+              worldId={worldId}
+              sessionId={sessionId}
+            />
           </CollapsibleSection>
         </div>
       )}

--- a/src/components/GameSession/ManuscriptDrawerPanels.tsx
+++ b/src/components/GameSession/ManuscriptDrawerPanels.tsx
@@ -25,12 +25,22 @@ export const CharacterDrawerContent: React.FC<CharacterDrawerContentProps> = ({ 
 
 interface InventoryDrawerContentProps {
   characterId: EntityID;
+  worldId: EntityID;
+  sessionId: EntityID;
 }
 
-export const InventoryDrawerContent: React.FC<InventoryDrawerContentProps> = ({ characterId }) => {
+export const InventoryDrawerContent: React.FC<InventoryDrawerContentProps> = ({
+  characterId,
+  worldId,
+  sessionId,
+}) => {
   return (
     <div className="manuscript-drawer-panel-section">
-      <InventoryList characterId={characterId} />
+      <InventoryList
+        characterId={characterId}
+        worldId={worldId}
+        sessionId={sessionId}
+      />
     </div>
   );
 };

--- a/src/components/Narrative/NarrativeController.tsx
+++ b/src/components/Narrative/NarrativeController.tsx
@@ -37,19 +37,9 @@ import type {
   InitialTurnCommand,
   TurnResult,
 } from '@/types/turnResolver.types';
-import type { NarrativeError } from '@/lib/narrative/narrativeErrors';
-
+import { PARTIAL_RECONCILIATION_ERROR } from '@/lib/narrative/narrativeErrors';
 
 const EMPTY_NPC_IDS: string[] = [];
-const PARTIAL_RECONCILIATION_ERROR: NarrativeError = {
-  title: 'The story paused',
-  message: 'The story advanced, but some session changes did not finish.',
-  suggestion: 'Stop here rather than making another choice.',
-  retryable: false,
-  retryLabel: 'Continue the story',
-  severity: 'error',
-};
-
 interface NarrativeControllerProps {
   worldId: string;
   sessionId: string;

--- a/src/components/inventory/InventoryList.tsx
+++ b/src/components/inventory/InventoryList.tsx
@@ -4,7 +4,6 @@ import React, { useState } from 'react';
 import { clsx } from 'clsx';
 import { Shield } from 'lucide-react';
 import { useInventoryStore } from '@/state/inventoryStore';
-import { useSessionStore } from '@/state/sessionStore';
 import { EntityID } from '@/types/common.types';
 import { InventoryItem } from '@/types/inventory.types';
 import { Button } from '@/components/ui/button';
@@ -22,6 +21,8 @@ import { DropConfirmationDialog } from './DropConfirmationDialog';
 
 interface InventoryListProps {
   characterId: EntityID;
+  worldId: EntityID;
+  sessionId: EntityID;
   className?: string;
 }
 
@@ -113,6 +114,8 @@ const InventoryItemImage: React.FC<InventoryItemImageProps> = ({
  */
 export const InventoryList: React.FC<InventoryListProps> = ({
   characterId,
+  worldId,
+  sessionId,
   className = '',
 }) => {
   // Select items and character inventory to re-render on changes
@@ -147,7 +150,6 @@ export const InventoryList: React.FC<InventoryListProps> = ({
       .map((id) => itemsObject[id])
       .filter((item): item is InventoryItem => Boolean(item));
   }, [itemsObject, characterInventories, characterId]);
-  const sessionId = useSessionStore((state) => state.id);
   const toggleEquipItem = useInventoryStore((state) => state.toggleEquipItem);
   const [usingItemId, setUsingItemId] = useState<EntityID | null>(null);
   const [errorFeedback, setErrorFeedback] = useState<string | null>(null);
@@ -167,11 +169,12 @@ export const InventoryList: React.FC<InventoryListProps> = ({
     setErrorFeedback(null);
 
     try {
-      const result = await processItemUsage(
+      const result = await processItemUsage({
+        sessionId,
+        worldId,
         characterId,
         itemId,
-        sessionId || undefined
-      );
+      });
 
       if (result.success) {
         // Success path handled via narrative segment entry; no inline feedback needed.

--- a/src/components/inventory/InventoryList.tsx
+++ b/src/components/inventory/InventoryList.tsx
@@ -309,9 +309,7 @@ export const InventoryList: React.FC<InventoryListProps> = ({
                           className="manuscript-inventory-action-button"
                           variant="outline"
                           onClick={() => handleUseItem(item.id)}
-                          disabled={
-                            usingItemId === item.id || item.quantity <= 0
-                          }
+                          disabled={usingItemId !== null || item.quantity <= 0}
                         >
                           {usingItemId === item.id ? 'USING...' : 'USE'}
                         </Button>

--- a/src/components/inventory/__tests__/InventoryList.itemUsage.test.tsx
+++ b/src/components/inventory/__tests__/InventoryList.itemUsage.test.tsx
@@ -2,7 +2,7 @@
 // Verifies that users can interact with the "Use" button and see appropriate feedback
 
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { InventoryList } from '../InventoryList';
 import { useInventoryStore } from '@/state/inventoryStore';
@@ -231,6 +231,78 @@ describe('InventoryList - Item Usage', () => {
       // Button should show loading state during usage
       await waitFor(() => {
         expect(useButton).toHaveTextContent('USING...');
+      });
+    });
+
+    it('should block another item use while one is pending', async () => {
+      const user = userEvent.setup();
+      let resolveUsage!: (
+        result: Awaited<ReturnType<typeof processItemUsage>>
+      ) => void;
+      const mockProcessItemUsage = processItemUsage as jest.MockedFunction<
+        typeof processItemUsage
+      >;
+      mockProcessItemUsage.mockImplementationOnce(
+        () =>
+          new Promise<Awaited<ReturnType<typeof processItemUsage>>>((resolve) => {
+            resolveUsage = resolve;
+          })
+      );
+
+      for (const name of ['Health Potion', 'Antidote']) {
+        useInventoryStore.getState().addItem(characterId, {
+          name,
+          stackable: true,
+          quantity: 1,
+          categorization: {
+            categoryId: 'consumables',
+            source: 'manual',
+            classifiedAt: new Date().toISOString(),
+          },
+          acquisition: {
+            method: 'loot',
+            acquiredAt: new Date().toISOString(),
+            quantity: 1,
+          },
+        });
+      }
+
+      renderInventoryList();
+
+      const healthPotionCard = screen.getByText('Health Potion').closest('article');
+      const antidoteCard = screen.getByText('Antidote').closest('article');
+      expect(healthPotionCard).not.toBeNull();
+      expect(antidoteCard).not.toBeNull();
+
+      const healthPotionButton = within(healthPotionCard!).getByRole('button', {
+        name: 'USE',
+      });
+      const antidoteButton = within(antidoteCard!).getByRole('button', {
+        name: 'USE',
+      });
+
+      await user.click(healthPotionButton);
+
+      expect(healthPotionButton).toHaveTextContent('USING...');
+      expect(healthPotionButton).toBeDisabled();
+      expect(antidoteButton).toBeDisabled();
+
+      await user.click(antidoteButton);
+      expect(mockProcessItemUsage).toHaveBeenCalledTimes(1);
+
+      resolveUsage({
+        success: true,
+        narrative: 'The potion takes effect.',
+        itemName: 'Health Potion',
+        categoryId: 'consumables',
+        wasConsumed: true,
+        remainingQuantity: 0,
+      });
+
+      await waitFor(() => {
+        expect(healthPotionButton).toHaveTextContent('USE');
+        expect(healthPotionButton).toBeEnabled();
+        expect(antidoteButton).toBeEnabled();
       });
     });
 

--- a/src/components/inventory/__tests__/InventoryList.itemUsage.test.tsx
+++ b/src/components/inventory/__tests__/InventoryList.itemUsage.test.tsx
@@ -16,6 +16,16 @@ jest.mock('@/lib/inventory/itemUsageService');
 describe('InventoryList - Item Usage', () => {
   let worldId: string;
   let characterId: string;
+  const sessionId = 'session-1';
+
+  const renderInventoryList = () =>
+    render(
+      <InventoryList
+        characterId={characterId}
+        worldId={worldId}
+        sessionId={sessionId}
+      />
+    );
 
   beforeEach(() => {
     // Reset stores
@@ -86,7 +96,7 @@ describe('InventoryList - Item Usage', () => {
         },
       });
 
-      render(<InventoryList characterId={characterId} />);
+      renderInventoryList();
 
       // Verify Use button appears
       const useButtons = screen.getAllByRole('button', { name: /use/i });
@@ -114,7 +124,7 @@ describe('InventoryList - Item Usage', () => {
       // Set quantity to 0
       useInventoryStore.getState().updateItem(itemId, { quantity: 0 });
 
-      render(<InventoryList characterId={characterId} />);
+      renderInventoryList();
 
       const useButton = screen.getByRole('button', { name: /use/i });
       expect(useButton).toBeDisabled();
@@ -134,9 +144,11 @@ describe('InventoryList - Item Usage', () => {
       const mockProcessItemUsage = processItemUsage as jest.MockedFunction<
         typeof processItemUsage
       >;
-      mockProcessItemUsage.mockImplementation(async (charId, itemId) => {
+      mockProcessItemUsage.mockImplementation(async (command) => {
         // Call the real store method to update inventory
-        const result = useInventoryStore.getState().useItem(charId, itemId);
+        const result = useInventoryStore
+          .getState()
+          .useItem(command.characterId, command.itemId);
         return result;
       });
 
@@ -157,11 +169,18 @@ describe('InventoryList - Item Usage', () => {
         },
       });
 
-      render(<InventoryList characterId={characterId} />);
+      renderInventoryList();
 
       // Click Use button
       const useButton = screen.getByRole('button', { name: /use/i });
       await user.click(useButton);
+
+      expect(processItemUsage).toHaveBeenCalledWith({
+        sessionId,
+        worldId,
+        characterId,
+        itemId: expect.any(String),
+      });
 
       // Verify item quantity decreased
       await waitFor(() => {
@@ -180,9 +199,11 @@ describe('InventoryList - Item Usage', () => {
       const mockProcessItemUsage = processItemUsage as jest.MockedFunction<
         typeof processItemUsage
       >;
-      mockProcessItemUsage.mockImplementation(async (charId, itemId) => {
+      mockProcessItemUsage.mockImplementation(async (command) => {
         await new Promise((resolve) => setTimeout(resolve, 100));
-        return useInventoryStore.getState().useItem(charId, itemId);
+        return useInventoryStore
+          .getState()
+          .useItem(command.characterId, command.itemId);
       });
 
       useInventoryStore.getState().addItem(characterId, {
@@ -200,7 +221,7 @@ describe('InventoryList - Item Usage', () => {
         },
       });
 
-      render(<InventoryList characterId={characterId} />);
+      renderInventoryList();
 
       const useButton = screen.getByRole('button', { name: /USE/i });
 
@@ -220,8 +241,10 @@ describe('InventoryList - Item Usage', () => {
       const mockProcessItemUsage = processItemUsage as jest.MockedFunction<
         typeof processItemUsage
       >;
-      mockProcessItemUsage.mockImplementation(async (charId, itemId) => {
-        return useInventoryStore.getState().useItem(charId, itemId);
+      mockProcessItemUsage.mockImplementation(async (command) => {
+        return useInventoryStore
+          .getState()
+          .useItem(command.characterId, command.itemId);
       });
 
       useInventoryStore.getState().addItem(characterId, {
@@ -240,7 +263,7 @@ describe('InventoryList - Item Usage', () => {
         },
       });
 
-      render(<InventoryList characterId={characterId} />);
+      renderInventoryList();
 
       // Verify item appears initially
       expect(screen.getByText('Magic Berry')).toBeInTheDocument();
@@ -294,7 +317,7 @@ describe('InventoryList - Item Usage', () => {
         },
       });
 
-      render(<InventoryList characterId={characterId} />);
+      renderInventoryList();
 
       const useButton = screen.getByRole('button', { name: /use/i });
       await user.click(useButton);
@@ -339,7 +362,7 @@ describe('InventoryList - Item Usage', () => {
         },
       });
 
-      render(<InventoryList characterId={characterId} />);
+      renderInventoryList();
 
       const useButton = screen.getByRole('button', { name: /use/i });
       await user.click(useButton);

--- a/src/components/inventory/__tests__/InventoryList.test.tsx
+++ b/src/components/inventory/__tests__/InventoryList.test.tsx
@@ -121,6 +121,13 @@ const createItem = (overrides: Partial<InventoryItem>): InventoryItem => {
 
 describe('InventoryList', () => {
   const characterId = 'char-1';
+  const inventoryList = () => (
+    <InventoryList
+      characterId={characterId}
+      worldId="world-1"
+      sessionId="session-1"
+    />
+  );
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -158,7 +165,7 @@ describe('InventoryList', () => {
       selector ? selector(mockStore) : mockStore
     );
 
-    render(<InventoryList characterId={characterId} />);
+    render(inventoryList());
 
     expect(screen.getByRole('heading', { name: 'Equipment' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Consumables' })).toBeInTheDocument();
@@ -193,7 +200,7 @@ describe('InventoryList', () => {
       selector ? selector(mockStore) : mockStore
     );
 
-    render(<InventoryList characterId={characterId} />);
+    render(inventoryList());
 
     expect(screen.getByText(/×12/)).toBeInTheDocument();
   });
@@ -210,7 +217,7 @@ describe('InventoryList', () => {
       selector ? selector(mockStore) : mockStore
     );
 
-    render(<InventoryList characterId={characterId} />);
+    render(inventoryList());
 
     expect(screen.getByText(/no items in inventory/i)).toBeInTheDocument();
   });
@@ -237,7 +244,7 @@ describe('InventoryList', () => {
       selector ? selector(mockStore) : mockStore
     );
 
-    const { rerender } = render(<InventoryList characterId={characterId} />);
+    const { rerender } = render(inventoryList());
     expect(screen.getByText(/no items in inventory/i)).toBeInTheDocument();
 
     // Second render: item added to inventory
@@ -249,7 +256,7 @@ describe('InventoryList', () => {
       removeItem: jest.fn(),
     });
 
-    rerender(<InventoryList characterId={characterId} />);
+    rerender(inventoryList());
 
     expect(screen.getByText('Arcane Tome')).toBeInTheDocument();
   });
@@ -277,7 +284,7 @@ describe('InventoryList', () => {
       selector ? selector(mockStore) : mockStore
     );
 
-    render(<InventoryList characterId={characterId} />);
+    render(inventoryList());
 
     const image = screen.getByAltText('Enchanted Ring') as HTMLImageElement;
     expect(image).toBeInTheDocument();
@@ -300,7 +307,7 @@ describe('InventoryList', () => {
       selector ? selector(mockStore) : mockStore
     );
 
-    render(<InventoryList characterId={characterId} />);
+    render(inventoryList());
 
     expect(
       screen.getByLabelText('Image unavailable for Broken Compass')
@@ -327,7 +334,7 @@ describe('InventoryList', () => {
       selector ? selector(mockStore) : mockStore
     );
 
-    render(<InventoryList characterId={characterId} />);
+    render(inventoryList());
 
     expect(
       screen.getByLabelText('Image unavailable for Faded Locket')
@@ -350,7 +357,7 @@ describe('InventoryList', () => {
       selector ? selector(mockStore) : mockStore
     );
 
-    render(<InventoryList characterId={characterId} />);
+    render(inventoryList());
 
     expect(
       screen.getByLabelText('Generating image for Summoned Blade')
@@ -380,7 +387,7 @@ describe('InventoryList', () => {
     // Mock getState needed for the hook
     (mockUseInventoryStore as unknown as { getState: () => InventoryStore }).getState = () => mockStore;
 
-    render(<InventoryList characterId={characterId} />);
+    render(inventoryList());
 
     // Find drop button
     const dropButton = screen.getByLabelText('Drop Test Item');
@@ -413,7 +420,7 @@ describe('InventoryList', () => {
       selector ? selector(mockStore) : mockStore
     );
 
-    const { container } = render(<InventoryList characterId={characterId} />);
+    const { container } = render(inventoryList());
 
     expect(screen.getByText('Equipped')).toBeInTheDocument();
     expect(container.querySelector('.manuscript-inventory-item.is-equipped')).toBeInTheDocument();
@@ -439,7 +446,7 @@ describe('InventoryList', () => {
       selector ? selector(mockStore) : mockStore
     );
 
-    render(<InventoryList characterId={characterId} />);
+    render(inventoryList());
 
     await user.click(screen.getByRole('button', { name: 'Equip Steel Sword' }));
 
@@ -462,7 +469,7 @@ describe('InventoryList', () => {
       selector ? selector(mockStore) : mockStore
     );
 
-    render(<InventoryList characterId={characterId} />);
+    render(inventoryList());
 
     expect(screen.queryByRole('button', { name: /Equip Health Potion/i })).not.toBeInTheDocument();
   });
@@ -491,7 +498,7 @@ describe('InventoryList', () => {
       selector ? selector(mockStore) : mockStore
     );
 
-    render(<InventoryList characterId={characterId} />);
+    render(inventoryList());
 
     await user.click(screen.getByRole('button', { name: 'Equip Lucky Charm' }));
 

--- a/src/lib/inventory/__tests__/itemUsageService.choiceSkip.test.ts
+++ b/src/lib/inventory/__tests__/itemUsageService.choiceSkip.test.ts
@@ -14,6 +14,33 @@ jest.mock('@/lib/ai/defaultGeminiClient', () => ({
   createDefaultGeminiClient: jest.fn(() => ({ generateContent: jest.fn() })),
 }));
 
+jest.mock('@/lib/narrative/applyWorldClockUpdates', () => ({
+  applyWorldClockUpdates: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@/lib/narrative/applyWorldStateThreadUpdates', () => ({
+  applyWorldStateThreadUpdates: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/lib/ai/narrativeGenerator.npc', () => ({
+  ...jest.requireActual('@/lib/ai/narrativeGenerator.npc'),
+  syncNpcMetadata: jest.fn(),
+}));
+
+jest.mock('@/lib/ai/structuredLoreExtractor', () => ({
+  extractStructuredLore: jest.fn().mockResolvedValue({
+    characters: [],
+    locations: [],
+    events: [],
+    rules: [],
+  }),
+}));
+
+jest.mock('@/lib/ai/loreContextHelper', () => ({
+  ...jest.requireActual('@/lib/ai/loreContextHelper'),
+  getLoreContextForPrompt: jest.fn(() => ''),
+}));
+
 const mockGenerateSegment = jest.fn();
 const mockGeneratePlayerChoices = jest.fn();
 
@@ -115,7 +142,12 @@ describe('processItemUsage - skip choice regeneration on session end (#925)', ()
   it('regenerates choices after a normal item-usage segment', async () => {
     mockGenerateSegment.mockResolvedValue(buildGeneration(['item-usage']));
 
-    const result = await processItemUsage(characterId, itemId, sessionId);
+    const result = await processItemUsage({
+      characterId,
+      itemId,
+      sessionId,
+      worldId,
+    });
 
     expect(result.success).toBe(true);
     expect(mockGeneratePlayerChoices).toHaveBeenCalledTimes(1);
@@ -132,7 +164,12 @@ describe('processItemUsage - skip choice regeneration on session end (#925)', ()
       options: [{ id: 'existing-1', text: 'Stay' }],
     });
 
-    const result = await processItemUsage(characterId, itemId, sessionId);
+    const result = await processItemUsage({
+      characterId,
+      itemId,
+      sessionId,
+      worldId,
+    });
 
     expect(result.success).toBe(true);
     expect(mockGeneratePlayerChoices).not.toHaveBeenCalled();

--- a/src/lib/inventory/__tests__/itemUsageService.test.ts
+++ b/src/lib/inventory/__tests__/itemUsageService.test.ts
@@ -14,6 +14,8 @@ import { useJournalStore } from '@/state/journalStore';
 import { useSessionStore } from '@/state/sessionStore';
 import type { InventoryItem } from '@/types/inventory.types';
 import { useNarrativeStore } from '@/state/narrativeStore';
+import * as worldClockUpdates from '@/lib/narrative/applyWorldClockUpdates';
+import { PARTIAL_RECONCILIATION_ERROR } from '@/lib/narrative/narrativeErrors';
 
 // Mock AI client
 jest.mock('@/lib/ai/defaultGeminiClient', () => ({
@@ -24,6 +26,33 @@ jest.mock('@/lib/ai/defaultGeminiClient', () => ({
       tokenUsage: 50,
     }),
   })),
+}));
+
+jest.mock('@/lib/narrative/applyWorldClockUpdates', () => ({
+  applyWorldClockUpdates: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@/lib/narrative/applyWorldStateThreadUpdates', () => ({
+  applyWorldStateThreadUpdates: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/lib/ai/narrativeGenerator.npc', () => ({
+  ...jest.requireActual('@/lib/ai/narrativeGenerator.npc'),
+  syncNpcMetadata: jest.fn(),
+}));
+
+jest.mock('@/lib/ai/structuredLoreExtractor', () => ({
+  extractStructuredLore: jest.fn().mockResolvedValue({
+    characters: [],
+    locations: [],
+    events: [],
+    rules: [],
+  }),
+}));
+
+jest.mock('@/lib/ai/loreContextHelper', () => ({
+  ...jest.requireActual('@/lib/ai/loreContextHelper'),
+  getLoreContextForPrompt: jest.fn(() => ''),
 }));
 
 describe('Item Usage Service', () => {
@@ -88,6 +117,10 @@ describe('Item Usage Service', () => {
     useSessionStore.getState().setSessionId(sessionId);
     useSessionStore.getState().setCharacterId(characterId);
     useSessionStore.setState({ worldId });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   describe('isNarrativelySignificant', () => {
@@ -313,7 +346,12 @@ describe('Item Usage Service', () => {
         },
       });
 
-      const result = await processItemUsage(characterId, itemId, sessionId);
+      const result = await processItemUsage({
+        characterId,
+        itemId,
+        sessionId,
+        worldId,
+      });
 
       expect(result.success).toBe(true);
       expect(result.narrative).toBeTruthy();
@@ -348,7 +386,12 @@ describe('Item Usage Service', () => {
         },
       });
 
-      const result = await processItemUsage(characterId, itemId, sessionId);
+      const result = await processItemUsage({
+        characterId,
+        itemId,
+        sessionId,
+        worldId,
+      });
       expect(result.segmentId).toBeTruthy();
       expect(result.previousQuantity).toBe(1);
 
@@ -388,7 +431,12 @@ describe('Item Usage Service', () => {
         .getState()
         .getSessionEntries(sessionId).length;
 
-      const result = await processItemUsage(characterId, itemId, sessionId);
+      const result = await processItemUsage({
+        characterId,
+        itemId,
+        sessionId,
+        worldId,
+      });
 
       const journalCountAfter = useJournalStore
         .getState()
@@ -399,6 +447,47 @@ describe('Item Usage Service', () => {
       expect(result.segmentId).toBeTruthy();
       expect(result.narrative).toBeTruthy();
       expect(result.previousQuantity).toBe(5);
+    });
+
+    it('surfaces the non-retryable pause state after partial settlement', async () => {
+      const itemId = useInventoryStore.getState().addItem(characterId, {
+        name: 'Cracked Compass',
+        stackable: false,
+        categorization: {
+          categoryId: 'equipment',
+          source: 'manual',
+          classifiedAt: new Date().toISOString(),
+        },
+        acquisition: {
+          method: 'loot',
+          acquiredAt: new Date().toISOString(),
+          quantity: 1,
+        },
+      });
+      useNarrativeStore.getState().addDecision(sessionId, {
+        prompt: 'Existing decision',
+        options: [{ id: 'existing-1', text: 'Wait' }],
+      });
+      jest
+        .spyOn(worldClockUpdates, 'applyWorldClockUpdates')
+        .mockRejectedValueOnce(new Error('clock unavailable'));
+
+      const result = await processItemUsage({
+        characterId,
+        itemId,
+        sessionId,
+        worldId,
+      });
+
+      expect(result.success).toBe(true);
+      expect(useNarrativeStore.getState().generationError).toEqual(
+        PARTIAL_RECONCILIATION_ERROR
+      );
+      expect(
+        useNarrativeStore.getState().getSessionDecisions(sessionId)
+      ).toEqual([
+        expect.objectContaining({ prompt: 'Existing decision' }),
+      ]);
     });
   });
 

--- a/src/lib/inventory/__tests__/itemUsageService.test.ts
+++ b/src/lib/inventory/__tests__/itemUsageService.test.ts
@@ -464,6 +464,21 @@ describe('Item Usage Service', () => {
           quantity: 1,
         },
       });
+      const laterItemId = useInventoryStore.getState().addItem(characterId, {
+        name: 'Spare Tonic',
+        stackable: true,
+        quantity: 2,
+        categorization: {
+          categoryId: 'consumables',
+          source: 'manual',
+          classifiedAt: new Date().toISOString(),
+        },
+        acquisition: {
+          method: 'loot',
+          acquiredAt: new Date().toISOString(),
+          quantity: 2,
+        },
+      });
       useNarrativeStore.getState().addDecision(sessionId, {
         prompt: 'Existing decision',
         options: [{ id: 'existing-1', text: 'Wait' }],
@@ -488,6 +503,24 @@ describe('Item Usage Service', () => {
       ).toEqual([
         expect.objectContaining({ prompt: 'Existing decision' }),
       ]);
+
+      const pauseError = useNarrativeStore.getState().generationError;
+      const reconciliationCallsAfterPartial = (
+        worldClockUpdates.applyWorldClockUpdates as jest.Mock
+      ).mock.calls.length;
+      const laterResult = await processItemUsage({
+        characterId,
+        itemId: laterItemId,
+        sessionId,
+        worldId,
+      });
+
+      expect(laterResult.success).toBe(false);
+      expect(useInventoryStore.getState().items[laterItemId]?.quantity).toBe(2);
+      expect(useNarrativeStore.getState().generationError).toBe(pauseError);
+      expect(worldClockUpdates.applyWorldClockUpdates).toHaveBeenCalledTimes(
+        reconciliationCallsAfterPartial
+      );
     });
   });
 

--- a/src/lib/inventory/itemUsageNarrative.ts
+++ b/src/lib/inventory/itemUsageNarrative.ts
@@ -1,0 +1,194 @@
+import type { NarrativeGenerator } from '@/lib/ai/narrativeGenerator';
+import { mergeTurnTags } from '@/lib/narrative/turnTags';
+import { useCharacterStore } from '@/state/characterStore';
+import { useNarrativeStore } from '@/state/narrativeStore';
+import { useWorldStore } from '@/state/worldStore';
+import type { EntityID } from '@/types/common.types';
+import type { InventoryItem } from '@/types/inventory.types';
+import type { NarrativeGenerationResult } from '@/types/narrative.types';
+import { safeTrim } from '@/lib/utils';
+
+export interface ItemUsageNarrativeDetails {
+  wasConsumed?: boolean;
+  remainingQuantity?: number;
+  previousQuantity?: number;
+}
+
+interface ItemUsageNarrativeRequest {
+  item: InventoryItem;
+  characterId: EntityID;
+  worldId: EntityID;
+  sessionId: EntityID;
+  usageDetails: ItemUsageNarrativeDetails;
+}
+
+/**
+ * Builds local fallback prose for an item-use turn.
+ */
+export function buildUsageNarrative(
+  item: InventoryItem,
+  usageDetails: ItemUsageNarrativeDetails,
+  tone: 'detailed' | 'simple' = 'simple'
+): string {
+  const previousQuantity = usageDetails.previousQuantity ?? item.quantity;
+  const remainingQuantity =
+    usageDetails.remainingQuantity ??
+    (usageDetails.wasConsumed
+      ? Math.max(previousQuantity - 1, 0)
+      : previousQuantity);
+  const narrativeParts: string[] = [];
+
+  if (tone === 'detailed') {
+    narrativeParts.push(
+      `You use ${previousQuantity === 1 ? 'the' : 'one of the'} ${item.name}${item.description ? `. ${item.description}` : '.'}`
+    );
+  } else {
+    if (usageDetails.wasConsumed) {
+      narrativeParts.push(
+        remainingQuantity > 0
+          ? `You use one of the ${item.name}, leaving ${remainingQuantity} remaining.`
+          : `You use the last of the ${item.name}.`
+      );
+    } else {
+      narrativeParts.push(
+        `You use the ${item.name}${item.description ? `. ${item.description}` : '.'}`
+      );
+    }
+
+    return narrativeParts.map((part) => safeTrim(part)).join(' ');
+  }
+
+  if (usageDetails.wasConsumed) {
+    narrativeParts.push(
+      remainingQuantity > 0
+        ? `You still have ${remainingQuantity} ${remainingQuantity === 1 ? 'remaining' : 'remaining pieces'} to draw upon.`
+        : 'That was the last of this item.'
+    );
+  } else {
+    narrativeParts.push(
+      'The item remains firmly in your grasp as the moment passes.'
+    );
+  }
+
+  return narrativeParts.map((part) => safeTrim(part)).join(' ');
+}
+
+/**
+ * Generates an item-specific action beat through the resolver-managed
+ * generator seam. Provider failures fall back to local prose.
+ */
+export async function generateItemUsageNarrative(
+  {
+    item,
+    characterId,
+    worldId,
+    sessionId,
+    usageDetails,
+  }: ItemUsageNarrativeRequest,
+  generator: NarrativeGenerator
+): Promise<NarrativeGenerationResult> {
+  const world = useWorldStore.getState().worlds[worldId];
+  const character = useCharacterStore.getState().characters[characterId];
+
+  if (!world || !character) {
+    throw new Error('World or character not found');
+  }
+
+  try {
+    const previousSegments = useNarrativeStore
+      .getState()
+      .getSessionSegments(sessionId);
+    const recentSegments = previousSegments.slice(-5);
+    const lastSegment = previousSegments[previousSegments.length - 1];
+    const currentTags = mergeTurnTags(lastSegment?.metadata?.tags || [], [
+      'item-usage',
+      `item-${item.categoryId}`,
+    ]);
+    const itemSituationLines = [
+      `The player immediately uses the item "${item.name}".`,
+      'Describe the precise motion of using it and the sensory details that follow.',
+      'Show the item altering the current stakes or environment right away.',
+      'Avoid simply repeating the inventory description; translate it into lived action.',
+    ];
+
+    if (
+      usageDetails.wasConsumed &&
+      typeof usageDetails.previousQuantity === 'number'
+    ) {
+      const previousQuantity = usageDetails.previousQuantity;
+      const remainingQuantity =
+        usageDetails.remainingQuantity ?? Math.max(previousQuantity - 1, 0);
+      if (previousQuantity > 1 && remainingQuantity > 0) {
+        itemSituationLines.push(
+          `Only one unit is used in this moment. Make it clear the character still has ${remainingQuantity} remaining for future scenes.`
+        );
+      } else if (remainingQuantity === 0) {
+        itemSituationLines.push(
+          'This was the final unit of the item. Emphasize that the supply is now exhausted.'
+        );
+      }
+    } else if (!usageDetails.wasConsumed) {
+      itemSituationLines.push(
+        'The item remains in the character’s possession after the action.'
+      );
+    }
+
+    const situationLines = [...itemSituationLines];
+    if (item.description) {
+      situationLines.push(`The item is known for: ${item.description}.`);
+    }
+    situationLines.push(`Category context: ${item.categoryId}.`);
+
+    const includedTopics = [
+      `item:${item.name}`,
+      `category:${item.categoryId}`,
+      'item-usage-effect',
+    ];
+    if (item.description) {
+      includedTopics.push(`item-detail:${item.description}`);
+    }
+
+    return await generator.generateSegment(
+      {
+        worldId,
+        sessionId,
+        characterIds: [characterId],
+        narrativeContext: {
+          worldId,
+          sessionId,
+          currentSceneId: `item-usage-${item.id}`,
+          characterIds: [characterId],
+          previousSegments,
+          recentSegments,
+          currentTags,
+          currentLocation: lastSegment?.metadata?.location,
+          currentSituation: situationLines.join(' '),
+          importantEntities: [
+            {
+              id: item.id,
+              type: 'item',
+              name: item.name,
+            },
+          ],
+        },
+        generationParameters: {
+          segmentType: 'action',
+          desiredLength: 'short',
+          includedTopics,
+          disableItemAcquisitionProcessing: true,
+          disableItemLossProcessing: true,
+        },
+      },
+      { resolverManaged: true }
+    );
+  } catch {
+    return {
+      content: buildUsageNarrative(item, usageDetails, 'detailed'),
+      segmentType: 'action',
+      metadata: {
+        characterIds: [characterId],
+        tags: ['item-usage', item.categoryId],
+      },
+    };
+  }
+}

--- a/src/lib/inventory/itemUsageService.ts
+++ b/src/lib/inventory/itemUsageService.ts
@@ -1,32 +1,26 @@
-// Item usage service - handles item usage logic, narrative generation, and journal integration
-
-import type { InventoryItem, ItemUsageResult, StandardInventoryCategory } from '@/types/inventory.types';
-import type { EntityID } from '@/types/common.types';
 import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
-import { useWorldStore } from '@/state/worldStore';
-import { useCharacterStore } from '@/state/characterStore';
-import { createItemUsageJournalEntry } from './itemUsageJournalIntegration';
 import { NarrativeGenerator } from '@/lib/ai/narrativeGenerator';
+import { PARTIAL_RECONCILIATION_ERROR } from '@/lib/narrative/narrativeErrors';
+import { resolveItemUseTurn } from '@/lib/narrative/turnResolver';
+import { useJournalStore } from '@/state/journalStore';
+import { useNarrativeStore } from '@/state/narrativeStore';
+import type {
+  InventoryItem,
+  ItemUsageResult,
+  StandardInventoryCategory,
+} from '@/types/inventory.types';
 import type { NarrativeGenerationResult } from '@/types/narrative.types';
-import { isSessionEndingSegment } from '@/lib/narrative/isSessionEndingSegment';
-import { mergeTurnTags } from '@/lib/narrative/turnTags';
-import { safeTrim } from '@/lib/utils';
+import type { ItemUseTurnCommand } from '@/types/turnResolver.types';
+import {
+  generateItemUsageNarrative as generateResolverManagedItemNarrative,
+  type ItemUsageNarrativeDetails,
+} from './itemUsageNarrative';
+import { createItemUsageJournalEntry } from './itemUsageJournalIntegration';
 
-import Logger from '@/lib/utils/logger';
-const logger = new Logger('ItemUsageService');
-
-interface ItemUsageNarrativeDetails {
-  wasConsumed?: boolean;
-  remainingQuantity?: number;
-  previousQuantity?: number;
-}
+export { buildUsageNarrative } from './itemUsageNarrative';
 
 /**
- * Determines if an item's usage is narratively significant enough to warrant
- * AI-generated effects and journal entries.
- *
- * Significant items: quest items, equipment, documents, valuables
- * Insignificant items: common consumables, miscellaneous items
+ * Determines whether item usage warrants a journal entry.
  */
 export function isNarrativelySignificant(item: InventoryItem): boolean {
   const significantCategories: StandardInventoryCategory[] = [
@@ -40,343 +34,54 @@ export function isNarrativelySignificant(item: InventoryItem): boolean {
 }
 
 /**
- * Builds fallback narrative text for item usage.
- * Centralizes the logic for constructing narrative based on consumption state.
- *
- * @param item - The item being used
- * @param usageDetails - Details about the usage (consumption, quantities)
- * @param tone - 'detailed' for longer descriptions, 'simple' for concise ones
- * @returns Narrative text describing the item usage
+ * Generates item-use prose with the default provider client.
+ * TurnResolver injects its existing generator through the lower-level helper.
  */
-export function buildUsageNarrative(
+export function generateItemUsageNarrative(
   item: InventoryItem,
-  usageDetails: ItemUsageNarrativeDetails,
-  tone: 'detailed' | 'simple' = 'simple'
-): string {
-  const previousQuantity = usageDetails.previousQuantity ?? item.quantity;
-  const remainingQuantity =
-    usageDetails.remainingQuantity ??
-    (usageDetails.wasConsumed ? Math.max(previousQuantity - 1, 0) : previousQuantity);
-
-  const narrativeParts: string[] = [];
-
-  // Opening line
-  if (tone === 'detailed') {
-    narrativeParts.push(
-      `You use ${previousQuantity === 1 ? 'the' : 'one of the'} ${item.name}${item.description ? `. ${item.description}` : '.'}`
-    );
-  } else {
-    if (usageDetails.wasConsumed) {
-      if (remainingQuantity > 0) {
-        narrativeParts.push(`You use one of the ${item.name}, leaving ${remainingQuantity} remaining.`);
-      } else {
-        narrativeParts.push(`You use the last of the ${item.name}.`);
-      }
-    } else {
-      narrativeParts.push(`You use the ${item.name}${item.description ? `. ${item.description}` : '.'}`);
-    }
-    return narrativeParts.map(part => safeTrim(part)).join(' ');
-  }
-
-  // Consumption details (detailed tone only)
-  if (usageDetails.wasConsumed) {
-    if (remainingQuantity > 0) {
-      narrativeParts.push(
-        `You still have ${remainingQuantity} ${remainingQuantity === 1 ? 'remaining' : 'remaining pieces'} to draw upon.`
-      );
-    } else {
-      narrativeParts.push('That was the last of this item.');
-    }
-  } else {
-    narrativeParts.push('The item remains firmly in your grasp as the moment passes.');
-  }
-
-  return narrativeParts.map(part => safeTrim(part)).join(' ');
-}
-
-/**
- * Generates narrative text describing the effects of using an item.
- * Uses AI to create contextual, world-appropriate descriptions.
- */
-export async function generateItemUsageNarrative(
-  item: InventoryItem,
-  characterId: EntityID,
-  worldId: EntityID,
-  sessionId: EntityID,
+  characterId: ItemUseTurnCommand['characterId'],
+  worldId: ItemUseTurnCommand['worldId'],
+  sessionId: ItemUseTurnCommand['sessionId'],
   usageDetails: ItemUsageNarrativeDetails
 ): Promise<NarrativeGenerationResult> {
-  // Get world and character context up front to keep error handling consistent
-  const world = useWorldStore.getState().worlds[worldId];
-  const character = useCharacterStore.getState().characters[characterId];
-
-  if (!world || !character) {
-    throw new Error('World or character not found');
-  }
-
-  try {
-    const { useNarrativeStore } = await import('@/state/narrativeStore');
-    const narrativeStore = useNarrativeStore.getState();
-    const previousSegments = narrativeStore.getSessionSegments(sessionId);
-    const recentSegments = previousSegments.slice(-5);
-    const lastSegment = previousSegments[previousSegments.length - 1];
-    const currentTags = mergeTurnTags(lastSegment?.metadata?.tags || [], [
-      'item-usage',
-      `item-${item.categoryId}`,
-    ]);
-
-    const generator = new NarrativeGenerator(createDefaultGeminiClient());
-
-    const itemSituationLines = [
-      `The player immediately uses the item "${item.name}".`,
-      'Describe the precise motion of using it and the sensory details that follow.',
-      'Show the item altering the current stakes or environment right away.',
-      'Avoid simply repeating the inventory description; translate it into lived action.'
-    ];
-
-    if (usageDetails.wasConsumed && typeof usageDetails.previousQuantity === 'number') {
-      const previousQuantity = usageDetails.previousQuantity;
-      const remainingQuantity = usageDetails.remainingQuantity ?? Math.max(previousQuantity - 1, 0);
-      if (previousQuantity > 1 && remainingQuantity > 0) {
-        itemSituationLines.push(
-          `Only one unit is used in this moment. Make it clear the character still has ${remainingQuantity} remaining for future scenes.`
-        );
-      } else if (remainingQuantity === 0) {
-        itemSituationLines.push('This was the final unit of the item. Emphasize that the supply is now exhausted.');
-      }
-    } else if (!usageDetails.wasConsumed) {
-      itemSituationLines.push('The item remains in the character’s possession after the action.');
-    }
-
-    const situationLines = [...itemSituationLines];
-    if (item.description) {
-      situationLines.push(`The item is known for: ${item.description}.`);
-    }
-    situationLines.push(`Category context: ${item.categoryId}.`);
-
-    const includedTopics = [
-      `item:${item.name}`,
-      `category:${item.categoryId}`,
-      'item-usage-effect',
-    ];
-    if (item.description) {
-      includedTopics.push(`item-detail:${item.description}`);
-    }
-
-    return await generator.generateSegment({
-      worldId,
-      sessionId,
-      characterIds: [characterId],
-      narrativeContext: {
-        worldId,
-        sessionId,
-        currentSceneId: `item-usage-${item.id}`,
-        characterIds: [characterId],
-        previousSegments,
-        recentSegments,
-        currentTags,
-        currentLocation: lastSegment?.metadata?.location,
-        currentSituation: situationLines.join(' '),
-        importantEntities: [
-          {
-            id: item.id,
-            type: 'item',
-            name: item.name,
-          },
-        ],
-      },
-      generationParameters: {
-        segmentType: 'action',
-        desiredLength: 'short',
-        includedTopics,
-        disableItemAcquisitionProcessing: true,
-      },
-    });
-  } catch {
-    // Fallback narrative if AI generation fails or context unavailable
-    return {
-      content: buildUsageNarrative(item, usageDetails, 'detailed'),
-      segmentType: 'action',
-      metadata: {
-        characterIds: [characterId],
-        tags: ['item-usage', item.categoryId],
-      },
-    };
-  }
+  return generateResolverManagedItemNarrative(
+    { item, characterId, worldId, sessionId, usageDetails },
+    new NarrativeGenerator(createDefaultGeminiClient())
+  );
 }
 
 /**
- * Uses an item with full effects: inventory changes, narrative generation,
- * and journal entries for significant items.
+ * Uses an item through the session's authoritative TurnResolver pipeline.
  */
 export async function processItemUsage(
-  characterId: EntityID,
-  itemId: EntityID,
-  sessionId?: EntityID
+  command: ItemUseTurnCommand
 ): Promise<ItemUsageResult> {
-  // Import dynamically to avoid circular dependencies
-  const { useInventoryStore } = await import('@/state/inventoryStore');
-  const { useJournalStore } = await import('@/state/journalStore');
-  const { useSessionStore } = await import('@/state/sessionStore');
+  const generator = new NarrativeGenerator(createDefaultGeminiClient());
+  const outcome = await resolveItemUseTurn(command, generator);
 
-  const inventoryStore = useInventoryStore.getState();
-  const item = inventoryStore.items[itemId];
-
-  if (!item) {
-    return {
-      success: false,
-      error: {
-        type: 'VALIDATION',
-        title: 'Item Not Found',
-        message: 'The specified item could not be found.',
-      },
-    };
+  if (!outcome.success) {
+    return outcome;
   }
 
-  // Check if character owns this item
-  const characterItems = inventoryStore.characterInventories[characterId] || [];
-  if (!characterItems.includes(itemId)) {
-    return {
-      success: false,
-      error: {
-        type: 'VALIDATION',
-        title: 'Item Not Available',
-        message: 'This item is not in your inventory.',
-      },
-    };
+  if (outcome.turn.status === 'partial') {
+    useNarrativeStore
+      .getState()
+      .setGenerationError(PARTIAL_RECONCILIATION_ERROR);
   }
 
-  // Use the item via inventory store
-  const usageResult = inventoryStore.useItem(characterId, itemId);
-
-  if (!usageResult.success) {
-    return usageResult;
-  }
-
-  const sessionStore = useSessionStore.getState();
-  const worldId = sessionStore.worldId;
-  const resolvedSessionId = sessionId ?? sessionStore.id;
-
-  let narrative: string | undefined;
-  let segmentId: EntityID | undefined;
-
-  if (worldId && resolvedSessionId) {
-    try {
-      const generation = await generateItemUsageNarrative(
-        item,
-        characterId,
-        worldId,
-        resolvedSessionId,
-        {
-          wasConsumed: usageResult.wasConsumed,
-          remainingQuantity: usageResult.remainingQuantity,
-          previousQuantity: usageResult.previousQuantity,
-        }
-      );
-
-      narrative = generation.content;
-      if (!narrative || !narrative.trim()) {
-        narrative = `You use the ${item.name}${item.description ? `. ${item.description}` : '.'}`;
-      }
-
-      const { useNarrativeStore } = await import('@/state/narrativeStore');
-      const narrativeStore = useNarrativeStore.getState();
-      const now = new Date();
-
-      const baseTags = new Set<string>(['item-usage', item.categoryId]);
-      generation.metadata?.tags?.forEach((tag) => {
-        if (tag) {
-          baseTags.add(tag);
-        }
-      });
-
-      const metadataCharacterIds =
-        generation.metadata?.characterIds?.length
-          ? generation.metadata.characterIds
-          : [characterId];
-
-      segmentId = narrativeStore.addSegment(resolvedSessionId, {
-        content: generation.content,
-        type: generation.segmentType,
-        characterIds: metadataCharacterIds,
-        metadata: {
-          ...generation.metadata,
-          tags: Array.from(baseTags),
-          characterIds: metadataCharacterIds,
-        },
-        timestamp: now,
-        updatedAt: now.toISOString(),
-      });
-
-      // Create journal entry for significant usage
-      if (isNarrativelySignificant(item)) {
-        const journalEntry = createItemUsageJournalEntry(
-          item,
-          generation.content,
-          worldId,
-          characterId
-        );
-
-        const journalStore = useJournalStore.getState();
-        journalStore.addEntry(resolvedSessionId, journalEntry);
-      }
-
-      // After item-usage narrative, clear any stale decisions and generate fresh choices
-      try {
-        const recentSegments = narrativeStore.getSessionSegments(resolvedSessionId).slice(-5);
-        const lastSegment = recentSegments[recentSegments.length - 1];
-
-        // If using the item ended the session (fatal/ending segment), skip choice
-        // regeneration — the choices would never be shown, and existing decisions
-        // stay intact rather than being cleared.
-        if (!lastSegment || !isSessionEndingSegment(lastSegment)) {
-          const narrativeContext = {
-            worldId,
-            sessionId: resolvedSessionId,
-            currentSceneId: `item-usage-${item.id}-${Date.now()}`,
-            characterIds: [characterId],
-            previousSegments: recentSegments,
-            recentSegments,
-            currentTags: lastSegment?.metadata?.tags || [],
-            currentLocation: lastSegment?.metadata?.location,
-          };
-
-          // Yield so the UI can render a loading/skeleton state before new choices arrive
-          await new Promise((resolve) => setTimeout(resolve, 0));
-
-          const geminiClient = createDefaultGeminiClient();
-          const generator = new NarrativeGenerator(geminiClient);
-          const decision = await generator.generatePlayerChoices(
-            worldId,
-            narrativeContext,
-            [characterId],
-            resolvedSessionId
-          );
-
-          // Clear old decisions only after successful generation
-          narrativeStore.clearSessionDecisions(resolvedSessionId);
-
-          // Persist new decision in store for UI to pick up
-          narrativeStore.addDecision(resolvedSessionId, {
-            prompt: decision.prompt,
-            options: decision.options,
-            decisionWeight: decision.decisionWeight,
-            contextSummary: decision.contextSummary,
-          });
-        }
-      } catch (error) {
-        // If generation fails, existing decisions remain intact (not cleared)
-        logger.warn('Failed to generate choices after item usage, keeping existing decisions', error);
-      }
-    } catch {
-      narrative = buildUsageNarrative(item, usageResult, 'simple');
-    }
-  } else {
-    narrative = buildUsageNarrative(item, usageResult, 'simple');
+  if (isNarrativelySignificant(outcome.item)) {
+    const journalEntry = createItemUsageJournalEntry(
+      outcome.item,
+      outcome.turn.segment.content,
+      command.worldId,
+      command.characterId
+    );
+    useJournalStore.getState().addEntry(command.sessionId, journalEntry);
   }
 
   return {
-    ...usageResult,
-    narrative,
-    segmentId,
+    ...outcome.usage,
+    narrative: outcome.turn.segment.content,
+    segmentId: outcome.turn.segment.id,
   };
 }

--- a/src/lib/inventory/itemUsageService.ts
+++ b/src/lib/inventory/itemUsageService.ts
@@ -1,9 +1,7 @@
 import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
 import { NarrativeGenerator } from '@/lib/ai/narrativeGenerator';
-import { PARTIAL_RECONCILIATION_ERROR } from '@/lib/narrative/narrativeErrors';
 import { resolveItemUseTurn } from '@/lib/narrative/turnResolver';
 import { useJournalStore } from '@/state/journalStore';
-import { useNarrativeStore } from '@/state/narrativeStore';
 import type {
   InventoryItem,
   ItemUsageResult,
@@ -61,12 +59,6 @@ export async function processItemUsage(
 
   if (!outcome.success) {
     return outcome;
-  }
-
-  if (outcome.turn.status === 'partial') {
-    useNarrativeStore
-      .getState()
-      .setGenerationError(PARTIAL_RECONCILIATION_ERROR);
   }
 
   if (isNarrativelySignificant(outcome.item)) {

--- a/src/lib/narrative/__tests__/turnResolver.test.ts
+++ b/src/lib/narrative/__tests__/turnResolver.test.ts
@@ -11,6 +11,7 @@ import { useCharacterStore } from '@/state/characterStore';
 import { useInventoryStore } from '@/state/inventoryStore';
 import { useWorldThreadStore } from '@/state/worldThreadStore';
 import { useWorldStore } from '@/state/worldStore';
+import { PARTIAL_RECONCILIATION_ERROR } from '@/lib/narrative/narrativeErrors';
 import type { NarrativeGenerationResult } from '@/types/narrative.types';
 import type { TurnCommand } from '@/types/turnResolver.types';
 import type { NarrativeGenerator } from '@/lib/ai/narrativeGenerator';
@@ -52,6 +53,13 @@ jest.mock('../itemLossInference', () => ({
   inferItemsLostFromNarrative: jest.fn(() => []),
 }));
 
+jest.mock('@/lib/inventory/checkItemSimilarityClient', () => ({
+  checkItemSimilarityClient: jest.fn().mockResolvedValue({
+    similar: false,
+    confidence: 0,
+  }),
+}));
+
 jest.mock('@/lib/ai/loreContextHelper', () => ({
   getLoreContextForPrompt: jest.fn(() => ''),
   checkAndRecordLoreMentions: jest.fn(),
@@ -87,6 +95,9 @@ const { applyWorldClockUpdates } = jest.requireMock('../applyWorldClockUpdates')
 const { applyWorldStateThreadUpdates } = jest.requireMock('../applyWorldStateThreadUpdates');
 const { processAcquiredItems } = jest.requireMock('../itemAcquisitionProcessor');
 const { processLostItems } = jest.requireMock('../itemLossProcessor');
+const { inferItemsLostFromNarrative } = jest.requireMock('../itemLossInference');
+const { inferItemsLostFromNarrative: inferItemsLostFromNarrativeActual } =
+  jest.requireActual('../itemLossInference');
 const { syncNpcMetadata } = jest.requireMock('@/lib/ai/narrativeGenerator.npc');
 const { extractStructuredLore } = jest.requireMock('@/lib/ai/structuredLoreExtractor');
 
@@ -703,6 +714,135 @@ describe('TurnResolver', () => {
       );
     });
 
+    it('excludes a pluralized loss record for the consumed item', async () => {
+      const ids = seedItemUseStores(3);
+      useInventoryStore.getState().update(ids.itemId, { name: 'Health Potion' });
+      const generator = makeItemUseGenerator(
+        makeGenerationResult({
+          content: 'You drink one of the health potions.',
+          segmentType: 'action',
+          metadata: {
+            characterIds: [],
+            tags: ['item-usage'],
+            itemsLost: [
+              {
+                name: 'health potions',
+                quantity: 2,
+                lossReason: 'consumed',
+              },
+            ],
+          },
+        })
+      );
+
+      const outcome = await resolveItemUseTurn(ids, generator);
+
+      expect(outcome.success).toBe(true);
+      expect(useInventoryStore.getState().items[ids.itemId]?.quantity).toBe(2);
+      expect(processLostItems).not.toHaveBeenCalled();
+    });
+
+    it('reconciles genuine loss metadata when the used item was not consumed', async () => {
+      const ids = seedItemUseStores();
+      const questItemId = useInventoryStore.getState().addItem(
+        ids.characterId,
+        {
+          name: 'Ancient Amulet',
+          description: 'A relic bound to the old kingdom',
+          stackable: false,
+          quantity: 1,
+          categorization: {
+            categoryId: 'quest-items',
+            source: 'manual',
+            classifiedAt: new Date().toISOString(),
+          },
+          acquisition: {
+            method: 'loot',
+            acquiredAt: new Date().toISOString(),
+            quantity: 1,
+          },
+        }
+      );
+      const command = { ...ids, itemId: questItemId };
+      const generator = makeItemUseGenerator(
+        makeGenerationResult({
+          content: 'The ancient amulet cracks and falls to dust.',
+          segmentType: 'action',
+          metadata: {
+            characterIds: [],
+            tags: ['item-usage'],
+            itemsLost: [
+              {
+                itemId: questItemId,
+                name: 'Ancient Amulet',
+                quantity: 1,
+                lossReason: 'destroyed',
+              },
+            ],
+          },
+        })
+      );
+
+      const outcome = await resolveItemUseTurn(command, generator);
+
+      expect(outcome.success).toBe(true);
+      expect(processLostItems).toHaveBeenCalledWith(
+        [
+          {
+            itemId: questItemId,
+            name: 'Ancient Amulet',
+            quantity: 1,
+            lossReason: 'destroyed',
+          },
+        ],
+        ids.characterId,
+        ids.sessionId,
+        expect.any(Function)
+      );
+    });
+
+    it('infers and reconciles another item lost in item-use prose', async () => {
+      const ids = seedItemUseStores(3);
+      useInventoryStore.getState().addItem(ids.characterId, {
+        name: 'Old Key',
+        description: 'A tarnished iron key',
+        stackable: false,
+        quantity: 1,
+        categorization: {
+          categoryId: 'miscellaneous',
+          source: 'manual',
+          classifiedAt: new Date().toISOString(),
+        },
+        acquisition: {
+          method: 'loot',
+          acquiredAt: new Date().toISOString(),
+          quantity: 1,
+        },
+      });
+      inferItemsLostFromNarrative.mockImplementationOnce(
+        inferItemsLostFromNarrativeActual
+      );
+      const generator = makeItemUseGenerator(
+        makeGenerationResult({
+          content:
+            'Healing magic surges through you as the old key is dropped into the chasm.',
+          segmentType: 'action',
+          metadata: { characterIds: [], tags: ['item-usage'] },
+        })
+      );
+
+      const outcome = await resolveItemUseTurn(ids, generator);
+
+      expect(outcome.success).toBe(true);
+      expect(processLostItems).toHaveBeenCalledWith(
+        [{ name: 'Old Key', quantity: 1, lossReason: 'dropped' }],
+        ids.characterId,
+        ids.sessionId,
+        expect.any(Function)
+      );
+      expect(processAcquiredItems).not.toHaveBeenCalled();
+    });
+
     it('commits fallback prose and blocks choices when reconciliation is partial', async () => {
       const ids = seedItemUseStores();
       const generator = makeItemUseGenerator();
@@ -731,6 +871,62 @@ describe('TurnResolver', () => {
       ).toEqual([
         expect.objectContaining({ prompt: 'Existing decision' }),
       ]);
+      expect(useNarrativeStore.getState().generationError).toEqual(
+        PARTIAL_RECONCILIATION_ERROR
+      );
+    });
+
+    it('rejects a queued item use after partial settlement before another mutation or generation', async () => {
+      const ids = seedItemUseStores();
+      const firstGenerator = makeItemUseGenerator();
+      const secondGenerator = makeItemUseGenerator();
+      (applyWorldClockUpdates as jest.Mock).mockRejectedValueOnce(
+        new Error('clock unavailable')
+      );
+
+      const firstTurn = resolveItemUseTurn(ids, firstGenerator);
+      const secondTurn = resolveItemUseTurn(ids, secondGenerator);
+      const [firstOutcome, secondOutcome] = await Promise.all([
+        firstTurn,
+        secondTurn,
+      ]);
+
+      expect(firstOutcome.success).toBe(true);
+      if (!firstOutcome.success) {
+        throw new Error('Expected the partially settled item use to commit');
+      }
+      expect(firstOutcome.turn.status).toBe('partial');
+      expect(secondOutcome).toMatchObject({
+        success: false,
+        error: {
+          title: PARTIAL_RECONCILIATION_ERROR.title,
+          message: PARTIAL_RECONCILIATION_ERROR.message,
+        },
+      });
+      expect(useInventoryStore.getState().items[ids.itemId]?.quantity).toBe(1);
+      expect(firstGenerator.generateSegment).toHaveBeenCalledTimes(1);
+      expect(secondGenerator.generateSegment).not.toHaveBeenCalled();
+      expect(useNarrativeStore.getState().generationError).toEqual(
+        PARTIAL_RECONCILIATION_ERROR
+      );
+    });
+
+    it('does not apply the active session pause to another session', async () => {
+      const ids = seedItemUseStores(3);
+      (applyWorldClockUpdates as jest.Mock).mockRejectedValueOnce(
+        new Error('clock unavailable')
+      );
+      await resolveItemUseTurn(ids, makeItemUseGenerator());
+      const otherSessionGenerator = makeItemUseGenerator();
+
+      const outcome = await resolveItemUseTurn(
+        { ...ids, sessionId: 'session-other' },
+        otherSessionGenerator
+      );
+
+      expect(outcome.success).toBe(true);
+      expect(otherSessionGenerator.generateSegment).toHaveBeenCalledTimes(1);
+      expect(useInventoryStore.getState().items[ids.itemId]?.quantity).toBe(1);
     });
 
     it('keeps existing decisions when replacement choice generation fails', async () => {

--- a/src/lib/narrative/__tests__/turnResolver.test.ts
+++ b/src/lib/narrative/__tests__/turnResolver.test.ts
@@ -1,4 +1,8 @@
-import { resolveTurn, resolveInitialTurn } from '../turnResolver';
+import {
+  resolveTurn,
+  resolveInitialTurn,
+  resolveItemUseTurn,
+} from '../turnResolver';
 import { isResolverManaged } from '../resolverGuard';
 import { assembleSessionSnapshot } from '../sessionSnapshotAssembler';
 import { useNarrativeStore } from '@/state/narrativeStore';
@@ -6,6 +10,7 @@ import { useSessionStore } from '@/state/sessionStore';
 import { useCharacterStore } from '@/state/characterStore';
 import { useInventoryStore } from '@/state/inventoryStore';
 import { useWorldThreadStore } from '@/state/worldThreadStore';
+import { useWorldStore } from '@/state/worldStore';
 import type { NarrativeGenerationResult } from '@/types/narrative.types';
 import type { TurnCommand } from '@/types/turnResolver.types';
 import type { NarrativeGenerator } from '@/lib/ai/narrativeGenerator';
@@ -168,6 +173,95 @@ function seedStores() {
     sessionThreads: {},
     seedAttempts: {},
   } as never);
+}
+
+function seedItemUseStores(quantity = 2) {
+  useWorldStore.getState().reset();
+  useCharacterStore.getState().reset();
+  useInventoryStore.getState().reset();
+  useNarrativeStore.getState().reset();
+
+  const worldId = useWorldStore.getState().create({
+    name: 'Test World',
+    description: 'A world for resolver tests',
+    genre: 'fantasy',
+    attributes: [],
+    skills: [],
+    settings: {
+      maxAttributes: 10,
+      maxSkills: 10,
+      attributePointPool: 10,
+      skillPointPool: 10,
+    },
+  });
+  const characterId = useCharacterStore.getState().create({
+    name: 'Test Character',
+    worldId,
+    description: 'A test character',
+    level: 1,
+    isPlayer: true,
+    status: { conditions: [] },
+    inventory: {
+      characterId: '',
+      items: [],
+      capacity: 0,
+      categories: [],
+      itemOrder: [],
+    },
+    background: {
+      history: 'A test history',
+      personality: 'Careful',
+      goals: [],
+      fears: [],
+      relationships: [],
+    },
+    attributes: [],
+    skills: [],
+    derivedStats: [],
+  });
+  const sessionId = `session-${worldId}-${characterId}`;
+  useSessionStore.setState({
+    id: sessionId,
+    worldId,
+    characterId,
+    status: 'active',
+  } as never);
+  const itemId = useInventoryStore.getState().addItem(characterId, {
+    name: 'Healing Potion',
+    description: 'Restores vitality',
+    stackable: true,
+    quantity,
+    categorization: {
+      categoryId: 'consumables',
+      source: 'manual',
+      classifiedAt: new Date().toISOString(),
+    },
+    acquisition: {
+      method: 'loot',
+      acquiredAt: new Date().toISOString(),
+      quantity,
+    },
+  });
+
+  return { sessionId, worldId, characterId, itemId };
+}
+
+function makeItemUseGenerator(
+  result: NarrativeGenerationResult = makeGenerationResult({
+    content: 'You drink the potion and warmth returns to your limbs.',
+    segmentType: 'action',
+    metadata: { characterIds: [], tags: ['item-usage'] },
+  })
+): NarrativeGenerator {
+  return {
+    generateSegment: jest.fn().mockResolvedValue(result),
+    generatePlayerChoices: jest.fn().mockResolvedValue({
+      prompt: 'What do you do next?',
+      options: [{ id: 'option-1', text: 'Continue onward' }],
+      decisionWeight: 'minor',
+      contextSummary: 'After using the potion',
+    }),
+  } as unknown as NarrativeGenerator;
 }
 
 /** Returns a { promise, resolve, reject } triple for test control. */
@@ -479,6 +573,185 @@ describe('TurnResolver', () => {
 
       // Verify sequential execution: gen-start, gen-end, gen-start, gen-end
       expect(callOrder).toEqual(['gen-start', 'gen-end', 'gen-start', 'gen-end']);
+    });
+  });
+
+  describe('resolveItemUseTurn', () => {
+    it('keeps replacement choices blocked until reconciliation settles', async () => {
+      const ids = seedItemUseStores();
+      const clockDeferred = deferred<null>();
+      (applyWorldClockUpdates as jest.Mock).mockReturnValue(clockDeferred.promise);
+      const generator = makeItemUseGenerator();
+
+      useNarrativeStore.getState().addDecision(ids.sessionId, {
+        prompt: 'Existing decision',
+        options: [{ id: 'existing-1', text: 'Wait' }],
+      });
+
+      const itemTurnPromise = resolveItemUseTurn(ids, generator);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(generator.generatePlayerChoices).not.toHaveBeenCalled();
+      expect(
+        useNarrativeStore.getState().getSessionDecisions(ids.sessionId)
+      ).toEqual([
+        expect.objectContaining({ prompt: 'Existing decision' }),
+      ]);
+
+      clockDeferred.resolve(null);
+      const outcome = await itemTurnPromise;
+
+      expect(outcome.success).toBe(true);
+      expect(generator.generateSegment).toHaveBeenCalledWith(
+        expect.any(Object),
+        { resolverManaged: true }
+      );
+      expect(generator.generatePlayerChoices).toHaveBeenCalledTimes(1);
+      expect(
+        useNarrativeStore.getState().getSessionDecisions(ids.sessionId)
+      ).toEqual([
+        expect.objectContaining({ prompt: 'What do you do next?' }),
+      ]);
+    });
+
+    it('serializes item generation, replacement choices, and a concurrent controller turn', async () => {
+      const ids = seedItemUseStores();
+      const callOrder: string[] = [];
+      const itemGenerator = makeItemUseGenerator();
+      (itemGenerator.generateSegment as jest.Mock).mockImplementation(async () => {
+        callOrder.push('item-generation');
+        return makeGenerationResult({
+          content: 'You drink the potion.',
+          segmentType: 'action',
+          metadata: { characterIds: [], tags: ['item-usage'] },
+        });
+      });
+      (itemGenerator.generatePlayerChoices as jest.Mock).mockImplementation(
+        async () => {
+          callOrder.push('item-choices');
+          return {
+            prompt: 'What follows?',
+            options: [{ id: 'option-1', text: 'Keep moving' }],
+          };
+        }
+      );
+      const controllerGenerator = makeMockGenerator();
+      (controllerGenerator.generateSegment as jest.Mock).mockImplementation(
+        async () => {
+          callOrder.push('controller-generation');
+          return makeGenerationResult();
+        }
+      );
+
+      const [itemOutcome, controllerResult] = await Promise.all([
+        resolveItemUseTurn(ids, itemGenerator),
+        resolveTurn(
+          makeCommand({
+            sessionId: ids.sessionId,
+            worldId: ids.worldId,
+            characterId: ids.characterId,
+          }),
+          controllerGenerator
+        ),
+      ]);
+
+      expect(itemOutcome.success).toBe(true);
+      expect(controllerResult.status).toBe('settled');
+      expect(callOrder).toEqual([
+        'item-generation',
+        'item-choices',
+        'controller-generation',
+      ]);
+      expect(
+        useNarrativeStore.getState().getSessionSegments(ids.sessionId)
+      ).toHaveLength(2);
+      expect(applyWorldClockUpdates).toHaveBeenCalledTimes(2);
+      expect(useInventoryStore.getState().items[ids.itemId]?.quantity).toBe(1);
+    });
+
+    it('consumes the explicit item once while reconciling other reported losses', async () => {
+      const ids = seedItemUseStores(3);
+      const generator = makeItemUseGenerator(
+        makeGenerationResult({
+          content: 'You drink the potion and drop an old key.',
+          segmentType: 'action',
+          metadata: {
+            characterIds: [],
+            tags: ['item-usage'],
+            itemsLost: [
+              {
+                itemId: ids.itemId,
+                name: 'Healing Potion',
+                quantity: 1,
+                lossReason: 'consumed',
+              },
+              { name: 'Old Key', quantity: 1, lossReason: 'dropped' },
+            ],
+          },
+        })
+      );
+
+      const outcome = await resolveItemUseTurn(ids, generator);
+
+      expect(outcome.success).toBe(true);
+      expect(useInventoryStore.getState().items[ids.itemId]?.quantity).toBe(2);
+      expect(processLostItems).toHaveBeenCalledWith(
+        [{ name: 'Old Key', quantity: 1, lossReason: 'dropped' }],
+        ids.characterId,
+        ids.sessionId,
+        expect.any(Function)
+      );
+    });
+
+    it('commits fallback prose and blocks choices when reconciliation is partial', async () => {
+      const ids = seedItemUseStores();
+      const generator = makeItemUseGenerator();
+      (generator.generateSegment as jest.Mock).mockRejectedValue(
+        new Error('provider unavailable')
+      );
+      (applyWorldClockUpdates as jest.Mock).mockRejectedValueOnce(
+        new Error('clock unavailable')
+      );
+      useNarrativeStore.getState().addDecision(ids.sessionId, {
+        prompt: 'Existing decision',
+        options: [{ id: 'existing-1', text: 'Wait' }],
+      });
+
+      const outcome = await resolveItemUseTurn(ids, generator);
+
+      expect(outcome.success).toBe(true);
+      if (!outcome.success) {
+        throw new Error('Expected item use to commit');
+      }
+      expect(outcome.turn.status).toBe('partial');
+      expect(outcome.turn.segment.content).toContain('Healing Potion');
+      expect(generator.generatePlayerChoices).not.toHaveBeenCalled();
+      expect(
+        useNarrativeStore.getState().getSessionDecisions(ids.sessionId)
+      ).toEqual([
+        expect.objectContaining({ prompt: 'Existing decision' }),
+      ]);
+    });
+
+    it('keeps existing decisions when replacement choice generation fails', async () => {
+      const ids = seedItemUseStores();
+      const generator = makeItemUseGenerator();
+      (generator.generatePlayerChoices as jest.Mock).mockRejectedValue(
+        new Error('choice provider unavailable')
+      );
+      useNarrativeStore.getState().addDecision(ids.sessionId, {
+        prompt: 'Existing decision',
+        options: [{ id: 'existing-1', text: 'Wait' }],
+      });
+
+      const outcome = await resolveItemUseTurn(ids, generator);
+
+      expect(outcome.success).toBe(true);
+      expect(
+        useNarrativeStore.getState().getSessionDecisions(ids.sessionId)
+      ).toEqual([
+        expect.objectContaining({ prompt: 'Existing decision' }),
+      ]);
     });
   });
 

--- a/src/lib/narrative/narrativeErrors.ts
+++ b/src/lib/narrative/narrativeErrors.ts
@@ -26,6 +26,15 @@ export interface NarrativeError {
   severity: ErrorSeverity;
 }
 
+export const PARTIAL_RECONCILIATION_ERROR: NarrativeError = {
+  title: 'The story paused',
+  message: 'The story advanced, but some session changes did not finish.',
+  suggestion: 'Stop here rather than making another choice.',
+  retryable: false,
+  retryLabel: 'Continue the story',
+  severity: 'error',
+};
+
 const RETRY_LABEL = 'Continue the story';
 
 const NARRATIVE_COPY: Record<

--- a/src/lib/narrative/turnResolver.ts
+++ b/src/lib/narrative/turnResolver.ts
@@ -17,13 +17,16 @@ import type {
 import type { NarrativeGenerator } from '@/lib/ai/narrativeGenerator';
 import type { ReconciledSegmentNotes } from '@/lib/narrative/applyWorldClockUpdates';
 import { useNarrativeStore } from '@/state/narrativeStore';
+import { useSessionStore } from '@/state/sessionStore';
 import { useCharacterStore } from '@/state/characterStore';
 import { applyWorldClockUpdates } from '@/lib/narrative/applyWorldClockUpdates';
 import { applyWorldStateThreadUpdates } from '@/lib/narrative/applyWorldStateThreadUpdates';
 import { processAcquiredItems } from '@/lib/narrative/itemAcquisitionProcessor';
 import { processLostItems } from '@/lib/narrative/itemLossProcessor';
+import { itemNamesMatch } from '@/lib/narrative/itemProcessorShared';
 import { syncNpcMetadata } from '@/lib/ai/narrativeGenerator.npc';
 import { isSessionEndingSegment } from '@/lib/narrative/isSessionEndingSegment';
+import { PARTIAL_RECONCILIATION_ERROR } from '@/lib/narrative/narrativeErrors';
 import { countWorldClockTurns } from '@/lib/narrative/worldClock';
 import { buildWorldClockPromptContext } from '@/lib/narrative/worldClock';
 import { isFeatureEnabled } from '@/lib/featureFlags';
@@ -42,7 +45,6 @@ import {
   buildUsageNarrative,
   generateItemUsageNarrative,
 } from '@/lib/inventory/itemUsageNarrative';
-import { normalizeText, NORM_NAME } from '@/lib/utils';
 
 /**
  * Per-session lock so concurrent resolveTurn calls execute sequentially.
@@ -238,30 +240,17 @@ async function resolveTurnInner(
     command.signal
   );
 
-  // Infer item losses from the narrative text when the AI didn't tag them
-  let metadata = { ...result.metadata };
-  if (
-    (!metadata.itemsLost || metadata.itemsLost.length === 0) &&
-    result.content
-  ) {
-    const characterInventory = useInventoryStore
-      .getState()
-      .getCharacterItems(characterId);
-    const inferredLosses = inferItemsLostFromNarrative(
-      result.content,
-      characterInventory
-    );
-    if (inferredLosses.length > 0) {
-      metadata = { ...metadata, itemsLost: inferredLosses };
-    }
-  }
+  const resultWithInferredLosses = inferMissingItemLosses(result, characterId);
 
   return commitAndSettleGeneratedTurn({
     result: {
-      ...result,
+      ...resultWithInferredLosses,
       metadata: {
-        ...metadata,
-        tags: [...(metadata.tags || []), ...command.skillCheckTags],
+        ...resultWithInferredLosses.metadata,
+        tags: [
+          ...(resultWithInferredLosses.metadata.tags || []),
+          ...command.skillCheckTags,
+        ],
         decisionOutcome: command.decisionOutcome,
         pacingEscalationRequested: command.pacingEscalationRequested,
         fatalRiskAllowed: command.fatalRiskAllowed,
@@ -328,6 +317,16 @@ async function resolveItemUseTurnInner(
   generator: NarrativeGenerator
 ): Promise<ItemUseTurnOutcome> {
   const { sessionId, worldId, characterId, itemId } = command;
+  const generationError = useNarrativeStore.getState().generationError;
+  const activeSessionId = useSessionStore.getState().id;
+
+  if (
+    sessionId === activeSessionId &&
+    generationError === PARTIAL_RECONCILIATION_ERROR
+  ) {
+    return validationFailure(generationError.title, generationError.message);
+  }
+
   const world = useWorldStore.getState().worlds[worldId];
   const character = useCharacterStore.getState().characters[characterId];
 
@@ -384,9 +383,8 @@ async function resolveItemUseTurnInner(
   const characterIds = generated.metadata.characterIds.length
     ? generated.metadata.characterIds
     : [characterId];
-
-  const turn = await commitAndSettleGeneratedTurn({
-    result: {
+  const result = inferMissingItemLosses(
+    {
       ...generated,
       content,
       metadata: {
@@ -395,6 +393,11 @@ async function resolveItemUseTurnInner(
         characterIds,
       },
     },
+    characterId
+  );
+
+  const turn = await commitAndSettleGeneratedTurn({
+    result,
     segmentId: `seg-${worldId}-item-${itemId}-${Date.now()}`,
     sessionId,
     worldId,
@@ -404,9 +407,17 @@ async function resolveItemUseTurnInner(
     playerCharacterName: character.name,
     reconciliationPolicy: {
       skipItemAcquisition: true,
-      excludedItemLoss: { id: item.id, name: item.name },
+      excludedItemLoss: usage.wasConsumed
+        ? { id: item.id, name: item.name }
+        : undefined,
     },
   });
+
+  if (turn.status === 'partial') {
+    useNarrativeStore
+      .getState()
+      .setGenerationError(PARTIAL_RECONCILIATION_ERROR);
+  }
 
   if (turn.status === 'settled' && !turn.isEnding) {
     await replaceChoicesAfterItemUse(command, item.id, turn, generator);
@@ -417,6 +428,32 @@ async function resolveItemUseTurnInner(
     item,
     usage: { ...usage, success: true },
     turn,
+  };
+}
+
+function inferMissingItemLosses(
+  result: NarrativeGenerationResult,
+  characterId: EntityID
+): NarrativeGenerationResult {
+  if (result.metadata.itemsLost?.length || !result.content) {
+    return result;
+  }
+
+  const characterInventory = useInventoryStore
+    .getState()
+    .getCharacterItems(characterId);
+  const inferredLosses = inferItemsLostFromNarrative(
+    result.content,
+    characterInventory
+  );
+
+  if (inferredLosses.length === 0) {
+    return result;
+  }
+
+  return {
+    ...result,
+    metadata: { ...result.metadata, itemsLost: inferredLosses },
   };
 }
 
@@ -705,7 +742,7 @@ async function reconcileCoreSideEffects({
   }
 
   try {
-    const itemsLost = filterExplicitItemLoss(
+    const itemsLost = await filterExplicitItemLoss(
       metadata.itemsLost ?? [],
       policy?.excludedItemLoss
     );
@@ -733,30 +770,27 @@ async function reconcileCoreSideEffects({
   return { notes, errors };
 }
 
-function filterExplicitItemLoss(
+async function filterExplicitItemLoss(
   itemsLost: LostItemMetadata[],
   excludedItem?: { id: EntityID; name: string }
-): LostItemMetadata[] {
+): Promise<LostItemMetadata[]> {
   if (!excludedItem) {
     return itemsLost;
   }
 
-  const excludedName = normalizeText(excludedItem.name, NORM_NAME).toLowerCase();
-  let hasExcludedExplicitUse = false;
+  const filteredItems: LostItemMetadata[] = [];
 
-  return itemsLost.filter((item) => {
+  for (const item of itemsLost) {
     const matchesExplicitUse =
       item.itemId === excludedItem.id ||
-      (!item.itemId &&
-        normalizeText(item.name, NORM_NAME).toLowerCase() === excludedName);
+      (!item.itemId && await itemNamesMatch(item.name, excludedItem.name));
 
-    if (!hasExcludedExplicitUse && matchesExplicitUse) {
-      hasExcludedExplicitUse = true;
-      return false;
+    if (!matchesExplicitUse) {
+      filteredItems.push(item);
     }
+  }
 
-    return true;
-  });
+  return filteredItems;
 }
 
 /**

--- a/src/lib/narrative/turnResolver.ts
+++ b/src/lib/narrative/turnResolver.ts
@@ -1,10 +1,16 @@
 // src/lib/narrative/turnResolver.ts
 
 import type { EntityID } from '@/types/common.types';
-import type { NarrativeSegment } from '@/types/narrative.types';
+import type {
+  LostItemMetadata,
+  NarrativeGenerationResult,
+  NarrativeSegment,
+} from '@/types/narrative.types';
 import type {
   TurnCommand,
   InitialTurnCommand,
+  ItemUseTurnCommand,
+  ItemUseTurnOutcome,
   TurnResult,
   ReconciliationError,
 } from '@/types/turnResolver.types';
@@ -31,6 +37,12 @@ import { logger } from '@/lib/utils/logger';
 import { inferItemsLostFromNarrative } from '@/lib/narrative/itemLossInference';
 import { mergeTurnTags } from '@/lib/narrative/turnTags';
 import { useInventoryStore } from '@/state/inventoryStore';
+import { useWorldStore } from '@/state/worldStore';
+import {
+  buildUsageNarrative,
+  generateItemUsageNarrative,
+} from '@/lib/inventory/itemUsageNarrative';
+import { normalizeText, NORM_NAME } from '@/lib/utils';
 
 /**
  * Per-session lock so concurrent resolveTurn calls execute sequentially.
@@ -140,6 +152,19 @@ export function resolveInitialTurn(
   );
 }
 
+/**
+ * Uses an inventory item as a first-class Turn. Validation, consumption,
+ * generation, settlement, and replacement choices share the session lock.
+ */
+export function resolveItemUseTurn(
+  command: ItemUseTurnCommand,
+  generator: NarrativeGenerator
+): Promise<ItemUseTurnOutcome> {
+  return withTurnLock(command.sessionId, () =>
+    resolveItemUseTurnInner(command, generator)
+  );
+}
+
 // -- Internal implementation --------------------------------------------------
 
 async function resolveTurnInner(
@@ -231,95 +256,25 @@ async function resolveTurnInner(
     }
   }
 
-  // Build the segment
-  const segmentId = `seg-${worldId}-${command.choiceId}-${Date.now()}`;
-  const now = new Date();
-  const newSegment: NarrativeSegment = {
-    id: segmentId,
-    content: result.content,
-    type: result.segmentType,
-    characterIds: metadata.characterIds || [],
-    metadata: {
-      ...metadata,
-      tags: [...(metadata.tags || []), ...command.skillCheckTags],
-      decisionOutcome: command.decisionOutcome,
-      pacingEscalationRequested: command.pacingEscalationRequested,
-      fatalRiskAllowed: command.fatalRiskAllowed,
+  return commitAndSettleGeneratedTurn({
+    result: {
+      ...result,
+      metadata: {
+        ...metadata,
+        tags: [...(metadata.tags || []), ...command.skillCheckTags],
+        decisionOutcome: command.decisionOutcome,
+        pacingEscalationRequested: command.pacingEscalationRequested,
+        fatalRiskAllowed: command.fatalRiskAllowed,
+      },
     },
+    segmentId: `seg-${worldId}-${command.choiceId}-${Date.now()}`,
     sessionId,
     worldId,
-    timestamp: now,
-    createdAt: now.toISOString(),
-    updatedAt: now.toISOString(),
-  };
-
-  // Commit the segment. The resolverManaged flag tells addSegment to skip
-  // its own fire-and-forget tails; the resolver handles those below.
-  const storedSegmentId = useNarrativeStore.getState().addSegment(
-    sessionId,
-    {
-      content: newSegment.content,
-      type: newSegment.type,
-      characterIds: newSegment.characterIds || [],
-      metadata: newSegment.metadata,
-      worldId: newSegment.worldId,
-      updatedAt: newSegment.updatedAt,
-      timestamp: newSegment.timestamp,
-    },
-    { resolverManaged: true }
-  );
-
-  // Read back the gated version (addSegment runs content dedup/sanitization)
-  const storedSegment =
-    useNarrativeStore.getState().segments[storedSegmentId] ?? newSegment;
-
-  // -- Core reconciliation: awaited, not fire-and-forget --
-
-  const { notes, errors } = await reconcileCoreSideEffects({
-    segment: storedSegment,
-    segmentId: storedSegmentId,
-    sessionId,
     characterId,
-    metadata,
     isFirstSegment: false,
+    isFatalCriticalFailure: command.isFatalCriticalFailure,
+    playerCharacterName: preTurnSnapshot.character?.name,
   });
-
-  // Synchronous NPC sync (already not fire-and-forget)
-  syncNpcMetadata(worldId, result.metadata.characters);
-
-  // Fire lore extraction as fire-and-forget. It doesn't block the turn
-  // but still runs so facts introduced in this turn's prose are
-  // available to later prompts.
-  fireLoreExtraction(
-    result,
-    { worldId, sessionId, characterIds: characterId ? [characterId] : [] },
-    preTurnSnapshot.character?.name
-  );
-
-  // Read the settled segment after reconciliation may have stamped tags
-  const settledSegment =
-    useNarrativeStore.getState().segments[storedSegmentId] ?? storedSegment;
-
-  // Post-turn snapshot: the settled revision
-  const postTurnSnapshot = assembleSessionSnapshot(sessionId, ids);
-
-  // isFatal reports whether a fatal outcome was detected, but does NOT
-  // fold into isEnding unconditionally. The controller decides what to
-  // do with a fatal flag based on its own handler availability.
-  const isFatal =
-    command.isFatalCriticalFailure ||
-    settledSegment.metadata?.tags?.includes('fatal-outcome') === true;
-  const isEnding = isSessionEndingSegment(settledSegment);
-
-  return {
-    segment: settledSegment,
-    status: errors.length === 0 ? 'settled' : 'partial',
-    snapshot: postTurnSnapshot,
-    isFatal,
-    isEnding,
-    reconciledNotes: notes ?? undefined,
-    reconciliationErrors: errors,
-  };
 }
 
 async function resolveInitialTurnInner(
@@ -354,7 +309,200 @@ async function resolveInitialTurnInner(
     command.signal
   );
 
-  const segmentId = `seg-${worldId}-${Date.now()}`;
+  const playerCharacterName =
+    useCharacterStore.getState().characters[characterId]?.name;
+  return commitAndSettleGeneratedTurn({
+    result,
+    segmentId: `seg-${worldId}-${Date.now()}`,
+    sessionId,
+    worldId,
+    characterId,
+    isFirstSegment: true,
+    isFatalCriticalFailure: false,
+    playerCharacterName,
+  });
+}
+
+async function resolveItemUseTurnInner(
+  command: ItemUseTurnCommand,
+  generator: NarrativeGenerator
+): Promise<ItemUseTurnOutcome> {
+  const { sessionId, worldId, characterId, itemId } = command;
+  const world = useWorldStore.getState().worlds[worldId];
+  const character = useCharacterStore.getState().characters[characterId];
+
+  if (!world) {
+    return validationFailure(
+      'World Not Found',
+      'The world for this item-use turn could not be found.'
+    );
+  }
+
+  if (!character || character.worldId !== worldId) {
+    return validationFailure(
+      'Character Not Found',
+      'The character for this item-use turn could not be found in this world.'
+    );
+  }
+
+  const inventoryStore = useInventoryStore.getState();
+  const currentItem = inventoryStore.items[itemId];
+  const item = currentItem
+    ? {
+        ...currentItem,
+        acquisitionHistory: [...currentItem.acquisitionHistory],
+        categorization: { ...currentItem.categorization },
+      }
+    : undefined;
+  const usage = inventoryStore.useItem(characterId, itemId);
+
+  if (!usage.success || !item) {
+    return {
+      success: false,
+      error: usage.error ?? {
+        type: 'VALIDATION',
+        title: 'Item Not Found',
+        message: 'The specified item could not be found.',
+      },
+    };
+  }
+
+  const usageDetails = {
+    wasConsumed: usage.wasConsumed,
+    remainingQuantity: usage.remainingQuantity,
+    previousQuantity: usage.previousQuantity,
+  };
+  const generated = await generateItemUsageNarrative(
+    { item, characterId, worldId, sessionId, usageDetails },
+    generator
+  );
+  const content = generated.content?.trim()
+    ? generated.content
+    : buildUsageNarrative(item, usageDetails, 'detailed');
+  const tags = new Set(['item-usage', item.categoryId]);
+  generated.metadata.tags.forEach((tag) => tags.add(tag));
+  const characterIds = generated.metadata.characterIds.length
+    ? generated.metadata.characterIds
+    : [characterId];
+
+  const turn = await commitAndSettleGeneratedTurn({
+    result: {
+      ...generated,
+      content,
+      metadata: {
+        ...generated.metadata,
+        tags: [...tags],
+        characterIds,
+      },
+    },
+    segmentId: `seg-${worldId}-item-${itemId}-${Date.now()}`,
+    sessionId,
+    worldId,
+    characterId,
+    isFirstSegment: false,
+    isFatalCriticalFailure: false,
+    playerCharacterName: character.name,
+    reconciliationPolicy: {
+      skipItemAcquisition: true,
+      excludedItemLoss: { id: item.id, name: item.name },
+    },
+  });
+
+  if (turn.status === 'settled' && !turn.isEnding) {
+    await replaceChoicesAfterItemUse(command, item.id, turn, generator);
+  }
+
+  return {
+    success: true,
+    item,
+    usage: { ...usage, success: true },
+    turn,
+  };
+}
+
+function validationFailure(
+  title: string,
+  message: string
+): ItemUseTurnOutcome {
+  return {
+    success: false,
+    error: { type: 'VALIDATION', title, message },
+  };
+}
+
+async function replaceChoicesAfterItemUse(
+  command: ItemUseTurnCommand,
+  itemId: EntityID,
+  turn: TurnResult,
+  generator: NarrativeGenerator
+): Promise<void> {
+  const { sessionId, worldId, characterId } = command;
+  const recentSegments = [...turn.snapshot.segments.slice(-5)];
+  const lastSegment = recentSegments[recentSegments.length - 1];
+
+  try {
+    const decision = await generator.generatePlayerChoices(
+      worldId,
+      {
+        worldId,
+        sessionId,
+        currentSceneId: `item-usage-${itemId}-${Date.now()}`,
+        characterIds: [characterId],
+        previousSegments: recentSegments,
+        recentSegments,
+        currentTags: lastSegment?.metadata?.tags || [],
+        currentLocation: lastSegment?.metadata?.location,
+      },
+      [characterId],
+      sessionId
+    );
+
+    const narrativeStore = useNarrativeStore.getState();
+    narrativeStore.clearSessionDecisions(sessionId);
+    narrativeStore.addDecision(sessionId, {
+      prompt: decision.prompt,
+      options: decision.options,
+      decisionWeight: decision.decisionWeight,
+      contextSummary: decision.contextSummary,
+    });
+  } catch (error) {
+    logger.warn(
+      '[TurnResolver] Failed to replace choices after item use:',
+      error
+    );
+  }
+}
+
+interface ReconciliationPolicy {
+  skipItemAcquisition?: boolean;
+  excludedItemLoss?: { id: EntityID; name: string };
+}
+
+interface CommitAndSettleParams {
+  result: Omit<NarrativeGenerationResult, 'metadata'> & {
+    metadata: NarrativeSegment['metadata'];
+  };
+  segmentId: EntityID;
+  sessionId: EntityID;
+  worldId: EntityID;
+  characterId: EntityID;
+  isFirstSegment: boolean;
+  isFatalCriticalFailure: boolean;
+  playerCharacterName?: string;
+  reconciliationPolicy?: ReconciliationPolicy;
+}
+
+async function commitAndSettleGeneratedTurn({
+  result,
+  segmentId,
+  sessionId,
+  worldId,
+  characterId,
+  isFirstSegment,
+  isFatalCriticalFailure,
+  playerCharacterName,
+  reconciliationPolicy,
+}: CommitAndSettleParams): Promise<TurnResult> {
   const now = new Date();
   const newSegment: NarrativeSegment = {
     id: segmentId,
@@ -368,7 +516,6 @@ async function resolveInitialTurnInner(
     createdAt: now.toISOString(),
     updatedAt: now.toISOString(),
   };
-
   const storedSegmentId = useNarrativeStore.getState().addSegment(
     sessionId,
     {
@@ -382,23 +529,19 @@ async function resolveInitialTurnInner(
     },
     { resolverManaged: true }
   );
-
   const storedSegment =
     useNarrativeStore.getState().segments[storedSegmentId] ?? newSegment;
-
   const { notes, errors } = await reconcileCoreSideEffects({
     segment: storedSegment,
     segmentId: storedSegmentId,
     sessionId,
     characterId,
     metadata: result.metadata,
-    isFirstSegment: true,
+    isFirstSegment,
+    policy: reconciliationPolicy,
   });
 
   syncNpcMetadata(worldId, result.metadata.characters);
-
-  const playerCharacterName =
-    useCharacterStore.getState().characters[characterId]?.name;
   fireLoreExtraction(
     result,
     { worldId, sessionId, characterIds: characterId ? [characterId] : [] },
@@ -408,13 +551,13 @@ async function resolveInitialTurnInner(
   const settledSegment =
     useNarrativeStore.getState().segments[storedSegmentId] ?? storedSegment;
 
-  const postTurnSnapshot = assembleSessionSnapshot(sessionId, ids);
-
   return {
     segment: settledSegment,
     status: errors.length === 0 ? 'settled' : 'partial',
-    snapshot: postTurnSnapshot,
-    isFatal: false,
+    snapshot: assembleSessionSnapshot(sessionId, { worldId, characterId }),
+    isFatal:
+      isFatalCriticalFailure ||
+      settledSegment.metadata?.tags?.includes('fatal-outcome') === true,
     isEnding: isSessionEndingSegment(settledSegment),
     reconciledNotes: notes ?? undefined,
     reconciliationErrors: errors,
@@ -433,6 +576,7 @@ interface ReconcileParams {
   characterId: EntityID;
   metadata: NarrativeSegment['metadata'];
   isFirstSegment: boolean;
+  policy?: ReconciliationPolicy;
 }
 
 interface ReconcileResult {
@@ -447,6 +591,7 @@ async function reconcileCoreSideEffects({
   characterId,
   metadata,
   isFirstSegment,
+  policy,
 }: ReconcileParams): Promise<ReconcileResult> {
   const errors: ReconciliationError[] = [];
   const recordError = (
@@ -534,7 +679,11 @@ async function reconcileCoreSideEffects({
 
   // 3. Inventory mutations
   try {
-    if (metadata.itemsAcquired && metadata.itemsAcquired.length > 0) {
+    if (
+      !policy?.skipItemAcquisition &&
+      metadata.itemsAcquired &&
+      metadata.itemsAcquired.length > 0
+    ) {
       await processAcquiredItems(
         metadata.itemsAcquired,
         characterId,
@@ -556,9 +705,13 @@ async function reconcileCoreSideEffects({
   }
 
   try {
-    if (metadata.itemsLost && metadata.itemsLost.length > 0) {
+    const itemsLost = filterExplicitItemLoss(
+      metadata.itemsLost ?? [],
+      policy?.excludedItemLoss
+    );
+    if (itemsLost.length > 0) {
       await processLostItems(
-        metadata.itemsLost,
+        itemsLost,
         characterId,
         sessionId,
         (error) =>
@@ -578,6 +731,32 @@ async function reconcileCoreSideEffects({
   }
 
   return { notes, errors };
+}
+
+function filterExplicitItemLoss(
+  itemsLost: LostItemMetadata[],
+  excludedItem?: { id: EntityID; name: string }
+): LostItemMetadata[] {
+  if (!excludedItem) {
+    return itemsLost;
+  }
+
+  const excludedName = normalizeText(excludedItem.name, NORM_NAME).toLowerCase();
+  let hasExcludedExplicitUse = false;
+
+  return itemsLost.filter((item) => {
+    const matchesExplicitUse =
+      item.itemId === excludedItem.id ||
+      (!item.itemId &&
+        normalizeText(item.name, NORM_NAME).toLowerCase() === excludedName);
+
+    if (!hasExcludedExplicitUse && matchesExplicitUse) {
+      hasExcludedExplicitUse = true;
+      return false;
+    }
+
+    return true;
+  });
 }
 
 /**

--- a/src/stories/03-organisms/inventory/InventoryList.stories.tsx
+++ b/src/stories/03-organisms/inventory/InventoryList.stories.tsx
@@ -39,6 +39,8 @@ const createAcquisition = (quantity: number, timestamp: string) => ({
 export const Default: Story = {
   args: {
     characterId: 'char-story-default',
+    worldId: 'world-story-default',
+    sessionId: 'session-story-default',
   },
   decorators: [
     (StoryComponent) => {
@@ -122,6 +124,8 @@ export const Default: Story = {
 export const WithImages: Story = {
   args: {
     characterId: 'char-story-images',
+    worldId: 'world-story-images',
+    sessionId: 'session-story-images',
   },
   decorators: [
     (StoryComponent) => {
@@ -188,6 +192,8 @@ export const WithImages: Story = {
 export const SingleCategory: Story = {
   args: {
     characterId: 'char-story-single',
+    worldId: 'world-story-single',
+    sessionId: 'session-story-single',
   },
   decorators: [
     (StoryComponent) => {

--- a/src/types/turnResolver.types.ts
+++ b/src/types/turnResolver.types.ts
@@ -3,7 +3,7 @@
 import type { EntityID } from './common.types';
 import type { NarrativeSegment, Decision, DecisionWeight, DecisionOutcome, SkillCheckRoll, EndingTone } from './narrative.types';
 import type { Character } from '@/state/characterStore.types';
-import type { InventoryItem } from './inventory.types';
+import type { InventoryItem, ItemUsageResult } from './inventory.types';
 import type { WorldThread } from './worldThread.types';
 import type { WorldState } from './world-state.types';
 import type { NPC } from './npc.types';
@@ -78,6 +78,14 @@ export interface InitialTurnCommand {
   onChunk?: (chunk: string) => void;
 }
 
+/** Authoritative identity for one item-use turn. */
+export interface ItemUseTurnCommand {
+  sessionId: EntityID;
+  worldId: EntityID;
+  characterId: EntityID;
+  itemId: EntityID;
+}
+
 /** The settlement state of a committed Turn. */
 export type TurnSettlementStatus = 'settled' | 'partial';
 
@@ -105,6 +113,18 @@ export interface TurnResult {
   /** Errors from core reconciliation steps. Empty when `status` is settled. */
   reconciliationErrors: ReconciliationError[];
 }
+
+export type ItemUseTurnOutcome =
+  | {
+      success: false;
+      error: NonNullable<ItemUsageResult['error']>;
+    }
+  | {
+      success: true;
+      item: InventoryItem;
+      usage: ItemUsageResult & { success: true };
+      turn: TurnResult;
+    };
 
 /** A core reconciliation step that failed while settling the Turn. */
 export interface ReconciliationError {


### PR DESCRIPTION
## Description

Item-use turns could replace the current Decision before their world clock and world-state work had finished. This routes them through the same per-session `TurnResolver` lock as controller turns, which keeps consumption, generation, commitment, reconciliation, and replacement-choice persistence in one ordered sequence.

The existing behavior stays intact: one item is consumed, provider failures commit fallback prose, ending and partial turns keep the existing choices, significant uses still create journal entries, and the explicitly used item is excluded once from metadata-driven loss processing.

## Related Issue

Closes #1985

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [x] Test addition or improvement

## TDD Compliance

The acceptance cases cover the session lock, deferred reconciliation, concurrent controller and item-use turns, fallback prose, duplicate loss metadata, ending and partial settlement, retained choices, journal creation, and the required command object.

- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed

- Item use can't expose a replacement Decision until the turn's core state changes have settled.
- Concurrent item-use and controller turns for one session both commit in order without dropping side effects.
- Item quantity, fallback narrative, ending behavior, and significant-item journal entries remain consistent.

## Flow Diagrams

Not applicable. The issue's serialized flow is covered by deterministic resolver tests.

## Component Development

`InventoryList` passes the authoritative command IDs and disables every Use button while any item use is pending. Its Storybook stories were updated for the required props; no CSS or static layout changed.

- [x] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes

`processItemUsage` now requires `{ sessionId, worldId, characterId, itemId }` with no positional compatibility overload. `resolveItemUseTurn` returns a discriminated internal outcome while the service keeps the existing `ItemUsageResult` contract.

Normal, initial, and item-use turns share the same private commitment and reconciliation helper. Item-specific prompt and fallback construction moved to `itemUsageNarrative.ts`, where the injected generator runs with `resolverManaged: true`.

Choice generation and persistence stay inside the item-use lock. Decisions are cleared only after replacement generation succeeds. Partial settlement exposes the same non-retryable pause state used by `NarrativeController`, while journal creation happens after the resolver releases the lock.

`turnResolver.ts` was already over the repository's 300-line guideline and remains over it. The shared lock and private settlement pipeline stay together here; item-specific narrative construction was split into its own 194-line module.

## Screenshots

Not applicable. The UI change is limited to the pending interaction state; layout and styling didn't change.

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

The pre-PR scope audit found no out-of-scope changes or missing acceptance criteria. Every changed file maps to the resolver path, command-object caller migration, regression coverage, or the existing game-mechanics guide.

## Chrome DevTools MCP Verification Summary (if applicable)

Not applicable. The pending-button interaction is covered by a component test and doesn't change the DOM structure or styling.

## Quality Checks (if applicable)

- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Also passed `npm run knip`, `npm run deps:validate`, and `npm run deps:check`.

## Testing Instructions

Run the focused regression suites first:

```bash
npm test -- src/lib/narrative/__tests__/turnResolver.test.ts src/lib/inventory/__tests__/itemUsageService.test.ts src/lib/inventory/__tests__/itemUsageService.choiceSkip.test.ts src/components/inventory/__tests__/InventoryList.itemUsage.test.tsx src/components/inventory/__tests__/InventoryList.test.tsx --runInBand
```

Then run the full unit suite and static gates:

```bash
npm test -- --maxWorkers=2
npm run type-check
npm run lint
npm run knip
npm run deps:validate
npm run deps:check
```

The default-parallel `npm test` command hit unrelated 5-second UI timeouts on this machine. Each affected case passed twice in isolation, and the full bounded-worker run passed 452 suites and 3,218 tests. Lint completed with zero errors and the repository's existing visual-test warnings. No local visual suite was run because layout and styling didn't change; CI covers the visual and E2E checks.

## Checklist

- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
