### PR TITLE
test(visual): stop seedTestData re-triggering the world-creation tour

### DIFF
--- a/tests/visual/utils/seedTestData.ts
+++ b/tests/visual/utils/seedTestData.ts
@@ -617,7 +617,10 @@ export async function seedTestData(page: Page): Promise<void> {
           tutorialProgress: {
             phases: {
               intro: { completed: true, skipped: false },
-              worldCreation: { completed: true, skipped: false, lastStep: 6 },
+              // lastStep must clear the highest tour index that maps to a wizard
+              // step, or WorldCreationWizard's shouldAutoStartTour re-launches the
+              // tour and its step-sync effect fights manual wizard navigation.
+              worldCreation: { completed: true, skipped: false, lastStep: 999 },
               worldGeneration: { completed: true, skipped: false, lastStep: 0 },
               characterCreation: { completed: true, skipped: false, lastStep: 5 },
               firstPlay: { completed: true, skipped: false },


### PR DESCRIPTION
## Description

`Visual Regression (2)` has been red on `develop` since PR #2037 merged. The
`world-creation-ai-guidance.spec.ts` cases at lines 95 and 127 fail with
`locator.fill` / `locator.click` timing out on "element was detached from the
DOM", and the textarea's `useId` regenerates on every retry.

Root cause: `seedTestData` seeds `tutorialProgress.worldCreation` as completed,
but its runtime `setState` path used `lastStep: 6` while the IndexedDB and
localStorage paths in the same file use `999`. Wizard step 0 has tour indices
up to 7, so `WorldCreationWizard.shouldAutoStartTour` evaluated `6 < 7` and
relaunched the tour after seeding. PR #2037's new tour-step-sync effect then
forced the wizard back to step 0 while the test was on the Description step,
unmounting `DescriptionStep` and remounting it on a loop.

Fix: align the runtime path with the other two (`lastStep: 999`).

Reproduced against a local production build (`PLAYWRIGHT_PROD_SERVER` mirrors
CI): the three failing cases went from ~12s of retry-thrashing to 2.6s clean,
stable across three runs. `world-creation.spec.ts` (the other `seedTestData`
wizard spec) still passes.

Separately: PR #2037's step-sync effect reverting a manual "Next" is a real,
if narrower, product bug for a user mid-tour. Filed as its own follow-up
rather than fixed here.

## Related Issue

Addresses the `world-creation-ai-guidance` thread of #2067. The three
pixel-diff specs in that issue (`narrative-dialogue-segment`,
`manuscript-layout`, `manuscript-regression-assertions`) are unrelated and
stay open.

Closes #

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Not applicable in the usual sense: this is a test-fixture fix. The evidence is
the previously-failing spec now passing (see Testing Instructions).

## User Stories Addressed

Not applicable. Internal test infrastructure.

## Flow Diagrams

None.

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

Not applicable. No component or style change.

## Implementation Notes

One line changed in `tests/visual/utils/seedTestData.ts`, plus a comment
explaining why the value is load-bearing. No product code touched.

## Screenshots

Not applicable.

## Visual Baseline Changes

None. No files under `tests/visual/**-snapshots/**` changed.

## Code Review Summary (if applicable)

Not applicable.

## Chrome DevTools MCP Verification Summary (if applicable)

Not applicable.

## Quality Checks (if applicable)
- [ ] Linting passed
- [ ] Type checking passed
- [ ] Security audit passed
- [ ] No console.log statements in production code
- [ ] No unhandled promises

Deferred to CI. Change is a single numeric literal in a test helper.

## Testing Instructions

1. `NEXT_PUBLIC_SITE_URL=http://localhost:3000 npm run build:app`
2. Start the prod server on your checkout's port, e.g. `npx next start -p <port>`
3. `npx playwright test tests/visual/world-creation-ai-guidance.spec.ts --project=chromium --workers=1`

On `develop` cases 2 and 3 time out after ~12s each. With this change all
three pass in ~8s total.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed
