### PR TITLE
Add advisory full-dependency audit to CI security scan

### DIFF
--- a/.github/scripts/__tests__/generate-security-summary.test.js
+++ b/.github/scripts/__tests__/generate-security-summary.test.js
@@ -1,0 +1,264 @@
+/**
+ * @jest-environment node
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  formatProductionAudit,
+  formatFullAudit,
+  formatOutdated,
+  buildSummaryMarkdown,
+  generateSecuritySummary,
+} from '../generate-security-summary.js';
+
+describe('generate-security-summary', () => {
+  let tempDir;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ci-security-test-'));
+  });
+
+  afterEach(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('formatProductionAudit', () => {
+    it('formats a clean production audit with passed status and zero counts', () => {
+      const prodAudit = {
+        metadata: {
+          vulnerabilities: {
+            info: 0,
+            low: 0,
+            moderate: 0,
+            high: 0,
+            critical: 0,
+            total: 0,
+          },
+        },
+        vulnerabilities: {},
+      };
+
+      const lines = formatProductionAudit(prodAudit);
+      expect(lines).toContain('## Production Dependencies Audit (Blocking Gate)');
+      expect(lines).toContain('Status: Passed (0 vulnerabilities detected)');
+      expect(lines).toContain('- Critical: 0');
+      expect(lines).toContain('- High: 0');
+      expect(lines).toContain('- Moderate: 0');
+      expect(lines).toContain('- Low: 0');
+      expect(lines.join('\n')).not.toContain('Packages requiring attention');
+    });
+
+    it('formats an audit report with vulnerabilities requiring action', () => {
+      const prodAudit = {
+        metadata: {
+          vulnerabilities: {
+            critical: 1,
+            high: 2,
+            moderate: 0,
+            low: 0,
+          },
+        },
+        vulnerabilities: {
+          foo: {
+            severity: 'critical',
+            via: [{ title: 'Remote Code Execution' }],
+          },
+        },
+      };
+
+      const lines = formatProductionAudit(prodAudit);
+      expect(lines).toContain('## Production Dependencies Audit (Blocking Gate)');
+      expect(lines).toContain('Status: Action required (3 total vulnerabilities detected)');
+      expect(lines).toContain('- Critical: 1');
+      expect(lines).toContain('- High: 2');
+      expect(lines).toContain('- Moderate: 0');
+      expect(lines).toContain('- Low: 0');
+      expect(lines).toContain('- foo (critical) - Remote Code Execution');
+    });
+
+    it('handles missing audit data gracefully', () => {
+      const lines = formatProductionAudit(null);
+      expect(lines).toContain('## Production Dependencies Audit (Blocking Gate)');
+      expect(lines).toContain('*No production audit report generated.*');
+    });
+  });
+
+  describe('formatFullAudit', () => {
+    it('formats advisory full dependency audit with totals, severity breakdown, and package list', () => {
+      const fullAudit = {
+        metadata: {
+          vulnerabilities: {
+            critical: 3,
+            high: 14,
+            moderate: 6,
+            low: 11,
+          },
+        },
+        vulnerabilities: {
+          'form-data': {
+            severity: 'critical',
+            via: [{ title: 'unsafe form data parsing' }],
+          },
+          yaml: {
+            severity: 'moderate',
+            via: [{ title: 'Stack Overflow' }],
+          },
+        },
+      };
+
+      const lines = formatFullAudit(fullAudit);
+      expect(lines).toContain('## Full Dependency Audit (Dev & Tooling - Advisory / Non-blocking)');
+      expect(lines).toContain('Detected 34 total vulnerabilities across severity levels.');
+      expect(lines).toContain('- Critical: 3');
+      expect(lines).toContain('- High: 14');
+      expect(lines).toContain('- Moderate: 6');
+      expect(lines).toContain('- Low: 11');
+      expect(lines).toContain('Packages requiring attention (up to 5):');
+      expect(lines).toContain('- form-data (critical) - unsafe form data parsing');
+      expect(lines).toContain('- yaml (moderate) - Stack Overflow');
+    });
+
+    it('formats a clean full dependency audit when zero vulnerabilities exist', () => {
+      const fullAudit = {
+        metadata: {
+          vulnerabilities: {
+            critical: 0,
+            high: 0,
+            moderate: 0,
+            low: 0,
+          },
+        },
+        vulnerabilities: {},
+      };
+
+      const lines = formatFullAudit(fullAudit);
+      expect(lines).toContain('## Full Dependency Audit (Dev & Tooling - Advisory / Non-blocking)');
+      expect(lines).toContain('No vulnerabilities detected.');
+      expect(lines.join('\n')).not.toContain('Packages requiring attention');
+    });
+
+    it('handles missing full audit data gracefully', () => {
+      const lines = formatFullAudit(null);
+      expect(lines).toContain('## Full Dependency Audit (Dev & Tooling - Advisory / Non-blocking)');
+      expect(lines).toContain('*No full dependency audit report generated.*');
+    });
+  });
+
+  describe('formatOutdated', () => {
+    it('formats outdated dependencies list', () => {
+      const outdated = {
+        next: {
+          current: '15.5.0',
+          wanted: '15.5.25',
+          latest: '16.0.0',
+          type: 'dependencies',
+        },
+      };
+
+      const lines = formatOutdated(outdated);
+      expect(lines).toContain('## Outdated dependencies (1)');
+      expect(lines).toContain('- next (dependencies) - current: 15.5.0, wanted: 15.5.25, latest: 16.0.0');
+    });
+
+    it('handles empty outdated dependencies', () => {
+      const lines = formatOutdated({});
+      expect(lines).toContain('## Outdated dependencies');
+      expect(lines).toContain('No outdated packages detected.');
+    });
+  });
+
+  describe('buildSummaryMarkdown', () => {
+    it('assembles a full summary document with timestamp and artifacts footer', () => {
+      const markdown = buildSummaryMarkdown({
+        prodAudit: null,
+        fullAudit: null,
+        outdatedData: null,
+        timestamp: '2026-09-08T12:00:00.000Z',
+      });
+
+      expect(markdown).toContain('# CI Security Scan Summary');
+      expect(markdown).toContain('Generated: 2026-09-08T12:00:00.000Z');
+      expect(markdown).toContain('## Production Dependencies Audit (Blocking Gate)');
+      expect(markdown).toContain('## Full Dependency Audit (Dev & Tooling - Advisory / Non-blocking)');
+      expect(markdown).toContain('## Outdated dependencies');
+      expect(markdown).toContain('Reports are attached as workflow artifacts.');
+    });
+  });
+
+  describe('generateSecuritySummary', () => {
+    it('reads audit JSON files from directory and outputs summary.md with both audit sections', () => {
+      const prodAudit = {
+        metadata: {
+          vulnerabilities: {
+            critical: 0,
+            high: 0,
+            moderate: 0,
+            low: 0,
+          },
+        },
+        vulnerabilities: {},
+      };
+      const fullAudit = {
+        metadata: {
+          vulnerabilities: {
+            critical: 3,
+            high: 14,
+            moderate: 6,
+            low: 11,
+          },
+        },
+        vulnerabilities: {
+          'form-data': {
+            severity: 'critical',
+            via: [{ title: 'unsafe form data' }],
+          },
+        },
+      };
+      const outdated = {
+        next: {
+          current: '15.5.0',
+          wanted: '15.5.25',
+          latest: '16.0.0',
+          type: 'dependencies',
+        },
+      };
+
+      fs.writeFileSync(path.join(tempDir, 'npm-audit.json'), JSON.stringify(prodAudit));
+      fs.writeFileSync(path.join(tempDir, 'npm-audit-full.json'), JSON.stringify(fullAudit));
+      fs.writeFileSync(path.join(tempDir, 'npm-outdated.json'), JSON.stringify(outdated));
+
+      const summaryPath = generateSecuritySummary(tempDir);
+      expect(fs.existsSync(summaryPath)).toBe(true);
+
+      const summaryContent = fs.readFileSync(summaryPath, 'utf8');
+
+      // Check production section
+      expect(summaryContent).toContain('## Production Dependencies Audit (Blocking Gate)');
+      expect(summaryContent).toContain('Status: Passed (0 vulnerabilities detected)');
+
+      // Check full dependency advisory section
+      expect(summaryContent).toContain('## Full Dependency Audit (Dev & Tooling - Advisory / Non-blocking)');
+      expect(summaryContent).toContain('Detected 34 total vulnerabilities across severity levels.');
+      expect(summaryContent).toContain('- form-data (critical) - unsafe form data');
+
+      // Check outdated section
+      expect(summaryContent).toContain('## Outdated dependencies (1)');
+      expect(summaryContent).toContain('- next (dependencies) - current: 15.5.0, wanted: 15.5.25, latest: 16.0.0');
+      expect(summaryContent).toContain('Reports are attached as workflow artifacts.');
+    });
+
+    it('handles missing input files without throwing and writes fallback summary', () => {
+      const summaryPath = generateSecuritySummary(tempDir);
+      expect(fs.existsSync(summaryPath)).toBe(true);
+
+      const summaryContent = fs.readFileSync(summaryPath, 'utf8');
+      expect(summaryContent).toContain('*No production audit report generated.*');
+      expect(summaryContent).toContain('*No full dependency audit report generated.*');
+      expect(summaryContent).toContain('No outdated packages detected.');
+    });
+  });
+});

--- a/.github/scripts/generate-security-summary.js
+++ b/.github/scripts/generate-security-summary.js
@@ -5,80 +5,142 @@ import path from 'node:path';
 // The script is invoked from the security workflow and operates on the
 // directory provided via argv[2] (defaults to "ci-security").
 
-const reportDir = process.argv[2] ?? 'ci-security';
+export const SEVERITIES = ['critical', 'high', 'moderate', 'low'];
 
-const summaryLines = [
-  '# CI Security Scan Summary',
-  `Generated: ${new Date().toISOString()}`,
-  ''
-];
+export function formatPackageList(vulnerabilities = {}) {
+  const entries = Object.entries(vulnerabilities);
+  if (!entries.length) return [];
 
-const readJson = (filename) => {
-  try {
-    const content = fs.readFileSync(path.join(reportDir, filename), 'utf8').trim();
-    return content ? JSON.parse(content) : null;
-  } catch (error) {
-    return null;
+  const lines = ['', 'Packages requiring attention (up to 5):'];
+  entries.slice(0, 5).forEach(([pkg, details]) => {
+    const severity = details?.severity ?? 'unknown';
+    const via = Array.isArray(details?.via)
+      ? details.via
+          .filter((item) => typeof item === 'object' && item?.title)
+          .map((item) => item.title)
+      : [];
+    const viaLabel = via.length ? ` - ${via.slice(0, 2).join('; ')}` : '';
+    lines.push(`- ${pkg} (${severity})${viaLabel}`);
+  });
+  return lines;
+}
+
+export function formatProductionAudit(auditData) {
+  const lines = ['## Production Dependencies Audit (Blocking Gate)'];
+  if (!auditData?.metadata?.vulnerabilities) {
+    lines.push('*No production audit report generated.*');
+    return lines;
   }
-};
 
-const auditData = readJson('npm-audit.json');
-if (auditData?.metadata?.vulnerabilities) {
   const counts = auditData.metadata.vulnerabilities;
-  const severities = ['critical', 'high', 'moderate', 'low'];
-  const total = severities.reduce((acc, level) => acc + (counts[level] ?? 0), 0);
+  const total = SEVERITIES.reduce((acc, level) => acc + (counts[level] ?? 0), 0);
+  const status = total === 0 ? 'Passed (0 vulnerabilities detected)' : `Action required (${total} total vulnerabilities detected)`;
 
-  summaryLines.push('## npm audit results');
-  summaryLines.push(
+  lines.push(`Status: ${status}`);
+  SEVERITIES.forEach((level) => {
+    const label = level.charAt(0).toUpperCase() + level.slice(1);
+    lines.push(`- ${label}: ${counts[level] ?? 0}`);
+  });
+
+  const packageLines = formatPackageList(auditData.vulnerabilities);
+  if (packageLines.length) {
+    lines.push(...packageLines);
+  }
+
+  return lines;
+}
+
+export function formatFullAudit(auditData) {
+  const lines = ['## Full Dependency Audit (Dev & Tooling - Advisory / Non-blocking)'];
+  if (!auditData?.metadata?.vulnerabilities) {
+    lines.push('*No full dependency audit report generated.*');
+    return lines;
+  }
+
+  const counts = auditData.metadata.vulnerabilities;
+  const total = SEVERITIES.reduce((acc, level) => acc + (counts[level] ?? 0), 0);
+
+  lines.push(
     total
       ? `Detected ${total} total vulnerabilities across severity levels.`
-      : 'No vulnerabilities detected at the configured threshold.'
+      : 'No vulnerabilities detected.'
   );
 
-  severities.forEach((level) => {
-    if (counts[level] !== undefined) {
-      const label = level.charAt(0).toUpperCase() + level.slice(1);
-      summaryLines.push(`- ${label}: ${counts[level]}`);
-    }
+  SEVERITIES.forEach((level) => {
+    const label = level.charAt(0).toUpperCase() + level.slice(1);
+    lines.push(`- ${label}: ${counts[level] ?? 0}`);
   });
 
-  const vulnerablePackages = Object.entries(auditData.vulnerabilities ?? {});
-  if (vulnerablePackages.length) {
-    summaryLines.push('', 'Packages requiring attention (up to 5):');
-    vulnerablePackages.slice(0, 5).forEach(([pkg, details]) => {
-      const severity = details?.severity ?? 'unknown';
-      const via = Array.isArray(details?.via)
-        ? details.via
-            .filter((item) => typeof item === 'object' && item.title)
-            .map((item) => item.title)
-        : [];
-      const viaLabel = via.length ? ` – ${via.slice(0, 2).join('; ')}` : '';
-      summaryLines.push(`- ${pkg} (${severity})${viaLabel}`);
-    });
+  const packageLines = formatPackageList(auditData.vulnerabilities);
+  if (packageLines.length) {
+    lines.push(...packageLines);
   }
-} else {
-  summaryLines.push('## npm audit results');
-  summaryLines.push('*No npm audit report generated.*');
+
+  return lines;
 }
 
-const outdatedData = readJson('npm-outdated.json');
-if (outdatedData && Object.keys(outdatedData).length) {
-  const entries = Object.entries(outdatedData);
-  summaryLines.push('', `## Outdated dependencies (${entries.length})`);
-  summaryLines.push('First 5 entries:');
-  entries.slice(0, 5).forEach(([pkg, info]) => {
-    const current = info?.current ?? 'unknown';
-    const wanted = info?.wanted ?? 'unknown';
-    const latest = info?.latest ?? 'unknown';
-    const type = info?.type ?? 'prod';
-    summaryLines.push(`- ${pkg} (${type}) – current: ${current}, wanted: ${wanted}, latest: ${latest}`);
-  });
-} else {
-  summaryLines.push('', '## Outdated dependencies');
-  summaryLines.push('No outdated packages detected.');
+export function formatOutdated(outdatedData) {
+  const lines = [];
+  if (outdatedData && Object.keys(outdatedData).length) {
+    const entries = Object.entries(outdatedData);
+    lines.push(`## Outdated dependencies (${entries.length})`);
+    lines.push('First 5 entries:');
+    entries.slice(0, 5).forEach(([pkg, info]) => {
+      const current = info?.current ?? 'unknown';
+      const wanted = info?.wanted ?? 'unknown';
+      const latest = info?.latest ?? 'unknown';
+      const type = info?.type ?? 'prod';
+      lines.push(`- ${pkg} (${type}) - current: ${current}, wanted: ${wanted}, latest: ${latest}`);
+    });
+  } else {
+    lines.push('## Outdated dependencies');
+    lines.push('No outdated packages detected.');
+  }
+  return lines;
 }
 
-summaryLines.push('', 'Reports are attached as workflow artifacts.');
+export function buildSummaryMarkdown({ prodAudit, fullAudit, outdatedData, timestamp = new Date().toISOString() }) {
+  const lines = [
+    '# CI Security Scan Summary',
+    `Generated: ${timestamp}`,
+    '',
+    ...formatProductionAudit(prodAudit),
+    '',
+    ...formatFullAudit(fullAudit),
+    '',
+    ...formatOutdated(outdatedData),
+    '',
+    'Reports are attached as workflow artifacts.',
+  ];
+  return `${lines.join('\n')}\n`;
+}
 
-fs.writeFileSync(path.join(reportDir, 'summary.md'), `${summaryLines.join('\n')}\n`);
-console.log('Security summary written to', path.join(reportDir, 'summary.md'));
+export function generateSecuritySummary(reportDir = 'ci-security') {
+  const readJson = (filename) => {
+    try {
+      const content = fs.readFileSync(path.join(reportDir, filename), 'utf8').trim();
+      return content ? JSON.parse(content) : null;
+    } catch {
+      return null;
+    }
+  };
+
+  const prodAudit = readJson('npm-audit.json');
+  const fullAudit = readJson('npm-audit-full.json');
+  const outdatedData = readJson('npm-outdated.json');
+
+  const summaryContent = buildSummaryMarkdown({ prodAudit, fullAudit, outdatedData });
+  fs.mkdirSync(reportDir, { recursive: true });
+  const summaryPath = path.join(reportDir, 'summary.md');
+  fs.writeFileSync(summaryPath, summaryContent);
+  // eslint-disable-next-line no-console
+  console.log('Security summary written to', summaryPath);
+  return summaryPath;
+}
+
+// CLI entry: `node .github/scripts/generate-security-summary.js`
+// Avoids import.meta so the module also loads cleanly under ts-jest (CJS).
+if (process.argv[1] && process.argv[1].endsWith('generate-security-summary.js')) {
+  const reportDir = process.argv[2] ?? 'ci-security';
+  generateSecuritySummary(reportDir);
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,8 +444,6 @@ jobs:
     name: Security Scan
     runs-on: ubuntu-latest
     needs: [setup]
-    env:
-      NODE_ENV: production
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -474,6 +472,14 @@ jobs:
 
       - name: Generate npm audit JSON report
         run: npm audit --omit=dev --json > ci-security/npm-audit.json
+        continue-on-error: true
+
+      - name: Run full npm audit (non-blocking advisory)
+        run: npm audit | tee ci-security/npm-audit-full.txt || true
+        continue-on-error: true
+
+      - name: Generate full npm audit JSON report
+        run: npm audit --json > ci-security/npm-audit-full.json || true
         continue-on-error: true
 
       - name: Capture dependency update suggestions

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -36,6 +36,7 @@ const config = {
     '<rootDir>/src/**/*.test.{ts,tsx}',
     '<rootDir>/__tests__/**/*.test.{js,jsx,ts,tsx}',
     '<rootDir>/scripts/**/*.test.{js,mjs}',
+    '<rootDir>/.github/scripts/**/__tests__/**/*.test.{js,mjs}',
   ],
   testPathIgnorePatterns: [
     '<rootDir>/node_modules/',


### PR DESCRIPTION
## Description
The CI Security Scan gate was only looking at production dependencies via `npm audit --omit=dev`, and the job environment had `NODE_ENV: production` set. That meant vulnerabilities in dev tooling and build dependencies stayed invisible in PR reports.

This change adds an advisory full-dependency audit to CI that checks both production and dev dependencies. The existing blocking audit remains untouched on moderate and higher severity production issues, while the summary artifact now separates the blocking gate from the advisory tooling findings.

## Related Issue
Closes #2002

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Unit tests in `.github/scripts/__tests__/generate-security-summary.test.js` verify that both production and full dependency audit JSON outputs are parsed and formatted into distinct sections.

## User Stories Addressed
None (CI infrastructure and developer tooling security visibility).

## Flow Diagrams
None.

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

N/A - CI workflow and script changes only.

## Implementation Notes
- Removed `NODE_ENV: production` from the `security` job in `.github/workflows/ci.yml` so `npm audit` can inspect the dev dependency graph instead of silently omitting it.
- Added non-blocking steps to run `npm audit` across all dependencies and save both text and JSON reports to `ci-security/npm-audit-full.txt` and `ci-security/npm-audit-full.json`.
- Updated `.github/scripts/generate-security-summary.js` to render a `Production Dependencies Audit (Blocking Gate)` section with status and severity counts, alongside a `Full Dependency Audit (Dev & Tooling - Advisory / Non-blocking)` section listing total vulnerabilities and up to 5 packages requiring attention.
- Updated `jest.config.cjs` so `npm test` discovers `.github/scripts` unit tests.

## Screenshots
N/A - Non-UI change.

## Visual Baseline Changes
None.

## Code Review Summary (if applicable)
Confirmed that `npm audit --omit=dev` continues to enforce the blocking gate on moderate+ vulnerabilities. The full dependency scan runs with `|| true` and `continue-on-error: true` so existing dev dependency advisories won't block merges.

## Chrome DevTools MCP Verification Summary (if applicable)
N/A - Backend and CI tooling changes only.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [x] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. Run `npm test` to verify the full Jest suite including `.github/scripts/__tests__/generate-security-summary.test.js`.
2. Run `npm run type-check` and `npm run lint` to verify types and code style.
3. Test the summary generator directly: `node .github/scripts/generate-security-summary.js` and verify output in `ci-security/summary.md`.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed