### PR TITLE
Flip WORLD_COST default to true (#1882)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,13 +8,13 @@ GEMINI_API_KEY=your-gemini-api-key-here
 # Feature flags. Their defaults live in src/lib/featureFlags.ts - leave these
 # unset to get them. Each line below is the override, not the default, so
 # uncommenting one flips that flag away from what the code ships with.
-# Every flag gets a line here, including the two kill switches for shipped
-# features (WORLD_CLOCK, UNRECORDED_EXCHANGE_GUARD) - you shouldn't have to
+# Every flag gets a line here, including kill switches for shipped
+# features (WORLD_CLOCK, WORLD_COST, UNRECORDED_EXCHANGE_GUARD) - you shouldn't have to
 # read src/lib/ to find those during an incident.
 # NEXT_PUBLIC_FEATURE_BUFFERED_STREAMING=true
 # NEXT_PUBLIC_FEATURE_PROGRESSIVE_DISCLOSURE=false
 # NEXT_PUBLIC_FEATURE_WORLD_CLOCK=false
-# NEXT_PUBLIC_FEATURE_WORLD_COST=true
+# NEXT_PUBLIC_FEATURE_WORLD_COST=false
 # NEXT_PUBLIC_FEATURE_WORLD_DESCRIPTION_IN_SCENE=false
 # NEXT_PUBLIC_FEATURE_UNRECORDED_EXCHANGE_GUARD=false
 # NEXT_PUBLIC_FEATURE_SETTLED_COMMITMENT_CHOICES=true

--- a/src/lib/__tests__/featureFlags.test.ts
+++ b/src/lib/__tests__/featureFlags.test.ts
@@ -63,6 +63,14 @@ describe('featureFlags', () => {
     expect(load({ NEXT_PUBLIC_FEATURE_WORLD_CLOCK: 'FALSE' }).isFeatureEnabled('WORLD_CLOCK')).toBe(true);
   });
 
+  it('defaults WORLD_COST to true and turns it off only for the exact string "false"', () => {
+    expect(load({ NEXT_PUBLIC_FEATURE_WORLD_COST: undefined }).isFeatureEnabled('WORLD_COST')).toBe(true);
+    jest.resetModules();
+    expect(load({ NEXT_PUBLIC_FEATURE_WORLD_COST: 'false' }).isFeatureEnabled('WORLD_COST')).toBe(false);
+    jest.resetModules();
+    expect(load({ NEXT_PUBLIC_FEATURE_WORLD_COST: 'FALSE' }).isFeatureEnabled('WORLD_COST')).toBe(true);
+  });
+
   it('defaults WORLD_DESCRIPTION_IN_SCENE to true and turns it off only for the exact string "false"', () => {
     expect(
       load({ NEXT_PUBLIC_FEATURE_WORLD_DESCRIPTION_IN_SCENE: undefined }).isFeatureEnabled(

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -26,9 +26,9 @@ const FEATURE_FLAG_DEFAULTS = {
   // The world can take something from the character: the post-segment
   // extraction records a cost (a condition written to the character, an item
   // loss attributed to the thread that took it) and the scene prompt carries
-  // the character's conditions. Off until the playtest declared in
-  // narraitor-prompt-template-governance/eval-logs/1882-world-cost.md measures it.
-  WORLD_COST: false,
+  // the character's conditions. On since the #1983 live matrix evaluation;
+  // the env var is the kill switch.
+  WORLD_COST: true,
   // Renders the world's founding description in the per-turn scene prompt.
   // Measured and shipped in issue #1865: keeps world-specific contextual pressure
   // (e.g. deadlines, stakes) alive across 20+ turns without prompt amnesia or looping.


### PR DESCRIPTION
## Description
Flips the WORLD_COST feature flag default from false to true in src/lib/featureFlags.ts. The world-cost path was evaluated in the #1983 integrated live matrix (PR #2011), with the verdict explicitly recommending flipping the flag. With this default active, landed threats impose recorded consequences (status conditions on the character or item losses) instead of leaving arrived threats without mechanical impact.

## Related Issue
Closes #1882

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
When threats arrive in the narrative, they mechanically impose recorded consequences on the player character rather than idling indefinitely without effect.

## Flow Diagrams
None

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes
- Flipped FEATURE_FLAG_DEFAULTS.WORLD_COST from false to true in src/lib/featureFlags.ts.
- Updated .env.example override to # NEXT_PUBLIC_FEATURE_WORLD_COST=false and documented it among the kill switches for shipped features.
- Added unit test in src/lib/__tests__/featureFlags.test.ts verifying default-on behavior and exact 'false' override semantics.

## Screenshots
None

## Visual Baseline Changes
None

## Code Review Summary (if applicable)
Clean flag flip matching the precommitted decision rule and evaluation verdict in 1983-turnresolver-integrated-matrix.md.

## Chrome DevTools MCP Verification Summary (if applicable)
None

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
Run tests locally:
```bash
npm test -- src/lib/__tests__/featureFlags.test.ts
npm test -- src/lib/narrative/__tests__/itemLossProcessor.test.ts src/state/__tests__/characterStore.conditions.test.ts src/lib/ai/__tests__/worldThreadExtraction.test.ts src/components/Narrative/__tests__/NarrativeDisplay.consequence.test.tsx
npm run type-check
npm run lint
npm test
```

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed