### PR TITLE
Scope exchange denials to the claimed conversation

### DIFF
--- a/src/lib/lore/__tests__/continuityGuardrail.test.ts
+++ b/src/lib/lore/__tests__/continuityGuardrail.test.ts
@@ -527,6 +527,17 @@ describe('unrecorded exchange (#1857)', () => {
       )
     ).toEqual([]);
   });
+
+  it('does not let unrelated negation hide a recounted exchange', () => {
+    const contract = buildExchangeContract(3);
+
+    expect(
+      detectContinuityIssues(
+        'Davies does not hesitate. "What I told you privately was that the mayor buried the report," he says.',
+        contract
+      )
+    ).toMatchObject([{ type: 'invented-exchange', entity: 'Davies' }]);
+  });
 });
 
 describe('delivered-commitment bait guards (#1963)', () => {

--- a/src/lib/lore/continuityGuardrail.ts
+++ b/src/lib/lore/continuityGuardrail.ts
@@ -35,7 +35,10 @@ import {
   termPattern,
   topicTerms,
 } from './continuityLedger';
-import { recountsUnrecordedExchange } from './unrecordedExchange';
+import {
+  recountsUnrecordedExchange,
+  refusesUnrecordedExchange,
+} from './unrecordedExchange';
 
 /** Routes correction responses in tests and marks the call in debug output. */
 export const CONTINUITY_CORRECTION_HEADER = 'CONTINUITY CORRECTION';
@@ -378,14 +381,15 @@ export function detectContinuityIssues(
   // so the segment is that claim's answer and recounting anywhere in it is the
   // invention. Denial is what the change wants, and it is guarded.
   for (const exchange of contract.unrecordedExchanges) {
-    // Read the refusal guard across the whole answer before locating an
-    // excerpt. An NPC may echo the player's question in one sentence and deny
-    // it in the next; sentence-local detection mistakes that refusal for a
-    // recount.
-    if (!recountsUnrecordedExchange(content)) continue;
-    const sentence =
-      sentences.find((candidate) => recountsUnrecordedExchange(candidate)) ??
-      content;
+    const sentence = sentences.find((candidate, index) => {
+      if (!recountsUnrecordedExchange(candidate)) return false;
+
+      // An NPC may echo the player's question and deny it immediately after.
+      // Only a direct exchange refusal in the following two sentences guards
+      // that echo; unrelated negation elsewhere must not hide a recount.
+      const response = sentences.slice(index + 1, index + 3).join(' ');
+      return !refusesUnrecordedExchange(response);
+    });
     if (sentence) {
       issues.push({
         type: 'invented-exchange',

--- a/src/lib/lore/unrecordedExchange.ts
+++ b/src/lib/lore/unrecordedExchange.ts
@@ -67,6 +67,14 @@ const RECOUNT_LEXICON =
  */
 const DENIAL_LEXICON = /\b(?:never|no\s+such|nothing|not|nor)\b|n['’]t\b/i;
 
+/**
+ * A direct refusal of the claimed exchange. Unlike DENIAL_LEXICON, this is
+ * safe to apply to nearby sentences because it requires the negation to name
+ * memory, the conversation, or the act of speaking.
+ */
+const EXCHANGE_REFUSAL_LEXICON =
+  /\b(?:do\s+not|don['’]t|cannot|can['’]t|never)\s+(?:recall|remember|recollect)\b|\bno\s+such\s+(?:conversation|talk|chat|exchange|meeting|consultation)\b|\b(?:I|we)\s+(?:never|did\s+not|didn['’]t)\s+(?:speak|spoke|talk|talked|meet|met|tell|told)\b|\bnothing\s+to\s+(?:repeat|recount|confirm)\b|\byou\s+(?:are|must\s+be)\s+mistaken\b/i;
+
 /** Co-presence per NPC, read off the segments the session already persisted. */
 export interface SharedSceneRecord {
   /** Narrated scenes in which this NPC was present with the protagonist. */
@@ -182,4 +190,9 @@ export function recountsUnrecordedExchange(sentence: string): boolean {
   if (!sentence) return false;
   if (DENIAL_LEXICON.test(sentence)) return false;
   return RECOUNT_LEXICON.test(sentence);
+}
+
+/** True when nearby prose directly refuses the claimed exchange. */
+export function refusesUnrecordedExchange(text: string): boolean {
+  return Boolean(text && EXCHANGE_REFUSAL_LEXICON.test(text));
 }


### PR DESCRIPTION
## Description

Narrows the adjacent-sentence refusal guard added in #2016. A direct exchange refusal can still protect an echoed question, but unrelated negation elsewhere in the response can no longer hide a real recount from correction and lore quarantine.

## Related Issue

Follow-up to #1857 and #2016.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed

- Keep invented private exchanges on the correction and quarantine path even when unrelated narration contains a negation.
- Preserve the valid refusal case where an NPC echoes the question and denies the claimed exchange in the next sentence.

## Flow Diagrams

Not applicable.

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

Not applicable. No UI components changed.

## Implementation Notes

Nearby prose now suppresses a recount only when it directly denies memory of the exchange, the conversation itself, or the act of speaking. The existing conservative same-sentence denial behavior stays unchanged.

## Screenshots

Not applicable.

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

Fixes the P1 finding in discussion `r3936991819`. The reviewer example was reproduced as a failing test before the implementation changed.

## Chrome DevTools MCP Verification Summary (if applicable)

Not applicable. This is a deterministic detector correction covered at the pure-function boundary.

## Quality Checks (if applicable)

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions

1. Run `npm test -- src/lib/lore/__tests__/continuityGuardrail.test.ts -t "unrecorded exchange"`.
2. Run `npm test -- src/lib/ai/__tests__/narrativeGenerator.continuity.test.ts src/lib/lore/__tests__/continuityGuardrail.test.ts src/lib/lore/__tests__/unrecordedExchange.test.ts`.
3. Run `npm run type-check` and `npm run lint`.

## Checklist

- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed
