### PR TITLE
Cover the six untested non-loop API routes (#2027)

### DIFF
--- a/src/app/api/ai/analyze-world/__tests__/route.test.ts
+++ b/src/app/api/ai/analyze-world/__tests__/route.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * The interesting behavior on this path is downstream of the model's string:
+ * the analyzer recovers JSON out of fences or prose, then fills in the bounds
+ * and base values the wizard needs, and falls back to a default set when none
+ * of that works. The client is faked so all of that runs for real.
+ *
+ * `fetch` would be the wrong seam: `createDefaultGeminiClient` returns a canned
+ * mock under the test runner, so nothing on this route ever reaches the
+ * provider adapter.
+ */
+
+jest.mock('@/lib/ai/defaultGeminiClient');
+
+import { POST } from '../route';
+import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
+import { buildAIRequest } from '../../../__tests__/routeHarness';
+
+const mockCreateClient = createDefaultGeminiClient as jest.MockedFunction<
+  typeof createDefaultGeminiClient
+>;
+
+function respondWith(content: string) {
+  mockCreateClient.mockReturnValue({
+    generateContent: jest.fn().mockResolvedValue({ content }),
+  } as unknown as ReturnType<typeof createDefaultGeminiClient>);
+}
+
+const analyzeRequest = (body: unknown) =>
+  buildAIRequest('/api/ai/analyze-world', body);
+
+const ANALYSIS = {
+  attributes: [
+    { name: 'Grit', description: 'Endurance under pressure', category: 'Physical' },
+    { name: 'Cunning', description: 'Reading a room', minValue: 2, maxValue: 8 },
+  ],
+  skills: [
+    {
+      name: 'Duelling',
+      description: 'Formal single combat',
+      difficulty: 'hard',
+      linkedAttributeNames: ['Grit'],
+    },
+  ],
+};
+
+describe('POST /api/ai/analyze-world', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects a blank description before calling the model', async () => {
+    respondWith('{}');
+
+    const response = await POST(analyzeRequest({ description: '   ' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('World description is required');
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  it('turns a fenced analysis into wizard-ready suggestions', async () => {
+    respondWith('```json\n' + JSON.stringify(ANALYSIS) + '\n```');
+
+    const response = await POST(
+      analyzeRequest({ description: 'A duelling culture built on debt and honour.' })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.attributes).toEqual([
+      {
+        name: 'Grit',
+        description: 'Endurance under pressure',
+        // Bounds the model omitted are filled in, and the base value is the midpoint.
+        minValue: 1,
+        maxValue: 10,
+        baseValue: 5,
+        category: 'Physical',
+        accepted: true,
+      },
+      {
+        name: 'Cunning',
+        description: 'Reading a room',
+        minValue: 2,
+        maxValue: 8,
+        baseValue: 5,
+        category: undefined,
+        accepted: true,
+      },
+    ]);
+    expect(data.skills).toEqual([
+      {
+        name: 'Duelling',
+        description: 'Formal single combat',
+        difficulty: 'hard',
+        category: undefined,
+        linkedAttributeNames: ['Grit'],
+        accepted: true,
+        baseValue: 5,
+        minValue: 1,
+        maxValue: 10,
+      },
+    ]);
+  });
+
+  it('serves the default suggestion set when the model returns nothing usable', async () => {
+    respondWith('I would rather not answer that.');
+
+    const response = await POST(
+      analyzeRequest({ description: 'A duelling culture built on debt and honour.' })
+    );
+    const data = await response.json();
+
+    // The wizard always gets something to work with rather than an error page.
+    expect(response.status).toBe(200);
+    expect(data.attributes.map((a: { name: string }) => a.name)).toContain('Strength');
+    expect(data.skills.map((s: { name: string }) => s.name)).toContain('Perception');
+  });
+
+  it('returns 500 when the body is not JSON', async () => {
+    respondWith('{}');
+
+    const response = await POST(analyzeRequest('{"description":'));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe('Failed to analyze world description');
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/debug/__tests__/route.test.ts
+++ b/src/app/api/debug/__tests__/route.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * No seam to choose: the route reads two environment variables and answers.
+ * Nothing is faked.
+ */
+
+import { GET } from '../route';
+
+const setNodeEnv = (value: string) => {
+  (process.env as Record<string, string | undefined>).NODE_ENV = value;
+};
+
+describe('GET /api/debug', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalApiKey = process.env.GEMINI_API_KEY;
+
+  afterEach(() => {
+    setNodeEnv(originalNodeEnv as string);
+    process.env.GEMINI_API_KEY = originalApiKey;
+  });
+
+  it('reports whether a server key is configured outside production', async () => {
+    setNodeEnv('development');
+    process.env.GEMINI_API_KEY = 'a-server-key';
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      apiKeyConfigured: true,
+      nodeEnv: 'development',
+      security: 'server-side-only',
+    });
+  });
+
+  it('reports no key when the environment has none', async () => {
+    setNodeEnv('development');
+    delete process.env.GEMINI_API_KEY;
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.apiKeyConfigured).toBe(false);
+  });
+
+  it('is not reachable in production', async () => {
+    setNodeEnv('production');
+    process.env.GEMINI_API_KEY = 'a-server-key';
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error).toBe('Debug endpoint not available in production');
+    // Nothing about the deployment leaks alongside the 404.
+    expect(data.apiKeyConfigured).toBeUndefined();
+    expect(data.nodeEnv).toBeUndefined();
+  });
+});

--- a/src/app/api/generate-item-image/__tests__/route.test.ts
+++ b/src/app/api/generate-item-image/__tests__/route.test.ts
@@ -4,8 +4,8 @@
 
 /**
  * Image generation never goes through the text provider adapter, so `fetch` is
- * not the seam here. The image client is faked — the same seam the other image
- * routes already use — which leaves the route's own work running for real: the
+ * not the seam here. The image client is faked - the same seam the other image
+ * routes already use - which leaves the route's own work running for real: the
  * input check, the prompt it builds from the item, and the choice between a
  * real generation, the placeholder, and a 500.
  */
@@ -85,19 +85,13 @@ describe('POST /api/generate-item-image', () => {
     expect(data.image.url).toContain('api.dicebear.com');
   });
 
-  /**
-   * Pinning what the route DOES, which is not what it reads like it does.
-   *
-   * The handler ends in `return generateImageWithFallback(...)` with no await,
-   * so a hard failure rejects after the try block has already been left and
-   * the route's own catch — the one that answers 'Failed to generate item
-   * image' — never runs. Every other image route awaits the helper inside its
-   * try and gets a shaped 500. Filed as a follow-up rather than fixed here:
-   * this PR is coverage only, and the fix is a production change.
-   */
-  it('rejects instead of answering 500 when generation fails hard', async () => {
+  it('returns 500 when generation fails hard', async () => {
     mockGenerate.mockRejectedValue(new Error('quota exhausted'));
 
-    await expect(POST(itemRequest({ item: ITEM }))).rejects.toThrow('quota exhausted');
+    const response = await POST(itemRequest({ item: ITEM }));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe('Failed to generate item image');
   });
 });

--- a/src/app/api/generate-item-image/__tests__/route.test.ts
+++ b/src/app/api/generate-item-image/__tests__/route.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Image generation never goes through the text provider adapter, so `fetch` is
+ * not the seam here. The image client is faked — the same seam the other image
+ * routes already use — which leaves the route's own work running for real: the
+ * input check, the prompt it builds from the item, and the choice between a
+ * real generation, the placeholder, and a 500.
+ */
+
+jest.mock('@/lib/ai/geminiImageGenerator', () => ({
+  generateImageWithGemini: jest.fn(),
+}));
+
+import { POST } from '../route';
+import { generateImageWithGemini } from '@/lib/ai/geminiImageGenerator';
+import { buildAIRequest } from '../../__tests__/routeHarness';
+
+const mockGenerate = generateImageWithGemini as jest.MockedFunction<
+  typeof generateImageWithGemini
+>;
+
+const itemRequest = (body: unknown, options?: { withoutKey?: boolean }) =>
+  buildAIRequest('/api/generate-item-image', body, options);
+
+const ITEM = { name: 'Rusty Iron Sword', description: 'A pitted blade' };
+
+describe('POST /api/generate-item-image', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects a request with no item before generating anything', async () => {
+    const response = await POST(itemRequest({ genre: 'fantasy' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Item object is required');
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it('returns the generated image and sends a prompt built from the item', async () => {
+    mockGenerate.mockResolvedValue({
+      url: 'data:image/png;base64,abc123',
+      mimeType: 'image/png',
+      base64Data: 'abc123',
+    });
+
+    const response = await POST(itemRequest({ item: ITEM }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.image.type).toBe('ai-generated');
+    expect(data.image.url).toBe('data:image/png;base64,abc123');
+
+    const [prompt, apiKey] = mockGenerate.mock.calls[0];
+    expect(prompt).toContain('Rusty Iron Sword');
+    expect(prompt).toContain('A pitted blade');
+    expect(prompt).toContain('white background');
+    // The player's own key, taken off the request rather than the environment.
+    expect(apiKey).toBe('test-provider-key');
+  });
+
+  it('serves a placeholder when the request resolves no key', async () => {
+    const response = await POST(itemRequest({ item: ITEM }, { withoutKey: true }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.image.type).toBe('placeholder');
+    expect(data.image.url).toContain('api.dicebear.com/7.x/shapes/svg');
+    expect(data.image.url).toContain('seed=Rusty+Iron+Sword');
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it('serves a placeholder when generation returns no image', async () => {
+    mockGenerate.mockResolvedValue(null);
+
+    const response = await POST(itemRequest({ item: ITEM }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.image.type).toBe('placeholder');
+    expect(data.image.url).toContain('api.dicebear.com');
+  });
+
+  /**
+   * Pinning what the route DOES, which is not what it reads like it does.
+   *
+   * The handler ends in `return generateImageWithFallback(...)` with no await,
+   * so a hard failure rejects after the try block has already been left and
+   * the route's own catch — the one that answers 'Failed to generate item
+   * image' — never runs. Every other image route awaits the helper inside its
+   * try and gets a shaped 500. Filed as a follow-up rather than fixed here:
+   * this PR is coverage only, and the fix is a production change.
+   */
+  it('rejects instead of answering 500 when generation fails hard', async () => {
+    mockGenerate.mockRejectedValue(new Error('quota exhausted'));
+
+    await expect(POST(itemRequest({ item: ITEM }))).rejects.toThrow('quota exhausted');
+  });
+});

--- a/src/app/api/generate-item-image/route.ts
+++ b/src/app/api/generate-item-image/route.ts
@@ -41,7 +41,7 @@ export const POST = withAIRoute(async (request: NextRequest) => {
     logger.debug('generate-item-image API', 'Prompt built', { length: prompt.length });
 
     // Use centralized helper for image generation with fallback
-    return generateImageWithFallback({
+    return await generateImageWithFallback({
       prompt,
       apiKey: resolveApiKey(request),
       fallback: {

--- a/src/app/api/inventory/check-similarity/__tests__/route.test.ts
+++ b/src/app/api/inventory/check-similarity/__tests__/route.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * The route's own work is everything that happens to the model's string after
+ * it arrives — recovering the JSON out of whatever prose surrounds it, and
+ * filling in defaults when a field is missing — plus the exact-match
+ * short-circuit that answers without asking the model at all. So the client is
+ * faked and the shared handler runs for real.
+ *
+ * Faking `fetch` instead would prove nothing here: `createDefaultGeminiClient`
+ * hands back a canned mock under the test runner, so no request ever reaches
+ * the provider adapter on this path.
+ */
+
+jest.mock('@/lib/ai/defaultGeminiClient');
+
+import { POST } from '../route';
+import { createDefaultGeminiClient } from '@/lib/ai/defaultGeminiClient';
+import { buildAIRequest } from '../../../__tests__/routeHarness';
+
+const mockCreateClient = createDefaultGeminiClient as jest.MockedFunction<
+  typeof createDefaultGeminiClient
+>;
+
+function respondWith(content: string) {
+  mockCreateClient.mockReturnValue({
+    generateContent: jest.fn().mockResolvedValue({ content }),
+  } as unknown as ReturnType<typeof createDefaultGeminiClient>);
+}
+
+const similarityRequest = (body: unknown) =>
+  buildAIRequest('/api/inventory/check-similarity', body);
+
+describe('POST /api/inventory/check-similarity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects a request missing one of the names before calling the model', async () => {
+    respondWith('{}');
+
+    const response = await POST(similarityRequest({ name1: 'Iron Sword' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Both name1 and name2 are required');
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  it('answers an exact match without spending a model call', async () => {
+    respondWith('{}');
+
+    const response = await POST(
+      similarityRequest({ name1: 'Iron Sword', name2: '  iron sword  ' })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      similar: true,
+      confidence: 1.0,
+      rationale: 'Exact match',
+    });
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  it('reads the verdict out of a response wrapped in prose', async () => {
+    respondWith(
+      'Sure, here you go:\n{"similar": true, "confidence": 0.92, "rationale": "Both name the same blade"}\nHope that helps.'
+    );
+
+    const response = await POST(
+      similarityRequest({ name1: 'Rusty Iron Sword', name2: 'Iron Sword' })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      similar: true,
+      confidence: 0.92,
+      rationale: 'Both name the same blade',
+    });
+  });
+
+  it('falls back to not-similar when the model returns no JSON at all', async () => {
+    respondWith('They look about the same to me.');
+
+    const response = await POST(
+      similarityRequest({ name1: 'Gold Coins', name2: 'Silver Coins' })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.similar).toBe(false);
+    expect(data.confidence).toBe(0.0);
+    expect(data.rationale).toBe('Could not parse AI response');
+  });
+
+  it('returns 500 when the body is not JSON', async () => {
+    respondWith('{}');
+
+    const response = await POST(similarityRequest('{"name1": "Iron Sword",'));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe('Failed to check item similarity');
+  });
+});

--- a/src/app/api/narrative/validate-event-significance/__tests__/route.test.ts
+++ b/src/app/api/narrative/validate-event-significance/__tests__/route.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * This route does not go through the provider adapter or the default client —
+ * the validator constructs the Gemini SDK directly — so the SDK is the client
+ * to fake. Everything downstream of the model's string then runs for real:
+ * prompt assembly, the JSON recovery, and the fail-open behavior that decides
+ * what happens when the model answers with something unusable.
+ */
+
+const mockGenerateContent = jest.fn();
+
+jest.mock('@google/genai', () => ({
+  GoogleGenAI: jest.fn().mockImplementation(() => ({
+    models: { generateContent: mockGenerateContent },
+  })),
+}));
+
+import { POST } from '../route';
+import { GoogleGenAI } from '@google/genai';
+import { buildAIRequest } from '../../../__tests__/routeHarness';
+
+const mockGenAI = GoogleGenAI as unknown as jest.Mock;
+
+const validateRequest = (body: unknown) =>
+  buildAIRequest('/api/narrative/validate-event-significance', body);
+
+describe('POST /api/narrative/validate-event-significance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects a missing majorEvent before reaching the model', async () => {
+    const response = await POST(validateRequest({ context: { location: 'Ruins' } }));
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('majorEvent is required and must be a string');
+    expect(mockGenAI).not.toHaveBeenCalled();
+  });
+
+  it('rejects a majorEvent that is not a string', async () => {
+    const response = await POST(validateRequest({ majorEvent: { text: 'found the key' } }));
+
+    expect(response.status).toBe(400);
+    expect(mockGenAI).not.toHaveBeenCalled();
+  });
+
+  it('returns the verdict and puts the caller context in the prompt', async () => {
+    mockGenerateContent.mockResolvedValue({
+      text: '{"isSignificant": false, "reason": "Movement, not arrival"}',
+    });
+
+    const response = await POST(
+      validateRequest({
+        majorEvent: 'The player descends further into the shaft',
+        context: { location: 'The Shaft', characterName: 'Wren' },
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      isSignificant: false,
+      reason: 'Movement, not arrival',
+    });
+
+    const prompt = mockGenerateContent.mock.calls[0][0].contents as string;
+    expect(prompt).toContain('The player descends further into the shaft');
+    expect(prompt).toContain('Location: The Shaft');
+    expect(prompt).toContain('Character: Wren');
+  });
+
+  it('accepts the event when the model answers with something unparseable', async () => {
+    mockGenerateContent.mockResolvedValue({ text: 'Probably significant, yes.' });
+
+    const response = await POST(
+      validateRequest({ majorEvent: 'The player opens the vault' })
+    );
+    const data = await response.json();
+
+    // Fail open: an unreadable verdict must not silently swallow a checkpoint.
+    expect(response.status).toBe(200);
+    expect(data.isSignificant).toBe(true);
+    expect(data.reason).toContain('Parse error');
+  });
+
+  it('accepts the event when the model call fails outright', async () => {
+    mockGenerateContent.mockRejectedValue(new Error('upstream refused'));
+
+    const response = await POST(
+      validateRequest({ majorEvent: 'The player opens the vault' })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.isSignificant).toBe(true);
+    expect(data.reason).toContain('upstream refused');
+  });
+
+  it('returns 500 when the body is not JSON', async () => {
+    const response = await POST(validateRequest('{"majorEvent":'));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe('Failed to validate event significance');
+    expect(mockGenAI).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/telemetry/error/__tests__/route.test.ts
+++ b/src/app/api/telemetry/error/__tests__/route.test.ts
@@ -1,0 +1,157 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * This route is an unauthenticated write sink: anyone can POST to it and the
+ * body lands in the runtime log. Its whole job is deciding what of a hostile
+ * payload is allowed through, so the seam is the sink itself — `logErrorReport`
+ * is faked and every sanitizer between the request and it runs for real. Faking
+ * anything lower would skip the code that is the point of the route.
+ *
+ * No provider is involved, so there is no fetch to stub and no key header to
+ * send; a plain NextRequest is what a real caller sends here.
+ */
+
+jest.mock('@/lib/telemetry/reportServerError', () => ({
+  logErrorReport: jest.fn(),
+}));
+
+import { NextRequest } from 'next/server';
+import { POST } from '../route';
+import { logErrorReport } from '@/lib/telemetry/reportServerError';
+import type { ErrorReport } from '@/lib/telemetry/errorReport';
+import { ErrorType } from '@/lib/utils/errorUtils';
+
+const mockLog = logErrorReport as jest.MockedFunction<typeof logErrorReport>;
+
+const postReport = (body: unknown) =>
+  new NextRequest('http://localhost:3000/api/telemetry/error', {
+    method: 'POST',
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+
+const loggedReport = (): ErrorReport => mockLog.mock.calls[0][0];
+
+const VALID_REPORT = {
+  source: 'error-boundary',
+  name: 'TypeError',
+  type: 'network',
+  route: '/play/world-1753812345678-a1b2',
+  digest: '3f9a2b',
+  frames: ['    at renderScene (/app/src/components/Scene.tsx:42:9)'],
+};
+
+describe('POST /api/telemetry/error', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('accepts a well-formed report and passes the sanitized fields to the sink', async () => {
+    const response = await POST(postReport(VALID_REPORT));
+
+    expect(response.status).toBe(204);
+    expect(mockLog).toHaveBeenCalledTimes(1);
+    expect(loggedReport()).toEqual({
+      source: 'error-boundary',
+      name: 'TypeError',
+      type: ErrorType.NETWORK,
+      // The entity id in the path is masked before anything is written.
+      route: '/play/:id',
+      digest: '3f9a2b',
+      frames: ['at renderScene (/app/src/components/Scene.tsx:42:9)'],
+    });
+  });
+
+  it('drops posted lines that are not stack frames', async () => {
+    await POST(
+      postReport({
+        ...VALID_REPORT,
+        frames: [
+          '    at renderScene (/app/src/components/Scene.tsx:42:9)',
+          'Error: the player pasted their own prose in here',
+          'at loadWorld (webpack-internal:///./src/lib/world.ts?id=42:10:3)',
+        ],
+      })
+    );
+
+    const report = loggedReport();
+    expect(report.frames).toEqual([
+      'at renderScene (/app/src/components/Scene.tsx:42:9)',
+      // The frame survives; the query string riding on it does not.
+      'at loadWorld (webpack-internal:///./src/lib/world.ts)',
+    ]);
+    expect(report.frames.join('\n')).not.toContain('pasted their own prose');
+  });
+
+  it('ignores fields outside the schema', async () => {
+    await POST(
+      postReport({
+        ...VALID_REPORT,
+        message: 'the free-form message that must never travel',
+        apiKey: 'a-players-provider-key',
+        world: { description: 'private world content' },
+      })
+    );
+
+    const report = loggedReport();
+    expect(Object.keys(report).sort()).toEqual([
+      'digest',
+      'frames',
+      'name',
+      'route',
+      'source',
+      'type',
+    ]);
+    expect(JSON.stringify(report)).not.toContain('a-players-provider-key');
+    expect(JSON.stringify(report)).not.toContain('must never travel');
+  });
+
+  it('collapses values outside the closed vocabulary to their defaults', async () => {
+    await POST(
+      postReport({
+        source: 'attacker-supplied-source',
+        name: 'a whole sentence, not a class name',
+        type: 'invented-category',
+        route: '/worlds?search=something+private#frag',
+        digest: 'not-hex-at-all',
+        frames: 'not-an-array',
+      })
+    );
+
+    expect(loggedReport()).toEqual({
+      source: 'client',
+      name: 'Error',
+      type: ErrorType.UNKNOWN,
+      // Query string and hash are dropped whole.
+      route: '/worlds',
+      frames: [],
+    });
+  });
+
+  it('drops a body over the size ceiling without logging it', async () => {
+    const oversized = {
+      ...VALID_REPORT,
+      frames: [`    at pad (${'x'.repeat(5000)}.ts:1:1)`],
+    };
+
+    const response = await POST(postReport(oversized));
+
+    expect(response.status).toBe(204);
+    expect(mockLog).not.toHaveBeenCalled();
+  });
+
+  it('answers 204 and logs nothing when the body is not JSON', async () => {
+    const response = await POST(postReport('{"source": "client",'));
+
+    expect(response.status).toBe(204);
+    expect(mockLog).not.toHaveBeenCalled();
+  });
+
+  it('answers 204 and logs nothing when the body is JSON but not an object', async () => {
+    const response = await POST(postReport('"just a string"'));
+
+    expect(response.status).toBe(204);
+    expect(mockLog).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

Adds route-tier tests for the six non-loop API routes that had none. The issue said seven and named `delete-image` as the one that mattered - that route no longer exists, so this corrects the record as well as closing the gap.

Also includes a one-word production fix in `generate-item-image/route.ts` to `await generateImageWithFallback`, so hard generation failures are caught inside the try block and return the route's shaped 500 response.

## Related Issue

Closes #2027

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

For the existing routes, meaningful assertions were shown to go red against deliberate mutations of the behaviors they guard. For the `generate-item-image` fix, the test was updated to expect 500 on hard failure (turning red without the `await` and green with it).

## User Stories Addressed

Not applicable. Internal test debt and error-handling fix, no user-visible behavior changes.

## Flow Diagrams

Not applicable.

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

Not applicable. No UI in this change.

## Implementation Notes

### The count is six, not seven

The issue's premise is stale. `src/app/api/delete-image/` was deleted on develop in commit `43359af2f`, "Delete the unreachable image-deletion path and cover the rate limiter (#1996) (#2029)", merged 2026-09-05. That commit removed the route, `fileStorage.deleteImage`, the worldStore fetch, and the Storybook MSW handler together, because the path had been unreachable since #1442 switched world images to data URLs and no released version ever wrote a `/uploads/` URL.

Two consequences for this issue:

- The real count is six untested routes, not seven.
- The #1996 cross-reference is moot. #1996's own resolution was to delete the guard the mutation broke rather than pin a guard nothing reaches, so there is no sanitization left to test. Nothing here restores the route.

With `delete-image` gone, `telemetry/error` is the only security-relevant one left, and it got the careful pass.

### Seam per route

Following the rule #1995 settled: fake only `fetch` where the route goes through the provider adapter; fake the client where the route's own logic is downstream of the model's string.

| Route | Seam | Why |
|---|---|---|
| `telemetry/error` | fake `logErrorReport` | No provider. The sink is the boundary; every sanitizer between the request and it runs for real, which is the whole point of the route. |
| `ai/analyze-world` | fake `@/lib/ai/defaultGeminiClient` | `fetch` would prove nothing: `createDefaultGeminiClient` hands back a canned mock under the test runner, so no request reaches the adapter on this path. Faking the client leaves the analyzer's fence stripping, bound defaults, and fallback set running for real. |
| `inventory/check-similarity` | fake `@/lib/ai/defaultGeminiClient` | Same reason. Leaves the exact-match short-circuit and the JSON recovery in the shared handler running for real. |
| `narrative/validate-event-significance` | fake `@google/genai` | The validator constructs the SDK directly rather than going through the adapter or the default client, so the SDK is the client here. Prompt assembly, JSON recovery, and fail-open all run for real. |
| `generate-item-image` | fake `@/lib/ai/geminiImageGenerator` | Image generation never touches the text adapter. This matches the seam the other four image routes already use. |
| `debug` | nothing faked | Reads two environment variables and answers. |

Per route: happy path, the main input-validation rejection, and the error path. `telemetry/error` goes further, since an unauthenticated write sink deserves it.

### telemetry/error: red-then-green evidence

Three mutations of the route, each run against the new suite, then reverted. The route file is unchanged in this PR.

Mutation A - remove the 4KB body ceiling (`if (raw.length <= MAX_BODY_CHARS)` to `if (true)`):

```
✕ drops a body over the size ceiling without logging it
Tests: 1 failed, 6 passed, 7 total
```

Mutation B - ship the posted frames verbatim instead of re-running `sanitizeStack`:

```
✕ accepts a well-formed report and passes the sanitized fields to the sink
✕ drops posted lines that are not stack frames
Tests: 2 failed, 5 passed, 7 total
```

Mutation C - log the parsed body instead of the rebuilt report:

```
✕ accepts a well-formed report and passes the sanitized fields to the sink
✕ drops posted lines that are not stack frames
✕ ignores fields outside the schema
✕ collapses values outside the closed vocabulary to their defaults
Tests: 4 failed, 3 passed, 7 total
```

What that covers: the size ceiling, the frame filter that keeps free text and query strings out of the log, the closed vocabulary for source/name/type/digest, the route masking that turns an entity id into `:id`, and the schema rebuild that drops crafted extra fields. No guard was invented - every assertion pins something the route already does.

### Follow-up notes

**`generate-item-image` hard failure catch:** The handler had ended in `return generateImageWithFallback(...)` with no `await`, so hard rejections escaped after leaving the try block and bypassed the route catch. Added `await` and updated the test to verify that hard failures return 500 with `Failed to generate item image`.

**`debug` reachability, the question the issue raised:** It is already guarded: the route returns 404 when `NODE_ENV === 'production'` and leaks nothing alongside it. Both branches are now tested. Whether the endpoint should exist at all is still a product question, but it is not an exposure, and it is out of scope here.

## Screenshots

Not applicable.

## Visual Baseline Changes

None. This PR does not touch `tests/visual/**-snapshots/**`.

## Code Review Summary (if applicable)

Not applicable.

## Chrome DevTools MCP Verification Summary (if applicable)

Not applicable. No browser-facing change.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit is unchecked because it was not run locally; CI runs it.

## Testing Instructions

```bash
npm test -- src/app/api/telemetry/error src/app/api/debug src/app/api/ai/analyze-world \
  src/app/api/inventory/check-similarity src/app/api/narrative/validate-event-significance \
  src/app/api/generate-item-image
```

30 tests across 6 suites.

Full gate run locally on this branch:

- `npm test` - 469 suites, 3389 tests, all passing
- `npm run type-check` - clean
- `npm run lint` - 0 errors (124 pre-existing warnings, none from these files)
- `npm run knip` - clean
- `npm run audit:tests` - none of the six new files land in the mock-only or single-assertion buckets

Visual and E2E suites were deliberately skipped: they are macOS-baseline-bound and irrelevant to route tests.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed

Accessibility is unchecked as not applicable: no UI in this change.
