### PR TITLE
Make overdue world-clock threads cross scene boundaries

### DIFF
--- a/.claude/skills/narraitor-prompt-template-governance/eval-logs/1822-world-clock.md
+++ b/.claude/skills/narraitor-prompt-template-governance/eval-logs/1822-world-clock.md
@@ -44,3 +44,26 @@ Matrix shortfall, stated: the protocol asks for 2 worlds x 2 characters; this ro
 - Improved on the evaluated matrix. The headline symptom (#1822: nothing happens the player did not cause) moves in both cells: Harrowgate world-moved 1/0/0 -> 4/4/4, Crystal Lake 3 -> 10 in the first treated block. Momentum, Stakes and Surprise rise in the first treated block of both cells; Memory, Voice and Choice hold at control.
 - Known failure mode, filed not fixed: threads are advanced by restatement and never come due, so the last block re-announces instead of paying off (Harrowgate block 3 Momentum 3 -> 2, Crystal Lake block 3 Momentum 1). #1872 carries the fix shape; #1873 the empty seed on the established path. Both are prompt-side experiments behind the same flag.
 - Ship/hold decision recorded at: `.claude/skills/narraitor-feature-experiment-lifecycle/memos/1822-world-clock.md` (SHIP; linked from PR #1869).
+
+## Round 12 re-entry precommit (#1872)
+
+- Date / evaluator: 2026-09-04, Codex. Live Gemini through `/worlds/[id]/play`; no mocked provider calls.
+- Intervention: when the resolver selects an unfired DUE NOW deadline, or a fired DUE NOW thread has reached the three-strike cap, it requests and records a `transition` segment. The next turn's recent context starts at that boundary. Actor and consequence arrivals, plus fired threads below the cap, keep the current-scene path.
+- Matrix: Harrowgate Mills and Camp Crystal Lake x unfired deadline / fired three-strike conclusion x 3 independent probes = 12 turns. One follow-up turn per world checks that prompt context stays beyond the cut.
+- Primary gates: 12/12 segments recorded as `transition` with the `transition` tag; 0 backward time cuts; at least 10/12 visible forward cuts or clean conclusions; each world's fired-conclusion cell resolves at least once; both follow-ups stay beyond the prior scene.
+- Decision rule: SHIP if every deterministic gate passes and the qualitative misses stay within the declared 2/12 allowance. HOLD if boundary metadata is missing, time moves backward, either world never resolves its fired thread, or a follow-up re-enters the pre-boundary scene.
+- Scope boundary: this is a focused architecture re-entry on the measured failure cause, not a repeat of the earlier 150-turn mechanical matrix. That matrix already established 19 resolutions, 0 dropped threads, and 150/150 clock stamps while exposing the single-scene stall this round targets.
+
+### Round 12 results
+
+| World | Trigger | Runs | Boundary result | Ledger result | Representative result |
+|---|---|---:|---|---|---|
+| Harrowgate Mills | unfired overdue deadline | 3 | 3/3 `transition` type and tag; 3/3 forward cuts; 0 backward cuts | 2 resolved, 1 landed and re-fused | Afternoon became evening, the hall opened, and the long-awaited vote began. |
+| Harrowgate Mills | fired thread at three strikes | 3 | 3/3 `transition` type and tag; 3/3 clean conclusions | 3 resolved | A final gavel strike ended the argument and fixed the council's decision. |
+| Camp Crystal Lake | unfired overdue deadline | 3 | 3/3 `transition` type and tag; 3/3 forward cuts; 0 backward cuts | 2 resolved, 1 landed and re-fused | Midnight passed without the evacuation boat, leaving the character stranded. |
+| Camp Crystal Lake | fired thread at three strikes | 3 | 3/3 `transition` type and tag; 3/3 clean conclusions | 3 resolved | The attacker fell into the water, was defeated in the boathouse, or was escaped. |
+
+- Aggregate: 12/12 deterministic boundaries; 12/12 visible forward cuts or clean conclusions; 0 backward time cuts; 10 resolved threads and 2 deadline arrivals that advanced and re-fused instead of being restated.
+- Boundary carry-forward: the Harrowgate follow-up began after the vote with the crowd leaving the hall. The Crystal Lake follow-up began outside the boathouse and moved deeper into the camp. Neither prompt re-entered its pre-transition scene.
+- Failure drill: no provider, parsing, or reconciliation failures occurred in the 14 live turns. The two deadline arrivals left their threads open intentionally because the event began without its outcome; both produced an observable change and the store re-fused them.
+- Verdict: SHIP. Every precommitted gate passed. This closes the measured one-room stall through a resolver-owned boundary rather than another wording-only prompt round.

--- a/src/lib/ai/__tests__/narrativeGenerator.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.test.ts
@@ -166,6 +166,27 @@ describe('NarrativeGenerator', () => {
       expect(result.segmentType).toBe('transition');
     });
 
+    it('keeps a requested transition as a scene boundary when the model labels it scene', async () => {
+      mockGeminiClient.generateContent.mockResolvedValue({
+        content: JSON.stringify({
+          content: 'Three days later, the council gathers for the vote.',
+          type: 'scene',
+          metadata: { mood: 'tense', tags: ['council'] },
+        }),
+        finishReason: 'stop',
+      });
+
+      const result = await narrativeGenerator.generateSegment({
+        worldId: 'world-123',
+        sessionId: 'session-123',
+        characterIds: ['char-1'],
+        generationParameters: { segmentType: 'transition' },
+      });
+
+      expect(result.segmentType).toBe('transition');
+      expect(result.metadata.tags).toContain('transition');
+    });
+
     it('handles errors gracefully', async () => {
       mockGeminiClient.generateContent.mockRejectedValue(
         new Error('API Error')

--- a/src/lib/ai/__tests__/narrativeGenerator.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.test.ts
@@ -1,4 +1,5 @@
 import { NarrativeGenerator } from '../narrativeGenerator';
+import { WORLD_CLOCK_TRANSITION_TAG } from '@/lib/narrative/turnTags';
 import { GeminiClient } from '../geminiClient';
 import { getNarrativeTemplate } from '../../promptTemplates/narrativeTemplateManager';
 import { useWorldStore } from '@/state/worldStore';
@@ -184,7 +185,9 @@ describe('NarrativeGenerator', () => {
       });
 
       expect(result.segmentType).toBe('transition');
-      expect(result.metadata.tags).toContain('transition');
+      expect(result.metadata.tags).toEqual(
+        expect.arrayContaining(['transition', WORLD_CLOCK_TRANSITION_TAG])
+      );
     });
 
     it('handles errors gracefully', async () => {

--- a/src/lib/ai/narrativeGenerator.ts
+++ b/src/lib/ai/narrativeGenerator.ts
@@ -198,6 +198,20 @@ export class NarrativeGenerator {
         worldId: request.worldId,
         sessionId: request.sessionId,
       });
+
+      // A world-clock boundary is resolver-selected state, not a model
+      // classification. Keep it recorded even if the response labels its own
+      // prose as a scene, so the next turn starts on the far side of the cut.
+      if (request.generationParameters?.segmentType === 'transition') {
+        result = {
+          ...result,
+          segmentType: 'transition',
+          metadata: {
+            ...result.metadata,
+            tags: Array.from(new Set([...(result.metadata.tags ?? []), 'transition'])),
+          },
+        };
+      }
       // Re-check before the store-mutating tail (lore extraction, item
       // acquisition/loss, NPC sync) in case the caller aborted mid-pipeline.
       throwIfAborted(options?.signal);

--- a/src/lib/ai/narrativeGenerator.ts
+++ b/src/lib/ai/narrativeGenerator.ts
@@ -58,6 +58,7 @@ import {
   enhancePromptWithContinuityExpectations,
 } from './narrativeGenerator.continuity';
 import { isResolverManaged } from '@/lib/narrative/resolverGuard';
+import { WORLD_CLOCK_TRANSITION_TAG } from '@/lib/narrative/turnTags';
 import {
   buildKnownNameTokens,
   enhancePromptWithPhraseVariety,
@@ -208,7 +209,11 @@ export class NarrativeGenerator {
           segmentType: 'transition',
           metadata: {
             ...result.metadata,
-            tags: Array.from(new Set([...(result.metadata.tags ?? []), 'transition'])),
+            tags: Array.from(new Set([
+              ...(result.metadata.tags ?? []),
+              'transition',
+              WORLD_CLOCK_TRANSITION_TAG,
+            ])),
           },
         };
       }

--- a/src/lib/narrative/__tests__/turnResolver.test.ts
+++ b/src/lib/narrative/__tests__/turnResolver.test.ts
@@ -12,7 +12,10 @@ import { useInventoryStore } from '@/state/inventoryStore';
 import { useWorldThreadStore } from '@/state/worldThreadStore';
 import { useWorldStore } from '@/state/worldStore';
 import { PARTIAL_RECONCILIATION_ERROR } from '@/lib/narrative/narrativeErrors';
-import type { NarrativeGenerationResult } from '@/types/narrative.types';
+import type {
+  NarrativeGenerationResult,
+  NarrativeSegment,
+} from '@/types/narrative.types';
 import type { TurnCommand } from '@/types/turnResolver.types';
 import type { NarrativeGenerator } from '@/lib/ai/narrativeGenerator';
 
@@ -43,6 +46,7 @@ jest.mock('@/lib/ai/narrativeGenerator.npc', () => ({
 jest.mock('../worldClock', () => ({
   countWorldClockTurns: jest.fn((segments: unknown[]) => segments.length),
   buildWorldClockPromptContext: jest.fn(),
+  needsSceneTransition: jest.fn(() => false),
 }));
 
 jest.mock('../turnsSinceComplication', () => ({
@@ -100,6 +104,7 @@ const { inferItemsLostFromNarrative: inferItemsLostFromNarrativeActual } =
   jest.requireActual('../itemLossInference');
 const { syncNpcMetadata } = jest.requireMock('@/lib/ai/narrativeGenerator.npc');
 const { extractStructuredLore } = jest.requireMock('@/lib/ai/structuredLoreExtractor');
+const { buildWorldClockPromptContext, needsSceneTransition } = jest.requireMock('../worldClock');
 
 function makeGenerationResult(overrides: Partial<NarrativeGenerationResult> = {}): NarrativeGenerationResult {
   return {
@@ -305,6 +310,70 @@ describe('TurnResolver', () => {
       expect(result.segment.sessionId).toBe('session-1');
       expect(result.snapshot).toBeDefined();
       expect(result.snapshot.sessionId).toBe('session-1');
+    });
+
+    it('requests a transition when the world clock requires a scene boundary', async () => {
+      const { isFeatureEnabled } = jest.requireMock('@/lib/featureFlags');
+      (isFeatureEnabled as jest.Mock).mockImplementation(
+        (flag: string) => flag === 'WORLD_CLOCK'
+      );
+      (buildWorldClockPromptContext as jest.Mock).mockReturnValue({
+        currentTurn: 6,
+        turnsSinceWorldMoved: 3,
+        threads: [],
+      });
+      (needsSceneTransition as jest.Mock).mockReturnValue(true);
+      const generator = makeMockGenerator();
+
+      await resolveTurn(makeCommand(), generator);
+
+      expect(generator.generateSegment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          generationParameters: expect.objectContaining({
+            segmentType: 'transition',
+          }),
+        }),
+        expect.anything()
+      );
+    });
+
+    it('starts prompt context at the latest transition boundary', async () => {
+      const makeSegment = (
+        id: string,
+        type: NarrativeSegment['type']
+      ): NarrativeSegment => ({
+        id,
+        sessionId: 'session-1',
+        worldId: 'world-1',
+        content: id,
+        type,
+        metadata: { tags: [] },
+        timestamp: new Date('2026-01-01T00:00:00.000Z'),
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      });
+      const beforeBoundary = makeSegment('before-boundary', 'scene');
+      const boundary = makeSegment('boundary', 'transition');
+      useNarrativeStore.setState({
+        segments: {
+          [beforeBoundary.id]: beforeBoundary,
+          [boundary.id]: boundary,
+        },
+        sessionSegments: {
+          'session-1': [beforeBoundary.id, boundary.id],
+        },
+      });
+      const generator = makeMockGenerator();
+
+      await resolveTurn(makeCommand(), generator);
+
+      const generationRequest = (generator.generateSegment as jest.Mock).mock
+        .calls[0][0];
+      expect(
+        generationRequest.narrativeContext.recentSegments.map(
+          (segment: NarrativeSegment) => segment.id
+        )
+      ).toEqual(['boundary']);
     });
 
     it('rejects before commit when an abort-ignoring generator is cancelled', async () => {

--- a/src/lib/narrative/__tests__/turnResolver.test.ts
+++ b/src/lib/narrative/__tests__/turnResolver.test.ts
@@ -45,6 +45,10 @@ jest.mock('@/lib/ai/narrativeGenerator.npc', () => ({
 
 jest.mock('../worldClock', () => ({
   countWorldClockTurns: jest.fn((segments: unknown[]) => segments.length),
+  isWorldClockTurnSegment: jest.fn(
+    (segment: { metadata?: { tags?: string[] } }) =>
+      !segment.metadata?.tags?.includes('item-usage')
+  ),
   buildWorldClockPromptContext: jest.fn(),
   needsSceneTransition: jest.fn(() => false),
 }));
@@ -78,6 +82,7 @@ jest.mock('@/lib/narrative/narrativeContentGate', () => ({
 }));
 
 jest.mock('../turnTags', () => ({
+  WORLD_CLOCK_TRANSITION_TAG: 'world-clock-transition',
   mergeTurnTags: jest.fn((_prev: string[], current: string[]) => current),
 }));
 
@@ -337,17 +342,18 @@ describe('TurnResolver', () => {
       );
     });
 
-    it('starts prompt context at the latest transition boundary', async () => {
+    it('does not treat a generic transition classification as a world-clock boundary', async () => {
       const makeSegment = (
         id: string,
-        type: NarrativeSegment['type']
+        type: NarrativeSegment['type'],
+        tags: string[] = []
       ): NarrativeSegment => ({
         id,
         sessionId: 'session-1',
         worldId: 'world-1',
         content: id,
         type,
-        metadata: { tags: [] },
+        metadata: { tags },
         timestamp: new Date('2026-01-01T00:00:00.000Z'),
         createdAt: '2026-01-01T00:00:00.000Z',
         updatedAt: '2026-01-01T00:00:00.000Z',
@@ -373,7 +379,87 @@ describe('TurnResolver', () => {
         generationRequest.narrativeContext.recentSegments.map(
           (segment: NarrativeSegment) => segment.id
         )
+      ).toEqual(['before-boundary', 'boundary']);
+    });
+
+    it('starts prompt context at the latest resolver-owned world-clock boundary', async () => {
+      const makeSegment = (id: string, tags: string[] = []): NarrativeSegment => ({
+        id,
+        sessionId: 'session-1',
+        worldId: 'world-1',
+        content: id,
+        type: 'scene',
+        metadata: { tags },
+        timestamp: new Date('2026-01-01T00:00:00.000Z'),
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      });
+      const beforeBoundary = makeSegment('before-boundary');
+      const boundary = makeSegment('boundary', ['world-clock-transition']);
+      useNarrativeStore.setState({
+        segments: {
+          [beforeBoundary.id]: beforeBoundary,
+          [boundary.id]: boundary,
+        },
+        sessionSegments: {
+          'session-1': [beforeBoundary.id, boundary.id],
+        },
+      });
+      const generator = makeMockGenerator();
+
+      await resolveTurn(makeCommand(), generator);
+
+      const generationRequest = (generator.generateSegment as jest.Mock).mock
+        .calls[0][0];
+      expect(
+        generationRequest.narrativeContext.recentSegments.map(
+          (segment: NarrativeSegment) => segment.id
+        )
       ).toEqual(['boundary']);
+    });
+
+    it('does not request consecutive world-clock boundaries', async () => {
+      const { isFeatureEnabled } = jest.requireMock('@/lib/featureFlags');
+      (isFeatureEnabled as jest.Mock).mockImplementation(
+        (flag: string) => flag === 'WORLD_CLOCK'
+      );
+      (buildWorldClockPromptContext as jest.Mock).mockReturnValue({
+        currentTurn: 7,
+        turnsSinceWorldMoved: 4,
+        threads: [],
+      });
+      (needsSceneTransition as jest.Mock).mockReturnValue(true);
+      const boundary: NarrativeSegment = {
+        id: 'boundary',
+        sessionId: 'session-1',
+        worldId: 'world-1',
+        content: 'Three days pass.',
+        type: 'transition',
+        metadata: { tags: ['world-clock-transition'] },
+        timestamp: new Date('2026-01-01T00:00:00.000Z'),
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      };
+      const itemUse: NarrativeSegment = {
+        ...boundary,
+        id: 'item-use',
+        content: 'You drink the potion.',
+        type: 'action',
+        metadata: { tags: ['item-usage'] },
+      };
+      useNarrativeStore.setState({
+        segments: { [boundary.id]: boundary, [itemUse.id]: itemUse },
+        sessionSegments: { 'session-1': [boundary.id, itemUse.id] },
+      });
+      const generator = makeMockGenerator();
+
+      await resolveTurn(makeCommand(), generator);
+
+      const generationRequest = (generator.generateSegment as jest.Mock).mock
+        .calls[0][0];
+      expect(generationRequest.generationParameters).not.toHaveProperty(
+        'segmentType'
+      );
     });
 
     it('rejects before commit when an abort-ignoring generator is cancelled', async () => {
@@ -705,6 +791,52 @@ describe('TurnResolver', () => {
   });
 
   describe('resolveItemUseTurn', () => {
+    it('keeps replacement-choice context behind the latest world-clock boundary', async () => {
+      const ids = seedItemUseStores();
+      const beforeBoundary: NarrativeSegment = {
+        id: 'before-boundary',
+        sessionId: ids.sessionId,
+        worldId: ids.worldId,
+        content: 'The old room lingers.',
+        type: 'scene',
+        metadata: { tags: [] },
+        timestamp: new Date('2026-01-01T00:00:00.000Z'),
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      };
+      const boundary: NarrativeSegment = {
+        ...beforeBoundary,
+        id: 'boundary',
+        content: 'Three days later, you reach the council hall.',
+        type: 'transition',
+        metadata: { tags: ['world-clock-transition'] },
+      };
+      useNarrativeStore.setState({
+        segments: {
+          [beforeBoundary.id]: beforeBoundary,
+          [boundary.id]: boundary,
+        },
+        sessionSegments: {
+          [ids.sessionId]: [beforeBoundary.id, boundary.id],
+        },
+      });
+      const generator = makeItemUseGenerator();
+
+      const outcome = await resolveItemUseTurn(ids, generator);
+
+      expect(outcome.success).toBe(true);
+      const choiceContext = (generator.generatePlayerChoices as jest.Mock).mock
+        .calls[0][1];
+      expect(
+        choiceContext.recentSegments.map(
+          (segment: NarrativeSegment) => segment.content
+        )
+      ).toEqual([
+        'Three days later, you reach the council hall.',
+        'You drink the potion and warmth returns to your limbs.',
+      ]);
+    });
+
     it('keeps replacement choices blocked until reconciliation settles', async () => {
       const ids = seedItemUseStores();
       const clockDeferred = deferred<null>();

--- a/src/lib/narrative/__tests__/turnTags.test.ts
+++ b/src/lib/narrative/__tests__/turnTags.test.ts
@@ -1,4 +1,4 @@
-import { mergeTurnTags } from '../turnTags';
+import { WORLD_CLOCK_TRANSITION_TAG, mergeTurnTags } from '../turnTags';
 import { sceneTemplate } from '@/lib/promptTemplates/templates/narrative/sceneTemplate';
 
 describe('mergeTurnTags', () => {
@@ -21,6 +21,13 @@ describe('mergeTurnTags', () => {
 
   it('drops previous item-usage tags before building the next turn', () => {
     expect(mergeTurnTags(['forest', 'item-usage'], ['combat'])).toEqual(['forest', 'combat']);
+  });
+
+  it('drops a recorded world-clock boundary before building the next turn', () => {
+    expect(mergeTurnTags(['forest', WORLD_CLOCK_TRANSITION_TAG], ['combat'])).toEqual([
+      'forest',
+      'combat',
+    ]);
   });
 });
 

--- a/src/lib/narrative/__tests__/worldClock.test.ts
+++ b/src/lib/narrative/__tests__/worldClock.test.ts
@@ -6,6 +6,7 @@ import {
   isOverdue,
   isWorldClockTurnSegment,
   needsOpenAsk,
+  needsSceneTransition,
   overdueByTurns,
   selectDueNowThread,
   selectThreadsForPrompt,
@@ -201,6 +202,16 @@ describe('worldClock', () => {
   test('buildWorldClockPromptContext carries a thread\'s strike count into the prompt shape', () => {
     const threads = [makeThread({ summary: 'The thing in the boathouse', dueByTurn: 11, firedAtTurn: 8, strikeCount: 3 })];
     expect(buildWorldClockPromptContext(threads, 11).threads[0].strikes).toBe(3);
+  });
+
+  test.each([
+    ['an unfired deadline that is due now', makeThread({ kind: 'deadline', dueByTurn: 3 }), 6, true],
+    ['an unfired actor that can enter the current scene', makeThread({ kind: 'actor', dueByTurn: 3 }), 6, false],
+    ['a fired thread below the strike cap', makeThread({ dueByTurn: 6, firedAtTurn: 3, strikeCount: 2 }), 6, false],
+    ['a fired thread at the strike cap', makeThread({ dueByTurn: 6, firedAtTurn: 3, strikeCount: 3 }), 6, true],
+  ])('needsSceneTransition: %s', (_label, thread, currentTurn, expected) => {
+    const context = buildWorldClockPromptContext([thread], currentTurn);
+    expect(needsSceneTransition(context)).toBe(expected);
   });
 
   test('needsOpenAsk fires only when the quiet window has passed and nothing unfired is due inside it', () => {

--- a/src/lib/narrative/__tests__/worldClock.test.ts
+++ b/src/lib/narrative/__tests__/worldClock.test.ts
@@ -204,6 +204,26 @@ describe('worldClock', () => {
     expect(buildWorldClockPromptContext(threads, 11).threads[0].strikes).toBe(3);
   });
 
+  test('buildWorldClockPromptContext retains the due-now thread when the prompt cap is full', () => {
+    const firedAtFuse = makeThread({
+      id: 'fired-at-fuse',
+      kind: 'deadline',
+      openedAtTurn: 10,
+      dueByTurn: 20,
+      firedAtTurn: 17,
+      strikeCount: 3,
+    });
+    const olderOverdueThreads = Array.from({ length: 8 }, (_, index) =>
+      makeThread({ id: `overdue-${index}`, openedAtTurn: index + 1, dueByTurn: 10 })
+    );
+
+    const context = buildWorldClockPromptContext([...olderOverdueThreads, firedAtFuse], 20);
+
+    expect(context.threads).toHaveLength(8);
+    expect(context.threads.find((thread) => thread.dueNow)?.summary).toBe(firedAtFuse.summary);
+    expect(needsSceneTransition(context)).toBe(true);
+  });
+
   test.each([
     ['an unfired deadline that is due now', makeThread({ kind: 'deadline', dueByTurn: 3 }), 6, true],
     ['an unfired actor that can enter the current scene', makeThread({ kind: 'actor', dueByTurn: 3 }), 6, false],

--- a/src/lib/narrative/turnResolver.ts
+++ b/src/lib/narrative/turnResolver.ts
@@ -27,8 +27,11 @@ import { itemNamesMatch } from '@/lib/narrative/itemProcessorShared';
 import { syncNpcMetadata } from '@/lib/ai/narrativeGenerator.npc';
 import { isSessionEndingSegment } from '@/lib/narrative/isSessionEndingSegment';
 import { PARTIAL_RECONCILIATION_ERROR } from '@/lib/narrative/narrativeErrors';
-import { countWorldClockTurns } from '@/lib/narrative/worldClock';
-import { buildWorldClockPromptContext } from '@/lib/narrative/worldClock';
+import {
+  buildWorldClockPromptContext,
+  countWorldClockTurns,
+  needsSceneTransition,
+} from '@/lib/narrative/worldClock';
 import { isFeatureEnabled } from '@/lib/featureFlags';
 import { computeTurnsSinceComplication } from '@/lib/narrative/turnsSinceComplication';
 import { useWorldThreadStore } from '@/state/worldThreadStore';
@@ -51,6 +54,18 @@ import {
  * Modeled after chainBySession in applyWorldClockUpdates.ts.
  */
 const turnLockBySession = new Map<EntityID, Promise<unknown>>();
+
+const recentSceneSegments = (
+  segments: readonly NarrativeSegment[],
+  limit = 3
+): NarrativeSegment[] => {
+  const recent = segments.slice(-limit);
+  let latestBoundary = -1;
+  recent.forEach((segment, index) => {
+    if (segment.type === 'transition') latestBoundary = index;
+  });
+  return latestBoundary >= 0 ? recent.slice(latestBoundary) : recent;
+};
 
 function withTurnLock<T>(
   sessionId: EntityID,
@@ -178,7 +193,7 @@ async function resolveTurnInner(
 
   // Pre-turn snapshot for prompt context
   const preTurnSnapshot = assembleSessionSnapshot(sessionId, ids);
-  const recentSegments = preTurnSnapshot.segments.slice(-3);
+  const recentSegments = recentSceneSegments(preTurnSnapshot.segments);
   const turnsSinceComplication = computeTurnsSinceComplication(
     [...preTurnSnapshot.segments]
   );
@@ -235,6 +250,9 @@ async function resolveTurnInner(
           includedTopics: command.generationParams?.includedTopics ?? [command.choiceText],
           decisionWeight: command.decisionWeight,
           desiredTone: command.generationParams?.desiredTone,
+          ...(needsSceneTransition(worldClock)
+            ? { segmentType: 'transition' as const }
+            : {}),
         },
       },
       { signal: command.signal, onChunk: command.onChunk, resolverManaged: true }

--- a/src/lib/narrative/turnResolver.ts
+++ b/src/lib/narrative/turnResolver.ts
@@ -30,6 +30,7 @@ import { PARTIAL_RECONCILIATION_ERROR } from '@/lib/narrative/narrativeErrors';
 import {
   buildWorldClockPromptContext,
   countWorldClockTurns,
+  isWorldClockTurnSegment,
   needsSceneTransition,
 } from '@/lib/narrative/worldClock';
 import { isFeatureEnabled } from '@/lib/featureFlags';
@@ -41,7 +42,10 @@ import { getLoreContextForPrompt } from '@/lib/ai/loreContextHelper';
 import { collectContinuityTopicsFromStores } from '@/lib/ai/narrativeGenerator.continuity';
 import { logger } from '@/lib/utils/logger';
 import { inferItemsLostFromNarrative } from '@/lib/narrative/itemLossInference';
-import { mergeTurnTags } from '@/lib/narrative/turnTags';
+import {
+  mergeTurnTags,
+  WORLD_CLOCK_TRANSITION_TAG,
+} from '@/lib/narrative/turnTags';
 import { useInventoryStore } from '@/state/inventoryStore';
 import { useWorldStore } from '@/state/worldStore';
 import {
@@ -62,9 +66,22 @@ const recentSceneSegments = (
   const recent = segments.slice(-limit);
   let latestBoundary = -1;
   recent.forEach((segment, index) => {
-    if (segment.type === 'transition') latestBoundary = index;
+    if (segment.metadata?.tags?.includes(WORLD_CLOCK_TRANSITION_TAG)) {
+      latestBoundary = index;
+    }
   });
   return latestBoundary >= 0 ? recent.slice(latestBoundary) : recent;
+};
+
+const didWorldClockTransitionLastClockTurn = (
+  segments: readonly NarrativeSegment[]
+): boolean => {
+  for (let index = segments.length - 1; index >= 0; index -= 1) {
+    const segment = segments[index];
+    if (!isWorldClockTurnSegment(segment)) continue;
+    return segment.metadata?.tags?.includes(WORLD_CLOCK_TRANSITION_TAG) ?? false;
+  }
+  return false;
 };
 
 function withTurnLock<T>(
@@ -210,6 +227,9 @@ async function resolveTurnInner(
         world?.toneSettings?.customInstructions
       )
     : undefined;
+  const shouldRequestSceneTransition =
+    needsSceneTransition(worldClock) &&
+    !didWorldClockTransitionLastClockTurn(preTurnSnapshot.segments);
 
   // Build skill check context string for the AI prompt
   let skillCheckContext = '';
@@ -250,7 +270,7 @@ async function resolveTurnInner(
           includedTopics: command.generationParams?.includedTopics ?? [command.choiceText],
           decisionWeight: command.decisionWeight,
           desiredTone: command.generationParams?.desiredTone,
-          ...(needsSceneTransition(worldClock)
+          ...(shouldRequestSceneTransition
             ? { segmentType: 'transition' as const }
             : {}),
         },
@@ -494,7 +514,7 @@ async function replaceChoicesAfterItemUse(
   generator: NarrativeGenerator
 ): Promise<void> {
   const { sessionId, worldId, characterId } = command;
-  const recentSegments = [...turn.snapshot.segments.slice(-5)];
+  const recentSegments = recentSceneSegments(turn.snapshot.segments, 5);
   const lastSegment = recentSegments[recentSegments.length - 1];
 
   try {

--- a/src/lib/narrative/turnTags.ts
+++ b/src/lib/narrative/turnTags.ts
@@ -1,5 +1,6 @@
 const SKILL_CHECK_TAG_PREFIX = 'skill-';
-const TRANSIENT_TURN_TAGS = new Set(['item-usage']);
+export const WORLD_CLOCK_TRANSITION_TAG = 'world-clock-transition';
+const TRANSIENT_TURN_TAGS = new Set(['item-usage', WORLD_CLOCK_TRANSITION_TAG]);
 
 /**
  * Builds the tag list a turn's prompt sees.

--- a/src/lib/narrative/worldClock.ts
+++ b/src/lib/narrative/worldClock.ts
@@ -110,6 +110,20 @@ export const selectDueNowThread = (
     )[0];
 
 /**
+ * A deadline needs a forward cut when it comes due, and a fired thread needs
+ * a clean scene exit once it has exhausted its strikes. Other arrivals can
+ * still land inside the current scene without forcing a boundary.
+ */
+export const needsSceneTransition = (
+  worldClock?: WorldClockPromptContext
+): boolean => {
+  const dueNow = worldClock?.threads.find((thread) => thread.dueNow);
+  if (!dueNow) return false;
+  if (!dueNow.fired) return dueNow.kind === 'deadline';
+  return dueNow.strikes >= FIRED_THREAD_MAX_STRIKES;
+};
+
+/**
  * Turns since the ledger last moved in any direction. Resolved threads count:
  * a payoff last turn means the world just moved even if nothing is open now.
  */

--- a/src/lib/narrative/worldClock.ts
+++ b/src/lib/narrative/worldClock.ts
@@ -158,12 +158,16 @@ export const buildWorldClockPromptContext = (
 ): WorldClockPromptContext => {
   const openThreads = sessionThreads.filter((thread) => thread.status === 'open');
   const dueNow = selectDueNowThread(openThreads, currentTurn);
+  const promptThreads = selectThreadsForPrompt(openThreads, currentTurn);
+  if (dueNow && !promptThreads.some((thread) => thread.id === dueNow.id)) {
+    promptThreads[promptThreads.length - 1] = dueNow;
+  }
   const trimmedRegister = register?.trim();
   return {
     currentTurn,
     turnsSinceWorldMoved: turnsSinceWorldMoved(sessionThreads, currentTurn),
     ...(trimmedRegister ? { register: trimmedRegister } : {}),
-    threads: selectThreadsForPrompt(openThreads, currentTurn).map((thread) => ({
+    threads: promptThreads.map((thread) => ({
       kind: thread.kind,
       summary: thread.summary,
       ageTurns: currentTurn - thread.openedAtTurn,

--- a/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.worldClock.test.ts
+++ b/src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.worldClock.test.ts
@@ -107,6 +107,21 @@ describe('sceneTemplate world clock block', () => {
     expect(prompt).not.toContain('Prefer an OVERDUE thread');
   });
 
+  it('replaces immediate-continuity rules when the resolver requests a transition', () => {
+    const context = makeContext({
+      currentTurn: 12,
+      turnsSinceWorldMoved: 3,
+      threads: [],
+    });
+    context.generationParameters = { segmentType: 'transition' };
+
+    const prompt = sceneTemplate(context);
+
+    expect(prompt).toContain('cross the requested scene boundary');
+    expect(prompt).toContain('Open on the far side of the transition');
+    expect(prompt).not.toContain('Pick up IMMEDIATELY');
+  });
+
   it('renders a fired thread as already in the scene by its own summary, and asks for something new when everything has fired', () => {
     const fired = {
       kind: 'actor' as const,

--- a/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
+++ b/src/lib/promptTemplates/templates/narrative/sceneTemplate.ts
@@ -177,10 +177,15 @@ PIVOTAL DECISION (LIFE OR DEATH):
 ` : ''}
 
 CRITICAL CONTINUITY RULES:
-- The player is EXACTLY where the last scene ended
+${segmentType === 'transition'
+    ? `- Preserve cause and effect from the last scene, then cross the requested scene boundary
+- Time may move FORWARD as far as the transition requires, never backward
+- Carry the player's action through the cut instead of abandoning or undoing it
+- Open on the far side of the transition, where the due event lands or the current matter has concluded`
+    : `- The player is EXACTLY where the last scene ended
 - Time has NOT reset or jumped backward
 - Pick up IMMEDIATELY from where the story left off
-- The player's action happens RIGHT NOW in the current moment
+- The player's action happens RIGHT NOW in the current moment`}
 
 ${formattedRoster}
 


### PR DESCRIPTION
## Description

The world clock could know a deadline was overdue and still leave the story in the same room forever. This makes the resolver request a real transition when an unfired deadline comes due or a fired thread exhausts its strike fuse. The recorded transition also becomes the next turn's context boundary, so later prose starts on the far side of the cut instead of falling back into the prior scene.

The live re-entry matrix passed all precommitted gates across Harrowgate Mills and Camp Crystal Lake: 12/12 boundary turns were recorded as transitions, all 12 moved forward or concluded the matter, 10 resolved the thread, and neither follow-up returned to the prior scene.

## Related Issue

Closes #1872

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The resolver-selection, model-misclassification, prompt-continuity, and context-boundary tests failed first, then passed after the implementation.

## User Stories Addressed

- As a player, I need overdue deadlines to arrive instead of being announced again inside an endless scene.
- As a player, I need a landed threat to conclude once its strike fuse is exhausted.

## Flow Diagrams

Not applicable. The implementation follows the existing TurnResolver generation and settlement path.

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

Not applicable. No component or visual behavior changed.

## Implementation Notes

- `needsSceneTransition` keeps the boundary rule next to the world-clock turn arithmetic.
- The exact DUE NOW pick is retained inside the eight-thread prompt cap, so prompt trimming cannot suppress a required transition.
- `TurnResolver` requests a transition only for due deadlines and fired threads at the strike cap. Actor and consequence arrivals can still enter the current scene.
- `NarrativeGenerator` treats the resolver's requested segment type as authoritative even if the model labels its response as a scene.
- Recent prompt context starts at the latest recorded transition, which prevents the next turn from re-entering the old scene.
- The focused live results and decision rule are recorded in the existing world-clock evaluation log.

## Screenshots

Not applicable. No visual changes.

## Visual Baseline Changes

None.

## Code Review Summary (if applicable)

Self-review found no release blocker. The behavior sits at the resolver seam that already owns generation intent and committed segment metadata; no store migration or new persistence shape is needed.

## Chrome DevTools MCP Verification Summary (if applicable)

Not applicable to Chrome DevTools. Live verification used the local play surface at `/worlds/[id]/play` with real Gemini calls: two worlds, two trigger shapes, three fresh sessions per cell, plus one follow-up per world. All precommitted gates passed.

## Quality Checks (if applicable)

- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Also passed: Knip, CSS selector audit, dependency validation, and dependency-baseline check.

## Testing Instructions

1. Run the four focused suites:
   `npm test -- src/lib/narrative/__tests__/worldClock.test.ts src/lib/narrative/__tests__/turnResolver.test.ts src/lib/ai/__tests__/narrativeGenerator.test.ts src/lib/promptTemplates/templates/narrative/__tests__/sceneTemplate.worldClock.test.ts`
2. Run `npm test`, `npm run type-check`, `npm run lint`, `npm run knip`, `npm run audit:css`, `npm run deps:validate`, and `npm run deps:check`.
3. In a live session, make an overdue deadline DUE NOW and verify the next segment is a transition. On the following turn, verify the narrative continues beyond that cut.

## Checklist

- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

The touched generator and resolver files already exceed 300 lines; this change adds the minimum logic at their existing ownership seams. Accessibility is unaffected because there is no UI change.
