### PR TITLE
Let an explicit keyed descriptor beat the test-runner branch in createDefaultGeminiClient

### DIFF
--- a/src/lib/ai/__tests__/defaultGeminiClient.test.ts
+++ b/src/lib/ai/__tests__/defaultGeminiClient.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * The factory used to return the mock for anything at all once the test runner
+ * was active, which made its real branches — the descriptor dispatch and
+ * `toDescriptor` — impossible to reach from a test. Now an explicitly-passed
+ * descriptor that actually carries a key wins over that branch, and everything
+ * else keeps the mock.
+ *
+ * Node environment on purpose: this factory is server-side, and jsdom would hit
+ * the browser-proxy branch instead.
+ */
+
+import { createDefaultGeminiClient, toDescriptor } from '../defaultGeminiClient';
+import { GeminiClient } from '../geminiClient';
+import { OpenAICompatibleClient } from '../providers/openai-compatible/client';
+import { DEFAULT_TEXT_MODEL } from '../config';
+import type { ProviderDescriptor } from '../providers/types';
+
+const geminiDescriptor: ProviderDescriptor = {
+  type: 'gemini',
+  endpoint: '',
+  model: 'gemini-2.5-flash',
+  apiKey: 'player-supplied-key',
+};
+
+const openAiDescriptor: ProviderDescriptor = {
+  type: 'openai-compatible',
+  endpoint: 'https://openrouter.ai/api/v1/chat/completions',
+  model: 'anthropic/claude-3.5-sonnet',
+  apiKey: 'player-supplied-key',
+};
+
+describe('createDefaultGeminiClient', () => {
+  const originalEnvKey = process.env.GEMINI_API_KEY;
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    process.env.GEMINI_API_KEY = originalEnvKey;
+  });
+
+  describe('an explicit descriptor with a key reaches the real factory', () => {
+    it('builds a GeminiClient for a gemini descriptor, without any network call', () => {
+      const client = createDefaultGeminiClient(geminiDescriptor);
+
+      expect(client).toBeInstanceOf(GeminiClient);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('builds an OpenAICompatibleClient for an openai-compatible descriptor, without any network call', () => {
+      const client = createDefaultGeminiClient(openAiDescriptor);
+
+      expect(client).toBeInstanceOf(OpenAICompatibleClient);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('everything else still gets the mock', () => {
+    it('returns the mock when no credential is passed', () => {
+      expect(createDefaultGeminiClient().constructor.name).toBe('MockGeminiClient');
+    });
+
+    it('returns the mock for an explicit null credential', () => {
+      expect(createDefaultGeminiClient(null).constructor.name).toBe('MockGeminiClient');
+    });
+
+    it('returns the mock for a descriptor with no apiKey', () => {
+      const keyless: ProviderDescriptor = { ...geminiDescriptor, apiKey: null };
+
+      expect(createDefaultGeminiClient(keyless).constructor.name).toBe('MockGeminiClient');
+    });
+
+    it('returns the mock for a descriptor with an empty apiKey', () => {
+      const empty: ProviderDescriptor = { ...geminiDescriptor, apiKey: '' };
+
+      expect(createDefaultGeminiClient(empty).constructor.name).toBe('MockGeminiClient');
+    });
+
+    it('returns the mock for a bare string key', () => {
+      expect(createDefaultGeminiClient('a-bare-gemini-key').constructor.name).toBe(
+        'MockGeminiClient'
+      );
+    });
+
+    it('returns the mock when the env key is the MOCK_API_KEY sentinel', () => {
+      process.env.GEMINI_API_KEY = 'MOCK_API_KEY';
+
+      expect(createDefaultGeminiClient().constructor.name).toBe('MockGeminiClient');
+    });
+
+    it('returns the mock even when a real env key is configured', () => {
+      process.env.GEMINI_API_KEY = 'a-real-looking-env-key';
+
+      expect(createDefaultGeminiClient().constructor.name).toBe('MockGeminiClient');
+    });
+
+    it('makes no network call on any of those', () => {
+      createDefaultGeminiClient();
+      createDefaultGeminiClient(null);
+      createDefaultGeminiClient('a-bare-gemini-key');
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('toDescriptor', () => {
+  const originalEnvKey = process.env.GEMINI_API_KEY;
+
+  afterEach(() => {
+    process.env.GEMINI_API_KEY = originalEnvKey;
+  });
+
+  it('passes an object credential through when it carries a key', () => {
+    expect(toDescriptor(geminiDescriptor)).toBe(geminiDescriptor);
+  });
+
+  it('rejects an object credential with no key', () => {
+    expect(toDescriptor({ ...geminiDescriptor, apiKey: null })).toBeNull();
+  });
+
+  it('falls back to the env key when the credential is omitted', () => {
+    process.env.GEMINI_API_KEY = 'a-real-looking-env-key';
+
+    expect(toDescriptor()).toEqual({
+      type: 'gemini',
+      endpoint: '',
+      model: DEFAULT_TEXT_MODEL,
+      apiKey: 'a-real-looking-env-key',
+    });
+  });
+
+  it('does not fall back to the env key for an explicit null', () => {
+    process.env.GEMINI_API_KEY = 'a-real-looking-env-key';
+
+    expect(toDescriptor(null)).toBeNull();
+  });
+
+  it('treats the MOCK_API_KEY sentinel as no env key at all', () => {
+    process.env.GEMINI_API_KEY = 'MOCK_API_KEY';
+
+    expect(toDescriptor()).toBeNull();
+  });
+
+  it('wraps a bare string key, honouring the model override', () => {
+    expect(toDescriptor('a-bare-gemini-key', 'gemini-2.5-pro')).toEqual({
+      type: 'gemini',
+      endpoint: '',
+      model: 'gemini-2.5-pro',
+      apiKey: 'a-bare-gemini-key',
+    });
+  });
+});

--- a/src/lib/ai/defaultGeminiClient.ts
+++ b/src/lib/ai/defaultGeminiClient.ts
@@ -7,15 +7,25 @@ import type { ProviderCredential, ProviderDescriptor } from './providers/types';
  * Creates the AI client for server-side generation.
  *
  * Environment-aware client selection:
- * - Test environment: Uses mock from __mocks__
+ * - Test environment, unless handed a descriptor that carries a key: mock from __mocks__
  * - Browser (client-side): Uses secure proxy
  * - Server-side with a credential: the client for the configured provider
  * - Server-side without one: Uses mock (for local development)
  *
- * The environment branches are unchanged; what is new is that the final branch
- * dispatches on *configuration* rather than assuming Gemini. Pass
- * a descriptor from `resolveProvider` and a player on any supported provider
- * gets that provider; pass a bare key and it behaves exactly as it always did.
+ * The final branch dispatches on *configuration* rather than assuming Gemini.
+ * Pass a descriptor from `resolveProvider` and a player on any supported
+ * provider gets that provider; pass a bare key and it behaves exactly as it
+ * always did.
+ *
+ * The test branch is a safety net against an unmocked test making a real
+ * network call, so it stays — but it no longer swallows *everything*, because
+ * that made the descriptor dispatch below it unreachable by any test that could
+ * be written. A caller that hands over a descriptor object with a real key has
+ * said what it wants unambiguously, and that wins. Nothing else does: no
+ * argument, an explicit null, a keyless descriptor and a bare string key all
+ * still get the mock, and the server env key under the unit suite is the
+ * MOCK_API_KEY sentinel that `toDescriptor` reads as no key at all. So a test
+ * only reaches a real client by deliberately constructing one.
  *
  * @param credential - the resolved provider descriptor for this request, or a
  *   bare Gemini key for the Gemini-only callers (the image routes).
@@ -26,8 +36,15 @@ export const createDefaultGeminiClient = (
   credential?: ProviderCredential | null,
   modelOverride?: string | null
 ): AIClient => {
-  // In test environment, Jest will automatically use the mock from __mocks__/geminiClient.mock.ts
-  if (process.env.NODE_ENV === 'test' || process.env.JEST_WORKER_ID) {
+  // In test environment, Jest will automatically use the mock from
+  // __mocks__/geminiClient.mock.ts — unless the caller passed a descriptor
+  // carrying a real key, which is a deliberate request for the real thing.
+  const underTestRunner =
+    process.env.NODE_ENV === 'test' || Boolean(process.env.JEST_WORKER_ID);
+  const explicitlyKeyedDescriptor =
+    typeof credential === 'object' && credential !== null && Boolean(credential.apiKey);
+
+  if (underTestRunner && !explicitlyKeyedDescriptor) {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { MockGeminiClient } = require('./__mocks__/geminiClient.mock');
     return new MockGeminiClient();
@@ -61,8 +78,11 @@ export const createDefaultGeminiClient = (
  * keeps local development working with nothing configured. An explicit null
  * does not: that is a request that resolved no Gemini key, and a player on
  * another provider produces it on every turn.
+ *
+ * Exported for its own tests: the two absent forms above behave differently and
+ * nothing else in the factory's surface can tell them apart.
  */
-function toDescriptor(
+export function toDescriptor(
   credential?: ProviderCredential | null,
   modelOverride?: string | null
 ): ProviderDescriptor | null {


### PR DESCRIPTION
## Description

`createDefaultGeminiClient` opened by checking for the test runner and returning `MockGeminiClient` whenever it found one. Everything below that check — the browser proxy branch, the descriptor-driven provider dispatch, the no-key fallback, and `toDescriptor` — was unreachable from any test that could be written. For the four game-loop routes that build their client through this factory, that was the binding reason the real client-construction path had no coverage.

The branch is also the safety net that stops an unmocked test making a real network call, so removing it would have been the wrong fix. Instead it now yields to one specific case: an explicitly-passed descriptor object carrying a real `apiKey`. That is a caller saying unambiguously what it wants. Everything else still gets the mock.

## Related Issue

Closes #2024

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance

- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

`src/lib/ai/__tests__/defaultGeminiClient.test.ts` went in first and failed, then the source change turned it green. Evidence in Implementation Notes.

## User Stories Addressed

None directly. This is test-confidence work under the #2005 epic — it makes a provider-selection defect (wrong branch taken, descriptor built wrong, key not carried) catchable by a test, which it was not before.

## Flow Diagrams

Not applicable.

## Component Development

- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

Not applicable — no UI in this change.

## Implementation Notes

### The exact new ordering

`createDefaultGeminiClient` now computes two flags up front and gates only the first branch on them:

```
underTestRunner        = NODE_ENV === 'test' || Boolean(JEST_WORKER_ID)
explicitlyKeyedDescriptor = typeof credential === 'object' && credential !== null && Boolean(credential.apiKey)

1. underTestRunner && !explicitlyKeyedDescriptor  -> MockGeminiClient
2. typeof window !== 'undefined'                  -> ClientGeminiClient
3. toDescriptor(credential, modelOverride) truthy -> createProviderClient(descriptor)   [lazy require kept]
4. otherwise                                      -> MockGeminiClient
```

Branches 2, 3 and 4 are untouched, including the lazy `require('./providers/factory')` and its comment. `resolveProvider` is untouched. The BYO-key architecture is untouched — the key still arrives per request in `x-provider-api-key`, and there is no server-held key store.

The browser branch still wins over the descriptor branch, so under jsdom an explicit descriptor gets `ClientGeminiClient`, exactly as in production. The new test file is `@jest-environment node`, which is the honest environment for a server-side factory.

`toDescriptor` is now exported. That is deliberate: an omitted credential falls back to the server env key and an explicit `null` does not, and nothing on the factory's public surface can tell those two apart — both return the mock. The comment on the function says why the distinction matters; now a test says it too.

### Full-suite before and after

| | Suites | Tests | Result |
|---|---|---|---|
| Base (`34484d8f0`, clean) | 463 | 3359 | all pass |
| After | 464 | 3375 | all pass |

+1 suite, +16 tests, zero pre-existing failures on either side and nothing newly broken. Wall time is unchanged: two warm post-change runs came in at 15.5s and 15.3s against a 19.6s baseline reading, so nothing got materially slower (the spread is cold-cache noise, not the change).

### How I confirmed the no-network safety net still holds

Not by assertion — by making the new path fail loudly and seeing who hit it. I temporarily replaced the new branch with a `throw`, so *any* code anywhere in the suite that reached the real provider factory under jest would blow up, and ran all 464 suites:

```
Test Suites: 1 failed, 463 passed, 464 total
Tests:       2 failed, 3373 passed, 3375 total
```

The only two tests in the entire repo that reach the real factory are the two in this PR that are supposed to. Every other test still gets the mock. That is an enumeration of the whole suite, not a spot check.

Two further checks:

- Construction is inert. `GeminiClient`'s constructor only calls `new GoogleGenAI({ apiKey })`, and `OpenAICompatibleClient`'s only reads `getGenerationConfig()`. Neither touches the network. The two new positive tests hold a `jest.spyOn(global, 'fetch')` and assert it was never called, so this is enforced rather than assumed.
- I audited the callers by hand as well. The route-tier tests that use `routeHarness` do send a real provider key header, but every one of them that would reach this factory mocks the layer above it first (`endingGenerator`, `worldGenerator`, `characterGenerator`, or `defaultGeminiClient` itself). The `choices` and `generate` routes never go through this factory at all — they use the generic core with a stubbed `fetch`.

### Red-then-green evidence

Test file added first, source unchanged:

```
Tests: 8 failed, 8 passed, 16 total
```

The 8 failures were the two positive cases (`Expected constructor: GeminiClient / Received constructor: MockGeminiClient`, same for `OpenAICompatibleClient`) and all six `toDescriptor` cases (`toDescriptor is not a function` — it was private). After the source change: `16 passed`.

The 8 that passed on both sides are the safety-net guards, and that is their job — they describe behaviour that must *not* change. So I proved they earn their keep a different way: I built the over-broad version of this fix (test branch removed entirely) and ran them against it.

```
✕ returns the mock for a bare string key
✕ returns the mock even when a real env key is configured
```

Those are precisely the two cases where the test branch is the only thing standing between an unmocked test and a real client. The other six stay green under that variant because `toDescriptor` independently returns null for them — real defence in depth, and worth recording as such rather than pretending all eight are load-bearing.

## Screenshots

Not applicable.

## Visual Baseline Changes

None. This PR does not touch `tests/visual/**-snapshots/**`.

## Code Review Summary (if applicable)

Not applicable.

## Chrome DevTools MCP Verification Summary (if applicable)

Not applicable.

## Quality Checks (if applicable)

- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit not run — no dependency changes in this PR. Lint reports 0 errors and 124 pre-existing `any` warnings, none from these files.

## Testing Instructions

```
npm test -- src/lib/ai/__tests__/defaultGeminiClient.test.ts
npm test
npm run type-check
npm run lint
npm run knip
npm run deps:validate
npm run deps:check
```

All seven pass. Visual and E2E suites were skipped deliberately: this change is server-side module wiring with no rendered output.

To reproduce the safety-net proof, replace `if (underTestRunner && !explicitlyKeyedDescriptor)` in `src/lib/ai/defaultGeminiClient.ts` with a `throw` on the inverse condition and run `npm test`. Only `defaultGeminiClient.test.ts` should fail.

## Checklist

- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed

No docs needed — the reasoning lives in the JSDoc on the function itself, which is where the next person will look. No UI, so no accessibility surface.
