### PR TITLE
Put the test audit on every PR and fix the cases it really found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,14 @@ jobs:
       - name: Enforce a shrinking dependency baseline
         run: npm run deps:check
 
+      # Advisory, not a gate: every case it lists is a candidate for human
+      # review, and plenty are legitimately mock-shaped -- a callback prop or a
+      # redirect has no other observable output. Exits 0 and prints a worklist
+      # (same failure ergonomics as `docs:check-symbols` below). Wire it to a
+      # threshold only once the counts have settled.
+      - name: Audit test quality (advisory)
+        run: npm run audit:tests
+
   knip:
     name: Knip (unused code)
     runs-on: ubuntu-latest

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -68,8 +68,10 @@ const eslintConfig = [
   },
   {
     // Dead/low-value test detection. Scoped to real test files (not stories or
-    // dev tooling). warn keeps these out of the blocking CI gate as a first-pass
-    // introduction, matching the markup-hygiene rules above.
+    // dev tooling). These were introduced at warn to phase them in; the backlog
+    // they landed against is now empty, so they are errors and the count stays
+    // at zero. `npm run audit:tests` covers the judgment-call cases these rules
+    // cannot see.
     files: [
       "**/*.test.{js,mjs,jsx,ts,tsx}",
       "**/__tests__/**/*.{js,mjs,jsx,ts,tsx}",
@@ -78,18 +80,18 @@ const eslintConfig = [
     rules: {
       // A test with no expect() asserts nothing. Recognize custom assertion
       // helpers (assertChoicesVisible, etc.) so delegating tests aren't flagged.
-      "jest/expect-expect": ["warn", { assertFunctionNames: ["expect", "assert*"] }],
+      "jest/expect-expect": ["error", { assertFunctionNames: ["expect", "assert*"] }],
       // Indefinitely skipped / commented-out tests are dead weight.
-      "jest/no-disabled-tests": "warn",
-      "jest/no-commented-out-tests": "warn",
+      "jest/no-disabled-tests": "error",
+      "jest/no-commented-out-tests": "error",
       // Handing an element its own layout geometry means the test is reading
       // back numbers it wrote, not observing layout. jsdom has no layout engine,
       // so there's no repair for this in a unit test — the check belongs in
       // Playwright. See public_docs/development/visual-testing-best-practices.md,
       // "Two tiers of layout assertion".
       //
-      // error rather than the warn the rules above use: those landed against an
-      // existing backlog and needed phasing in. This one starts at zero.
+      // This one started at zero rather than being phased in like the rules
+      // above, which had a backlog to clear first.
       "no-restricted-syntax": ["error",
         {
           selector: "CallExpression[callee.object.name='Object'][callee.property.name='defineProperty'] > Literal.arguments:matches([value='scrollHeight'], [value='clientHeight'], [value='scrollTop'], [value='getBoundingClientRect'], [value='offsetHeight'], [value='offsetTop'])",

--- a/scripts/audit-tests.mjs
+++ b/scripts/audit-tests.mjs
@@ -99,7 +99,13 @@ const IN_DOCUMENT = /\.(toBeInTheDocument|toBeVisible)\b/;
 const DEFINED_ONLY = /expect\s*\([^)]*\)\s*\.\s*(toBeDefined|toBeTruthy)\s*\(\s*\)/;
 const RENDER = /\brender\s*\(/;
 
-// Names that promise more than a mock assertion can deliver.
+// Names that promise more than a mock assertion can deliver. Matched against the
+// case NAME only, never the file path: this bucket exists to catch a name that
+// claims behavior the body never observes, and a path match flags whole files
+// whose names claim nothing -- storePubSub.test.ts on "store", LoadingOverlay on
+// "load", WorldListScreen.integration on "integrat". Seven of the twenty this
+// once reported were path artifacts, which is enough noise to make the bucket
+// unreadable.
 const PROMISE_WORDS =
   /\b(persist|persists|persisted|persistence|save|saves|saved|store[sd]?|restore[sd]?|load[sd]?|integrat|sync|write[sn]?|read[sn]?|hydrat)/i;
 
@@ -257,7 +263,7 @@ function scanFile(file) {
     if (expects.every((l) => MOCK_MATCHER.test(l))) {
       const entry = { at, name, assertions: expects.length };
       findings.mockOnly.push(entry);
-      if (PROMISE_WORDS.test(name) || PROMISE_WORDS.test(rel)) {
+      if (PROMISE_WORDS.test(name)) {
         findings.mockOnlyNameMismatch.push(entry);
       }
       return;

--- a/src/lib/narrative/__tests__/turnResolver.test.ts
+++ b/src/lib/narrative/__tests__/turnResolver.test.ts
@@ -539,6 +539,13 @@ describe('TurnResolver', () => {
     });
 
     it('processes acquired items synchronously in the turn pipeline', async () => {
+      // The payload check alone would pass just as happily against a
+      // void-fired call, which is the shape narrativeGenerator deliberately
+      // uses elsewhere. Hold the processor open and prove the turn waits.
+      const acquisitionDeferred = deferred<[]>();
+      (processAcquiredItems as jest.Mock).mockReturnValue(
+        acquisitionDeferred.promise
+      );
       const result = makeGenerationResult({
         metadata: {
           characterIds: [],
@@ -549,8 +556,9 @@ describe('TurnResolver', () => {
       const generator = makeMockGenerator(result);
       const command = makeCommand();
 
-      await resolveTurn(command, generator);
+      const turnPromise = resolveTurn(command, generator);
 
+      await new Promise((r) => setTimeout(r, 0));
       expect(processAcquiredItems).toHaveBeenCalledWith(
         [{ name: 'Iron sword' }],
         'char-1',
@@ -558,9 +566,22 @@ describe('TurnResolver', () => {
         expect.any(Function),
         expect.any(String)
       );
+
+      let settled = false;
+      turnPromise.then(() => {
+        settled = true;
+      });
+      await new Promise((r) => setTimeout(r, 0));
+      expect(settled).toBe(false);
+
+      acquisitionDeferred.resolve([]);
+      const resolved = await turnPromise;
+      expect(resolved.segment).toBeDefined();
     });
 
     it('processes lost items synchronously in the turn pipeline', async () => {
+      const lossDeferred = deferred<void>();
+      (processLostItems as jest.Mock).mockReturnValue(lossDeferred.promise);
       const result = makeGenerationResult({
         metadata: {
           characterIds: [],
@@ -571,17 +592,31 @@ describe('TurnResolver', () => {
       const generator = makeMockGenerator(result);
       const command = makeCommand();
 
-      await resolveTurn(command, generator);
+      const turnPromise = resolveTurn(command, generator);
 
+      await new Promise((r) => setTimeout(r, 0));
       expect(processLostItems).toHaveBeenCalledWith(
         [{ name: 'Healing potion' }],
         'char-1',
         'session-1',
         expect.any(Function)
       );
+
+      let settled = false;
+      turnPromise.then(() => {
+        settled = true;
+      });
+      await new Promise((r) => setTimeout(r, 0));
+      expect(settled).toBe(false);
+
+      lossDeferred.resolve();
+      const resolved = await turnPromise;
+      expect(resolved.segment).toBeDefined();
     });
 
-    it('calls syncNpcMetadata', async () => {
+    // Fire-and-forget by design in the resolver, so the call itself is the whole
+    // guarantee. Nothing later in the turn waits on it.
+    it('hands the segment NPC roster to the world during the turn', async () => {
       const result = makeGenerationResult({
         metadata: {
           characterIds: [],


### PR DESCRIPTION
## Description

The repo already had a tool that finds hollow tests (`scripts/audit-tests.mjs`). Nothing ever ran it, so its findings sat unread since the September adversarial audit. This puts it on every PR, fixes the cases it genuinely found, and starts the lint ratchet that would stop the next one landing.

Three changes:

**1. Advisory CI step.** `npm run audit:tests` runs in the `lint` job. The script exits 0 by construction, so the counts land in the log on every PR without becoming a gate. It mirrors the `docs:check-symbols` precedent in the `docs` job.

**2. The name-mismatch bucket now matches the case name only, never the file path.** This is the part worth reading closely. Seven of the twenty cases the issue asked me to rewrite were flagged on their *filename*: `storePubSub` matched `store`, `LoadingOverlay` matched `load`, `WorldListScreen.integration` matched `integrat`. The bucket's own stated contract is "the name promises behavior the body never observes", so judging it by path was a bug against its purpose. A strongest-signal list that is 35% noise on day one gets ignored, and the whole point of step 1 is that someone reads the number.

**3. Two real fixes in `turnResolver.test.ts`.** The item tests claimed the processors run "synchronously in the turn pipeline" while asserting only `toHaveBeenCalledWith`, which passes identically against a `void`-fired call. That is exactly the shape `narrativeGenerator.ts` uses deliberately at lines 349/365, so the name was making a promise the body could not keep. Both now hold the processor's promise open and prove the turn waits, using the `deferred()` pattern that already sits two tests above them.

**What I did not do:** rewrite the other seventeen. I read all twenty. Beyond the seven path artifacts, eleven are tests where the mock *is* the observable output: callback props (`onSave`, `onCancel`, `onRestore`, `onChange`), a redirect page whose only output is `router.replace`, `autoSaveService`'s `onSave` spying the real service's output channel, and `useAutoSave:166`, which already carries a comment saying exactly this. `narrativeGenerator.skillContext:151` likewise already asserts pending-then-settles ordering and the exact payload. Rewriting those makes them worse, so the triage is recorded on the issue rather than done.

The third turnResolver case, `calls syncNpcMetadata`, is fire-and-forget by design in the resolver, so the call check is the right assertion and only the name was wrong. Renamed, body untouched.

Counts: mismatch bucket 20 -> 13 from the heuristic fix, then 13 -> 10 once the two rewrites gained real assertions and left the mock-only set. Mock-only total 298 -> 296 for the same reason. Tier 1 stays at 0, which it was before and is the genuinely good news here.

## Related Issue

Closes #1997

Parent epic: #2005

Note for whoever reads the issue body: its line references for the turnResolver cases (386/408/429) had drifted. The cases were at 541/563/584.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The order here was inverted by the nature of the work: the tests *are* the change. What stands in for red-green is the mutation check. I removed the `await` from `processAcquiredItems` and `processLostItems` in `src/lib/narrative/turnResolver.ts`, confirmed both rewritten cases went red, and restored the source:

```
✕ processes acquired items synchronously in the turn pipeline
✕ processes lost items synchronously in the turn pipeline
✕ awaits lore extraction when SETTLED_COMMITMENT_CHOICES is enabled and passes acquired items
Tests: 3 failed, 42 passed, 45 total
```

The old versions of those two cases stayed green under the same mutation. That is the whole argument for the rewrite.

One honest gap: the `scripts/audit-tests.mjs` change has no unit test. The repo's convention for script tests (`scripts/__tests__/`) is to import pure functions from a `.js` lib, and Jest treats `.mjs` as ESM regardless of the transform config, so testing it needs `--experimental-vm-modules` or splitting the script into an entrypoint and a lib. Both are larger than this issue. The change is a single boolean expression, verified by running the script: 20 -> 13, with the three path-artifact files gone from the list.

## User Stories Addressed

Not applicable. Internal tooling and test quality.

## Flow Diagrams

Not applicable.

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

Not applicable. No UI in this change.

## Implementation Notes

The `deferred()` helper and the microtask-flush idiom were not invented here. They are copied from `blocks until world clock updates resolve` and `blocks until world state thread updates resolve` in the same file, which is why the timing is not a flake risk.

On the ESLint flip: `jest/expect-expect`, `jest/no-disabled-tests` and `jest/no-commented-out-tests` go from `warn` to `error`. I checked before flipping — the run has 124 warnings, 123 of them `@typescript-eslint/no-explicit-any` plus one `react-hooks/exhaustive-deps`, and zero from the jest rules. So the flip costs nothing today and stops the first regression rather than the hundredth. `--max-warnings 0` was the alternative and it is not viable: it would fail CI on the 123 pre-existing `any` warnings. `eslint.config.mjs` already documented this exact reasoning for its `no-restricted-syntax` block; I updated both comments so neither describes the old state.

Deliberately left for later: whether the mock-only count (296) becomes a ratchet. The issue is right that it is a judgment call worth making once the number is visible, and it is not visible yet.

## Screenshots

Not applicable.

## Visual Baseline Changes

None. This PR does not touch `tests/visual/**-snapshots/**`.

## Code Review Summary (if applicable)

Ran `narraitor-pattern-alignment-skill` over the diff. It flagged the missing test for the script change, which is what sent me down the `.mjs`/Jest-ESM path documented under TDD Compliance above. Nothing else.

## Chrome DevTools MCP Verification Summary (if applicable)

Not applicable. No browser-facing change.

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit not run: this change touches CI config, lint config, one script's regex, and one test file. No dependency or runtime surface moved.

```
npm run lint         exit 0   (124 warnings, 0 errors, 0 from the jest rules)
npm run type-check   exit 0
npm run knip         exit 0
npm run test:ci      exit 0   (463 suites, 3359 tests, all passed)
npm run audit:tests  exit 0   (0 tier-1, 296 mock-only, 10 mismatched, 44 render checks)
```

Visual regression and E2E were not run. Neither is reachable from a change to CI config, lint rules, a Node script, or a unit test.

## Testing Instructions

```bash
npm run audit:tests
```

Expect `0 tier-1, 296 mock-only (10 with a mismatched name), 44 single-assertion render checks`, and no `storePubSub` / `LoadingOverlay` / `WorldListScreen.integration` entries in the mismatch list.

```bash
npm test -- src/lib/narrative/__tests__/turnResolver.test.ts
```

45 pass. Then the check that actually matters: comment out the `await` on `processAcquiredItems` at `src/lib/narrative/turnResolver.ts:778`, re-run, watch `processes acquired items synchronously in the turn pipeline` go red, and restore.

```bash
npm run lint && npm run type-check
```

Both exit 0. On CI, confirm the new "Audit test quality (advisory)" step in the `lint` job printed its counts. It cannot fail, so a green tick is not the thing to look at.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed

Documentation: nothing to update. The reasoning that would have gone in a doc lives in the comments above `PROMISE_WORDS` and the CI step, next to the code it explains. Accessibility: not applicable, no UI.
