### PR TITLE
[BUG] World creation wizard draft auto-save and recovery (#2034)

### DIFF
--- a/src/components/WorldCreationWizard/WorldCreationWizard.tsx
+++ b/src/components/WorldCreationWizard/WorldCreationWizard.tsx
@@ -161,13 +161,19 @@ export default function WorldCreationWizard({
     }
   }, [hasRecoveryData]);
 
+  const wasTourPausedByRecoveryRef = React.useRef(false);
+
   React.useEffect(() => {
     if (showRecoveryModal) {
-      pauseTour?.();
-    } else {
+      if (isTourActive) {
+        wasTourPausedByRecoveryRef.current = true;
+        pauseTour?.();
+      }
+    } else if (wasTourPausedByRecoveryRef.current) {
+      wasTourPausedByRecoveryRef.current = false;
       resumeTour?.();
     }
-  }, [showRecoveryModal, pauseTour, resumeTour]);
+  }, [showRecoveryModal, isTourActive, pauseTour, resumeTour]);
 
   const handleDataChange = useCallback(
     (newData: WorldCreationData) => {

--- a/src/components/WorldCreationWizard/WorldCreationWizard.tsx
+++ b/src/components/WorldCreationWizard/WorldCreationWizard.tsx
@@ -20,6 +20,8 @@ import {
   WizardStep 
 } from '@/components/shared/wizard';
 import { ConfirmationDialog } from '@/components/ConfirmationDialog/ConfirmationDialog';
+import { useWorldCreationAutoSave } from '@/hooks/useWorldCreationAutoSave';
+import { RecoveryNotification } from '@/components/shared/RecoveryNotification';
 import BasicInfoStep from './steps/BasicInfoStep';
 import DescriptionStep from './steps/DescriptionStep';
 import AttributeReviewStep from './steps/AttributeReviewStep';
@@ -102,7 +104,7 @@ export default function WorldCreationWizard({
 }: WorldCreationWizardProps) {
   const router = useRouter();
   const createWorld = useWorldStore((state) => state.createWorld);
-  const { startTour, setCurrentWizardStep, isTourActive } = useTutorial();
+  const { startTour, setCurrentWizardStep, isTourActive, pauseTour, resumeTour } = useTutorial();
   const worldCreationProgress = useSessionStore(state => state.tutorialProgress.phases.worldCreation);
   
   // Initialize world creation data
@@ -140,6 +142,45 @@ export default function WorldCreationWizard({
     };
   }, []);
 
+  const {
+    data: autoSaveData,
+    setData: setAutoSaveData,
+    clearAutoSave,
+    dismissRecovery,
+    hasRecoveryData,
+    recoveryPreview,
+    hasCurrentData: autoSaveHasCurrentData,
+    isLoaded: isAutoSaveLoaded,
+  } = useWorldCreationAutoSave();
+
+  const [showRecoveryModal, setShowRecoveryModal] = useState(false);
+
+  React.useEffect(() => {
+    if (hasRecoveryData) {
+      setShowRecoveryModal(true);
+    }
+  }, [hasRecoveryData]);
+
+  React.useEffect(() => {
+    if (showRecoveryModal) {
+      pauseTour?.();
+    } else {
+      resumeTour?.();
+    }
+  }, [showRecoveryModal, pauseTour, resumeTour]);
+
+  const handleDataChange = useCallback(
+    (newData: WorldCreationData) => {
+      if (isAutoSaveLoaded && !hasRecoveryData && !showRecoveryModal) {
+        setAutoSaveData({
+          currentStep: wizardRef.current?.state.currentStep ?? 0,
+          worldData: newData,
+        });
+      }
+    },
+    [setAutoSaveData, isAutoSaveLoaded, hasRecoveryData, showRecoveryModal]
+  );
+
   // Wizard state management
   const wizard = useWizardState<WorldCreationData>({
     initialData: initialWorldData,
@@ -149,7 +190,36 @@ export default function WorldCreationWizard({
       const validator = stepValidators[stepIndex];
       return validator ? validator(data) : { valid: true, errors: [], touched: true };
     },
+    onDataChange: handleDataChange,
   });
+
+  const wizardRef = React.useRef(wizard);
+  wizardRef.current = wizard;
+
+  React.useEffect(() => {
+    if (isAutoSaveLoaded && wizard.state.data && !hasRecoveryData && !showRecoveryModal) {
+      setAutoSaveData({
+        currentStep: wizard.state.currentStep,
+        worldData: wizard.state.data,
+      });
+    }
+  }, [isAutoSaveLoaded, wizard.state.currentStep, hasRecoveryData, showRecoveryModal, setAutoSaveData]);
+
+  const handleRecoverProgress = useCallback(() => {
+    if (autoSaveData) {
+      wizard.reset(
+        autoSaveData.worldData,
+        autoSaveData.currentStep
+      );
+      dismissRecovery();
+    }
+    setShowRecoveryModal(false);
+  }, [autoSaveData, wizard, dismissRecovery]);
+
+  const handleDismissRecovery = useCallback(() => {
+    clearAutoSave();
+    setShowRecoveryModal(false);
+  }, [clearAutoSave]);
 
   // Sync wizard step with tutorial provider
   React.useEffect(() => {
@@ -287,6 +357,7 @@ export default function WorldCreationWizard({
       // Show confirmation dialog
       setShowCancelConfirmation(true);
     } else {
+      clearAutoSave();
       // Direct cancel for clean state
       if (onCancel) {
         onCancel();
@@ -294,16 +365,17 @@ export default function WorldCreationWizard({
         router.push('/worlds');
       }
     }
-  }, [isDirty, onCancel, router]);
+  }, [isDirty, clearAutoSave, onCancel, router]);
 
   const handleConfirmCancel = useCallback(() => {
+    clearAutoSave();
     setShowCancelConfirmation(false);
     if (onCancel) {
       onCancel();
     } else {
       router.push('/worlds');
     }
-  }, [onCancel, router]);
+  }, [clearAutoSave, onCancel, router]);
 
   const handleRejectCancel = useCallback(() => {
     setShowCancelConfirmation(false);
@@ -318,6 +390,7 @@ export default function WorldCreationWizard({
   }, [onComplete, router]);
 
   const handleComplete = useCallback(async () => {
+    clearAutoSave();
     const data = wizard.state.data;
 
     // If the world was already created (e.g. returning to finalize), just finish.
@@ -495,6 +568,25 @@ export default function WorldCreationWizard({
         variant="warning"
         confirmText="Yes, Cancel"
         cancelText="Continue Editing"
+      />
+
+      {/* Recovery Notification Dialog */}
+      <RecoveryNotification
+        isVisible={showRecoveryModal}
+        lastSaved={recoveryPreview?.lastSaved}
+        recoveryData={recoveryPreview}
+        hasCurrentData={autoSaveHasCurrentData}
+        title="World Creation Progress Found"
+        description="Found saved world creation progress from a previous session."
+        stepNames={[
+          'Basic Information',
+          'World Description',
+          'Review Attributes',
+          'Review Skills',
+          'Finalize',
+        ]}
+        onRecover={handleRecoverProgress}
+        onDismiss={handleDismissRecovery}
       />
     </WizardContainer>
   );

--- a/src/components/WorldCreationWizard/__tests__/WorldCreationWizard.recovery.test.tsx
+++ b/src/components/WorldCreationWizard/__tests__/WorldCreationWizard.recovery.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import WorldCreationWizard from '../WorldCreationWizard';
 import { DRAFT_STORAGE_KEY } from '@/hooks/useWorldCreationAutoSave';
@@ -145,6 +145,31 @@ describe('WorldCreationWizard draft auto-save and recovery', () => {
     });
 
     expect(localStorage.getItem(DRAFT_STORAGE_KEY)).toBeNull();
+  });
+
+  it('continues auto-saving new edits after Start Fresh is clicked', async () => {
+    const user = userEvent.setup();
+    const draft = {
+      currentStep: 0,
+      worldData: { name: 'Old World' },
+      lastSaved: '2026-09-07T20:00:00.000Z',
+    };
+    localStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft));
+
+    render(<WorldCreationWizard />);
+
+    const startFreshButton = await screen.findByRole('button', { name: /Start Fresh/i });
+    await user.click(startFreshButton);
+
+    const nameInput = screen.getByTestId('world-name-input');
+    await user.type(nameInput, 'New World');
+
+    await waitFor(() => {
+      const savedRaw = localStorage.getItem(DRAFT_STORAGE_KEY);
+      expect(savedRaw).not.toBeNull();
+      const saved = JSON.parse(savedRaw!);
+      expect(saved.worldData.name).toBe('New World');
+    });
   });
 
   it('clears draft from localStorage on cancel confirmation', async () => {

--- a/src/components/WorldCreationWizard/__tests__/WorldCreationWizard.recovery.test.tsx
+++ b/src/components/WorldCreationWizard/__tests__/WorldCreationWizard.recovery.test.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import WorldCreationWizard from '../WorldCreationWizard';
+import { DRAFT_STORAGE_KEY } from '@/hooks/useWorldCreationAutoSave';
+
+const mockPush = jest.fn();
+const mockCreateWorld = jest.fn().mockReturnValue('world-123');
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+  }),
+}));
+
+jest.mock('@/state/worldStore', () => ({
+  useWorldStore: (selector: any) => {
+    if (typeof selector === 'function') {
+      return selector({
+        createWorld: mockCreateWorld,
+        setCurrentWorld: jest.fn(),
+        updateWorld: jest.fn(),
+        worlds: {},
+      });
+    }
+    return {
+      createWorld: mockCreateWorld,
+      setCurrentWorld: jest.fn(),
+      updateWorld: jest.fn(),
+      worlds: {},
+    };
+  },
+}));
+
+jest.mock('@/state/sessionStore', () => ({
+  useSessionStore: () => ({
+    tutorialProgress: {
+      phases: {
+        worldCreation: { completed: true, skipped: false, lastStep: 0 },
+      },
+    },
+  }),
+}));
+
+jest.mock('@/components/TutorialProvider', () => ({
+  useTutorial: () => ({
+    setCurrentWizardStep: jest.fn(),
+    pauseTour: jest.fn(),
+    resumeTour: jest.fn(),
+    startTour: jest.fn(),
+    isTourActive: false,
+  }),
+}));
+
+jest.mock('@/lib/ai/worldImageGenerator', () => ({
+  generateWorldImage: jest.fn().mockResolvedValue({ url: 'http://example.com/image.png' }),
+}));
+
+jest.mock('@/lib/ai/worldAnalyzerClient', () => ({
+  analyzeWorldDescriptionClient: jest.fn().mockResolvedValue({
+    attributes: [],
+    skills: [],
+  }),
+}));
+
+jest.mock('@/lib/services/worldCreationService', () => ({
+  ensureWorldNpcRoster: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('WorldCreationWizard draft auto-save and recovery', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it('renders recovery dialog when draft exists in localStorage', async () => {
+    const draft = {
+      currentStep: 1,
+      worldData: {
+        name: 'Solaria',
+        genre: 'Sci-Fi',
+        description: 'A futuristic city-state among the stars with advanced cybernetics.',
+      },
+      lastSaved: '2026-09-07T20:00:00.000Z',
+    };
+    localStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft));
+
+    render(<WorldCreationWizard />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/World Creation Progress Found/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Solaria/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Sci-Fi/i)[0]).toBeInTheDocument();
+  });
+
+  it('restores draft into wizard state when Recover Progress is clicked', async () => {
+    const user = userEvent.setup();
+    const draft = {
+      currentStep: 1,
+      worldData: {
+        name: 'Solaria',
+        genre: 'Sci-Fi',
+        description: 'A futuristic city-state among the stars with advanced cybernetics.',
+      },
+      lastSaved: '2026-09-07T20:00:00.000Z',
+    };
+    localStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft));
+
+    render(<WorldCreationWizard />);
+
+    const recoverButton = await screen.findByRole('button', { name: /Recover Progress/i });
+    await user.click(recoverButton);
+
+    // Should switch to step 1 (Description) with restored description
+    await waitFor(() => {
+      expect(screen.getByTestId('description-step')).toBeInTheDocument();
+    });
+
+    const descriptionInput = screen.getByTestId('world-full-description');
+    expect(descriptionInput).toHaveValue('A futuristic city-state among the stars with advanced cybernetics.');
+  });
+
+  it('clears draft from localStorage when Start Fresh is clicked', async () => {
+    const user = userEvent.setup();
+    const draft = {
+      currentStep: 0,
+      worldData: {
+        name: 'Discarded World',
+        genre: 'Fantasy',
+      },
+    };
+    localStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft));
+
+    render(<WorldCreationWizard />);
+
+    const startFreshButton = await screen.findByRole('button', { name: /Start Fresh/i });
+    await user.click(startFreshButton);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/World Creation Progress Found/i)).not.toBeInTheDocument();
+    });
+
+    expect(localStorage.getItem(DRAFT_STORAGE_KEY)).toBeNull();
+  });
+
+  it('clears draft from localStorage on cancel confirmation', async () => {
+    const user = userEvent.setup();
+    render(<WorldCreationWizard />);
+
+    // Type a genre to make form dirty
+    const select = screen.getByLabelText(/genre/i);
+    await user.selectOptions(select, 'fantasy');
+
+    // Click cancel button
+    const cancelButton = screen.getByRole('button', { name: /Cancel/i });
+    await user.click(cancelButton);
+
+    // Confirmation dialog appears
+    const confirmButton = await screen.findByRole('button', { name: /Yes, Cancel/i });
+    await user.click(confirmButton);
+
+    expect(localStorage.getItem(DRAFT_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/src/components/shared/RecoveryNotification.tsx
+++ b/src/components/shared/RecoveryNotification.tsx
@@ -40,15 +40,19 @@ import { formatDateTime } from '@/lib/utils';
  * Recovery data structure containing analyzed save information for preview display
  */
 interface RecoveryData {
-  /** Character name from saved data */
+  /** Character or World name from saved data */
   name?: string;
+  /** Genre from saved data */
+  genre?: string;
+  /** Description from saved data */
+  description?: string;
   /** Current wizard step index (0-based) */
   currentStep?: number;
   /** ISO timestamp of when data was last saved */
   lastSaved?: string;
-  /** Whether character has allocated attribute points */
+  /** Whether character/world has allocated attributes */
   hasAttributes?: boolean;
-  /** Whether character has selected skills */
+  /** Whether character/world has selected skills */
   hasSkills?: boolean;
   /** Whether character has completed background information */
   hasBackground?: boolean;
@@ -56,6 +60,10 @@ interface RecoveryData {
   selectedSkillCount?: number;
   /** Total attribute points allocated across all attributes */
   totalAttributePoints?: number;
+  /** Number of attributes created or present */
+  attributeCount?: number;
+  /** Number of skills created or present */
+  skillCount?: number;
 }
 
 /**
@@ -74,6 +82,12 @@ interface RecoveryNotificationProps {
   onRecover: () => void;
   /** Callback fired when user chooses to dismiss recovery and start fresh */
   onDismiss: () => void;
+  /** Optional custom title for modal */
+  title?: string;
+  /** Optional custom description for modal */
+  description?: string;
+  /** Optional custom step names array */
+  stepNames?: string[];
 }
 
 /**
@@ -92,6 +106,9 @@ export function RecoveryNotification({
   hasCurrentData = false,
   onRecover,
   onDismiss,
+  title,
+  description,
+  stepNames,
 }: RecoveryNotificationProps) {
   /** Reference to the recover button for focus management */
   const recoverButtonRef = useRef<HTMLButtonElement>(null);
@@ -121,15 +138,15 @@ export function RecoveryNotification({
    * @returns Human-readable step description
    */
   const getStepDescription = (step?: number): string => {
-    const stepNames = [
+    const names = stepNames || [
       'Basic Info',
       'Attributes',
       'Skills',
       'Background',
       'Portrait',
     ];
-    if (step !== undefined && step >= 0 && step < stepNames.length) {
-      return `${stepNames[step]} step`;
+    if (step !== undefined && step >= 0 && step < names.length) {
+      return `${names[step]} step`;
     }
     return 'Unknown step';
   };
@@ -138,8 +155,8 @@ export function RecoveryNotification({
     <SimpleModal
       isOpen={isVisible}
       onClose={onDismiss}
-      title="Character Creation Progress Found"
-      description="Found saved character creation progress from a previous session."
+      title={title || "Character Creation Progress Found"}
+      description={description || "Found saved character creation progress from a previous session."}
       showCloseButton={true}
       ariaDescribedBy="recovery-notification-content"
     >
@@ -182,7 +199,12 @@ export function RecoveryNotification({
             <div>
               {recoveryData.name && (
                 <div>
-                  Character name: <span>{recoveryData.name}</span>
+                  Name: <span>{recoveryData.name}</span>
+                </div>
+              )}
+              {recoveryData.genre && (
+                <div>
+                  Genre: <span>{recoveryData.genre}</span>
                 </div>
               )}
               {recoveryData.currentStep !== undefined && (
@@ -192,17 +214,19 @@ export function RecoveryNotification({
                 </div>
               )}
               {recoveryData.hasAttributes &&
-                recoveryData.totalAttributePoints !== undefined && (
+                (recoveryData.totalAttributePoints !== undefined || recoveryData.attributeCount !== undefined) && (
                   <div>
-                    Attribute points allocated:{' '}
-                    <span>{recoveryData.totalAttributePoints}</span>
+                    {recoveryData.totalAttributePoints !== undefined
+                      ? `Attribute points allocated: ${recoveryData.totalAttributePoints}`
+                      : `Attributes: ${recoveryData.attributeCount}`}
                   </div>
                 )}
               {recoveryData.hasSkills &&
-                recoveryData.selectedSkillCount !== undefined && (
+                (recoveryData.selectedSkillCount !== undefined || recoveryData.skillCount !== undefined) && (
                   <div>
-                    Skills selected:{' '}
-                    <span>{recoveryData.selectedSkillCount}</span>
+                    {recoveryData.selectedSkillCount !== undefined
+                      ? `Skills selected: ${recoveryData.selectedSkillCount}`
+                      : `Skills: ${recoveryData.skillCount}`}
                   </div>
                 )}
               {recoveryData.hasBackground && (

--- a/src/hooks/__tests__/useWorldCreationAutoSave.test.ts
+++ b/src/hooks/__tests__/useWorldCreationAutoSave.test.ts
@@ -1,0 +1,143 @@
+import { renderHook, act } from '@testing-library/react';
+import { useWorldCreationAutoSave, DRAFT_STORAGE_KEY } from '../useWorldCreationAutoSave';
+
+describe('useWorldCreationAutoSave', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('initializes with default state when no saved draft exists', () => {
+    const { result } = renderHook(() => useWorldCreationAutoSave());
+
+    // Advance initial restoration timers
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(result.current.hasRecoveryData).toBe(false);
+    expect(result.current.recoveryPreview).toBeUndefined();
+    expect(result.current.hasCurrentData).toBe(false);
+    expect(result.current.saveStatus).toBe('idle');
+  });
+
+  it('restores draft data and generates preview on mount if localStorage has saved draft', () => {
+    const mockDraft = {
+      currentStep: 2,
+      worldData: {
+        name: 'Aethelgard',
+        genre: 'Fantasy',
+        description: 'A grand realm of ancient magic and soaring dragons.',
+        attributes: [
+          { name: 'Might', value: 5 },
+          { name: 'Wits', value: 6 },
+        ],
+        skills: [{ name: 'Arcana', value: 3 }],
+      },
+      lastSaved: '2026-09-07T20:00:00.000Z',
+    };
+
+    localStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(mockDraft));
+
+    const { result } = renderHook(() => useWorldCreationAutoSave());
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(result.current.hasRecoveryData).toBe(true);
+    expect(result.current.recoveryPreview).toEqual({
+      name: 'Aethelgard',
+      genre: 'Fantasy',
+      description: 'A grand realm of ancient magic and soaring dragons.',
+      currentStep: 2,
+      lastSaved: '2026-09-07T20:00:00.000Z',
+      hasAttributes: true,
+      attributeCount: 2,
+      hasSkills: true,
+      skillCount: 1,
+    });
+    expect(result.current.data?.worldData.name).toBe('Aethelgard');
+  });
+
+  it('debounces writing data to localStorage (300ms)', () => {
+    const { result } = renderHook(() => useWorldCreationAutoSave());
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    const update1 = {
+      currentStep: 0,
+      worldData: { name: 'Draft World 1' },
+    };
+
+    act(() => {
+      result.current.setData(update1);
+    });
+
+    // Save status is saving before 300ms
+    expect(result.current.saveStatus).toBe('saving');
+    expect(localStorage.getItem(DRAFT_STORAGE_KEY)).toBeNull();
+
+    // Advance 200ms (not yet 300ms)
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(localStorage.getItem(DRAFT_STORAGE_KEY)).toBeNull();
+
+    // Advance remaining 100ms
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(result.current.saveStatus).toBe('saved');
+    const stored = JSON.parse(localStorage.getItem(DRAFT_STORAGE_KEY) || '{}');
+    expect(stored.worldData.name).toBe('Draft World 1');
+  });
+
+  it('clears draft from localStorage and resets state on clearAutoSave', () => {
+    const mockDraft = {
+      currentStep: 1,
+      worldData: { name: 'World to Clear' },
+      lastSaved: '2026-09-07T20:00:00.000Z',
+    };
+    localStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(mockDraft));
+
+    const { result } = renderHook(() => useWorldCreationAutoSave());
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(result.current.hasRecoveryData).toBe(true);
+
+    act(() => {
+      result.current.clearAutoSave();
+    });
+
+    expect(localStorage.getItem(DRAFT_STORAGE_KEY)).toBeNull();
+    expect(result.current.hasRecoveryData).toBe(false);
+    expect(result.current.recoveryPreview).toBeUndefined();
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.saveStatus).toBe('idle');
+  });
+
+  it('handles corrupted localStorage JSON gracefully', () => {
+    localStorage.setItem(DRAFT_STORAGE_KEY, 'invalid-json-data');
+
+    const { result } = renderHook(() => useWorldCreationAutoSave());
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(result.current.hasRecoveryData).toBe(true);
+    expect(result.current.recoveryPreview).toBeUndefined();
+  });
+});

--- a/src/hooks/__tests__/useWorldCreationAutoSave.test.ts
+++ b/src/hooks/__tests__/useWorldCreationAutoSave.test.ts
@@ -137,7 +137,7 @@ describe('useWorldCreationAutoSave', () => {
       jest.advanceTimersByTime(100);
     });
 
-    expect(result.current.hasRecoveryData).toBe(true);
+    expect(result.current.hasRecoveryData).toBe(false);
     expect(result.current.recoveryPreview).toBeUndefined();
   });
 });

--- a/src/hooks/useWorldCreationAutoSave.ts
+++ b/src/hooks/useWorldCreationAutoSave.ts
@@ -1,0 +1,220 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { World } from '@/types/world.types';
+import { getTimestamp } from '@/lib/utils';
+import Logger from '@/lib/utils/logger';
+import { AttributeSuggestion, SkillSuggestion } from '@/components/WorldCreationWizard/WizardState';
+import { AIGuidanceSource } from '@/lib/constants/worldGuidance';
+
+const logger = new Logger('UseWorldCreationAutoSave');
+
+export const DRAFT_STORAGE_KEY = 'world-creation-draft';
+
+export interface WorldCreationData extends Partial<World> {
+  aiSuggestions?: {
+    attributes: AttributeSuggestion[];
+    skills: SkillSuggestion[];
+  };
+  aiSuggestionsGenerated?: boolean;
+  worldType?: 'original' | 'inspired_by' | 'set_within';
+  createdWorldId?: string;
+  aiSuggestionMeta?: {
+    source: AIGuidanceSource;
+    generatedAt?: string;
+    descriptionSnapshot?: string;
+  };
+}
+
+export interface WorldCreationState {
+  currentStep: number;
+  worldData: WorldCreationData;
+  lastSaved?: string;
+}
+
+export interface WorldCreationRecoveryPreview {
+  name?: string;
+  genre?: string;
+  description?: string;
+  currentStep?: number;
+  lastSaved?: string;
+  hasAttributes?: boolean;
+  hasSkills?: boolean;
+  attributeCount?: number;
+  skillCount?: number;
+}
+
+/**
+ * Analyzes world creation draft data to generate preview information
+ */
+function analyzeRecoveryData(data: WorldCreationState): WorldCreationRecoveryPreview {
+  const preview: WorldCreationRecoveryPreview = {
+    currentStep: data.currentStep,
+    lastSaved: data.lastSaved,
+  };
+
+  const worldData = data.worldData;
+  if (!worldData) {
+    return preview;
+  }
+
+  if (typeof worldData.name === 'string' && worldData.name.trim()) {
+    preview.name = worldData.name;
+  }
+
+  if (typeof worldData.genre === 'string' && worldData.genre.trim()) {
+    preview.genre = worldData.genre;
+  }
+
+  if (typeof worldData.description === 'string' && worldData.description.trim()) {
+    preview.description = worldData.description;
+  }
+
+  if (Array.isArray(worldData.attributes) && worldData.attributes.length > 0) {
+    preview.hasAttributes = true;
+    preview.attributeCount = worldData.attributes.length;
+  }
+
+  if (Array.isArray(worldData.skills) && worldData.skills.length > 0) {
+    preview.hasSkills = true;
+    preview.skillCount = worldData.skills.length;
+  }
+
+  return preview;
+}
+
+/**
+ * Checks if current form has meaningful data
+ */
+function hasCurrentFormData(data: WorldCreationState | undefined): boolean {
+  if (!data || !data.worldData) return false;
+
+  const worldData = data.worldData;
+
+  return !!(
+    worldData.name ||
+    worldData.genre ||
+    worldData.description ||
+    (Array.isArray(worldData.attributes) && worldData.attributes.length > 0) ||
+    (Array.isArray(worldData.skills) && worldData.skills.length > 0)
+  );
+}
+
+/**
+ * World Creation Auto-Save Hook
+ *
+ * Saves world creation progress to localStorage under key 'world-creation-draft',
+ * debounced at 300ms so typing doesn't thrash writes. Detects recoverable data on mount.
+ */
+export const useWorldCreationAutoSave = () => {
+  const [data, setDataInternal] = useState<WorldCreationState | undefined>();
+  const [hasRecoveryData, setHasRecoveryData] = useState(false);
+  const [recoveryPreview, setRecoveryPreview] = useState<WorldCreationRecoveryPreview | undefined>();
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved'>('idle');
+
+  const saveKey = DRAFT_STORAGE_KEY;
+  const hasLoadedRef = useRef(false);
+  const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Debounced auto-save to localStorage whenever data changes
+  useEffect(() => {
+    if (data && hasLoadedRef.current) {
+      setSaveStatus('saving');
+
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+      }
+
+      saveTimeoutRef.current = setTimeout(() => {
+        try {
+          const dataWithTimestamp = {
+            ...data,
+            lastSaved: getTimestamp(),
+          };
+          localStorage.setItem(saveKey, JSON.stringify(dataWithTimestamp));
+          setSaveStatus('saved');
+        } catch (error) {
+          logger.error('[AutoSave] Failed to save world creation data', error);
+          setSaveStatus('idle');
+        }
+      }, 300);
+    }
+  }, [data, saveKey]);
+
+  const hasRecoveryDataRef = useRef(false);
+  hasRecoveryDataRef.current = hasRecoveryData;
+
+  const setData = useCallback((newData: WorldCreationState | undefined) => {
+    if (!hasLoadedRef.current) return;
+    setDataInternal(newData);
+  }, []);
+
+  // Restore on mount
+  useEffect(() => {
+    if (hasLoadedRef.current) return;
+
+    const loadData = () => {
+      const saved = localStorage.getItem(saveKey);
+      if (saved) {
+        try {
+          const parsed = JSON.parse(saved);
+          setHasRecoveryData(true);
+          setRecoveryPreview(analyzeRecoveryData(parsed));
+          setDataInternal(parsed);
+          hasLoadedRef.current = true;
+        } catch (e) {
+          logger.error('[AutoSave] Failed to restore world creation data', e);
+          setHasRecoveryData(true);
+          setRecoveryPreview(undefined);
+          hasLoadedRef.current = true;
+        }
+      } else {
+        setHasRecoveryData(false);
+        setRecoveryPreview(undefined);
+        hasLoadedRef.current = true;
+      }
+    };
+
+    loadData();
+
+    const timeoutId = setTimeout(loadData, 50);
+
+    return () => clearTimeout(timeoutId);
+  }, [saveKey]);
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const dismissRecovery = useCallback(() => {
+    setHasRecoveryData(false);
+  }, []);
+
+  const clearAutoSave = useCallback(() => {
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+      saveTimeoutRef.current = null;
+    }
+    localStorage.removeItem(saveKey);
+    setHasRecoveryData(false);
+    setRecoveryPreview(undefined);
+    setDataInternal(undefined);
+    hasLoadedRef.current = false;
+    setSaveStatus('idle');
+  }, [saveKey]);
+
+  return {
+    data,
+    setData,
+    clearAutoSave,
+    dismissRecovery,
+    hasRecoveryData,
+    recoveryPreview,
+    hasCurrentData: hasCurrentFormData(data),
+    saveStatus,
+    isLoaded: hasLoadedRef.current,
+  };
+};

--- a/src/hooks/useWorldCreationAutoSave.ts
+++ b/src/hooks/useWorldCreationAutoSave.ts
@@ -162,8 +162,10 @@ export const useWorldCreationAutoSave = () => {
           hasLoadedRef.current = true;
         } catch (e) {
           logger.error('[AutoSave] Failed to restore world creation data', e);
-          setHasRecoveryData(true);
+          localStorage.removeItem(saveKey);
+          setHasRecoveryData(false);
           setRecoveryPreview(undefined);
+          setDataInternal(undefined);
           hasLoadedRef.current = true;
         }
       } else {
@@ -202,7 +204,7 @@ export const useWorldCreationAutoSave = () => {
     setHasRecoveryData(false);
     setRecoveryPreview(undefined);
     setDataInternal(undefined);
-    hasLoadedRef.current = false;
+    hasLoadedRef.current = true;
     setSaveStatus('idle');
   }, [saveKey]);
 


### PR DESCRIPTION
## Description
Implements draft auto-save and recovery for the world creation wizard so progress is preserved when a user reloads or navigates away.

## Related Issue
Closes #2034

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
As a user creating a world, I want my typed progress saved automatically so I don't lose data if the page reloads.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

## Implementation Notes
- Created `useWorldCreationAutoSave` hook storing draft state in `localStorage` under `world-creation-draft` with 300ms debounce.
- Integrated `RecoveryNotification` modal into `WorldCreationWizard` to prompt for draft recovery or starting fresh on mount.
- Added automatic draft clearing upon wizard completion (`handleComplete`) and cancellation (`handleConfirmCancel`).
- Added checks to prevent initial empty wizard state from overwriting pending drafts prior to recovery resolution.

## Screenshots
N/A

## Visual Baseline Changes
None

## Code Review Summary (if applicable)
Self-reviewed implementation and verified all unit test suites pass cleanly.

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. Open the World Creation Wizard and type a world name or description.
2. Reload the page before completing creation.
3. Verify the recovery modal appears offering to recover your saved draft.
4. Click "Recover Progress" and confirm that all typed fields and wizard step are restored.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed