### PR TITLE
Omit world image from portrait generation payload to prevent 413

### DIFF
--- a/src/components/CharacterCreationWizard/__tests__/CharacterCreationWizard.portrait.test.tsx
+++ b/src/components/CharacterCreationWizard/__tests__/CharacterCreationWizard.portrait.test.tsx
@@ -9,6 +9,9 @@ import { useWorldStore } from '../../../state/worldStore';
 import { PortraitStep } from '../steps/PortraitStep';
 import { getTimestamp } from '@/lib/utils/timestamp';
 import type { World } from '@/types/world.types';
+
+// Matches MAX_AI_BODY_BYTES in src/utils/apiHelpers.ts (64KB route limit)
+const MAX_AI_BODY_BYTES = 65_536;
 // Removed AI client imports - using API routes instead
 
 // Mock the dependencies
@@ -382,6 +385,60 @@ describe('PortraitStep Component', () => {
 
     expect(screen.queryByText(/just a preview/i)).not.toBeInTheDocument();
     expect(mockOnUpdate).not.toHaveBeenCalled();
+  });
+
+  it('omits world image from generation payload so request stays under MAX_AI_BODY_BYTES', async () => {
+    const user = userEvent.setup();
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          portrait: {
+            type: 'ai-generated',
+            url: 'data:image/png;base64,mockimage',
+            generatedAt: getTimestamp(),
+          },
+        }),
+    });
+
+    const worldWithLargeImage: Partial<World> = {
+      genre: 'fantasy',
+      image: {
+        type: 'ai-generated',
+        url: 'data:image/png;base64,' + 'x'.repeat(1024 * 1024),
+        prompt: 'A grand landscape',
+        generatedAt: getTimestamp(),
+      },
+    };
+
+    render(
+      <PortraitStep
+        data={mockData}
+        onUpdate={mockOnUpdate}
+        worldConfig={worldWithLargeImage}
+      />
+    );
+
+    const generateButton = screen.getByRole('button', {
+      name: /generate portrait/i,
+    });
+    await user.click(generateButton);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    const [endpoint, requestInit] = mockFetch.mock.calls[0];
+    expect(endpoint).toBe('/api/generate-portrait');
+
+    const requestBodyString = requestInit.body as string;
+    const bodyBytes = new TextEncoder().encode(requestBodyString).length;
+    expect(bodyBytes).toBeLessThan(MAX_AI_BODY_BYTES);
+
+    const parsedBody = JSON.parse(requestBodyString);
+    expect(parsedBody.world.image).toBeUndefined();
+    expect(parsedBody.world.genre).toBe('fantasy');
   });
 });
 

--- a/src/components/CharacterCreationWizard/steps/PortraitStep.tsx
+++ b/src/components/CharacterCreationWizard/steps/PortraitStep.tsx
@@ -116,9 +116,11 @@ export function PortraitStep({
     };
 
     try {
+      // Exclude the world image to keep the payload well under the AI route limit
+      const { image: _image, ...worldWithoutImage } = worldConfig ?? {};
       const generatedPortrait = await generate({
         character: characterForGeneration,
-        world: worldConfig,
+        world: worldWithoutImage,
         customDescription: localPhysicalDescription,
       });
       if (sourceEpochRef.current !== epoch) return;


### PR DESCRIPTION
## Description
Character portrait generation fails with HTTP 413 (Payload too large) whenever the active world has a generated image. The character wizard sends the entire World object to `/api/generate-portrait`, which carries the world's base64 image data URL (~1.26MB) along for the ride. The `withAIRoute` wrapper enforces a 64KB body ceiling (`MAX_AI_BODY_BYTES`), rejecting the request before it reaches the generation handler.

This strips the `image` field from `worldConfig` before passing it to `generate()` in `PortraitStep`. The backend prompt builder only needs `world.genre`, so shedding the image data URL brings the request payload back down under 2KB.

## Related Issue
Closes #2036

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
As a player creating a character in a world with an image, I want portrait generation to succeed so I can generate an avatar for my character without hitting payload size errors.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes
The route handler in `src/app/api/generate-portrait/route.ts` only consumes `world.genre` to contextualize the portrait prompt. `PortraitStep` now destructures `image` off `worldConfig` before dispatching the AI request.

## Screenshots
N/A

## Visual Baseline Changes
None

## Code Review Summary (if applicable)
Reviewed `PortraitStep.tsx` payload handling and test coverage in `CharacterCreationWizard.portrait.test.tsx`. The change is surgical and scoped to omitting the unused image field.

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
Run the portrait step test suite to confirm the generation payload stays under `MAX_AI_BODY_BYTES`:
```bash
npm test -- src/components/CharacterCreationWizard/__tests__/CharacterCreationWizard.portrait.test.tsx
```

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed