### PR TITLE
Fix character creation recovery dropping saved draft on restore

### DIFF
--- a/src/components/CharacterCreationWizard/CharacterCreationWizard.tsx
+++ b/src/components/CharacterCreationWizard/CharacterCreationWizard.tsx
@@ -21,6 +21,7 @@ import { BackgroundStep } from './steps/BackgroundStep';
 import { PortraitStep } from './steps/PortraitStep';
 import { normalizeSkillBounds } from './utils/skillAllocation';
 import { useTutorial } from '@/components/TutorialProvider';
+import type { WizardValidation } from '@/hooks/useWizardState';
 
 /**
  * Props for the CharacterCreationWizard component
@@ -73,66 +74,50 @@ export const CharacterCreationWizard: React.FC<CharacterCreationWizardProps> = (
     }
   }, [currentTour, isTourActive, pauseTour, resumeTour, showRecoveryDialog]);
 
-  // Initialize character data from auto-save or defaults
-  const initialCharacterData: CharacterCreationData = useMemo(() => {
-    if (data?.characterData) {
-      const existingSkills = (
-        (data.characterData as Partial<CharacterCreationData>)?.skills ?? []
-      ) as CharacterCreationData['skills'];
-
-      const skillsWithBounds = normalizeSkillBounds(existingSkills, world);
-
-      return {
-        ...(data.characterData as CharacterCreationData),
-        skills: skillsWithBounds,
-        worldId,
-      };
-    }
-
-    return {
-      worldId,
-      name: '',
-      description: '',
-      portraitPlaceholder: '',
-      portrait: {
-        type: 'placeholder',
-        url: null
-      },
-      attributes: world?.attributes.map(attr => ({
-        attributeId: attr.id,
-        name: attr.name,
-        description: attr.description,
-        value: attr.minValue,
-        minValue: attr.minValue,
-        maxValue: attr.maxValue,
+  // Default blank character data
+  const defaultCharacterData: CharacterCreationData = useMemo(() => ({
+    worldId,
+    name: '',
+    description: '',
+    portraitPlaceholder: '',
+    portrait: {
+      type: 'placeholder',
+      url: null
+    },
+    attributes: world?.attributes.map(attr => ({
+      attributeId: attr.id,
+      name: attr.name,
+      description: attr.description,
+      value: attr.minValue,
+      minValue: attr.minValue,
+      maxValue: attr.maxValue,
+    })) || [],
+    skills: normalizeSkillBounds(
+      world?.skills.map(skill => ({
+        skillId: skill.id,
+        name: skill.name,
+        description: skill.description,
+        level: skill.minValue,
+        minLevel: skill.minValue,
+        maxLevel: skill.maxValue,
+        attributeIds: skill.attributeIds || [],
+        linkedAttributeId: skill.attributeIds?.[0],
+        isSelected: false,
       })) || [],
-      skills: normalizeSkillBounds(
-        world?.skills.map(skill => ({
-          skillId: skill.id,
-          name: skill.name,
-          description: skill.description,
-          level: skill.minValue,
-          minLevel: skill.minValue,
-          maxLevel: skill.maxValue,
-          attributeIds: skill.attributeIds || [],
-          linkedAttributeId: skill.attributeIds?.[0],
-          isSelected: false,
-        })) || [],
-        world
-      ),
-      background: {
-        history: '',
-        personality: '',
-        goals: [],
-        motivation: '',
-      },
-    };
-  }, [data, worldId, world]);
+      world
+    ),
+    background: {
+      history: '',
+      personality: '',
+      goals: [],
+      motivation: '',
+    },
+  }), [worldId, world]);
 
   // Wizard state management
   const { wizard, steps, stepValidators } = useCharacterCreationWizard({
-    initialData: initialCharacterData,
-    initialStep: data?.currentStep || initialStep,
+    initialData: defaultCharacterData,
+    initialStep,
     worldId,
     world
   });
@@ -179,8 +164,63 @@ export const CharacterCreationWizard: React.FC<CharacterCreationWizardProps> = (
   };
 
   const handleRecoveryChoice = (choice: 'recover' | 'dismiss') => {
-    if (choice === 'dismiss') {
+    if (choice === 'recover' && data?.characterData) {
+      const existingSkills = (
+        (data.characterData as Partial<CharacterCreationData>)?.skills ?? []
+      ) as CharacterCreationData['skills'];
+
+      const skillsWithBounds = normalizeSkillBounds(existingSkills, world);
+
+      const savedAttributes = Array.isArray(
+        (data.characterData as Partial<CharacterCreationData>)?.attributes
+      )
+        ? (data.characterData as CharacterCreationData).attributes
+        : [];
+      const mergedAttributes = world?.attributes?.length
+        ? world.attributes.map(attr => {
+            const savedAttr = savedAttributes.find(a => a.attributeId === attr.id);
+            return savedAttr
+              ? {
+                  ...savedAttr,
+                  name: attr.name,
+                  description: attr.description,
+                  minValue: attr.minValue,
+                  maxValue: attr.maxValue,
+                }
+              : {
+                  attributeId: attr.id,
+                  name: attr.name,
+                  description: attr.description,
+                  value: attr.minValue,
+                  minValue: attr.minValue,
+                  maxValue: attr.maxValue,
+                };
+          })
+        : savedAttributes;
+
+      const restoredBackground = {
+        ...defaultCharacterData.background,
+        ...((data.characterData as Partial<CharacterCreationData>)?.background || {}),
+      };
+
+      const restoredData: CharacterCreationData = {
+        ...defaultCharacterData,
+        ...(data.characterData as CharacterCreationData),
+        attributes: mergedAttributes,
+        skills: skillsWithBounds,
+        background: restoredBackground,
+        worldId,
+      };
+
+      const restoredStep =
+        typeof data.currentStep === 'number' ? data.currentStep : initialStep;
+      const restoredValidation =
+        (data.validation as Record<number, WizardValidation>) || {};
+
+      wizard.reset(restoredData, restoredStep, restoredValidation);
+    } else if (choice === 'dismiss') {
       clearAutoSave();
+      wizard.reset(defaultCharacterData, initialStep, {});
     }
     setShowRecoveryDialog(false);
   };

--- a/src/components/CharacterCreationWizard/__tests__/CharacterCreationWizard.recovery.test.tsx
+++ b/src/components/CharacterCreationWizard/__tests__/CharacterCreationWizard.recovery.test.tsx
@@ -3,8 +3,28 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CharacterCreationWizard } from '../CharacterCreationWizard';
 
+import type { useCharacterCreationAutoSave as useAutoSaveHook } from '@/hooks/useCharacterCreationAutoSave';
+
+type AutoSaveReturn = ReturnType<typeof useAutoSaveHook>;
+
 const pauseTour = jest.fn();
 const resumeTour = jest.fn();
+const mockClearAutoSave = jest.fn();
+
+let mockAutoSaveState: AutoSaveReturn = {
+  data: undefined,
+  setData: jest.fn(),
+  clearAutoSave: mockClearAutoSave,
+  hasRecoveryData: true,
+  recoveryPreview: {
+    name: 'Peren Ashford',
+    currentStep: 1,
+    totalAttributePoints: 8,
+    hasAttributes: true,
+  },
+  hasCurrentData: false,
+  saveStatus: 'idle' as const,
+};
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
@@ -25,53 +45,7 @@ jest.mock('@/components/TutorialProvider', () => ({
 }));
 
 jest.mock('@/hooks/useCharacterCreationAutoSave', () => ({
-  useCharacterCreationAutoSave: () => ({
-    data: null,
-    setData: jest.fn(),
-    clearAutoSave: jest.fn(),
-    hasRecoveryData: true,
-    recoveryPreview: {
-      name: 'Bob Smith',
-      currentStep: 2,
-      totalAttributePoints: 6,
-      hasAttributes: true,
-    },
-    hasCurrentData: false,
-    saveStatus: 'idle' as const,
-  }),
-}));
-
-jest.mock('@/hooks/useCharacterCreationWizard', () => ({
-  useCharacterCreationWizard: () => ({
-    wizard: {
-      state: {
-        currentStep: 0,
-        data: {
-          worldId: 'world-1',
-          name: '',
-          description: '',
-          attributes: [],
-          skills: [],
-          background: {},
-        },
-        validation: {
-          0: { valid: true, touched: false, errors: [] },
-        },
-      },
-      canGoBack: false,
-      canGoNext: true,
-      isLastStep: false,
-      goNext: jest.fn(),
-      goBack: jest.fn(),
-      goToStep: jest.fn(),
-      updateData: jest.fn(),
-      setValidation: jest.fn(),
-    },
-    steps: [
-      { id: 'basic', label: 'Basic Info' },
-    ],
-    stepValidators: [],
-  }),
+  useCharacterCreationAutoSave: () => mockAutoSaveState,
 }));
 
 jest.mock('@/hooks/useCharacterPointPools', () => ({
@@ -89,6 +63,10 @@ jest.mock('@/state/worldStore', () => ({
         name: 'Test World',
         genre: 'fantasy',
         description: 'A test world',
+        settings: {
+          attributePointPool: 20,
+          skillPointPool: 20,
+        },
         attributes: [
           {
             id: 'strength',
@@ -114,11 +92,25 @@ jest.mock('@/state/worldStore', () => ({
 }));
 
 jest.mock('../steps/BasicInfoStep', () => ({
-  BasicInfoStep: () => <div data-testid="basic-info-step" />,
+  BasicInfoStep: ({ data }: { data: { characterData: { name: string; description: string } } }) => (
+    <div data-testid="basic-info-step">
+      <span data-testid="character-name-value">{data.characterData.name}</span>
+      <span data-testid="character-description-value">{data.characterData.description}</span>
+    </div>
+  ),
 }));
 
 jest.mock('../steps/AttributesStep', () => ({
-  AttributesStep: () => <div data-testid="attributes-step" />,
+  AttributesStep: ({
+    data,
+  }: {
+    data: { characterData: { name: string; attributes: Array<{ attributeId: string; value: number }> } };
+  }) => (
+    <div data-testid="attributes-step">
+      <span data-testid="attributes-character-name">{data.characterData.name}</span>
+      <span data-testid="attributes-count">{data.characterData.attributes.length}</span>
+    </div>
+  ),
 }));
 
 jest.mock('../steps/SkillsStep', () => ({
@@ -136,9 +128,67 @@ jest.mock('../steps/PortraitStep', () => ({
 describe('CharacterCreationWizard recovery modal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockAutoSaveState = {
+      data: {
+        currentStep: 1,
+        worldId: 'world-1',
+        characterData: {
+          worldId: 'world-1',
+          name: 'Peren Ashford',
+          description: 'A courageous adventurer',
+          portraitPlaceholder: '',
+          portrait: { type: 'placeholder', url: null },
+          attributes: [
+            {
+              attributeId: 'strength',
+              name: 'Strength',
+              description: 'Power',
+              value: 8,
+              minValue: 1,
+              maxValue: 10,
+            },
+          ],
+          skills: [
+            {
+              skillId: 'athletics',
+              name: 'Athletics',
+              description: 'Athletic ability',
+              level: 3,
+              minLevel: 0,
+              maxLevel: 5,
+              isSelected: true,
+            },
+          ],
+          background: {
+            history: 'Grew up in the forest',
+            personality: 'Brave',
+            goals: ['Explore ruins'],
+            motivation: 'Discovery',
+          },
+        },
+        validation: {
+          0: { valid: true, touched: true, errors: [] },
+        },
+        pointPools: {
+          attributes: 0,
+          skills: 0,
+        },
+      },
+      setData: jest.fn(),
+      clearAutoSave: mockClearAutoSave,
+      hasRecoveryData: true,
+      recoveryPreview: {
+        name: 'Peren Ashford',
+        currentStep: 1,
+        totalAttributePoints: 8,
+        hasAttributes: true,
+      },
+      hasCurrentData: false,
+      saveStatus: 'idle' as const,
+    };
   });
 
-  it('pauses the tutorial while the recovery dialog is', async () => {
+  it('pauses the tutorial while the recovery dialog is active', async () => {
     render(<CharacterCreationWizard worldId="world-1" />);
 
     await waitFor(() => {
@@ -156,5 +206,59 @@ describe('CharacterCreationWizard recovery modal', () => {
     await waitFor(() => {
       expect(resumeTour).toHaveBeenCalled();
     });
+    expect(mockClearAutoSave).toHaveBeenCalled();
+    expect(screen.getByTestId('basic-info-step')).toBeInTheDocument();
+    expect(screen.getByTestId('character-name-value')).toHaveTextContent('');
+  });
+
+  it('restores the saved draft values and step into the wizard when Recover Progress is clicked', async () => {
+    const user = userEvent.setup();
+    render(<CharacterCreationWizard worldId="world-1" />);
+
+    // Before clicking recover, dialog is visible
+    const recoverButton = await screen.findByRole('button', { name: 'Recover Progress' });
+    await user.click(recoverButton);
+
+    // Wizard should restore to step 1 (Attributes) with saved draft name and attributes
+    await waitFor(() => {
+      expect(screen.getByTestId('attributes-step')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('attributes-character-name')).toHaveTextContent('Peren Ashford');
+    expect(screen.getByTestId('attributes-count')).toHaveTextContent('1');
+
+    // Navigating back to step 0 should show restored Basic Info values
+    const backButton = screen.getByRole('button', { name: 'Back' });
+    await user.click(backButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('basic-info-step')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('character-name-value')).toHaveTextContent('Peren Ashford');
+    expect(screen.getByTestId('character-description-value')).toHaveTextContent(
+      'A courageous adventurer'
+    );
+  });
+
+  it('restores draft onto step 0 when saved on step 0', async () => {
+    if (mockAutoSaveState.data) {
+      mockAutoSaveState.data.currentStep = 0;
+    }
+    if (mockAutoSaveState.recoveryPreview) {
+      mockAutoSaveState.recoveryPreview.currentStep = 0;
+    }
+
+    const user = userEvent.setup();
+    render(<CharacterCreationWizard worldId="world-1" />);
+
+    const recoverButton = await screen.findByRole('button', { name: 'Recover Progress' });
+    await user.click(recoverButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('basic-info-step')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('character-name-value')).toHaveTextContent('Peren Ashford');
+    expect(screen.getByTestId('character-description-value')).toHaveTextContent(
+      'A courageous adventurer'
+    );
   });
 });

--- a/src/hooks/__tests__/useWizardState.test.ts
+++ b/src/hooks/__tests__/useWizardState.test.ts
@@ -132,4 +132,49 @@ describe('useWizardState', () => {
     });
     expect(result.current.canGoNext).toBe(false);
   });
+
+  it('resets state to provided restored data, step, and validation', () => {
+    const onDataChange = jest.fn();
+    const { result } = renderHook(() =>
+      useWizardState({
+        initialData,
+        steps: testSteps,
+        onDataChange,
+      })
+    );
+
+    act(() => {
+      result.current.reset(
+        { name: 'Alice', age: 30, email: 'alice@example.com' },
+        2,
+        { 0: { valid: true, errors: [], touched: true } }
+      );
+    });
+
+    expect(result.current.state.currentStep).toBe(2);
+    expect(result.current.state.data).toEqual({
+      name: 'Alice',
+      age: 30,
+      email: 'alice@example.com',
+    });
+    expect(result.current.state.validation[0]).toEqual({
+      valid: true,
+      errors: [],
+      touched: true,
+    });
+    expect(onDataChange).toHaveBeenCalledWith({
+      name: 'Alice',
+      age: 30,
+      email: 'alice@example.com',
+    });
+
+    // Calling reset() with no args resets back to initial data and step 0
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.state.currentStep).toBe(0);
+    expect(result.current.state.data).toEqual(initialData);
+    expect(result.current.state.validation).toEqual({});
+  });
 });

--- a/src/hooks/useWizardState.ts
+++ b/src/hooks/useWizardState.ts
@@ -51,7 +51,11 @@ export interface UseWizardStateReturn<TData> {
   setProcessing: (isProcessing: boolean) => void;
   setError: (key: string, error: string) => void;
   clearError: (key: string) => void;
-  reset: () => void;
+  reset: (
+    newData?: TData,
+    newStep?: number,
+    newValidation?: Record<number, WizardValidation>
+  ) => void;
 }
 
 export function useWizardState<TData = unknown>({
@@ -209,15 +213,30 @@ export function useWizardState<TData = unknown>({
     });
   }, []);
 
-  const reset = useCallback(() => {
-    setState({
-      currentStep: initialStep,
-      data: initialData,
-      validation: {},
-      isProcessing: false,
-      errors: {},
-    });
-  }, [initialData, initialStep]);
+  const reset = useCallback(
+    (
+      newData?: TData,
+      newStep?: number,
+      newValidation?: Record<number, WizardValidation>
+    ) => {
+      const nextData = newData ?? initialData;
+      let nextStep = newStep ?? initialStep;
+      if (nextStep < 0 || nextStep >= steps.length) {
+        nextStep = initialStep;
+      }
+      setState({
+        currentStep: nextStep,
+        data: nextData,
+        validation: newValidation ?? {},
+        isProcessing: false,
+        errors: {},
+      });
+      if (onDataChange) {
+        onDataChange(nextData);
+      }
+    },
+    [initialData, initialStep, steps.length, onDataChange]
+  );
 
   return {
     state,


### PR DESCRIPTION
## Description
Restores saved character draft data, the saved step index, and validation into the wizard state when the player clicks Recover Progress on the recovery dialog. Previously, clicking recover closed the modal but never populated the wizard's state or changed the step, leaving the player on an empty step 0 despite having saved progress in storage.

## Related Issue
Closes #2035

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
As a player returning to character creation with an in-progress draft, I want clicking Recover Progress to restore my character name, description, attributes, skills, and wizard step so that I do not lose my draft.

## Flow Diagrams
None

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes
The autosave hook loads data asynchronously after initial mount, meaning useWizardState was initially mounted with blank default data. When the user clicked Recover Progress, handleRecoveryChoice only dismissed the dialog without pushing the loaded draft into the wizard state.

This updates useWizardState's reset action to accept optional restored data, step, and validation objects so existing wizard instances can be repopulated cleanly. In CharacterCreationWizard, clicking Recover Progress now normalizes skills against world bounds, merges attributes and background into the draft, and resets the wizard state to the saved step. Clicking Start Fresh clears storage and resets the wizard to blank defaults at step 0.

## Screenshots
None

## Visual Baseline Changes
None

## Code Review Summary (if applicable)
None

## Chrome DevTools MCP Verification Summary (if applicable)
None

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. Run unit test suites:
   `npm test -- src/components/CharacterCreationWizard/__tests__/CharacterCreationWizard.recovery.test.tsx src/hooks/__tests__/useWizardState.test.ts`
2. Run type checking and linting:
   `npm run type-check`
   `npm run lint`
3. Manual verification:
   - Navigate to /characters/create.
   - Enter character name and description, click Next to Attributes step, and wait for autosave.
   - Reload the page. When the recovery dialog prompts to recover progress, click Recover Progress.
   - Confirm the wizard restores directly to Attributes with the saved draft values, and clicking Back shows the saved name and description.

## Checklist
- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed