### PR TITLE
Add route-tier tests for the six game-loop API routes (#1995)

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -14,16 +14,16 @@ const config = {
     '!src/**/*.d.ts',
     '!src/**/__mocks__/**',
   ],
-  // Baseline ratchet with untested production files included (#1994).
-  // Measured: statements 71.52%, branches 60.83%, functions 67.89%, lines 71.95%.
+  // Baseline ratchet with untested production files included.
+  // Measured: statements 72.42%, branches 61.56%, functions 68.20%, lines 72.87%.
   // Thresholds set with a ~1-2% cushion so regressions fail the build without
   // tripping on current code.
   coverageThreshold: {
     global: {
-      branches: 59,
+      branches: 60,
       functions: 66,
-      lines: 70,
-      statements: 70,
+      lines: 71,
+      statements: 71,
     },
   },
   moduleNameMapper: {

--- a/src/app/api/__tests__/fixtures/geminiPayloads.ts
+++ b/src/app/api/__tests__/fixtures/geminiPayloads.ts
@@ -1,0 +1,79 @@
+// src/app/api/__tests__/fixtures/geminiPayloads.ts
+
+/**
+ * Upstream payloads in the shapes Gemini's REST API returns.
+ *
+ * PROVENANCE: hand-built from the contract the Gemini adapter parses
+ * (`providers/gemini/adapter.ts` — `parseTextResponse` reads
+ * `candidates[0].content.parts[0].text`, `parseStreamFrame` reads the same path
+ * per SSE frame) and from the payloads already asserted in
+ * `providers/__tests__/adapters.test.ts` and `streamConsumer.test.ts`.
+ *
+ * They are NOT captured from a live call. That means they assert what we
+ * believe Gemini returns rather than what it does return, and they cannot
+ * notice the provider changing its response shape. Capturing them against a
+ * real key, and keeping them honest afterwards, is what the on-demand live tier
+ * is for.
+ */
+
+interface GeminiPayloadOptions {
+  finishReason?: string;
+  promptTokens?: number;
+  completionTokens?: number;
+}
+
+/** One complete non-streaming Gemini response carrying `text`. */
+export function geminiTextPayload(text: string, options: GeminiPayloadOptions = {}) {
+  const {
+    finishReason = 'STOP',
+    promptTokens = 128,
+    completionTokens = 64,
+  } = options;
+
+  return {
+    candidates: [
+      {
+        content: { parts: [{ text }] },
+        finishReason,
+      },
+    ],
+    usageMetadata: {
+      promptTokenCount: promptTokens,
+      candidatesTokenCount: completionTokens,
+    },
+  };
+}
+
+/** A response Gemini gives when it declines: candidates present, parts absent. */
+export const GEMINI_REFUSAL_PAYLOAD = {
+  candidates: [{ content: {}, finishReason: 'SAFETY' }],
+};
+
+/** SSE frames that spell out `text` one piece at a time, then report the finish. */
+export function geminiStreamFrames(pieces: string[], options: GeminiPayloadOptions = {}) {
+  const { finishReason = 'STOP', promptTokens = 128, completionTokens = 64 } = options;
+
+  const frames: unknown[] = pieces.map((piece) => ({
+    candidates: [{ content: { parts: [{ text: piece }] } }],
+  }));
+
+  frames.push({
+    candidates: [{ content: { parts: [{ text: '' }] }, finishReason }],
+    usageMetadata: {
+      promptTokenCount: promptTokens,
+      candidatesTokenCount: completionTokens,
+    },
+  });
+
+  return frames;
+}
+
+/**
+ * The response shape behind the dotted-key metadata dump: the model answers
+ * with its metadata flattened into `key: value` pairs instead of JSON, and the
+ * prose buried among them. The parse layer recovers the prose; what this
+ * fixture is here to prove is that the string reaches that layer intact through
+ * the route, the adapter and the stream framing.
+ */
+export const FLATTENED_METADATA_DUMP =
+  'metadata.characterIds: [] metadata.speakerId: null metadata.location: "Ruins" metadata.mood: "grim" content: "Panic claws at your throat as the shadow lunges forward." type: action';

--- a/src/app/api/__tests__/routeHarness.ts
+++ b/src/app/api/__tests__/routeHarness.ts
@@ -1,0 +1,136 @@
+// src/app/api/__tests__/routeHarness.ts
+
+import { NextRequest } from 'next/server';
+import {
+  PROVIDER_API_KEY_HEADER,
+  PROVIDER_MODEL_HEADER,
+} from '@/lib/ai/providerKeyHeader';
+import type { NarrativeStreamEvent } from '@/lib/ai/types';
+
+/**
+ * Shared plumbing for route-tier tests.
+ *
+ * The only thing faked here is the network. Everything between the HTTP request
+ * and `fetch` runs for real: the body-size ceiling, the rate limiter, provider
+ * resolution, prompt assembly, the Gemini adapter's own body building and
+ * response parsing, the SSE consumer, and the NDJSON encoder. That boundary is
+ * deliberate — the adapter's `parseTextResponse` and `parseStreamFrame` are
+ * where response-shape defects live, so a fake that replaced the adapter would
+ * skip the code most worth watching.
+ *
+ * Tests using this need `@jest-environment node`. jsdom has no ReadableStream
+ * or Response, which the streaming route builds directly.
+ */
+
+/**
+ * jest.setup.ts sets GEMINI_API_KEY to the MOCK_API_KEY sentinel, which
+ * resolveProvider deliberately reads as "no key". Routes therefore only reach a
+ * provider when the request carries a key header — the same bring-your-own-key
+ * path a real player uses.
+ */
+const TEST_PROVIDER_KEY = 'test-provider-key';
+const TEST_MODEL = 'gemini-2.5-flash';
+
+export interface BuildRequestOptions {
+  headers?: Record<string, string>;
+  /** Omit the provider key header, to exercise the unresolved-provider path. */
+  withoutKey?: boolean;
+}
+
+/** A POST carrying a player's key, as the browser client sends it. */
+export function buildAIRequest(
+  path: string,
+  body: unknown,
+  options: BuildRequestOptions = {}
+): NextRequest {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    [PROVIDER_MODEL_HEADER]: TEST_MODEL,
+    ...options.headers,
+  };
+
+  if (!options.withoutKey) {
+    headers[PROVIDER_API_KEY_HEADER] = TEST_PROVIDER_KEY;
+  }
+
+  return new NextRequest(`http://localhost:3000${path}`, {
+    method: 'POST',
+    headers,
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+/** Stub the upstream provider with a single non-streaming JSON body. */
+export function stubUpstreamJson(
+  payload: unknown,
+  init: { status?: number; statusText?: string } = {}
+): jest.Mock {
+  const { status = 200, statusText = 'OK' } = init;
+
+  const stub = jest.fn(async () =>
+    new Response(JSON.stringify(payload), {
+      status,
+      statusText,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  );
+
+  global.fetch = stub as unknown as typeof fetch;
+  return stub;
+}
+
+/** Stub the upstream provider with a non-ok status and an opaque error body. */
+export function stubUpstreamFailure(status: number, statusText = 'Error'): jest.Mock {
+  const stub = jest.fn(async () =>
+    new Response('upstream detail that must not reach the caller', { status, statusText })
+  );
+
+  global.fetch = stub as unknown as typeof fetch;
+  return stub;
+}
+
+/**
+ * Stub the upstream provider with an SSE stream.
+ *
+ * Each frame is emitted as its own chunk so the consumer's partial-line
+ * buffering runs on more than one read, which is the condition a single
+ * whole-body chunk would never reach.
+ */
+export function stubUpstreamStream(frames: unknown[]): jest.Mock {
+  const stub = jest.fn(async () => {
+    const encoder = new TextEncoder();
+
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const frame of frames) {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(frame)}\n\n`));
+        }
+        controller.close();
+      },
+    });
+
+    return new Response(body, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+  });
+
+  global.fetch = stub as unknown as typeof fetch;
+  return stub;
+}
+
+/** Read a route's NDJSON response back into the events the client would see. */
+export async function readNdjsonEvents(response: Response): Promise<NarrativeStreamEvent[]> {
+  const raw = await response.text();
+
+  return raw
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as NarrativeStreamEvent);
+}
+
+/** The request body the adapter sent upstream, for asserting on prompt assembly. */
+export function sentUpstreamBody(stub: jest.Mock): Record<string, unknown> {
+  const [, init] = stub.mock.calls[0] as [string, { body: string }];
+  return JSON.parse(init.body);
+}

--- a/src/app/api/generate-character/__tests__/route.test.ts
+++ b/src/app/api/generate-character/__tests__/route.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * The route's own guard is that a character cannot be generated without a world
+ * that passes validateWorld. Both rejections have to happen before the
+ * generator is reached, since that call is what costs money.
+ */
+
+jest.mock('@/lib/generators/characterGenerator');
+jest.mock('@/lib/telemetry/reportServerError');
+
+import { POST } from '../route';
+import { generateAICharacter } from '@/lib/generators/characterGenerator';
+import { buildAIRequest } from '../../__tests__/routeHarness';
+
+const mockGenerateCharacter = generateAICharacter as jest.MockedFunction<
+  typeof generateAICharacter
+>;
+
+const VALID_WORLD = {
+  id: 'world-1',
+  name: 'Ashfall',
+  description: 'A city under permanent snow.',
+  genre: 'fantasy',
+  theme: 'fantasy',
+  attributes: [],
+  skills: [],
+  settings: {
+    maxAttributes: 6,
+    maxSkills: 8,
+    attributePointPool: 20,
+    skillPointPool: 20,
+  },
+  createdAt: '2026-09-05T00:00:00Z',
+  updatedAt: '2026-09-05T00:00:00Z',
+};
+
+function characterRequest(body: Record<string, unknown>) {
+  return buildAIRequest('/api/generate-character', body);
+}
+
+describe('/api/generate-character', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGenerateCharacter.mockResolvedValue({ name: 'Wren' } as never);
+  });
+
+  it('rejects a request with no world before generating', async () => {
+    const response = await POST(characterRequest({ characterType: 'original' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBeDefined();
+    expect(mockGenerateCharacter).not.toHaveBeenCalled();
+  });
+
+  it('rejects a world that fails validation before generating', async () => {
+    const response = await POST(
+      characterRequest({ world: { name: 'Ashfall' } })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockGenerateCharacter).not.toHaveBeenCalled();
+  });
+
+  it('returns the generated character on the happy path', async () => {
+    const response = await POST(characterRequest({ world: VALID_WORLD }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.name).toBe('Wren');
+  });
+
+  it('defaults characterType and coerces a non-array existingNames', async () => {
+    await POST(
+      characterRequest({ world: VALID_WORLD, existingNames: 'not-an-array' })
+    );
+
+    expect(mockGenerateCharacter).toHaveBeenCalledWith(
+      expect.anything(),
+      [],
+      undefined,
+      'original',
+      undefined,
+      expect.anything()
+    );
+  });
+
+  it('maps a generator failure to a 500 error response', async () => {
+    mockGenerateCharacter.mockRejectedValue(new Error('provider exploded'));
+
+    const response = await POST(characterRequest({ world: VALID_WORLD }));
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/src/app/api/generate-world/__tests__/route.test.ts
+++ b/src/app/api/generate-world/__tests__/route.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Two branches the route owns and the generator does not: the relationship
+ * field is meaningless without a reference to relate to, and a generated world
+ * missing a name, description or genre is a server failure rather than
+ * something to hand back to the wizard.
+ */
+
+jest.mock('@/lib/generators/worldGenerator');
+jest.mock('@/lib/telemetry/reportServerError');
+
+import { POST } from '../route';
+import { generateWorld } from '@/lib/generators/worldGenerator';
+import { buildAIRequest } from '../../__tests__/routeHarness';
+
+const mockGenerateWorld = generateWorld as jest.MockedFunction<typeof generateWorld>;
+
+const COMPLETE_WORLD = {
+  name: 'Ashfall',
+  description: 'A city under permanent snow.',
+  genre: 'fantasy',
+};
+
+function worldRequest(body: Record<string, unknown>) {
+  return buildAIRequest('/api/generate-world', body);
+}
+
+describe('/api/generate-world', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGenerateWorld.mockResolvedValue(COMPLETE_WORLD as never);
+  });
+
+  it('rejects a relationship sent without a reference, before generating', async () => {
+    const response = await POST(worldRequest({ worldRelationship: 'set_within' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain('Existing setting is required');
+    expect(mockGenerateWorld).not.toHaveBeenCalled();
+  });
+
+  it('returns the generated world on the happy path', async () => {
+    const response = await POST(worldRequest({ worldReference: 'Ashfall' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.name).toBe('Ashfall');
+  });
+
+  it('defaults the relationship when only a reference is given', async () => {
+    await POST(worldRequest({ worldReference: 'Ashfall' }));
+
+    expect(mockGenerateWorld).toHaveBeenCalledWith(
+      expect.objectContaining({ relationship: 'inspired_by' }),
+      expect.anything()
+    );
+  });
+
+  it('refuses to return a world missing required fields', async () => {
+    mockGenerateWorld.mockResolvedValue({ name: 'Ashfall' } as never);
+
+    const response = await POST(worldRequest({ worldReference: 'Ashfall' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe('Generated world data is incomplete');
+  });
+
+  it('maps a generator failure to a 500 error response', async () => {
+    mockGenerateWorld.mockRejectedValue(new Error('provider exploded'));
+
+    const response = await POST(worldRequest({ worldReference: 'Ashfall' }));
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/src/app/api/narrative/choices/__tests__/route.test.ts
+++ b/src/app/api/narrative/choices/__tests__/route.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * The non-streaming half of the loop. Same seam as the generate route — only
+ * the network is faked — so the adapter's parseTextResponse runs for real,
+ * including the two ways a 200 can still be unusable.
+ */
+
+jest.mock('@/lib/telemetry/reportServerError');
+
+import { POST } from '../route';
+import {
+  buildAIRequest,
+  sentUpstreamBody,
+  stubUpstreamJson,
+  stubUpstreamFailure,
+} from '../../../__tests__/routeHarness';
+import {
+  GEMINI_REFUSAL_PAYLOAD,
+  geminiTextPayload,
+} from '../../../__tests__/fixtures/geminiPayloads';
+
+const originalFetch = global.fetch;
+
+const CHOICES_JSON = '{"choices":[{"text":"Cross the bridge"},{"text":"Turn back"}]}';
+
+function choicesRequest(body: Record<string, unknown>) {
+  return buildAIRequest('/api/narrative/choices', body);
+}
+
+describe('/api/narrative/choices', () => {
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it('returns the parsed content and token counts on the happy path', async () => {
+    stubUpstreamJson(geminiTextPayload(CHOICES_JSON));
+
+    const response = await POST(choicesRequest({ prompt: 'Offer choices.' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.content).toBe(CHOICES_JSON);
+    expect(data.finishReason).toBe('STOP');
+    expect(data.promptTokens).toBe(128);
+  });
+
+  it('asks the non-streaming endpoint and clamps to the route ceiling', async () => {
+    const upstream = stubUpstreamJson(geminiTextPayload(CHOICES_JSON));
+
+    await POST(choicesRequest({ prompt: 'Offer choices.', config: { maxTokens: 99999 } }));
+
+    const [url] = upstream.mock.calls[0] as [string];
+    expect(url).toContain(':generateContent');
+    expect(url).not.toContain('alt=sse');
+
+    const body = sentUpstreamBody(upstream) as {
+      generationConfig: { maxOutputTokens: number };
+    };
+    expect(body.generationConfig.maxOutputTokens).toBe(2048);
+  });
+
+  it('reports a refusal as a server error rather than empty choices', async () => {
+    stubUpstreamJson(GEMINI_REFUSAL_PAYLOAD);
+
+    const response = await POST(choicesRequest({ prompt: 'Offer choices.' }));
+
+    expect(response.status).toBe(500);
+  });
+
+  it('passes an upstream auth failure through as 401 without leaking the body', async () => {
+    stubUpstreamFailure(401, 'Unauthorized');
+
+    const response = await POST(choicesRequest({ prompt: 'Offer choices.' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(JSON.stringify(data)).not.toContain('upstream detail');
+  });
+
+  it('rejects a request with no prompt without reaching the provider', async () => {
+    const upstream = stubUpstreamJson(geminiTextPayload(CHOICES_JSON));
+
+    const response = await POST(choicesRequest({}));
+
+    expect(response.status).toBe(400);
+    expect(upstream).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/narrative/ending/__tests__/route.test.ts
+++ b/src/app/api/narrative/ending/__tests__/route.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * The ending route owns three allowlists and a catch block that maps a thrown
+ * message onto 404, 503 or 500 by substring. None of that had a test, and
+ * substring-matched error mapping is the kind that breaks silently when a
+ * message downstream is reworded.
+ */
+
+jest.mock('@/lib/ai/endingGenerator');
+jest.mock('@/lib/telemetry/reportServerError');
+
+import { POST, GET } from '../route';
+import { generateEnding } from '@/lib/ai/endingGenerator';
+import { buildAIRequest } from '../../../__tests__/routeHarness';
+
+const mockGenerateEnding = generateEnding as jest.MockedFunction<typeof generateEnding>;
+
+const VALID_BODY = {
+  sessionId: 'session-1',
+  characterId: 'char-1',
+  worldId: 'world-1',
+  endingType: 'story-complete',
+};
+
+function endingRequest(body: Record<string, unknown>) {
+  return buildAIRequest('/api/narrative/ending', body);
+}
+
+describe('/api/narrative/ending', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGenerateEnding.mockResolvedValue({
+      epilogue: 'The road ended at the sea.',
+      characterLegacy: 'Remembered for the crossing.',
+      worldImpact: 'The bridge stayed open.',
+      tone: 'hopeful',
+      achievements: ['Crossed the bridge'],
+      playTime: 42,
+    } as never);
+  });
+
+  it('rejects a body missing required ids without generating', async () => {
+    const response = await POST(endingRequest({ endingType: 'story-complete' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain('sessionId');
+    expect(mockGenerateEnding).not.toHaveBeenCalled();
+  });
+
+  it('rejects an ending type outside the allowlist', async () => {
+    const response = await POST(
+      endingRequest({ ...VALID_BODY, endingType: 'player-gave-up' })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain('Invalid ending type');
+    expect(mockGenerateEnding).not.toHaveBeenCalled();
+  });
+
+  it('rejects a tone outside the allowlist', async () => {
+    const response = await POST(
+      endingRequest({ ...VALID_BODY, desiredTone: 'bittersweet' })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain('Invalid tone');
+  });
+
+  it('returns the generated ending on the happy path', async () => {
+    const response = await POST(endingRequest(VALID_BODY));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data.epilogue).toBe('The road ended at the sea.');
+  });
+
+  it('maps a provider failure to 503 rather than a generic 500', async () => {
+    mockGenerateEnding.mockRejectedValue(new Error('API request failed'));
+
+    const response = await POST(endingRequest(VALID_BODY));
+    const data = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(data.error).toBe('Model provider unavailable');
+  });
+
+  it('maps a missing resource to 404 and anything else to 500', async () => {
+    mockGenerateEnding.mockRejectedValue(new Error('session not found'));
+    const notFound = await POST(endingRequest(VALID_BODY));
+    expect(notFound.status).toBe(404);
+
+    mockGenerateEnding.mockRejectedValue(new Error('something else broke'));
+    const serverError = await POST(endingRequest(VALID_BODY));
+    expect(serverError.status).toBe(500);
+  });
+
+  it('refuses GET', async () => {
+    const response = await GET();
+    expect(response.status).toBe(405);
+  });
+});

--- a/src/app/api/narrative/generate/__tests__/route.test.ts
+++ b/src/app/api/narrative/generate/__tests__/route.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * The one route that streams, and the only place the produce side of the
+ * NDJSON contract meets the consume side in `clientGeminiClient`. Only the
+ * network is faked here: the real Gemini adapter builds the upstream body and
+ * parses every frame, and the route's own encoder turns those frames into the
+ * lines the browser reads.
+ */
+
+jest.mock('@/lib/telemetry/reportServerError');
+
+import { POST } from '../route';
+import {
+  buildAIRequest,
+  readNdjsonEvents,
+  sentUpstreamBody,
+  stubUpstreamStream,
+  stubUpstreamFailure,
+} from '../../../__tests__/routeHarness';
+import {
+  FLATTENED_METADATA_DUMP,
+  geminiStreamFrames,
+} from '../../../__tests__/fixtures/geminiPayloads';
+
+const originalFetch = global.fetch;
+
+function generateRequest(body: Record<string, unknown>) {
+  return buildAIRequest('/api/narrative/generate', body);
+}
+
+describe('/api/narrative/generate', () => {
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it('rejects a request with no prompt without reaching the provider', async () => {
+    const upstream = stubUpstreamStream([]);
+
+    const response = await POST(generateRequest({ config: {} }));
+
+    expect(response.status).toBe(400);
+    expect(upstream).not.toHaveBeenCalled();
+  });
+
+  it('rejects a request carrying no provider key', async () => {
+    const upstream = stubUpstreamStream([]);
+
+    const response = await POST(
+      buildAIRequest('/api/narrative/generate', { prompt: 'Continue.' }, { withoutKey: true })
+    );
+
+    expect(response.status).toBe(500);
+    expect(upstream).not.toHaveBeenCalled();
+  });
+
+  it('sends a Gemini-shaped body built by the real adapter', async () => {
+    const upstream = stubUpstreamStream(geminiStreamFrames(['{"content":"Hello"}']));
+
+    await POST(generateRequest({ prompt: 'Continue the scene.' }));
+
+    const [url] = upstream.mock.calls[0] as [string];
+    expect(url).toContain(':streamGenerateContent');
+    expect(url).toContain('alt=sse');
+
+    const body = sentUpstreamBody(upstream) as {
+      contents: Array<{ parts: Array<{ text: string }> }>;
+      generationConfig: { maxOutputTokens: number };
+      safetySettings: unknown[];
+    };
+    expect(body.contents[0].parts[0].text).toContain('Continue the scene.');
+    expect(body.safetySettings).toHaveLength(4);
+    // The route's own ceiling, not the shared 1024 default.
+    expect(body.generationConfig.maxOutputTokens).toBe(2048);
+  });
+
+  it('answers NDJSON the client consumer can read line by line', async () => {
+    stubUpstreamStream(
+      geminiStreamFrames(['{"content":"The bridge ', 'held.","type":"scene"}'])
+    );
+
+    const response = await POST(generateRequest({ prompt: 'Continue.' }));
+
+    expect(response.headers.get('Content-Type')).toContain('application/x-ndjson');
+
+    const events = await readNdjsonEvents(response);
+    const done = events.at(-1) as { done: boolean; content: string; finishReason: string };
+
+    expect(done.done).toBe(true);
+    expect(done.content).toBe('{"content":"The bridge held.","type":"scene"}');
+    expect(done.finishReason).toBe('STOP');
+
+    // The prose is revealed progressively rather than only at the end.
+    const revealed = events
+      .filter((event): event is { delta: string } => 'delta' in event)
+      .map((event) => event.delta)
+      .join('');
+    expect(revealed).toBe('The bridge held.');
+  });
+
+  it('carries a flattened metadata dump through to the parse layer intact', async () => {
+    stubUpstreamStream(geminiStreamFrames([FLATTENED_METADATA_DUMP]));
+
+    const response = await POST(generateRequest({ prompt: 'Continue.' }));
+    const events = await readNdjsonEvents(response);
+    const done = events.at(-1) as { content: string };
+
+    // The route must not mangle or truncate a response the parse layer knows
+    // how to recover prose from — its job is delivery, not interpretation.
+    expect(done.content).toBe(FLATTENED_METADATA_DUMP);
+  });
+
+  it('passes an upstream rate limit through as 429 without leaking the body', async () => {
+    stubUpstreamFailure(429, 'Too Many Requests');
+
+    const response = await POST(generateRequest({ prompt: 'Continue.' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(429);
+    expect(JSON.stringify(data)).not.toContain('upstream detail');
+  });
+});

--- a/src/app/api/narrative/summarize/__tests__/route.test.ts
+++ b/src/app/api/narrative/summarize/__tests__/route.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * The route's own job is everything that happens to the model's string after it
+ * arrives: stripping fences, trimming to the outermost braces, validating the
+ * structure, and falling back when none of that works. That logic is what these
+ * tests drive, so the client is faked above it — the provider path underneath is
+ * covered by the provider suites and apiHelpers' own tests.
+ */
+
+jest.mock('@/lib/ai/defaultGeminiClient');
+
+import { POST } from '../route';
+import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
+import { buildAIRequest } from '../../../__tests__/routeHarness';
+
+const mockCreateClient = createDefaultGeminiClient as jest.MockedFunction<
+  typeof createDefaultGeminiClient
+>;
+
+function respondWith(content: string) {
+  mockCreateClient.mockReturnValue({
+    generateContent: jest.fn().mockResolvedValue({ content }),
+  } as unknown as ReturnType<typeof createDefaultGeminiClient>);
+}
+
+function summarizeRequest(body: Record<string, unknown>) {
+  return buildAIRequest('/api/narrative/summarize', body);
+}
+
+const VALID_BODY = {
+  content: 'She crossed the bridge and the lantern went out behind her.',
+  type: 'scene',
+  instructions: 'Summarize this.',
+};
+
+describe('/api/narrative/summarize', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects a request with no content before calling the model', async () => {
+    respondWith('{}');
+
+    const response = await POST(summarizeRequest({ type: 'scene' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Content is required');
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  it('reads a summary out of a fenced json response', async () => {
+    respondWith(
+      '```json\n{"summary":"I crossed the bridge","entryType":"discovery","significance":"major"}\n```'
+    );
+
+    const response = await POST(summarizeRequest(VALID_BODY));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      // The route appends terminal punctuation when the model omits it.
+      summary: 'I crossed the bridge.',
+      entryType: 'discovery',
+      significance: 'major',
+    });
+  });
+
+  it('reads a summary out of a response wrapped in prose on both sides', async () => {
+    respondWith(
+      'Here is the JSON you asked for:\n{"summary":"The lantern went out.","entryType":"world_event","significance":"minor"}\nLet me know if you need more.'
+    );
+
+    const response = await POST(summarizeRequest(VALID_BODY));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.summary).toBe('The lantern went out.');
+    expect(data.entryType).toBe('world_event');
+  });
+
+  it('replaces an entryType and significance outside the taxonomy with defaults', async () => {
+    respondWith(
+      '{"summary":"Something happened.","entryType":"invented_category","significance":"catastrophic"}'
+    );
+
+    const response = await POST(summarizeRequest(VALID_BODY));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.entryType).toBe('character_event');
+    expect(data.significance).toBe('minor');
+  });
+
+  it('falls back to the raw text and the decision weight when the structure is incomplete', async () => {
+    respondWith('{"summary":"I crossed the bridge","entryType":"discovery"}');
+
+    const response = await POST(
+      summarizeRequest({ ...VALID_BODY, decisionWeight: 'critical' })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.entryType).toBe('character_event');
+    // The weight the caller declared, not the hardcoded floor.
+    expect(data.significance).toBe('critical');
+  });
+
+  it('returns 500 when the model produces nothing', async () => {
+    respondWith('');
+
+    const response = await POST(summarizeRequest(VALID_BODY));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe('Failed to generate summary');
+  });
+});

--- a/src/app/api/narrative/summarize/route.ts
+++ b/src/app/api/narrative/summarize/route.ts
@@ -140,11 +140,15 @@ Do not include any explanatory text, code fences, markdown, or additional prose.
         jsonContent = jsonContent.replace(/```\s*/, '').replace(/\s*```/, '');
       }
 
+      // Both offsets are read against the string as it stands at that moment.
+      // Taking lastBrace before the leading slice would leave it pointing past
+      // where the closing brace ended up, so trailing prose survived the trim
+      // and the parse below failed on a response that was recoverable.
       const firstBrace = jsonContent.indexOf('{');
-      const lastBrace = jsonContent.lastIndexOf('}');
       if (firstBrace > 0) {
         jsonContent = jsonContent.slice(firstBrace);
       }
+      const lastBrace = jsonContent.lastIndexOf('}');
       if (lastBrace >= 0 && lastBrace < jsonContent.length - 1) {
         jsonContent = jsonContent.slice(0, lastBrace + 1);
       }


### PR DESCRIPTION
## Description

Before this, no automated test had ever run `POST()` on a game-loop API route. 13 of 20 routes had no test at all, and the untested set was the game: narrative generation, choices, endings, summaries, world and character creation. Every green check on a PR was silent about whether the game still works.

Six routes now have route-level tests, at the seam each route actually uses.

`narrative/generate` and `narrative/choices` delegate to `apiHelpers`, so those tests fake **only the network**. The real Gemini adapter builds the upstream body and parses every frame, the SSE consumer runs, and the NDJSON encoder produces the exact lines `clientGeminiClient` reads back. The other four generate through a client factory, and their own untested logic is downstream of the model's string, so that client is faked and the string is what gets driven.

Two corrections to the issue as written, both from reading the code:

- The issue says to start with `generate` and `choices` for having "the most branching". They are 26 and 18 lines of pure delegation, and `apiHelpers.test.ts` already covers the wrapper. The untested branching was in `summarize` (217 lines) and `ending` (120), which is where this started instead.
- The issue lists the `@google/genai` manual mock as a blocker. The loop routes never import that SDK - they reach Gemini through the provider adapter and `fetch` - so it was a non-issue here. The real blocker for the other four routes was something else, filed as #2024.

## Related Issue

Closes #1995

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The one production change here is a fix for a bug a test found, and that test was written first and failed first. Coverage moves from 71.52% to 72.42% statements and 60.83% to 61.56% branches, with the ratchet raised to match.

## User Stories Addressed

Not applicable - this is test coverage for existing behavior.

## Flow Diagrams

Not applicable.

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

Not applicable - no UI in this change.

## Implementation Notes

**The summarize tests found a live defect, and it is fixed here.**

`summarize/route.ts` read `lastBrace` against the original response string, then applied that index *after* slicing off leading prose. The offsets had shifted, so trailing prose was never trimmed, `JSON.parse` threw, and the route fell through to a fallback that put the model's entire raw response into the journal as the summary - technical text where narrative prose belongs, the same family as #1965. The fix reads both offsets against the string as it stands at that moment. The test fails without it.

**On the fixtures.** They are hand-built from the contract the Gemini adapter parses and from payloads already asserted in the provider suites, and the file says so at the top. They are **not** captured from a live call, so they assert what we believe Gemini returns rather than what it does, and they cannot notice the provider changing shape. Capturing them against a real key is what #2023 is for. This was a deliberate call to avoid spending on a live key mid-PR, and it is the one place this change is weaker than the spec it was written to.

**Two findings filed rather than fixed here:**

- #2024 - `createDefaultGeminiClient` returns a mock whenever the test runner is active, so the real client-construction path cannot be executed by any test. A fourth layer removing the AI path from the suite, and the binding one for four of these six routes.
- #2025 - the test config ignores a worktree path that does not exist, so every run prints ~40 duplicate-mock warnings.

## Screenshots

Not applicable.

## Visual Baseline Changes

None. This PR does not touch `tests/visual/**-snapshots/**`.

## Code Review Summary (if applicable)

Not applicable.

## Chrome DevTools MCP Verification Summary (if applicable)

Not applicable - no browser-observable change.

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit not run - no dependency or auth surface changed here. Lint reports 0 errors (128 pre-existing warnings, none in files this PR touches).

## Testing Instructions

```bash
npm test -- src/app/api
```

93 tests across 13 suites, all green.

To see the summarize fix earn its place, revert `src/app/api/narrative/summarize/route.ts` to compute `lastBrace` before the leading slice and re-run - "reads a summary out of a response wrapped in prose on both sides" fails, and the received value is the model's whole raw response.

Full gate as run locally:

```bash
npm test
npm run type-check
npm run lint
npm run knip
npm run deps:validate
```

461 suites / 3340 tests pass, type-check and lint clean, knip and both dependency gates green.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed

No docs needed - this adds coverage for existing behavior rather than changing it. Accessibility is not applicable to API route tests.
