### PR TITLE
Make the skill-choices test watch the skill gating it names (#1997)

### DIFF
--- a/src/lib/ai/__tests__/narrativeGenerator.skillChoices.test.ts
+++ b/src/lib/ai/__tests__/narrativeGenerator.skillChoices.test.ts
@@ -1,47 +1,32 @@
 /**
- * Tests for skill-based choice generation
- * Verifies that choices can have skill requirements
+ * Skill-gated choices have to survive the trip back through
+ * generatePlayerChoices. The method is a pass-through to the choice generator,
+ * and its catch path deliberately substitutes generic options carrying no skill
+ * requirements (asserted in narrativeGenerator.choices.test.ts). This file
+ * guards the other half: on the success path the requirements the choice
+ * generator produced reach the caller untouched, because ChoiceSelector and
+ * RequirementBadges render them and gate selection on them.
+ *
+ * Whether character skills reach the prompt at all is the choice generator's
+ * own contract, covered in choiceGenerator.skillBased.test.ts.
  */
 
-// Mock stores at module level (before imports)
-jest.mock('@/state/worldStore');
-jest.mock('@/state/characterStore');
 jest.mock('../choiceGenerator');
 
 import { NarrativeGenerator } from '../narrativeGenerator';
 import { NarrativeContext } from '@/types/narrative.types';
-import { createMockAIClient, createMockWorldWithSkills, createMockCharacterWithSkills } from './narrativeGenerator.skill.testHelpers';
-import { useWorldStore } from '@/state/worldStore';
-import { useCharacterStore } from '@/state/characterStore';
+import { createMockAIClient } from './narrativeGenerator.skill.testHelpers';
 import { generateChoices } from '../choiceGenerator';
-import { createMockWorldStore, createMockCharacterStore } from '@/lib/test-utils/mockStoreFactories';
 
 describe('NarrativeGenerator - Skill-Based Choices', () => {
   let narrativeGenerator: NarrativeGenerator;
-  let mockAIClient: ReturnType<typeof createMockAIClient>;
 
   beforeEach(() => {
     jest.clearAllMocks();
-
-    // Setup store mocks
-    const mockWorld = createMockWorldWithSkills();
-    const mockCharacter = createMockCharacterWithSkills();
-
-    (useWorldStore.getState as jest.Mock).mockReturnValue(createMockWorldStore({
-      worlds: { 'skill-world': mockWorld },
-      currentWorldId: 'skill-world'
-    }));
-
-    (useCharacterStore.getState as jest.Mock).mockReturnValue(createMockCharacterStore({
-      characters: { 'char-1': mockCharacter }
-    }));
-
-    mockAIClient = createMockAIClient();
-    narrativeGenerator = new NarrativeGenerator(mockAIClient);
+    narrativeGenerator = new NarrativeGenerator(createMockAIClient());
   });
 
-  test('should pass character skills to choice generator', async () => {
-    // Spy on the context passed to the choice generator
+  test('returns each option with the skill requirements the choice generator set on it', async () => {
     (generateChoices as jest.Mock).mockResolvedValue({
       id: 'decision-with-skills',
       prompt: 'What approach will you take?',
@@ -49,21 +34,19 @@ describe('NarrativeGenerator - Skill-Based Choices', () => {
         {
           id: 'opt-1',
           text: 'Climb the wall',
-          requirements: [{ type: 'skill' as const, targetId: 'athletics', operator: 'gte' as const, value: 5 }],
-          hint: 'Requires athletic ability'
+          requirements: [
+            { type: 'skill', targetId: 'athletics', operator: 'gte', value: 5 },
+          ],
         },
         {
           id: 'opt-2',
           text: 'Cast a levitation spell',
-          requirements: [{ type: 'skill' as const, targetId: 'magic', operator: 'gte' as const, value: 4 }],
-          hint: 'Requires magical knowledge'
+          requirements: [
+            { type: 'skill', targetId: 'magic', operator: 'gte', value: 4 },
+          ],
         },
-        {
-          id: 'opt-3',
-          text: 'Look for another way',
-          alignment: 'neutral' as const
-        }
-      ]
+        { id: 'opt-3', text: 'Look for another way', alignment: 'neutral' },
+      ],
     });
 
     const narrativeContext: NarrativeContext = {
@@ -74,26 +57,32 @@ describe('NarrativeGenerator - Skill-Based Choices', () => {
       previousSegments: [],
       currentTags: ['obstacle'],
       currentLocation: 'High Wall',
-      currentSituation: 'Facing a tall obstacle'
+      currentSituation: 'Facing a tall obstacle',
     };
 
-    await narrativeGenerator.generatePlayerChoices(
+    const decision = await narrativeGenerator.generatePlayerChoices(
       'skill-world',
       narrativeContext,
       ['char-1']
     );
 
-    // Verify the choice generator was called with the client and correct parameters
-    expect(generateChoices).toHaveBeenCalledWith(mockAIClient, {
-      worldId: 'skill-world',
-      narrativeContext,
-      characterIds: ['char-1'],
-      sessionId: 'session-1', // Now includes sessionId from narrativeContext
-      minOptions: 3,
-      maxOptions: 3,
-      useAlignedChoices: true
-    });
-
-    // Verify the choice generator was called - the choices themselves are tested in choiceGenerator tests
+    expect(decision.options).toEqual([
+      expect.objectContaining({
+        id: 'opt-1',
+        requirements: [
+          { type: 'skill', targetId: 'athletics', operator: 'gte', value: 5 },
+        ],
+      }),
+      expect.objectContaining({
+        id: 'opt-2',
+        requirements: [
+          { type: 'skill', targetId: 'magic', operator: 'gte', value: 4 },
+        ],
+      }),
+      expect.objectContaining({ id: 'opt-3' }),
+    ]);
+    // The ungated option stays ungated: a requirement invented on the way out
+    // would lock a choice the generator meant to leave open.
+    expect(decision.options[2].requirements).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Description

Closes out the last open finding on #1997. The `narrativeGenerator.skillChoices.test.ts` case named "should pass character skills to choice generator" built a 60-line decision payload full of skill requirements, then asserted only the arguments handed to `generateChoices` — an assertion `narrativeGenerator.choices.test.ts:88-96` already makes verbatim. The payload was never read. The world/character store mocks feeding it were dead too: `generatePlayerChoices` never touches either store.

It now watches what the file is named for. Skill requirements the choice generator sets have to reach the caller intact, because `ChoiceSelector` and `RequirementBadges` gate selection on them, and the method's catch path deliberately substitutes ungated generic options. The test asserts the returned options carry their requirements, and that the ungated option stays ungated.

The other open finding, `CharacterCreationWizard.recovery.test.tsx`, is not changed here — see Implementation Notes.

## Related Issue

Addresses the remaining unchecked findings on #1997. Not using a closing keyword: whether the mock-only count becomes a CI ratchet is still the open judgment call the issue deliberately parks, and `scripts/audit-tests.mjs` still has no unit test (Jest treats `.mjs` as ESM; that wants its own issue). Both are called out in the issue's own triage as left open on purpose.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

No production code changed, so there was nothing to write a test ahead of. The inverse discipline applies instead and is evidenced below: the rewritten assertion was proven to go red against a deliberately broken `generatePlayerChoices`, and the version it replaces was proven to stay green against the same break.

## User Stories Addressed

None directly. This is test-suite hygiene — no player-facing behavior moves.

## Flow Diagrams

Not applicable.

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

Not applicable. No component or style touched.

## Implementation Notes

### Audit counts, before and after

Run on the clean base (34484d8f0) and again after the change:

| | before | after |
|---|---|---|
| tier 1 | 0 | 0 |
| mock-only | 296 | 295 |
| of those, name mismatched | 10 | 10 |
| single-assertion render checks | 44 | 44 |

The rewritten case left the mock-only bucket entirely, because its assertions are no longer call-checks. It was never in the mismatch bucket — the heuristic did not flag it, the 2026-09-01 audit did, by hand.

### Red-then-green evidence

The behavior under test is that `generatePlayerChoices` returns the choice generator's options with their requirements intact. Temporarily broke exactly that in `src/lib/ai/narrativeGenerator.ts`, stripping `requirements` off each option on the way out:

```
return { ...result, options: result.options.map(({ requirements: _r, ...rest }) => rest) };
```

- New test against the break: **FAILED**, exit 1. `returns each option with the skill requirements the choice generator set on it`
- Old test against the same break: **PASSED**, exit 0. `should pass character skills to choice generator`
- New test against the restored source: **PASSED**, exit 0

The old case could not see the guarantee its own name claimed. That is the whole finding, and the reason a rename alone would not have been enough here.

`narrativeGenerator.ts` is byte-identical to the base — the break was reverted from a backup and the diff confirms only the test file changed.

### The 10 cases the audit still reports, and why they stay

All ten were assessed against their bodies rather than their names, and all ten hold. The issue's triage comment already reasoned through each; that reasoning was re-checked against the code at this head and stands, so it is honored rather than relitigated:

| case | why the call-check is the observation |
|---|---|
| `page.test.tsx:65` | redirect page — `router.replace` is the only output it has |
| `portrait.test.tsx:230` | race test; "ignores" is a negative call check by definition |
| `GameSessionRecoveryPrompt.test.tsx:45` | `onRestore` is the component's entire contract to its parent |
| `ProviderAdvancedSettings.test.tsx:94` | asserts `onChange` fires *without* the bad value — rejection has no other signal |
| `SkillEditor.test.tsx:279` | `onSave` is the save |
| `SkillEditor.test.tsx:315` | names the calls it checks; nothing overclaimed |
| `useAutoSave.test.ts:166` | already carries a comment saying exactly this, and points at the real coverage |
| `narrativeGenerator.skillContext.test.ts:151` | asserts ordering *and* payload; stronger than the bucket implies |
| `autoSaveService.test.ts:39,67` | `onSave` spies the **real** service's output channel, not a collaborator |

The pattern is the heuristic matching promise words — save, route, restore, load — inside names that are accurate. That is the detector being conservative, not tests lying. Left the heuristic alone deliberately: loosening it risks blinding the detector, and `audit-tests.mjs` cannot be unit tested today, so a change there would ship unproven.

`CharacterCreationWizard.recovery.test.tsx` is likewise unchanged. Asserting `pauseTour`/`resumeTour` fired **is** the contract under test — the tutorial pause is not observable any other way from that component, and the nine mocks are not hiding a better observation. Assessed and rejected as a finding.

### Deliberately out of scope

- No CI ratchet on the mock-only count. The issue parks that as a judgment call to make with the number on screen, which the advisory step now provides.
- No `--max-warnings 0`. Still not viable while 123 `no-explicit-any` warnings stand.
- No tests for `scripts/audit-tests.mjs`. Jest treats `.mjs` as ESM regardless of the transform config; covering it needs `--experimental-vm-modules` or an entrypoint/lib split, and that is its own issue.

## Screenshots

Not applicable.

## Visual Baseline Changes

None. This PR does not touch `tests/visual/**-snapshots/**`.

## Code Review Summary (if applicable)

Not applicable.

## Chrome DevTools MCP Verification Summary (if applicable)

Not applicable.

## Quality Checks

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

`npm run lint` exits 0 with 124 warnings, all pre-existing (123 `no-explicit-any`, one `react-hooks/exhaustive-deps`) — unchanged by this PR. Security audit not run locally; CI covers it.

## Testing Instructions

Run, in the worktree:

- `npm run audit:tests` — expect `0 tier-1, 295 mock-only (10 with a mismatched name), 44 single-assertion render checks`
- `npm test -- src/lib/ai/__tests__/narrativeGenerator.skillChoices.test.ts`
- `npm run type-check`, `npm run lint`, `npm run knip`

To reproduce the red proof, strip `requirements` off each option in the return of `generatePlayerChoices` (`src/lib/ai/narrativeGenerator.ts:830`) and re-run the file — it fails. Restore and it passes.

Full local run: 463 suites / 3359 tests passing. Visual and E2E suites skipped — they are macOS-baseline-bound and nothing here touches rendering.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed

Docs and accessibility both N/A — one test file changed, no user-facing surface.
