### PR TITLE
Include skill name in character creation skill toggle accessible name

### DIFF
--- a/src/components/CharacterCreationWizard/steps/SkillsStep.tsx
+++ b/src/components/CharacterCreationWizard/steps/SkillsStep.tsx
@@ -340,6 +340,7 @@ export const SkillsStep: React.FC<SkillsStepProps> = ({
                   isActive={skill.isSelected}
                   activeLabel="Selected"
                   inactiveLabel={isLocked ? 'Locked' : 'Not Selected'}
+                  ariaLabel={`${skill.name}, ${isLocked ? 'locked' : skill.isSelected ? 'selected' : 'not selected'}`}
                   onClick={() => handleSkillToggle(skill.skillId)}
                   testId={`skill-toggle-${safeKey}`}
                   disabled={isLocked}

--- a/src/components/CharacterCreationWizard/steps/__tests__/SkillsStep.allocation.test.tsx
+++ b/src/components/CharacterCreationWizard/steps/__tests__/SkillsStep.allocation.test.tsx
@@ -35,6 +35,18 @@ const buildWorldConfig = (skillPointPool: number): World => ({
       baseValue: 1,
       minValue: 1,
       maxValue: 5
+    },
+    {
+      id: 'skill-2',
+      worldId: 'world-1',
+      name: 'Athletics',
+      description: 'Run and jump.',
+      difficulty: 'medium',
+      category: 'physical',
+      attributeIds: ['attr-1'],
+      baseValue: 1,
+      minValue: 1,
+      maxValue: 5
     }
   ],
   settings: {
@@ -132,5 +144,51 @@ describe('SkillsStep - skill point allocation', () => {
     const updatedSkills = onUpdate.mock.calls[0][0].skills as Array<{ isSelected: boolean; level: number }>;
     expect(updatedSkills[0].isSelected).toBe(false);
     expect(updatedSkills[0].level).toBe(1);
+  });
+
+  it('includes skill name and selection state in toggle button accessible names', () => {
+    renderSkillsStep({
+      data: {
+        characterData: {
+          skills: [
+            {
+              skillId: 'skill-1',
+              name: 'Stealth',
+              description: 'Move unseen and unheard.',
+              attributeIds: ['attr-1'],
+              isSelected: true,
+              level: 2,
+              minLevel: 1,
+              maxLevel: 5,
+            },
+            {
+              skillId: 'skill-2',
+              name: 'Athletics',
+              description: 'Run and jump.',
+              attributeIds: ['attr-1'],
+              isSelected: false,
+              level: 1,
+              minLevel: 1,
+              maxLevel: 5,
+            },
+          ],
+        },
+        pointPools: {
+          skills: {
+            total: 3,
+            spent: 1,
+            remaining: 2,
+          },
+        },
+        validation: {},
+      },
+    });
+
+    expect(screen.getByRole('button', { name: 'Stealth, selected' })).toHaveAccessibleName(
+      'Stealth, selected'
+    );
+    expect(
+      screen.getByRole('button', { name: 'Athletics, not selected' })
+    ).toHaveAccessibleName('Athletics, not selected');
   });
 });

--- a/src/components/CharacterCreationWizard/steps/__tests__/SkillsStep.prerequisites.test.tsx
+++ b/src/components/CharacterCreationWizard/steps/__tests__/SkillsStep.prerequisites.test.tsx
@@ -96,6 +96,9 @@ describe('SkillsStep - attribute prerequisites', () => {
     renderStep(3);
 
     expect(screen.getByTestId('skill-toggle-skill-1')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Heavy Lifting, locked' })).toHaveAccessibleName(
+      'Heavy Lifting, locked'
+    );
     expect(screen.getByTestId('skill-requirement-skill-1')).toHaveTextContent(
       'Requires Strength 5 (you have 3)'
     );

--- a/src/components/shared/wizard/components/ToggleButton.tsx
+++ b/src/components/shared/wizard/components/ToggleButton.tsx
@@ -10,6 +10,8 @@ export interface ToggleButtonProps {
   className?: string;
   disabled?: boolean;
   title?: string;
+  ariaLabel?: string;
+  'aria-label'?: string;
 }
 
 export const ToggleButton: React.FC<ToggleButtonProps> = ({
@@ -21,7 +23,10 @@ export const ToggleButton: React.FC<ToggleButtonProps> = ({
   className = '',
   disabled = false,
   title,
+  ariaLabel,
+  'aria-label': ariaLabelProp,
 }) => {
+  const resolvedAriaLabel = ariaLabelProp ?? ariaLabel;
   return (
     <button
       type="button"
@@ -29,9 +34,10 @@ export const ToggleButton: React.FC<ToggleButtonProps> = ({
       onClick={onClick}
       disabled={disabled}
       title={title}
-      className={`${wizardStyles.toggle.button} ${
+      aria-label={resolvedAriaLabel}
+      className={`component-toggle-button ${wizardStyles.toggle.button} ${
         isActive ? wizardStyles.toggle.active : wizardStyles.toggle.inactive
-      } ${className}`}
+      } ${className}`.trim()}
     >
       {isActive ? activeLabel : inactiveLabel}
     </button>


### PR DESCRIPTION
## Description
On the character creation wizard's skill step, all twelve skill toggle buttons announced only "Not Selected" or "Selected", giving screen reader users no way to tell which skill they were toggling. This adds an aria-label prop to ToggleButton and wires it up in SkillsStep so each toggle announces both the skill name and its current state ("Stealth, not selected", "Stealth, selected", or "Heavy Lifting, locked").

## Related Issue
Closes #2041

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
Screen reader users navigating character creation can distinguish between skill toggle buttons and know which skill they are selecting or deselecting.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes
- Added an optional ariaLabel prop (also accepting aria-label) to ToggleButton and passed it down to the native button.
- Added the component-toggle-button identifying class attribute to ToggleButton.
- Passed `${skill.name}, ${isLocked ? 'locked' : skill.isSelected ? 'selected' : 'not selected'}` as the ariaLabel in SkillsStep.

## Screenshots
N/A

## Visual Baseline Changes
None

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. Run `npm test -- src/components/CharacterCreationWizard/steps/__tests__/SkillsStep.allocation.test.tsx src/components/CharacterCreationWizard/steps/__tests__/SkillsStep.prerequisites.test.tsx`
2. Run `npm run type-check` and `npm run lint`
3. In the UI, navigate to character creation, go to the skills step, and inspect the accessible names on the skill toggles via DevTools accessibility tree or assistive tech.

## Checklist
- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed