### PR TITLE
fix(tutorial): drive wizard steps on Joyride Next and require full tour completion (#2037)

### DIFF
--- a/src/components/CharacterCreationWizard/CharacterCreationWizard.tsx
+++ b/src/components/CharacterCreationWizard/CharacterCreationWizard.tsx
@@ -21,6 +21,7 @@ import { BackgroundStep } from './steps/BackgroundStep';
 import { PortraitStep } from './steps/PortraitStep';
 import { normalizeSkillBounds } from './utils/skillAllocation';
 import { useTutorial } from '@/components/TutorialProvider';
+import { tourStepToWizardStep } from '@/lib/tutorial/characterCreationWizardTour';
 import type { WizardValidation } from '@/hooks/useWizardState';
 
 /**
@@ -44,6 +45,7 @@ export const CharacterCreationWizard: React.FC<CharacterCreationWizardProps> = (
     resumeTour,
     currentTour,
     isTourActive,
+    stepIndex,
   } = useTutorial();
   const pausedForRecoveryRef = useRef(false);
 
@@ -126,6 +128,15 @@ export const CharacterCreationWizard: React.FC<CharacterCreationWizardProps> = (
   React.useEffect(() => {
     setCurrentWizardStep(wizard.state.currentStep);
   }, [wizard.state.currentStep, setCurrentWizardStep]);
+
+  // Sync tour step index to wizard step when tour is active
+  React.useEffect(() => {
+    if (!isTourActive || currentTour !== 'characterCreationWizard') return;
+    const targetWizardStep = tourStepToWizardStep[stepIndex];
+    if (targetWizardStep !== undefined && targetWizardStep !== wizard.state.currentStep) {
+      wizard.goToStep(targetWizardStep);
+    }
+  }, [stepIndex, isTourActive, currentTour, wizard]);
 
   // Point pool managers
   const { attributePool, skillPool } = useCharacterPointPools({

--- a/src/components/CharacterCreationWizard/CharacterCreationWizard.tsx
+++ b/src/components/CharacterCreationWizard/CharacterCreationWizard.tsx
@@ -45,6 +45,7 @@ export const CharacterCreationWizard: React.FC<CharacterCreationWizardProps> = (
     resumeTour,
     currentTour,
     isTourActive,
+    isPaused,
     stepIndex,
   } = useTutorial();
   const pausedForRecoveryRef = useRef(false);
@@ -129,14 +130,22 @@ export const CharacterCreationWizard: React.FC<CharacterCreationWizardProps> = (
     setCurrentWizardStep(wizard.state.currentStep);
   }, [wizard.state.currentStep, setCurrentWizardStep]);
 
-  // Sync tour step index to wizard step when tour is active
+  // Sync tour step index to wizard step when tour is active and not paused for recovery
   React.useEffect(() => {
-    if (!isTourActive || currentTour !== 'characterCreationWizard') return;
+    if (
+      !isTourActive ||
+      isPaused ||
+      pausedForRecoveryRef.current ||
+      showRecoveryDialog ||
+      currentTour !== 'characterCreationWizard'
+    ) {
+      return;
+    }
     const targetWizardStep = tourStepToWizardStep[stepIndex];
     if (targetWizardStep !== undefined && targetWizardStep !== wizard.state.currentStep) {
       wizard.goToStep(targetWizardStep);
     }
-  }, [stepIndex, isTourActive, currentTour, wizard]);
+  }, [stepIndex, isTourActive, isPaused, showRecoveryDialog, currentTour, wizard]);
 
   // Point pool managers
   const { attributePool, skillPool } = useCharacterPointPools({

--- a/src/components/CharacterCreationWizard/__tests__/CharacterCreationWizard.recovery.test.tsx
+++ b/src/components/CharacterCreationWizard/__tests__/CharacterCreationWizard.recovery.test.tsx
@@ -41,6 +41,8 @@ jest.mock('@/components/TutorialProvider', () => ({
     resumeTour,
     currentTour: 'characterCreationWizard',
     isTourActive: true,
+    isPaused: true,
+    stepIndex: 0,
   }),
 }));
 

--- a/src/components/CharacterCreationWizard/__tests__/CharacterCreationWizard.tour.test.tsx
+++ b/src/components/CharacterCreationWizard/__tests__/CharacterCreationWizard.tour.test.tsx
@@ -1,0 +1,250 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { TutorialProvider, useTutorial } from '@/components/TutorialProvider';
+import { CharacterCreationWizard } from '../CharacterCreationWizard';
+import { useSessionStore } from '@/state/sessionStore';
+
+// Mock next/navigation
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+  }),
+}));
+
+// Mock auto save to avoid recovery dialog surfacing
+jest.mock('@/hooks/useCharacterCreationAutoSave', () => ({
+  useCharacterCreationAutoSave: () => ({
+    data: undefined,
+    setData: jest.fn(),
+    clearAutoSave: jest.fn(),
+    hasRecoveryData: false,
+    recoveryPreview: undefined,
+    hasCurrentData: false,
+    saveStatus: 'idle' as const,
+  }),
+}));
+
+// Mock worldStore
+jest.mock('@/state/worldStore', () => ({
+  useWorldStore: () => ({
+    currentWorldId: 'world-1',
+    worlds: {
+      'world-1': {
+        id: 'world-1',
+        name: 'Test Realm',
+        genre: 'fantasy',
+        description: 'A fantasy world for testing',
+        settings: {
+          maxAttributes: 10,
+          maxSkills: 10,
+          attributePointPool: 20,
+          skillPointPool: 20,
+        },
+        attributes: [
+          {
+            id: 'strength',
+            name: 'Strength',
+            description: 'Physical power',
+            minValue: 1,
+            maxValue: 10,
+          },
+        ],
+        skills: [
+          {
+            id: 'athletics',
+            name: 'Athletics',
+            description: 'Athletic skill',
+            minValue: 0,
+            maxValue: 5,
+            attributeIds: ['strength'],
+          },
+        ],
+      },
+    },
+  }),
+}));
+
+// Mock react-joyride to simulate clicking Joyride's own Next/Finish buttons
+let lastJoyrideProps: Record<string, unknown> | null = null;
+
+jest.mock('react-joyride', () => {
+  const STATUS = {
+    FINISHED: 'finished',
+    SKIPPED: 'skipped',
+  };
+
+  const EVENTS = {
+    TARGET_NOT_FOUND: 'target_not_found',
+    STEP_AFTER: 'step_after',
+  };
+
+  const ACTIONS = {
+    NEXT: 'next',
+    PREV: 'prev',
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const DummyJoyride = ({ run, stepIndex, steps, callback, ...rest }: any) => {
+    lastJoyrideProps = { run, stepIndex, steps, callback, ...rest };
+    if (!run) return null;
+
+    const isLast = stepIndex >= steps.length - 1;
+
+    return (
+      <div data-testid="joyride-mock">
+        <div data-testid="joyride-step-index">{stepIndex}</div>
+        <div data-testid="joyride-total-steps">{steps.length}</div>
+        {!isLast && (
+          <button
+            data-testid="joyride-next-btn"
+            onClick={() => callback({ action: ACTIONS.NEXT, type: EVENTS.STEP_AFTER, index: stepIndex })}
+          >
+            Joyride Next
+          </button>
+        )}
+        {isLast && (
+          <button
+            data-testid="joyride-finish-btn"
+            onClick={() => callback({ status: STATUS.FINISHED, index: stepIndex })}
+          >
+            Finish Tutorial
+          </button>
+        )}
+        <button
+          data-testid="joyride-incomplete-finish-btn"
+          onClick={() => callback({ status: STATUS.FINISHED, index: stepIndex })}
+        >
+          Incomplete Finish
+        </button>
+        <button
+          data-testid="joyride-missing-target-btn"
+          onClick={() => callback({ type: EVENTS.TARGET_NOT_FOUND, index: stepIndex })}
+        >
+          Missing Target
+        </button>
+      </div>
+    );
+  };
+
+  return {
+    __esModule: true,
+    default: DummyJoyride,
+    STATUS,
+    EVENTS,
+    ACTIONS,
+  };
+});
+
+// Helper component to trigger tour start
+const TourTrigger = () => {
+  const { startTour, isTourActive } = useTutorial();
+  return (
+    <div>
+      <div data-testid="tour-active">{isTourActive ? 'yes' : 'no'}</div>
+      <button
+        data-testid="start-char-tour-btn"
+        onClick={() => startTour('characterCreationWizard')}
+      >
+        Start Character Creation Tour
+      </button>
+    </div>
+  );
+};
+
+describe('CharacterCreationWizard Joyride Next integration', () => {
+  beforeEach(() => {
+    useSessionStore.getState().resetTutorialProgress();
+    lastJoyrideProps = null;
+  });
+
+  it('reaches all five tutorial steps by clicking Joyrides own Next button', async () => {
+    render(
+      <TutorialProvider>
+        <TourTrigger />
+        <CharacterCreationWizard worldId="world-1" />
+      </TutorialProvider>
+    );
+
+    // Start tour
+    await act(async () => {
+      screen.getByTestId('start-char-tour-btn').click();
+    });
+
+    expect(screen.getByTestId('tour-active')).toHaveTextContent('yes');
+    expect(screen.getByTestId('joyride-step-index')).toHaveTextContent('0');
+
+    // Step 0: Basic Info step target should be present in DOM
+    expect(document.querySelector('[data-tutorial="basic-info"]')).not.toBeNull();
+
+    // Click Joyride Next on Step 0 -> advances to Step 1 (Attributes)
+    await act(async () => {
+      screen.getByTestId('joyride-next-btn').click();
+    });
+    expect(screen.getByTestId('joyride-step-index')).toHaveTextContent('1');
+    expect(document.querySelector('[data-tutorial="attribute-allocation"]')).not.toBeNull();
+
+    // Click Joyride Next on Step 1 -> advances to Step 2 (Skills)
+    await act(async () => {
+      screen.getByTestId('joyride-next-btn').click();
+    });
+    expect(screen.getByTestId('joyride-step-index')).toHaveTextContent('2');
+    expect(document.querySelector('[data-tutorial="skill-selection"]')).not.toBeNull();
+
+    // Click Joyride Next on Step 2 -> advances to Step 3 (Background)
+    await act(async () => {
+      screen.getByTestId('joyride-next-btn').click();
+    });
+    expect(screen.getByTestId('joyride-step-index')).toHaveTextContent('3');
+    expect(document.querySelector('[data-tutorial="background-editor"]')).not.toBeNull();
+
+    // Click Joyride Next on Step 3 -> advances to Step 4 (Portrait)
+    await act(async () => {
+      screen.getByTestId('joyride-next-btn').click();
+    });
+    expect(screen.getByTestId('joyride-step-index')).toHaveTextContent('4');
+    expect(document.querySelector('[data-tutorial="portrait-generator-action"]')).not.toBeNull();
+
+    // Click Finish on Step 4 -> completes tutorial phase
+    await act(async () => {
+      screen.getByTestId('joyride-finish-btn').click();
+    });
+
+    expect(screen.getByTestId('tour-active')).toHaveTextContent('no');
+    expect(
+      useSessionStore.getState().tutorialProgress.phases.characterCreation.completed
+    ).toBe(true);
+  });
+
+  it('does NOT mark tutorial phase as completed if tour terminates before final step', async () => {
+    render(
+      <TutorialProvider>
+        <TourTrigger />
+        <CharacterCreationWizard worldId="world-1" />
+      </TutorialProvider>
+    );
+
+    // Start tour
+    await act(async () => {
+      screen.getByTestId('start-char-tour-btn').click();
+    });
+
+    // Advance to Step 1
+    await act(async () => {
+      screen.getByTestId('joyride-next-btn').click();
+    });
+    expect(screen.getByTestId('joyride-step-index')).toHaveTextContent('1');
+
+    // Trigger an incomplete finish (e.g. early exit callback at step 1)
+    await act(async () => {
+      screen.getByTestId('joyride-incomplete-finish-btn').click();
+    });
+
+    // Verify tour ended but phase was NOT marked completed
+    expect(screen.getByTestId('tour-active')).toHaveTextContent('no');
+    expect(
+      useSessionStore.getState().tutorialProgress.phases.characterCreation.completed
+    ).toBe(false);
+  });
+});

--- a/src/components/TutorialProvider/TutorialProvider.tsx
+++ b/src/components/TutorialProvider/TutorialProvider.tsx
@@ -267,31 +267,30 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
     setPauseReason(null);
     missingTargetRef.current = null;
     if (activeTour) {
-      if (outcome === 'finished') {
-        if (activeTour === 'characterCreationWizard') {
-          completeTutorialPhase('characterCreation');
-        } else if (stepMapping) {
-          const wizardStepValues = Object.values(stepMapping);
-          const maxWizardStep = wizardStepValues.length > 0 ? Math.max(...wizardStepValues) : null;
-          const isFinalWizardStep = maxWizardStep !== null && currentWizardStep >= maxWizardStep;
-          const isFinalTourStep = steps.length > 0 && index >= steps.length - 1;
+      const phaseKey: TutorialPhase | null =
+        activeTour === 'characterCreationWizard'
+          ? 'characterCreation'
+          : (activeTour && activeTour in tutorialProgress.phases)
+            ? (activeTour as TutorialPhase)
+            : null;
 
-          if (isFinalWizardStep && isFinalTourStep) {
-            completeTutorialPhase(activeTour as TutorialPhase);
+      if (phaseKey) {
+        if (outcome === 'finished') {
+          const isFinalTourStep = steps.length > 0 && index >= steps.length - 1;
+          let isFinalWizardStep = true;
+          if (stepMapping) {
+            const wizardStepValues = Object.values(stepMapping);
+            const maxWizardStep = wizardStepValues.length > 0 ? Math.max(...wizardStepValues) : null;
+            isFinalWizardStep = maxWizardStep === null || currentWizardStep >= maxWizardStep;
+          }
+
+          if (isFinalTourStep && isFinalWizardStep) {
+            completeTutorialPhase(phaseKey);
           } else {
-            updateTutorialProgress(activeTour as TutorialPhase, { lastStep: index });
+            updateTutorialProgress(phaseKey, { lastStep: index });
           }
         } else {
-          // Check if it's a valid phase before completing
-          if (activeTour in tutorialProgress.phases) {
-            completeTutorialPhase(activeTour as TutorialPhase);
-          }
-        }
-      } else {
-        if (activeTour === 'characterCreationWizard') {
-          updateTutorialProgress('characterCreation', { skipped: true });
-        } else if (activeTour in tutorialProgress.phases) {
-          updateTutorialProgress(activeTour as TutorialPhase, { skipped: true });
+          updateTutorialProgress(phaseKey, { skipped: true });
         }
       }
     }
@@ -334,8 +333,15 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
       const nextIndex = index + (action === ACTIONS.PREV ? -1 : 1);
       
       if (activeTour) {
-        if (activeTour in tutorialProgress.phases) {
-          updateTutorialProgress(activeTour as TutorialPhase, { lastStep: index });
+        const phaseKey: TutorialPhase | null =
+          activeTour === 'characterCreationWizard'
+            ? 'characterCreation'
+            : (activeTour && activeTour in tutorialProgress.phases)
+              ? (activeTour as TutorialPhase)
+              : null;
+
+        if (phaseKey) {
+          updateTutorialProgress(phaseKey, { lastStep: index });
         }
         setStepIndex(nextIndex);
       }
@@ -344,18 +350,12 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
       // the target later, so a missing anchor won't reappear. Skip past the
       // unrenderable step instead of freezing on it — the old early-return left
       // Joyride mounted on a step it couldn't draw (a dark overlay with no tooltip
-      // and no way out). Reaching the end completes the phase so onboarding doesn't
-      // re-arm every session and isTourActive resolves. With progressive disclosure
-      // on (the default), every anchor is present and this never fires; it's the
-      // safety net for when the flag is off, where the Tools anchor isn't rendered.
+      // and no way out).
       if (!stepMapping) {
         const nextIndex = index + 1;
         if (Number.isInteger(nextIndex) && nextIndex < steps.length) {
           setStepIndex(nextIndex);
         } else {
-          if (activeTour && activeTour in tutorialProgress.phases) {
-            completeTutorialPhase(activeTour as TutorialPhase);
-          }
           stopTour();
         }
         return;

--- a/src/components/TutorialProvider/TutorialProvider.tsx
+++ b/src/components/TutorialProvider/TutorialProvider.tsx
@@ -30,6 +30,7 @@ interface TutorialContextValue {
   skipTour: () => void;
   resetTutorial: () => void;
   isTourActive: boolean;
+  isPaused?: boolean;
   currentTour: TutorialPhase | string | null;
   stepIndex: number;
   setCurrentWizardStep: (step: number) => void;
@@ -42,6 +43,15 @@ const normalizeSteps = (steps: Step[]) =>
     ...step,
     disableBeacon: true,
   }));
+
+const getPhaseKey = (
+  tourId: TutorialPhase | string | null,
+  phases: Record<string, unknown>
+): TutorialPhase | null => {
+  if (!tourId) return null;
+  if (tourId === 'characterCreationWizard') return 'characterCreation';
+  return tourId in phases ? (tourId as TutorialPhase) : null;
+};
 
 const loadTour = async (tourId: TutorialPhase | string): Promise<{ steps: Step[], mapping?: Record<number, number> }> => {
   try {
@@ -175,9 +185,9 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
     
     if (loadedSteps.length > 0) {
       // If resuming, check last step from store if not provided explicitly
-      // Safe check for phase existence
-      const isPhase = tourId in tutorialProgress.phases;
-      const phaseData = isPhase ? tutorialProgress.phases[tourId as TutorialPhase] : undefined;
+      // Safe check for phase existence with alias resolution
+      const phaseKey = getPhaseKey(tourId, tutorialProgress.phases);
+      const phaseData = phaseKey ? tutorialProgress.phases[phaseKey] : undefined;
       const lastStep = (phaseData && 'lastStep' in phaseData) ? (phaseData as { lastStep: number }).lastStep : 0;
 
       if (mapping && initialStepIndex === 0) {
@@ -267,12 +277,7 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
     setPauseReason(null);
     missingTargetRef.current = null;
     if (activeTour) {
-      const phaseKey: TutorialPhase | null =
-        activeTour === 'characterCreationWizard'
-          ? 'characterCreation'
-          : (activeTour && activeTour in tutorialProgress.phases)
-            ? (activeTour as TutorialPhase)
-            : null;
+      const phaseKey = getPhaseKey(activeTour, tutorialProgress.phases);
 
       if (phaseKey) {
         if (outcome === 'finished') {
@@ -333,12 +338,7 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
       const nextIndex = index + (action === ACTIONS.PREV ? -1 : 1);
       
       if (activeTour) {
-        const phaseKey: TutorialPhase | null =
-          activeTour === 'characterCreationWizard'
-            ? 'characterCreation'
-            : (activeTour && activeTour in tutorialProgress.phases)
-              ? (activeTour as TutorialPhase)
-              : null;
+        const phaseKey = getPhaseKey(activeTour, tutorialProgress.phases);
 
         if (phaseKey) {
           updateTutorialProgress(phaseKey, { lastStep: index });
@@ -468,10 +468,9 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
     setPauseReason(null);
     missingTargetRef.current = null;
     if (activeTour) {
-      if (activeTour === 'characterCreationWizard') {
-        updateTutorialProgress('characterCreation', { skipped: true });
-      } else if (activeTour in tutorialProgress.phases) {
-        updateTutorialProgress(activeTour as TutorialPhase, { skipped: true });
+      const phaseKey = getPhaseKey(activeTour, tutorialProgress.phases);
+      if (phaseKey) {
+        updateTutorialProgress(phaseKey, { skipped: true });
       }
     }
     setActiveTour(null);
@@ -496,6 +495,7 @@ export function TutorialProvider({ children }: TutorialProviderProps) {
       skipTour,
       resetTutorial,
       isTourActive: run || isPaused,
+      isPaused,
       currentTour: activeTour,
       stepIndex,
       setCurrentWizardStep,

--- a/src/components/TutorialProvider/__tests__/TutorialProvider.test.tsx
+++ b/src/components/TutorialProvider/__tests__/TutorialProvider.test.tsx
@@ -266,4 +266,26 @@ describe('TutorialProvider', () => {
       useSessionStore.getState().tutorialProgress.phases.firstPlay.completed
     ).toBe(false);
   });
+
+  it('resumes character creation tour from stored progress using aliased phase key', async () => {
+    useSessionStore.getState().updateTutorialProgress('characterCreation', { lastStep: 1 });
+
+    render(
+      <TutorialProvider>
+        <TestComponent />
+      </TutorialProvider>
+    );
+
+    await act(async () => {
+      screen.getByText('Wizard Step 1').click();
+    });
+
+    await act(async () => {
+      screen.getByText('Start Character Wizard Tour').click();
+    });
+
+    await screen.findByTestId('joyride-mock');
+    expect(screen.getByTestId('tour-status')).toHaveTextContent('Active');
+    expect(screen.getByTestId('step-index')).toHaveTextContent('1');
+  });
 });

--- a/src/components/TutorialProvider/__tests__/TutorialProvider.test.tsx
+++ b/src/components/TutorialProvider/__tests__/TutorialProvider.test.tsx
@@ -242,7 +242,7 @@ describe('TutorialProvider', () => {
     expect(screen.getByTestId('step-index')).toHaveTextContent('2');
   });
 
-  it('completes a mapping-less tour when its final target is missing instead of hanging', async () => {
+  it('stops a mapping-less tour when its final target is missing without marking phase completed', async () => {
     render(
       <TutorialProvider>
         <TestComponent />
@@ -255,9 +255,8 @@ describe('TutorialProvider', () => {
     await screen.findByTestId('joyride-mock');
     expect(screen.getByTestId('tour-status')).toHaveTextContent('Active');
 
-    // firstPlay has no stepMapping; a missing final anchor (e.g. the Tools button in
-    // DS3 / progressive-disclosure-off) must end the tour and mark the phase complete,
-    // not leave it paused with isTourActive stuck true.
+    // firstPlay has no stepMapping; a missing final anchor must end the tour
+    // without marking the phase as completed.
     await act(async () => {
       screen.getByText('Target Missing Last').click();
     });
@@ -265,6 +264,6 @@ describe('TutorialProvider', () => {
     expect(screen.getByTestId('tour-status')).toHaveTextContent('Inactive');
     expect(
       useSessionStore.getState().tutorialProgress.phases.firstPlay.completed
-    ).toBe(true);
+    ).toBe(false);
   });
 });

--- a/src/components/WorldCreationWizard/WorldCreationWizard.tsx
+++ b/src/components/WorldCreationWizard/WorldCreationWizard.tsx
@@ -104,7 +104,7 @@ export default function WorldCreationWizard({
 }: WorldCreationWizardProps) {
   const router = useRouter();
   const createWorld = useWorldStore((state) => state.createWorld);
-  const { startTour, setCurrentWizardStep, isTourActive, pauseTour, resumeTour, stepIndex, currentTour } = useTutorial();
+  const { startTour, setCurrentWizardStep, isTourActive, isPaused, pauseTour, resumeTour, stepIndex, currentTour } = useTutorial();
   const worldCreationProgress = useSessionStore(state => state.tutorialProgress.phases.worldCreation);
   
   // Initialize world creation data
@@ -232,14 +232,22 @@ export default function WorldCreationWizard({
     setCurrentWizardStep(wizard.state.currentStep);
   }, [wizard.state.currentStep, setCurrentWizardStep]);
 
-  // Sync tour step index to wizard step when tour is active
+  // Sync tour step index to wizard step when tour is active and not paused for recovery
   React.useEffect(() => {
-    if (!isTourActive || currentTour !== 'worldCreation') return;
+    if (
+      !isTourActive ||
+      isPaused ||
+      wasTourPausedByRecoveryRef.current ||
+      showRecoveryModal ||
+      currentTour !== 'worldCreation'
+    ) {
+      return;
+    }
     const targetWizardStep = tourStepToWizardStep[stepIndex];
     if (targetWizardStep !== undefined && targetWizardStep !== wizard.state.currentStep) {
       wizard.goToStep(targetWizardStep);
     }
-  }, [stepIndex, isTourActive, currentTour, wizard]);
+  }, [stepIndex, isTourActive, isPaused, showRecoveryModal, currentTour, wizard]);
 
   const shouldAutoStartTour = useMemo(() => {
     if (worldCreationProgress.skipped) return false;

--- a/src/components/WorldCreationWizard/WorldCreationWizard.tsx
+++ b/src/components/WorldCreationWizard/WorldCreationWizard.tsx
@@ -104,7 +104,7 @@ export default function WorldCreationWizard({
 }: WorldCreationWizardProps) {
   const router = useRouter();
   const createWorld = useWorldStore((state) => state.createWorld);
-  const { startTour, setCurrentWizardStep, isTourActive, pauseTour, resumeTour } = useTutorial();
+  const { startTour, setCurrentWizardStep, isTourActive, pauseTour, resumeTour, stepIndex, currentTour } = useTutorial();
   const worldCreationProgress = useSessionStore(state => state.tutorialProgress.phases.worldCreation);
   
   // Initialize world creation data
@@ -231,6 +231,15 @@ export default function WorldCreationWizard({
   React.useEffect(() => {
     setCurrentWizardStep(wizard.state.currentStep);
   }, [wizard.state.currentStep, setCurrentWizardStep]);
+
+  // Sync tour step index to wizard step when tour is active
+  React.useEffect(() => {
+    if (!isTourActive || currentTour !== 'worldCreation') return;
+    const targetWizardStep = tourStepToWizardStep[stepIndex];
+    if (targetWizardStep !== undefined && targetWizardStep !== wizard.state.currentStep) {
+      wizard.goToStep(targetWizardStep);
+    }
+  }, [stepIndex, isTourActive, currentTour, wizard]);
 
   const shouldAutoStartTour = useMemo(() => {
     if (worldCreationProgress.skipped) return false;


### PR DESCRIPTION
## Problem
The character creation tutorial only showed step 1 because clicking Joyride's Next button incremented Joyride's step index without advancing the wizard component's active step. Because wizard step 1 target elements were not mounted, Joyride encountered missing targets, causing the tour to pause and stall out. Additionally, incomplete or target-missing tour runs were incorrectly marking the tutorial phase as completed in state.

## Solution
1. Added an effect in CharacterCreationWizard (and WorldCreationWizard) to drive the wizard step (wizard.goToStep) whenever Joyride's stepIndex changes during an active mapped tour.
2. Updated TutorialProvider so that tutorial phases are only recorded as completed when the tour reaches the final step and final wizard step. Incomplete runs or tours terminating early due to missing targets update lastStep without setting completed: true.
3. Added a regression test suite CharacterCreationWizard.tour.test.tsx verifying that clicking Joyrides Next button sequentially advances through all 5 tutorial steps and mounts targets properly.