### PR TITLE
fix(tutorial): prevent manual wizard navigation from reverting mid-tour

### DIFF
--- a/src/components/CharacterCreationWizard/CharacterCreationWizard.tsx
+++ b/src/components/CharacterCreationWizard/CharacterCreationWizard.tsx
@@ -130,8 +130,13 @@ export const CharacterCreationWizard: React.FC<CharacterCreationWizardProps> = (
     setCurrentWizardStep(wizard.state.currentStep);
   }, [wizard.state.currentStep, setCurrentWizardStep]);
 
-  // Sync tour step index to wizard step when tour is active and not paused for recovery
+  const prevStepIndexRef = useRef(stepIndex);
+
+  // Sync tour step index to wizard step when tour step index advances while tour is active and not paused for recovery
   React.useEffect(() => {
+    const prevStepIndex = prevStepIndexRef.current;
+    prevStepIndexRef.current = stepIndex;
+
     if (
       !isTourActive ||
       isPaused ||
@@ -141,6 +146,11 @@ export const CharacterCreationWizard: React.FC<CharacterCreationWizardProps> = (
     ) {
       return;
     }
+
+    if (prevStepIndex === stepIndex) {
+      return;
+    }
+
     const targetWizardStep = tourStepToWizardStep[stepIndex];
     if (targetWizardStep !== undefined && targetWizardStep !== wizard.state.currentStep) {
       wizard.goToStep(targetWizardStep);

--- a/src/components/CharacterCreationWizard/__tests__/CharacterCreationWizard.tour.test.tsx
+++ b/src/components/CharacterCreationWizard/__tests__/CharacterCreationWizard.tour.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
 import { TutorialProvider, useTutorial } from '@/components/TutorialProvider';
 import { CharacterCreationWizard } from '../CharacterCreationWizard';
 import { useSessionStore } from '@/state/sessionStore';
@@ -263,4 +263,50 @@ describe('CharacterCreationWizard Joyride Next integration', () => {
       useSessionStore.getState().tutorialProgress.phases.characterCreation.completed
     ).toBe(false);
   });
+
+  it('preserves manual wizard Next navigation mid-tour without reverting', async () => {
+    render(
+      <TutorialProvider>
+        <TourTrigger />
+        <CharacterCreationWizard worldId="world-1" />
+      </TutorialProvider>
+    );
+
+    // Start tour
+    await act(async () => {
+      screen.getByTestId('start-char-tour-btn').click();
+    });
+
+    expect(screen.getByTestId('tour-active')).toHaveTextContent('yes');
+    expect(screen.getByTestId('joyride-step-index')).toHaveTextContent('0');
+    expect(document.querySelector('[data-tutorial="basic-info"]')).not.toBeNull();
+
+    // Fill in character name so step 0 is valid
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText(/character name/i), {
+        target: { value: 'Hero' },
+      });
+    });
+
+    // Click the wizard's own Next button (advancing wizard from step 0 to step 1)
+    const wizardNextButton = screen.getByRole('button', { name: /^next$/i });
+    await act(async () => {
+      wizardNextButton.click();
+    });
+
+    // Wizard should advance to step 1 (Attributes) and not be reverted to step 0
+    expect(document.querySelector('[data-tutorial="attribute-allocation"]')).not.toBeNull();
+    expect(document.querySelector('[data-tutorial="basic-info"]')).toBeNull();
+
+    // Click the wizard's own Back button (returning wizard from step 1 to step 0)
+    const wizardBackButton = screen.getByRole('button', { name: /^back$/i });
+    await act(async () => {
+      wizardBackButton.click();
+    });
+
+    // Wizard should return to step 0 (Basic Info) and not be reverted to step 1
+    expect(document.querySelector('[data-tutorial="basic-info"]')).not.toBeNull();
+    expect(document.querySelector('[data-tutorial="attribute-allocation"]')).toBeNull();
+  });
 });
+

--- a/src/components/WorldCreationWizard/WorldCreationWizard.tsx
+++ b/src/components/WorldCreationWizard/WorldCreationWizard.tsx
@@ -234,8 +234,13 @@ export default function WorldCreationWizard({
     setCurrentWizardStep(wizard.state.currentStep);
   }, [wizard.state.currentStep, setCurrentWizardStep]);
 
-  // Sync tour step index to wizard step when tour is active and not paused for recovery
+  const prevStepIndexRef = React.useRef(stepIndex);
+
+  // Sync tour step index to wizard step when tour step index advances while tour is active and not paused for recovery
   React.useEffect(() => {
+    const prevStepIndex = prevStepIndexRef.current;
+    prevStepIndexRef.current = stepIndex;
+
     if (
       !isTourActive ||
       isPaused ||
@@ -245,6 +250,11 @@ export default function WorldCreationWizard({
     ) {
       return;
     }
+
+    if (prevStepIndex === stepIndex) {
+      return;
+    }
+
     const targetWizardStep = tourStepToWizardStep[stepIndex];
     if (targetWizardStep !== undefined && targetWizardStep !== wizard.state.currentStep) {
       wizard.goToStep(targetWizardStep);

--- a/src/components/WorldCreationWizard/__tests__/WorldCreationWizard.tour.test.tsx
+++ b/src/components/WorldCreationWizard/__tests__/WorldCreationWizard.tour.test.tsx
@@ -1,0 +1,239 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { TutorialProvider, useTutorial } from '@/components/TutorialProvider';
+import WorldCreationWizard from '../WorldCreationWizard';
+import { useSessionStore } from '@/state/sessionStore';
+
+// Mock next/navigation
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+  }),
+}));
+
+// Mock auto save to avoid recovery dialog
+jest.mock('@/hooks/useWorldCreationAutoSave', () => ({
+  useWorldCreationAutoSave: () => ({
+    data: undefined,
+    setData: jest.fn(),
+    clearAutoSave: jest.fn(),
+    dismissRecovery: jest.fn(),
+    hasRecoveryData: false,
+    recoveryPreview: undefined,
+    hasCurrentData: false,
+    isLoaded: true,
+    saveStatus: 'idle' as const,
+    lastSaved: undefined,
+  }),
+}));
+
+// Mock worldStore
+const mockCreateWorld = jest.fn().mockReturnValue('world-123');
+
+jest.mock('@/state/worldStore', () => ({
+  useWorldStore: (selector: any) => {
+    if (typeof selector === 'function') {
+      return selector({
+        createWorld: mockCreateWorld,
+        setCurrentWorld: jest.fn(),
+        updateWorld: jest.fn(),
+        worlds: {},
+      });
+    }
+    return {
+      createWorld: mockCreateWorld,
+      setCurrentWorld: jest.fn(),
+      updateWorld: jest.fn(),
+      worlds: {},
+    };
+  },
+}));
+
+// Mock AI generators
+jest.mock('@/lib/ai/worldImageGenerator', () => ({
+  generateWorldImage: jest.fn().mockResolvedValue({ url: 'http://example.com/image.png' }),
+}));
+
+jest.mock('@/lib/ai/worldAnalyzerClient', () => ({
+  analyzeWorldDescriptionClient: jest.fn().mockResolvedValue({
+    attributes: [],
+    skills: [],
+  }),
+}));
+
+// Mock react-joyride to simulate clicking Joyride's own Next/Prev buttons
+let _lastJoyrideProps: Record<string, unknown> | null = null;
+
+jest.mock('react-joyride', () => {
+  const STATUS = {
+    FINISHED: 'finished',
+    SKIPPED: 'skipped',
+  };
+
+  const EVENTS = {
+    TARGET_NOT_FOUND: 'target_not_found',
+    STEP_AFTER: 'step_after',
+  };
+
+  const ACTIONS = {
+    NEXT: 'next',
+    PREV: 'prev',
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const DummyJoyride = ({ run, stepIndex, steps, callback, ...rest }: any) => {
+    _lastJoyrideProps = { run, stepIndex, steps, callback, ...rest };
+    if (!run) return null;
+
+    const isLast = stepIndex >= steps.length - 1;
+
+    return (
+      <div data-testid="joyride-mock">
+        <div data-testid="joyride-step-index">{stepIndex}</div>
+        <div data-testid="joyride-total-steps">{steps.length}</div>
+        {!isLast && (
+          <button
+            data-testid="joyride-next-btn"
+            onClick={() => callback({ action: ACTIONS.NEXT, type: EVENTS.STEP_AFTER, index: stepIndex })}
+          >
+            Joyride Next
+          </button>
+        )}
+        {stepIndex > 0 && (
+          <button
+            data-testid="joyride-prev-btn"
+            onClick={() => callback({ action: ACTIONS.PREV, type: EVENTS.STEP_AFTER, index: stepIndex })}
+          >
+            Joyride Prev
+          </button>
+        )}
+        {isLast && (
+          <button
+            data-testid="joyride-finish-btn"
+            onClick={() => callback({ status: STATUS.FINISHED, index: stepIndex })}
+          >
+            Finish Tutorial
+          </button>
+        )}
+      </div>
+    );
+  };
+
+  return {
+    __esModule: true,
+    default: DummyJoyride,
+    STATUS,
+    EVENTS,
+    ACTIONS,
+  };
+});
+
+// Helper component to trigger tour start
+const TourTrigger = () => {
+  const { startTour, isTourActive } = useTutorial();
+  return (
+    <div>
+      <div data-testid="tour-active">{isTourActive ? 'yes' : 'no'}</div>
+      <button
+        data-testid="start-world-tour-btn"
+        onClick={() => startTour('worldCreation')}
+      >
+        Start World Creation Tour
+      </button>
+    </div>
+  );
+};
+
+describe('WorldCreationWizard tour and step sync integration', () => {
+  beforeEach(() => {
+    useSessionStore.getState().resetTutorialProgress();
+    _lastJoyrideProps = null;
+  });
+
+  it('preserves manual wizard Next and Back navigation mid-tour without reverting', async () => {
+    render(
+      <TutorialProvider>
+        <TourTrigger />
+        <WorldCreationWizard initialData={{ genre: 'fantasy' }} />
+      </TutorialProvider>
+    );
+
+    // Start tour
+    await act(async () => {
+      screen.getByTestId('start-world-tour-btn').click();
+    });
+
+    expect(screen.getByTestId('tour-active')).toHaveTextContent('yes');
+    expect(screen.getByTestId('joyride-step-index')).toHaveTextContent('0');
+    expect(screen.getByTestId('basic-info-step')).toBeInTheDocument();
+
+    // Click the wizard's own Next button (advances wizard from step 0 to step 1)
+    const wizardNextButton = screen.getByRole('button', { name: /^next$/i });
+    await act(async () => {
+      wizardNextButton.click();
+    });
+
+    // Wizard should advance to step 1 (Description) and not be reverted to step 0
+    expect(screen.getByTestId('description-step')).toBeInTheDocument();
+    expect(screen.queryByTestId('basic-info-step')).toBeNull();
+
+    // Click the wizard's own Back button (returns wizard from step 1 to step 0)
+    const wizardBackButton = screen.getByRole('button', { name: /^back$/i });
+    await act(async () => {
+      wizardBackButton.click();
+    });
+
+    // Wizard should return to step 0 (Basic Info) and not be reverted to step 1
+    expect(screen.getByTestId('basic-info-step')).toBeInTheDocument();
+    expect(screen.queryByTestId('description-step')).toBeNull();
+  });
+
+  it('advances wizard step when tour stepIndex advances to a new wizard step via Joyride Next', async () => {
+    render(
+      <TutorialProvider>
+        <TourTrigger />
+        <WorldCreationWizard initialData={{ genre: 'fantasy' }} />
+      </TutorialProvider>
+    );
+
+    // Start tour
+    await act(async () => {
+      screen.getByTestId('start-world-tour-btn').click();
+    });
+
+    expect(screen.getByTestId('tour-active')).toHaveTextContent('yes');
+    expect(screen.getByTestId('joyride-step-index')).toHaveTextContent('0');
+    expect(screen.getByTestId('basic-info-step')).toBeInTheDocument();
+
+    // Advance through tour steps 0-7 (all mapped to wizard step 0)
+    for (let i = 0; i < 7; i++) {
+      await act(async () => {
+        screen.getByTestId('joyride-next-btn').click();
+      });
+    }
+
+    expect(screen.getByTestId('joyride-step-index')).toHaveTextContent('7');
+    expect(screen.getByTestId('basic-info-step')).toBeInTheDocument();
+
+    // Advance from step 7 to step 8 (mapped to wizard step 1)
+    await act(async () => {
+      screen.getByTestId('joyride-next-btn').click();
+    });
+
+    expect(screen.getByTestId('joyride-step-index')).toHaveTextContent('8');
+    // Wizard should have synced and advanced to step 1 (Description)
+    expect(screen.getByTestId('description-step')).toBeInTheDocument();
+    expect(screen.queryByTestId('basic-info-step')).toBeNull();
+
+    // Now click Joyride Prev (from step 8 back to step 7)
+    await act(async () => {
+      screen.getByTestId('joyride-prev-btn').click();
+    });
+
+    // Wizard should sync back to step 0 (Basic Info)
+    expect(screen.getByTestId('basic-info-step')).toBeInTheDocument();
+    expect(screen.queryByTestId('description-step')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Description
When you're running through the world creation or character creation tour and click the wizard's own "Next" or "Back" button, the wizard advances its step while Joyride's tour stepIndex hasn't caught up yet. In PR #2037, a step-sync effect was added to keep wizard steps aligned with tour steps. Because that effect was running on every render where wizard changed, it saw a mismatch between tourStepToWizardStep[stepIndex] and wizard.state.currentStep, and immediately called wizard.goToStep(targetWizardStep), reverting the user's manual step transition.

I've updated both WorldCreationWizard and CharacterCreationWizard so their step-sync effects track prevStepIndexRef and only trigger wizard.goToStep when stepIndex actually transitions. Manual wizard navigation is preserved, and Joyride Next/Prev still drives the wizard step forward and backward as intended.

## Related Issue
Closes #2069

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

## User Stories Addressed
- As a player creating a world or character during the tour, clicking the wizard's Next or Back button should move me to that step without immediately snapping back to the tour step.

## Flow Diagrams
None needed here since this is a ref-based transition guard on existing step-sync effects.

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [x] Visual consistency verified

## Implementation Notes
- Added prevStepIndexRef = useRef(stepIndex) in both WorldCreationWizard and CharacterCreationWizard.
- In the step-sync useEffect, we compare prevStepIndex === stepIndex. If stepIndex didn't change (e.g. re-render caused by wizard.goNext()), we bail out early so we don't clobber the user's manual step navigation.
- When stepIndex transitions (from Joyride's Next/Prev buttons or tour step sync), the check passes and wizard.goToStep synchronizes the wizard as expected.

## Screenshots
None (logic fix for step transition handling).

## Visual Baseline Changes
None

## Code Review Summary (if applicable)
Verified that both WorldCreationWizard and CharacterCreationWizard handle manual Next/Back clicks correctly during an active tour, and that Joyride Next/Prev step changes still drive the wizard.

## Chrome DevTools MCP Verification Summary (if applicable)
Not applicable (covered by unit test suites).

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. Run npm test -- src/components/WorldCreationWizard
2. Run npm test -- src/components/CharacterCreationWizard
3. Launch the app and start world creation or character creation with the tour active.
4. Click the wizard's "Next" button on step 1 and verify it stays on step 2 rather than jumping back.

## Checklist
- [x] Code follows the project's coding standards
- [ ] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed