### PR TITLE
[BUG] Fix dialog panel transparency text bleed-through (#2039)

### DIFF
--- a/src/components/ui/dialog.css
+++ b/src/components/ui/dialog.css
@@ -40,7 +40,7 @@
   overflow-y: auto;
   font-family: var(--font-interface);
   color: var(--color-text-primary);
-  background: var(--color-surface);
+  background: var(--color-surface-opaque);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-overlay);

--- a/src/lib/theme/themes/ds3.css
+++ b/src/lib/theme/themes/ds3.css
@@ -13,6 +13,7 @@
   /* Color tokens */
   --color-canvas: rgb(247 243 237);
   --color-surface: rgb(255 252 246 / 80%);
+  --color-surface-opaque: rgb(255 252 246);
   --color-surface-hover: rgb(239 233 224);
   --color-border: rgb(226 217 206);
   --color-border-strong: rgb(212 201 186);
@@ -147,6 +148,7 @@
 :root.dark {
   --color-canvas: rgb(23 19 16);
   --color-surface: rgb(30 26 22 / 80%);
+  --color-surface-opaque: rgb(30 26 22);
   --color-surface-hover: rgb(18 15 12);
   --color-border: rgb(48 41 35);
   --color-border-strong: rgb(61 53 45);


### PR DESCRIPTION
## Description
Dialog panels (`.dialog-content`) were using `--color-surface` which has 80% opacity (`rgb(255 252 246 / 80%)` in light mode, `rgb(30 26 22 / 80%)` in dark mode). This caused underlying page text and elements to bleed through into modal dialogs. Added `--color-surface-opaque` token to DS3 theme variables and updated `.dialog-content` to use it, restoring 100% opacity for all dialog panels.

## Related Issue
Closes #2039

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
- As a user, I want dialog panels to be opaque so text from the underlying page does not bleed through.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

## Implementation Notes
Added `--color-surface-opaque` (`rgb(255 252 246)` in light, `rgb(30 26 22)` in dark) in `src/lib/theme/themes/ds3.css`, and updated `.dialog-content` in `src/components/ui/dialog.css` to use `var(--color-surface-opaque)`.

## Screenshots
N/A

## Visual Baseline Changes
None

## Code Review Summary (if applicable)
N/A

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. Open any dialog in the app (e.g. keyboard shortcuts dialog or recovery notification dialog).
2. Confirm the dialog background is fully opaque with zero text bleed-through from the underlying page.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed