### PR TITLE
fix(theme): default unchosen color scheme to system preference

### DIFF
--- a/public_docs/design-system/global-styles.md
+++ b/public_docs/design-system/global-styles.md
@@ -161,7 +161,7 @@ Throws `Error('useTheme must be used within a ThemeProvider')` if called outside
 
 | Key | localStorage Key | Default | Purpose |
 |-----|-----------------|---------|---------|
-| Color scheme | `narraitor-color-scheme` | `'light'` | Light, dark, or system preference |
+| Color scheme | `narraitor-color-scheme` | `'system'` | Light, dark, or system preference |
 
 There's no theme key: the design-system axis was collapsed to one (ADR-013), and the vestigial `theme`/`setTheme` surface was removed from `useTheme()` along with the selector flatten (#1546).
 

--- a/src/lib/theme/__tests__/ThemeProvider.test.tsx
+++ b/src/lib/theme/__tests__/ThemeProvider.test.tsx
@@ -40,7 +40,46 @@ describe('ThemeProvider', () => {
     });
   });
 
-  it('defaults to light mode', () => {
+  it('defaults an unchosen color scheme to system', () => {
+    let ctx: ReturnType<typeof useTheme> | null = null;
+    renderWithProvider((c) => { ctx = c; });
+
+    expect(ctx!.colorScheme).toBe('system');
+    expect(ctx!.resolvedColorScheme).toBe('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('tracks system dark mode preference when no explicit choice is set', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation((query: string) => ({
+        matches: query.includes('prefers-color-scheme: dark'),
+        media: query,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      })),
+    });
+
+    let ctx: ReturnType<typeof useTheme> | null = null;
+    renderWithProvider((c) => { ctx = c; });
+
+    expect(ctx!.colorScheme).toBe('system');
+    expect(ctx!.resolvedColorScheme).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('preserves explicit light choice when system preference is dark', () => {
+    localStorage.setItem(STORAGE_KEY_COLOR_SCHEME, 'light');
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation((query: string) => ({
+        matches: query.includes('prefers-color-scheme: dark'),
+        media: query,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      })),
+    });
+
     let ctx: ReturnType<typeof useTheme> | null = null;
     renderWithProvider((c) => { ctx = c; });
 

--- a/src/lib/theme/__tests__/themeInitScript.test.ts
+++ b/src/lib/theme/__tests__/themeInitScript.test.ts
@@ -1,0 +1,51 @@
+import { THEME_INIT_SCRIPT } from '../themeInitScript';
+
+describe('THEME_INIT_SCRIPT', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+  });
+
+  function executeInitScript(matchesDark: boolean) {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation((query: string) => ({
+        matches: query.includes('prefers-color-scheme: dark') ? matchesDark : false,
+        media: query,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      })),
+    });
+
+    // Execute the string code via Function constructor to simulate inline script evaluation
+    new Function(THEME_INIT_SCRIPT)();
+  }
+
+  it('adds dark class on first paint when prefers-color-scheme: dark and no explicit preference is set', () => {
+    executeInitScript(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('does not add dark class on first paint when prefers-color-scheme is light and no explicit preference is set', () => {
+    executeInitScript(false);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('adds dark class on first paint when color scheme is explicitly system and prefers-color-scheme is dark', () => {
+    localStorage.setItem('narraitor-color-scheme', 'system');
+    executeInitScript(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('adds dark class on first paint when color scheme is explicitly dark regardless of system preference', () => {
+    localStorage.setItem('narraitor-color-scheme', 'dark');
+    executeInitScript(false);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('preserves explicit light preference on first paint even when prefers-color-scheme is dark', () => {
+    localStorage.setItem('narraitor-color-scheme', 'light');
+    executeInitScript(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+});

--- a/src/lib/theme/__tests__/themeInitScript.test.ts
+++ b/src/lib/theme/__tests__/themeInitScript.test.ts
@@ -48,4 +48,10 @@ describe('THEME_INIT_SCRIPT', () => {
     executeInitScript(true);
     expect(document.documentElement.classList.contains('dark')).toBe(false);
   });
+
+  it('treats invalid or unrecognized stored scheme as system default on dark-mode OS', () => {
+    localStorage.setItem('narraitor-color-scheme', 'invalid-scheme');
+    executeInitScript(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
 });

--- a/src/lib/theme/colorScheme.ts
+++ b/src/lib/theme/colorScheme.ts
@@ -1,5 +1,5 @@
 export type ColorScheme = 'light' | 'dark' | 'system';
 
-export const DEFAULT_COLOR_SCHEME: ColorScheme = 'light';
+export const DEFAULT_COLOR_SCHEME: ColorScheme = 'system';
 
 export const STORAGE_KEY_COLOR_SCHEME = 'narraitor-color-scheme';

--- a/src/lib/theme/themeInitScript.ts
+++ b/src/lib/theme/themeInitScript.ts
@@ -4,9 +4,9 @@
 export const THEME_INIT_SCRIPT = `(function () {
   try {
     var scheme = localStorage.getItem('narraitor-color-scheme');
+    var isExplicit = scheme === 'light' || scheme === 'dark';
     var systemPrefersDark =
-      (!scheme || scheme === 'system') &&
-      matchMedia('(prefers-color-scheme: dark)').matches;
+      !isExplicit && matchMedia('(prefers-color-scheme: dark)').matches;
     if (scheme === 'dark' || systemPrefersDark) {
       document.documentElement.classList.add('dark');
     }

--- a/src/lib/theme/themeInitScript.ts
+++ b/src/lib/theme/themeInitScript.ts
@@ -5,7 +5,7 @@ export const THEME_INIT_SCRIPT = `(function () {
   try {
     var scheme = localStorage.getItem('narraitor-color-scheme');
     var systemPrefersDark =
-      scheme === 'system' &&
+      (!scheme || scheme === 'system') &&
       matchMedia('(prefers-color-scheme: dark)').matches;
     if (scheme === 'dark' || systemPrefersDark) {
       document.documentElement.classList.add('dark');


### PR DESCRIPTION
## Description
Fixes issue where first page load pins light mode on a dark-mode system when no explicit color scheme choice has been stored in `localStorage`. Defaults unchosen color scheme to `system` and updates inline `<head>` script to check system dark mode preference when `narraitor-color-scheme` is missing or set to `system`.

## Related Issue
Closes #2045

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
- As a user with dark mode enabled on my device, opening Narraitor for the first time renders in dark mode without flashing light mode.

## Flow Diagrams
N/A

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

## Implementation Notes
- Updated `DEFAULT_COLOR_SCHEME` in `src/lib/theme/colorScheme.ts` from `'light'` to `'system'`.
- Updated `THEME_INIT_SCRIPT` in `src/lib/theme/themeInitScript.ts` to check `matchMedia('(prefers-color-scheme: dark)').matches` when `scheme` is falsy (not set in `localStorage`) or explicitly `'system'`.
- Updated `ThemeProvider` unit tests and added unit tests for `THEME_INIT_SCRIPT`.

## Screenshots
N/A

## Visual Baseline Changes
None

## Code Review Summary (if applicable)
Verified that explicit `localStorage` settings (`'light'` or `'dark'`) override system preference on first paint and after hydration.

## Chrome DevTools MCP Verification Summary (if applicable)
N/A

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. Clear `localStorage.removeItem('narraitor-color-scheme')` (or open in incognito).
2. Set OS appearance preference to dark mode.
3. Open page — first paint and rendered theme reflect dark mode.
4. Set explicit light or dark preference in Appearance menu — verify preference persists across reloads.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed