### PR TITLE
feat(narrative): charge world costs to decisions that incur them (#2020)

### DIFF
--- a/.claude/skills/narraitor-prompt-template-governance/eval-logs/2020-decision-attributed-world-costs.md
+++ b/.claude/skills/narraitor-prompt-template-governance/eval-logs/2020-decision-attributed-world-costs.md
@@ -1,0 +1,68 @@
+# Prompt/template eval log - decision-attributed world costs (#2020)
+
+- Change: pass the chosen decision and its outcome into world cost extraction; gate prompt-side decision attribution and schema rule on `DECISION_ATTRIBUTED_WORLD_COSTS` (`NEXT_PUBLIC_FEATURE_DECISION_ATTRIBUTED_WORLD_COSTS`); parse per-entry `causedByDecision: true`; record `decisionId` on segment metadata note when a cost was caused by the decision.
+  - Treatment: `DECISION_ATTRIBUTED_WORLD_COSTS=true`. Renders the chosen decision when present and adds extraction rule: `- If a cost was directly caused by the player's chosen decision above, set "causedByDecision" to true on that cost entry; otherwise false.`
+  - Control: `DECISION_ATTRIBUTED_WORLD_COSTS=false`. Omits decision context and rule, keeping prompt section byte-identical to baseline.
+- Diff: `src/types/worldCost.types.ts`, `src/lib/featureFlags.ts`, `.env.example`, `src/lib/ai/worldCostExtraction.ts`, `src/lib/narrative/applyWorldClockUpdates.ts`, `src/lib/narrative/applyWorldCost.ts`, plus tests.
+- Date / evaluator: 2026-09-10, live evaluation with Gemini 2.5 Flash.
+- Parent: #1882, #1883, #1983, issue #2020.
+
+## Precommitted Protocol and Decision Rule
+
+### Evaluated Matrix
+
+Paired decisions across two canonical story cells:
+1. **Camp Crystal Lake** (horror / slasher):
+   - Pair 1: Risky sprint into the storm toward radio tower vs Safe wedge pry bar and wait under cover.
+   - Pair 3: Risky wade across flooded spillway vs Safe retreat to boat shed.
+2. **Harrowgate Mills** (civic drama):
+   - Pair 2: Risky public accusation on council chamber floor without proof vs Safe observe quietly from gallery and transcribe notes.
+
+### Ship Criteria
+
+1. Prompt isolation: with flag off, prompt remains byte-identical to pre-change baseline. With flag on and no decision, prompt omits decision block cleanly.
+2. Risky decisions that result in injury, disgrace, or material loss have `causedByDecision: true` attributed to the resulting cost entry.
+3. Safe choices produce zero false-positive decision-attributed costs.
+4. Parsing integrity: parser keeps `causedByDecision: true` strictly on literal `true`, dropping strings, numbers, or false values.
+5. Store & note integrity: `applyWorldCost` records `decisionId` on `note.imposed` only when `causedByDecision` is true.
+
+### Rollout Decision Rule
+
+- **Pass**: If treatment correctly attributes 100% of risky-decision costs to the decision while producing zero false-positive costs on safe choices, flip flag default to `true` with kill switch in `.env.example`.
+- **Fail / Hold**: If model hallucinates attribution on safe choices, fails to attribute clear consequences, or regresses prompt parsing, retain default `false` and log failure mode.
+
+---
+
+## Live Evaluation Results (2026-09-10)
+
+Run against live Gemini 2.5 Flash across 3 paired cases (6 runs per arm, 12 calls total).
+
+### 1. Coverage Matrix & Results
+
+| Case | Cell & Action | Risky? | Treatment Imposed (`causedByDecision`) | Control Imposed | Verdict |
+|---|---|---|---|---|---|
+| Pair 1 Risky | Camp Crystal Lake: Sprint into the dark toward radio tower (failure) | Yes | `[{"kind":"condition","detail":"wrenched right ankle","causedByDecision":true}]` | `[{"kind":"condition","detail":"deep slice on right arm"}]` | Pass |
+| Pair 1 Safe | Camp Crystal Lake: Wedge pry bar and wait under cover (success) | No | `[]` | `[]` | Pass |
+| Pair 2 Risky | Harrowgate Mills: Accuse Thorne on council floor without proof (failure) | Yes | `[{"kind":"condition","detail":"discredited before the council","causedByDecision":true}]` | `[{"kind":"condition","detail":"discredited before the council"}]` | Pass |
+| Pair 2 Safe | Harrowgate Mills: Observe quietly from gallery and take notes (success) | No | `[]` | `[]` | Pass |
+| Pair 3 Risky | Camp Crystal Lake: Wade across flooded spillway in dark (mixed) | Yes | `[{"kind":"condition","detail":"deep gash on left thigh","causedByDecision":true}]` | `[{"kind":"condition","detail":"deep gash on left thigh"}]` | Pass |
+| Pair 3 Safe | Camp Crystal Lake: Retreat to boat shed and wait out flash flood (success) | No | `[]` | `[]` | Pass |
+
+### 2. Attribution Accuracy & False Positive Checks
+
+- **Risky Choice Attribution Rate**: 3 / 3 (100.0%) correctly set `causedByDecision: true`.
+- **Safe Choice False-Positive Rate**: 0 / 3 (0.0%). Safe turns imposed zero unearned costs.
+- **Control Arm Verification**: 0 / 3 in Control carried `causedByDecision` (field cleanly omitted by the parser when absent in model output).
+
+### 3. Latency & Token Overhead
+
+- **Token Delta**: ~25-35 input tokens for the decision block and schema instruction.
+- **Latency**:
+  - Treatment Average: 2,356 ms
+  - Control Average: 2,482 ms
+  - Delta: -126 ms (no latency penalty).
+
+## Verdict
+
+- **PASS**. All 3 risky choices accurately attributed the resulting condition to the decision (`causedByDecision: true`), while all 3 safe choices cleanly avoided imposing world costs.
+- Feature flag `DECISION_ATTRIBUTED_WORLD_COSTS` defaults to `true` in `src/lib/featureFlags.ts`, with `# NEXT_PUBLIC_FEATURE_DECISION_ATTRIBUTED_WORLD_COSTS=false` maintained as the kill switch in `.env.example`.

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@ GEMINI_API_KEY=your-gemini-api-key-here
 # NEXT_PUBLIC_FEATURE_WORLD_DESCRIPTION_IN_SCENE=false
 # NEXT_PUBLIC_FEATURE_UNRECORDED_EXCHANGE_GUARD=false
 # NEXT_PUBLIC_FEATURE_SETTLED_COMMITMENT_CHOICES=true
+# NEXT_PUBLIC_FEATURE_DECISION_ATTRIBUTED_WORLD_COSTS=false
 
 # Public site origin, used for metadataBase, robots.txt, and the sitemap.
 # Leave unset for local development - getSiteUrl() falls back to

--- a/src/lib/ai/__tests__/goalExtractor.test.ts
+++ b/src/lib/ai/__tests__/goalExtractor.test.ts
@@ -347,5 +347,66 @@ describe('goalExtractor', () => {
       expect(result.updatedGoals).toEqual([]);
       expect(result.completedGoals).toEqual([]);
     });
+
+    test('includes causedByDecision in worldCost skeleton when feature flag is enabled', async () => {
+      const originalEnv = process.env.NEXT_PUBLIC_FEATURE_DECISION_ATTRIBUTED_WORLD_COSTS;
+      try {
+        process.env.NEXT_PUBLIC_FEATURE_DECISION_ATTRIBUTED_WORLD_COSTS = 'true';
+        mockSentPrompts.length = 0;
+
+        const request: GoalExtractionRequest = {
+          content: 'You scramble up the cliffside.',
+          sessionId: 'session-123',
+          segmentId: 'segment-456',
+          existingGoals: [],
+          worldCost: {
+            conditions: [],
+            itemsLost: [],
+          },
+        };
+
+        await extractGoalsFromNarrative(request);
+
+        const prompt = mockSentPrompts[mockSentPrompts.length - 1];
+        expect(prompt).toContain('"causedByDecision": true|false');
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.NEXT_PUBLIC_FEATURE_DECISION_ATTRIBUTED_WORLD_COSTS;
+        } else {
+          process.env.NEXT_PUBLIC_FEATURE_DECISION_ATTRIBUTED_WORLD_COSTS = originalEnv;
+        }
+      }
+    });
+
+    test('omits causedByDecision from worldCost skeleton when feature flag is disabled', async () => {
+      const originalEnv = process.env.NEXT_PUBLIC_FEATURE_DECISION_ATTRIBUTED_WORLD_COSTS;
+      try {
+        process.env.NEXT_PUBLIC_FEATURE_DECISION_ATTRIBUTED_WORLD_COSTS = 'false';
+        mockSentPrompts.length = 0;
+
+        const request: GoalExtractionRequest = {
+          content: 'You scramble up the cliffside.',
+          sessionId: 'session-123',
+          segmentId: 'segment-456',
+          existingGoals: [],
+          worldCost: {
+            conditions: [],
+            itemsLost: [],
+          },
+        };
+
+        await extractGoalsFromNarrative(request);
+
+        const prompt = mockSentPrompts[mockSentPrompts.length - 1];
+        expect(prompt).not.toContain('"causedByDecision"');
+        expect(prompt).toContain('"imposed": [{ "kind": "condition|item", "detail": "...", "threadId": "thread-id or null" }]');
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.NEXT_PUBLIC_FEATURE_DECISION_ATTRIBUTED_WORLD_COSTS;
+        } else {
+          process.env.NEXT_PUBLIC_FEATURE_DECISION_ATTRIBUTED_WORLD_COSTS = originalEnv;
+        }
+      }
+    });
   });
 });

--- a/src/lib/ai/__tests__/worldCostExtraction.test.ts
+++ b/src/lib/ai/__tests__/worldCostExtraction.test.ts
@@ -99,5 +99,77 @@ describe('worldCostExtraction', () => {
       expect(parseWorldCostExtraction(undefined)).toBeUndefined();
       expect(parseWorldCostExtraction('nope')).toBeUndefined();
     });
+
+    it('keeps causedByDecision: true only on literal true, dropping non-boolean or missing', () => {
+      const result = parseWorldCostExtraction({
+        imposed: [
+          { kind: 'condition', detail: 'twisted ankle', causedByDecision: true },
+          { kind: 'item', detail: 'rusty shovel', causedByDecision: 'true' },
+          { kind: 'item', detail: 'torn backpack', causedByDecision: 1 },
+          { kind: 'item', detail: 'pocket knife', causedByDecision: false },
+          { kind: 'item', detail: 'compass' },
+        ],
+        cleared: [],
+      });
+
+      expect(result?.imposed).toEqual([
+        { kind: 'condition', detail: 'twisted ankle', causedByDecision: true },
+        { kind: 'item', detail: 'rusty shovel' },
+        { kind: 'item', detail: 'torn backpack' },
+        { kind: 'item', detail: 'pocket knife' },
+        { kind: 'item', detail: 'compass' },
+      ]);
+    });
+  });
+
+  describe('DECISION_ATTRIBUTED_WORLD_COSTS flag', () => {
+    const originalEnv = process.env.NEXT_PUBLIC_FEATURE_DECISION_ATTRIBUTED_WORLD_COSTS;
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.NEXT_PUBLIC_FEATURE_DECISION_ATTRIBUTED_WORLD_COSTS;
+      } else {
+        process.env.NEXT_PUBLIC_FEATURE_DECISION_ATTRIBUTED_WORLD_COSTS = originalEnv;
+      }
+    });
+
+    it('produces byte-identical prompt when the flag is off', () => {
+      process.env.NEXT_PUBLIC_FEATURE_DECISION_ATTRIBUTED_WORLD_COSTS = 'false';
+      const input = {
+        conditions: ['gashed left forearm'],
+        itemsLost: ['rusty shovel'],
+        decision: { id: 'dec-1', text: 'Confront the creature', outcome: 'mixed' },
+      };
+      const sectionWithDecision = buildWorldCostPromptSection(input);
+      const baselineSection = `WORLD COST (what the world took from the character this turn)
+Conditions the character already carries:
+- gashed left forearm
+Items the scene recorded as lost this turn:
+- rusty shovel
+
+A cost is something the character lost or now carries that they did not choose to spend: a lasting state (kind "condition"), or an item taken, broken or destroyed by someone or something else (kind "item"). The player using, spending, bracing with or giving away an item is not a cost. A failed action whose prose leaves a lasting mark on the character (discredited before the room, a bleeding hand) is a cost.
+- A condition is a lasting state the character will still have next scene, named as what is wrong with them ("gashed left forearm", "discredited before the council", "no longer welcome at the Hendersons'"). It is never a feeling, a sensation, a sound they made, a pressure they are under, or an event that happened to them. "cold dread", "urgency", "a desperate sound tearing at the throat" are not conditions.
+- IMPOSE at most ONE new condition per turn: the single most lasting thing the prose states. A blow to the arm that also dizzies and nauseates them is one condition, the arm. Items are not capped.
+- Do not impose a condition already on the list above, under the same or new wording. If a listed condition got worse, CLEAR its text and IMPOSE the new one, once.
+- Death, dying, unconsciousness and their kin are never conditions. If the prose killed the character or left them unable to act, set "fatal" to true and impose nothing for it.
+- "detail" is a short noun phrase in the character's terms, not a sentence. If an open thread from the WORLD CLOCK LEDGER imposed it, set "threadId" to that thread's id; otherwise null.
+- CLEAR a condition from the list above only when this segment's prose plainly ends it (the wound is bound, the room warms to the character again). Copy its text exactly.
+- "fatal" is true only when this segment's prose plainly killed the character or left them unable to act in the story: dead, dying past saving, unconscious with no way back in this scene. Wounded, cornered, captured, or awake and able to act is false.
+- Do not invent a cost the prose does not state. Most turns impose nothing and are not fatal; an empty list and false are the right answer then.
+Return it under the "worldCost" key of the JSON below.`;
+      expect(sectionWithDecision).toBe(baselineSection);
+    });
+
+    it('formats decision info and rule when the flag is on', () => {
+      process.env.NEXT_PUBLIC_FEATURE_DECISION_ATTRIBUTED_WORLD_COSTS = 'true';
+      const input = {
+        conditions: ['gashed left forearm'],
+        itemsLost: ['rusty shovel'],
+        decision: { id: 'dec-1', text: 'Confront the creature', outcome: 'mixed' },
+      };
+      const section = buildWorldCostPromptSection(input);
+      expect(section).toContain("Player's chosen decision:\nConfront the creature (outcome: mixed)");
+      expect(section).toContain('- If a cost was directly caused by the player\'s chosen decision above, set "causedByDecision" to true on that cost entry; otherwise false.');
+    });
   });
 });

--- a/src/lib/ai/goalExtractor.ts
+++ b/src/lib/ai/goalExtractor.ts
@@ -17,6 +17,7 @@ import {
   parseWorldThreadExtraction,
 } from './worldThreadExtraction';
 import { buildWorldCostPromptSection, parseWorldCostExtraction } from './worldCostExtraction';
+import { isFeatureEnabled } from '@/lib/featureFlags';
 
 import Logger from '@/lib/utils/logger';
 const logger = new Logger('GoalExtractor');
@@ -128,7 +129,7 @@ function buildGoalExtractionPrompt(request: GoalExtractionRequest): string {
   const worldCostSkeleton = request.worldCost
     ? `,
   "worldCost": {
-    "imposed": [{ "kind": "condition|item", "detail": "...", "threadId": "thread-id or null" }],
+    "imposed": [{ "kind": "condition|item", "detail": "...", "threadId": "thread-id or null"${isFeatureEnabled('DECISION_ATTRIBUTED_WORLD_COSTS') ? ', "causedByDecision": true|false' : ''} }],
     "cleared": ["condition text"],
     "fatal": false
   }`

--- a/src/lib/ai/worldCostExtraction.ts
+++ b/src/lib/ai/worldCostExtraction.ts
@@ -7,6 +7,7 @@ import type {
   WorldCostKind,
 } from '@/types/worldCost.types';
 import { isRecord, asTrimmedString, asArray } from '@/lib/utils/typeGuards';
+import { isFeatureEnabled } from '@/lib/featureFlags';
 
 /**
  * The cost channel rides along on goal extraction, like the world clock, so
@@ -29,7 +30,8 @@ const formatList = (items: string[]): string =>
  * thread ids the ledger section already shows.
  */
 export function buildWorldCostPromptSection(input: WorldCostExtractionInput): string {
-  return `${WORLD_COST_MARKER} (what the world took from the character this turn)
+  if (!isFeatureEnabled('DECISION_ATTRIBUTED_WORLD_COSTS')) {
+    return `${WORLD_COST_MARKER} (what the world took from the character this turn)
 Conditions the character already carries:
 ${formatList(input.conditions)}
 Items the scene recorded as lost this turn:
@@ -41,6 +43,29 @@ A cost is something the character lost or now carries that they did not choose t
 - Do not impose a condition already on the list above, under the same or new wording. If a listed condition got worse, CLEAR its text and IMPOSE the new one, once.
 - Death, dying, unconsciousness and their kin are never conditions. If the prose killed the character or left them unable to act, set "fatal" to true and impose nothing for it.
 - "detail" is a short noun phrase in the character's terms, not a sentence. If an open thread from the WORLD CLOCK LEDGER imposed it, set "threadId" to that thread's id; otherwise null.
+- CLEAR a condition from the list above only when this segment's prose plainly ends it (the wound is bound, the room warms to the character again). Copy its text exactly.
+- "fatal" is true only when this segment's prose plainly killed the character or left them unable to act in the story: dead, dying past saving, unconscious with no way back in this scene. Wounded, cornered, captured, or awake and able to act is false.
+- Do not invent a cost the prose does not state. Most turns impose nothing and are not fatal; an empty list and false are the right answer then.
+Return it under the "worldCost" key of the JSON below.`;
+  }
+
+  const decisionBlock = input.decision
+    ? `\nPlayer's chosen decision:\n${input.decision.text}${input.decision.outcome ? ` (outcome: ${input.decision.outcome})` : ''}`
+    : '';
+
+  return `${WORLD_COST_MARKER} (what the world took from the character this turn)
+Conditions the character already carries:
+${formatList(input.conditions)}
+Items the scene recorded as lost this turn:
+${formatList(input.itemsLost)}${decisionBlock}
+
+A cost is something the character lost or now carries that they did not choose to spend: a lasting state (kind "condition"), or an item taken, broken or destroyed by someone or something else (kind "item"). The player using, spending, bracing with or giving away an item is not a cost. A failed action whose prose leaves a lasting mark on the character (discredited before the room, a bleeding hand) is a cost.
+- A condition is a lasting state the character will still have next scene, named as what is wrong with them ("gashed left forearm", "discredited before the council", "no longer welcome at the Hendersons'"). It is never a feeling, a sensation, a sound they made, a pressure they are under, or an event that happened to them. "cold dread", "urgency", "a desperate sound tearing at the throat" are not conditions.
+- IMPOSE at most ONE new condition per turn: the single most lasting thing the prose states. A blow to the arm that also dizzies and nauseates them is one condition, the arm. Items are not capped.
+- Do not impose a condition already on the list above, under the same or new wording. If a listed condition got worse, CLEAR its text and IMPOSE the new one, once.
+- Death, dying, unconsciousness and their kin are never conditions. If the prose killed the character or left them unable to act, set "fatal" to true and impose nothing for it.
+- "detail" is a short noun phrase in the character's terms, not a sentence. If an open thread from the WORLD CLOCK LEDGER imposed it, set "threadId" to that thread's id; otherwise null.
+- If a cost was directly caused by the player's chosen decision above, set "causedByDecision" to true on that cost entry; otherwise false.
 - CLEAR a condition from the list above only when this segment's prose plainly ends it (the wound is bound, the room warms to the character again). Copy its text exactly.
 - "fatal" is true only when this segment's prose plainly killed the character or left them unable to act in the story: dead, dying past saving, unconscious with no way back in this scene. Wounded, cornered, captured, or awake and able to act is false.
 - Do not invent a cost the prose does not state. Most turns impose nothing and are not fatal; an empty list and false are the right answer then.
@@ -70,7 +95,12 @@ export function parseWorldCostExtraction(value: unknown): WorldCostExtractionRes
       conditionKept = true;
     }
     const threadId = asTrimmedString(entry.threadId);
-    imposed.push({ kind: kind as WorldCostKind, detail, ...(threadId ? { threadId } : {}) });
+    imposed.push({
+      kind: kind as WorldCostKind,
+      detail,
+      ...(threadId ? { threadId } : {}),
+      ...(entry.causedByDecision === true ? { causedByDecision: true } : {}),
+    });
   }
 
   const cleared = asArray(value.cleared)

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -44,6 +44,9 @@ const FEATURE_FLAG_DEFAULTS = {
   // Feeds delivered commitments into the live aligned-choice prompt as a short
   // already-settled block. Off by default until live evaluation passes.
   SETTLED_COMMITMENT_CHOICES: false,
+  // Attributes world costs to the player decision that directly incurred them.
+  // Shipped default-on following successful paired live evaluation (#2020).
+  DECISION_ATTRIBUTED_WORLD_COSTS: true,
 } as const;
 
 export type FeatureFlag = keyof typeof FEATURE_FLAG_DEFAULTS;
@@ -84,6 +87,10 @@ const getFeatureFlags = (): Record<FeatureFlag, boolean> => ({
   SETTLED_COMMITMENT_CHOICES: resolve(
     process.env.NEXT_PUBLIC_FEATURE_SETTLED_COMMITMENT_CHOICES,
     FEATURE_FLAG_DEFAULTS.SETTLED_COMMITMENT_CHOICES
+  ),
+  DECISION_ATTRIBUTED_WORLD_COSTS: resolve(
+    process.env.NEXT_PUBLIC_FEATURE_DECISION_ATTRIBUTED_WORLD_COSTS,
+    FEATURE_FLAG_DEFAULTS.DECISION_ATTRIBUTED_WORLD_COSTS
   ),
 });
 

--- a/src/lib/narrative/__tests__/applyWorldClockUpdates.costInput.test.ts
+++ b/src/lib/narrative/__tests__/applyWorldClockUpdates.costInput.test.ts
@@ -1,0 +1,97 @@
+import { buildCostInput } from '../applyWorldClockUpdates';
+import { useCharacterStore } from '@/state/characterStore';
+import type { StoreCharacter } from '@/state/characterStore.types';
+import type { NarrativeMetadata, NarrativeSegment } from '@/types/narrative.types';
+
+const makeCharacter = (id: string, conditions: string[] = []): StoreCharacter =>
+  ({
+    id,
+    name: 'Jamie Holt',
+    description: '',
+    worldId: 'world-1',
+    level: 1,
+    attributes: [],
+    skills: [],
+    derivedStats: [],
+    background: { history: '', personality: '', goals: [], fears: [], relationships: [] },
+    isPlayer: true,
+    status: { conditions },
+    inventory: { characterId: id, items: [], capacity: 10, categories: [], itemOrder: [] },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  }) as StoreCharacter;
+
+const makeSegment = (metadataOverrides: Partial<NarrativeMetadata> = {}): NarrativeSegment => ({
+  id: 'seg-1',
+  sessionId: 'session-1',
+  worldId: 'world-1',
+  content: 'Something happens.',
+  type: 'scene',
+  metadata: { tags: [], ...metadataOverrides },
+  timestamp: new Date('2026-01-01T00:00:00.000Z'),
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+});
+
+describe('buildCostInput', () => {
+  beforeEach(() => {
+    useCharacterStore.setState({ characters: {}, entities: {}, error: null });
+    useCharacterStore.setState((state) => ({
+      characters: { ...state.characters, 'char-1': makeCharacter('char-1', ['shaken']) },
+    }));
+  });
+
+  it('passes segment decision id, text, and outcome when present', () => {
+    const segment = makeSegment({
+      causedByDecisionId: 'decision-42',
+      causedByDecisionText: 'Confront the lurking figure',
+      decisionOutcome: 'failure',
+    });
+
+    const costInput = buildCostInput('char-1', segment);
+
+    expect(costInput).toEqual({
+      conditions: ['shaken'],
+      itemsLost: [],
+      decision: {
+        id: 'decision-42',
+        text: 'Confront the lurking figure',
+        outcome: 'failure',
+      },
+    });
+  });
+
+  it('falls back to empty string when causedByDecisionText is absent', () => {
+    const segment = makeSegment({
+      causedByDecisionId: 'decision-42',
+      decisionOutcome: 'mixed',
+    });
+
+    const costInput = buildCostInput('char-1', segment);
+
+    expect(costInput?.decision).toEqual({
+      id: 'decision-42',
+      text: '',
+      outcome: 'mixed',
+    });
+  });
+
+  it('leaves decision undefined when segment has no causedByDecisionId', () => {
+    const segment = makeSegment({
+      itemsLost: [{ name: 'rusty shovel', lossReason: 'destroyed' }],
+    });
+
+    const costInput = buildCostInput('char-1', segment);
+
+    expect(costInput).toEqual({
+      conditions: ['shaken'],
+      itemsLost: ['rusty shovel'],
+      decision: undefined,
+    });
+  });
+
+  it('returns undefined when character is not found', () => {
+    const segment = makeSegment({ causedByDecisionId: 'decision-1' });
+    expect(buildCostInput('unknown-char', segment)).toBeUndefined();
+  });
+});

--- a/src/lib/narrative/__tests__/applyWorldCost.test.ts
+++ b/src/lib/narrative/__tests__/applyWorldCost.test.ts
@@ -221,4 +221,45 @@ describe('applyWorldCost', () => {
     expect(note).toEqual({ imposed: [], cleared: [], fatal: true });
     expect(useCharacterStore.getState().characters['char-1'].status.conditions).toEqual(['shaken']);
   });
+
+  it('records decisionId only on costs where causedByDecision is true', () => {
+    const note = applyWorldCost({
+      sessionId: 'session-1',
+      characterId: 'char-1',
+      decisionId: 'decision-99',
+      result: {
+        imposed: [
+          { kind: 'condition', detail: 'gashed left forearm', causedByDecision: true },
+          { kind: 'item', detail: 'rusty shovel', threadId, causedByDecision: false },
+          { kind: 'item', detail: 'flashlight' },
+        ],
+        cleared: [],
+        fatal: false,
+      },
+    });
+
+    expect(note.imposed).toEqual([
+      { kind: 'condition', detail: 'gashed left forearm', decisionId: 'decision-99' },
+      { kind: 'item', detail: 'rusty shovel', thread: 'The creature comes through the shed wall' },
+      { kind: 'item', detail: 'flashlight' },
+    ]);
+  });
+
+  it('omits decisionId when no decisionId was provided even if causedByDecision is true', () => {
+    const note = applyWorldCost({
+      sessionId: 'session-1',
+      characterId: 'char-1',
+      result: {
+        imposed: [
+          { kind: 'condition', detail: 'gashed left forearm', causedByDecision: true },
+        ],
+        cleared: [],
+        fatal: false,
+      },
+    });
+
+    expect(note.imposed).toEqual([
+      { kind: 'condition', detail: 'gashed left forearm' },
+    ]);
+  });
 });

--- a/src/lib/narrative/applyWorldClockUpdates.ts
+++ b/src/lib/narrative/applyWorldClockUpdates.ts
@@ -110,7 +110,12 @@ async function reconcileSegment({
     // something. The extractor can only cite ids it was handed, so nothing it
     // attributes can belong to a thread opened by this same result.
     if (result.worldCost && playerCharacterId) {
-      notes.worldCost = applyWorldCost({ sessionId, characterId: playerCharacterId, result: result.worldCost });
+      notes.worldCost = applyWorldCost({
+        sessionId,
+        characterId: playerCharacterId,
+        result: result.worldCost,
+        decisionId: segment.metadata?.causedByDecisionId,
+      });
     }
 
     if (clockOn && result.worldThreads && worldId) {
@@ -153,12 +158,19 @@ function buildThreadInput(
 }
 
 /** What the character carries and what the scene took this turn, so the extractor records against real state. */
-function buildCostInput(characterId: EntityID, segment: NarrativeSegment): WorldCostExtractionInput | undefined {
+export function buildCostInput(characterId: EntityID, segment: NarrativeSegment): WorldCostExtractionInput | undefined {
   const character = useCharacterStore.getState().characters[characterId];
   if (!character) return undefined;
   return {
     conditions: character.status.conditions,
     itemsLost: segment.metadata?.itemsLost?.map((item) => item.name) ?? [],
+    decision: segment.metadata?.causedByDecisionId
+      ? {
+          id: segment.metadata.causedByDecisionId,
+          text: segment.metadata.causedByDecisionText ?? '',
+          outcome: segment.metadata.decisionOutcome,
+        }
+      : undefined,
   };
 }
 

--- a/src/lib/narrative/applyWorldCost.ts
+++ b/src/lib/narrative/applyWorldCost.ts
@@ -9,6 +9,7 @@ export interface ApplyWorldCostParams {
   sessionId: EntityID;
   characterId: EntityID;
   result: WorldCostExtractionResult;
+  decisionId?: EntityID;
 }
 
 /**
@@ -17,7 +18,7 @@ export interface ApplyWorldCostParams {
  * out of the inventory. Either kind is recorded on the thread that imposed
  * it when the extractor named one of this session's open threads.
  */
-export function applyWorldCost({ sessionId, characterId, result }: ApplyWorldCostParams): WorldCostSegmentNote {
+export function applyWorldCost({ sessionId, characterId, result, decisionId }: ApplyWorldCostParams): WorldCostSegmentNote {
   const characterStore = useCharacterStore.getState();
   const threadStore = useWorldThreadStore.getState();
   const note: WorldCostSegmentNote = { imposed: [], cleared: [] };
@@ -57,10 +58,12 @@ export function applyWorldCost({ sessionId, characterId, result }: ApplyWorldCos
       characterStore.addCondition(characterId, cost.detail);
     }
     const thread = cost.threadId ? threadStore.recordThreadCost(sessionId, cost.threadId, cost.detail) : undefined;
+    const causedByThisDecision = cost.causedByDecision && decisionId;
     note.imposed.push({
       kind: cost.kind,
       detail: cost.detail,
       ...(thread ? { thread: thread.summary } : {}),
+      ...(causedByThisDecision ? { decisionId } : {}),
     });
   }
 

--- a/src/types/worldCost.types.ts
+++ b/src/types/worldCost.types.ts
@@ -19,6 +19,10 @@ export interface WorldCostEntry {
   detail: string;
   /** The open world-clock thread whose landing or move imposed it, when one did. */
   threadId?: EntityID;
+  /** Set to true when the extractor determined the player's chosen decision caused this cost. */
+  causedByDecision?: boolean;
+  /** ID of the decision that caused this cost, stamped by the reconcile path. */
+  decisionId?: EntityID;
 }
 
 /** Input to the post-segment extraction's world-cost section. */
@@ -27,6 +31,8 @@ export interface WorldCostExtractionInput {
   conditions: string[];
   /** Item names the scene recorded as lost this turn. */
   itemsLost: string[];
+  /** The player's chosen decision and outcome that led into this turn's scene, if any. */
+  decision?: { id: string; text: string; outcome?: string };
 }
 
 /** What the extraction returns for the cost channel; both arrays may be empty. */
@@ -51,6 +57,8 @@ export interface WorldCostSegmentNote {
     detail: string;
     /** Summary of the thread it was attributed to, when it was. */
     thread?: string;
+    /** Decision ID that caused this cost, when attributed to the player's chosen decision. */
+    decisionId?: EntityID;
   }>;
   cleared: string[];
   /** Set when the extractor read a death or incapacitation in the prose; the segment is tagged fatal-outcome. */


### PR DESCRIPTION
## Description
World costs currently show up regardless of player decisions, reading like an unavoidable fee rather than an earned consequence. This change passes the player's chosen decision and outcome into the post-segment cost extraction input, adds an extraction rule attributing costs caused by the decision, parses a per-entry causedByDecision field, and records decisionId on the imposed costs in the segment metadata note.

## Related Issue
Closes #2020

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

Unit tests cover byte-identical prompt generation when the flag is off, decision info formatting and rule injection when the flag is on, strict boolean parsing for causedByDecision, decision data extraction in buildCostInput, and decisionId note stamping in applyWorldCost.

## User Stories Addressed
As a player, when the world imposes a lasting injury or lost item, I want the consequence tied directly to the decision that caused it so that world costs feel like responsive storytelling rather than arbitrary taxes.

## Flow Diagrams
Decision Option Selected -> Segment Metadata (causedByDecisionId, causedByDecisionText, decisionOutcome) -> buildCostInput -> Goal/Cost Extractor (with causedByDecision rule) -> parseWorldCostExtraction -> applyWorldCost (records decisionId on note.imposed)

## Component Development
Not applicable - backend narrative and AI extraction pipeline only.

## Implementation Notes
1. `src/types/worldCost.types.ts`: added `causedByDecision?: boolean; decisionId?: EntityID;` to `WorldCostEntry`, `decision` to `WorldCostExtractionInput`, and `decisionId?: EntityID` to `WorldCostSegmentNote.imposed`.
2. `src/lib/featureFlags.ts`: added `DECISION_ATTRIBUTED_WORLD_COSTS` (default on following live eval pass).
3. `.env.example`: added commented `# NEXT_PUBLIC_FEATURE_DECISION_ATTRIBUTED_WORLD_COSTS=false` kill switch.
4. `src/lib/ai/worldCostExtraction.ts`: gated decision context and rule on `DECISION_ATTRIBUTED_WORLD_COSTS`. Byte-identical when flag is off.
5. `src/lib/narrative/applyWorldClockUpdates.ts`: populated `decision` from segment metadata in `buildCostInput`, and forwarded `decisionId` to `applyWorldCost`.
6. `src/lib/narrative/applyWorldCost.ts`: stamped `decisionId` on `note.imposed` when `cost.causedByDecision` and `decisionId` are present.
7. Evaluated live with Gemini across 3 paired cases (risky vs safe choices in Camp Crystal Lake and Harrowgate Mills). Risky choices achieved 3/3 (100%) attribution, safe choices produced 0/3 false positives, and latency showed no penalty (-126 ms delta). Full eval log at `.claude/skills/narraitor-prompt-template-governance/eval-logs/2020-decision-attributed-world-costs.md`.

## Screenshots
Not applicable - non-visual backend change.

## Visual Baseline Changes
None

## Code Review Summary (if applicable)
Changes verified against type-check, eslint, and unit test suites. Flag off preserves exact prior prompt text.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. Run `npm test -- src/lib/ai/__tests__/worldCostExtraction.test.ts src/lib/narrative/__tests__/applyWorldCost.test.ts src/lib/narrative/__tests__/applyWorldClockUpdates.costInput.test.ts`.
2. Run `npm run type-check && npm run lint`.
3. Inspect `.claude/skills/narraitor-prompt-template-governance/eval-logs/2020-decision-attributed-world-costs.md` for live paired evaluation results.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated