### PR TITLE
Drop user-agent check in isPlaywrightEnv (#2001)

### DIFF
--- a/src/lib/utils/__tests__/isPlaywrightEnv.test.ts
+++ b/src/lib/utils/__tests__/isPlaywrightEnv.test.ts
@@ -1,0 +1,51 @@
+import { isPlaywrightEnv } from '../isPlaywrightEnv';
+
+describe('isPlaywrightEnv', () => {
+  const originalWindow = global.window;
+  const originalUserAgent = window.navigator.userAgent;
+
+  afterEach(() => {
+    if (global.window !== originalWindow) {
+      (global as Record<string, unknown>).window = originalWindow;
+    }
+    if (typeof window !== 'undefined') {
+      delete window.__PLAYWRIGHT__;
+      Object.defineProperty(window.navigator, 'userAgent', {
+        value: originalUserAgent,
+        configurable: true,
+      });
+    }
+  });
+
+  it('returns false when window is undefined', () => {
+    // @ts-expect-error simulating environment without a window global
+    delete global.window;
+
+    expect(isPlaywrightEnv()).toBe(false);
+  });
+
+  it('returns false when window is defined but __PLAYWRIGHT__ is not set (even if userAgent contains "Playwright")', () => {
+    delete window.__PLAYWRIGHT__;
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (Playwright)',
+      configurable: true,
+    });
+
+    expect(isPlaywrightEnv()).toBe(false);
+  });
+
+  it('returns true when window.__PLAYWRIGHT__ is true', () => {
+    window.__PLAYWRIGHT__ = true;
+
+    expect(isPlaywrightEnv()).toBe(true);
+  });
+
+  it('returns false when window.__PLAYWRIGHT__ is false or null', () => {
+    window.__PLAYWRIGHT__ = false;
+    expect(isPlaywrightEnv()).toBe(false);
+
+    // @ts-expect-error testing null runtime value
+    window.__PLAYWRIGHT__ = null;
+    expect(isPlaywrightEnv()).toBe(false);
+  });
+});

--- a/src/lib/utils/isPlaywrightEnv.ts
+++ b/src/lib/utils/isPlaywrightEnv.ts
@@ -1,15 +1,15 @@
 /**
  * Detects whether the app is running under a Playwright E2E/visual test.
- * Playwright sets `window.__PLAYWRIGHT__` before the app loads (see
- * tests/visual/global.setup.ts); the user-agent check is a fallback.
  *
- * Centralized so every call site agrees on the flag name and shape — a prior
- * copy-paste used the wrong casing (`__playwright`) and silently never matched.
+ * We key strictly off the explicit `window.__PLAYWRIGHT__` flag injected by our
+ * test harness before scripts execute (see tests/visual/global.setup.ts).
+ * We don't inspect the client user-agent string: user-agents are client-controlled,
+ * so matching on substrings like 'Playwright' risks tripping test mode for real
+ * production visitors (suppressing provider modals, AI narrative generation, and
+ * telemetry).
  *
- * Note: this gates render-path behaviour (AI generation, checkpoints) on top of
- * dev-UI suppression, so keep it tied to the explicit Playwright flag. Panel
- * suppression that needs to catch *any* automation lives in ClientOnlyDevTools.
+ * Centralized so call sites agree on the flag name and shape.
  */
 export const isPlaywrightEnv = (): boolean =>
-  typeof window !== 'undefined' &&
-  (window.navigator.userAgent.includes('Playwright') || !!window.__PLAYWRIGHT__);
+  typeof window !== 'undefined' && !!window.__PLAYWRIGHT__;
+


### PR DESCRIPTION
## Description
Removes the client user-agent string check in `isPlaywrightEnv()`, keeping only the explicit in-page `window.__PLAYWRIGHT__` flag set by test runners. Client user agents are client-controlled and easily collision-prone; matching substrings like "Playwright" trips automation mode for legitimate visitors and suppresses critical production features (AI narrative generation, provider setup modals, and telemetry).

## Related Issue
Closes #2001

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
Ensures visitors whose browser user-agent contains "Playwright" aren't incorrectly treated as automated test runners in production.

## Flow Diagrams
None

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes
- `isPlaywrightEnv()` now returns `typeof window !== 'undefined' && !!window.__PLAYWRIGHT__`.
- Added unit tests in `src/lib/utils/__tests__/isPlaywrightEnv.test.ts` verifying all states (window undefined, userAgent with Playwright substring, __PLAYWRIGHT__ true, __PLAYWRIGHT__ false/null).

## Screenshots
None

## Visual Baseline Changes
None

## Code Review Summary (if applicable)
Minimal, root-cause fix scoped strictly to `isPlaywrightEnv.ts` and its accompanying unit tests.

## Chrome DevTools MCP Verification Summary (if applicable)
None

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
Run unit tests locally:
```bash
npm test -- src/lib/utils/__tests__/isPlaywrightEnv.test.ts
npm run type-check
```

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed