### PR TITLE
chore: prepare v1.7.0 release

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -24,8 +24,8 @@ Narraitor is a world-adaptive storytelling app. You define a fictional world's r
 attributes, and tone; create characters that fit it; and play a generated, choice-driven story
 with tracked consequences, inventory, and a journal. The story adapts to your world's voice
 rather than defaulting to generic fantasy. Success is an immersive, coherent, replayable story
-loop that stays out of its own way. v1.6 shipped on 2026-09-10. v1.7 is in progress, and its
-flagship work charges world costs to the decisions that incur them.
+loop that stays out of its own way. v1.7 shipped on 2026-09-10, and its flagship work charges
+world costs to the decisions that incur them.
 
 ## Positioning
 

--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ src/
 
 ## Roadmap
 
-Version 1.0 shipped in August 2026: a single-player release you run in your browser with your own key, no account needed. The releases since have been refinements rather than big new features, and each one is written up in [RELEASES.md](RELEASES.md). The current version is 1.6.
+Version 1.0 shipped in August 2026: a single-player release you run in your browser with your own key, no account needed. The releases since have been refinements rather than big new features, and each one is written up in [RELEASES.md](RELEASES.md). The current version is 1.7.
 
 Recent work: a visual redesign, generated images for worlds and journal entries and endings, better keyboard support, longer stories that stay consistent turn to turn, and the option to generate with OpenAI or OpenRouter instead of Gemini (or your own server, if you run one).
 
-The next version, [1.7](https://github.com/jerseycheese/Narraitor/milestone/8), makes what the story takes away from you land as a consequence of your choices rather than something that would have happened regardless.
+Version [1.7](https://github.com/jerseycheese/Narraitor/milestone/8) made what the story takes away from you land as a consequence of your choices, not something that would have happened regardless. The next version doesn't have a milestone yet.
 
 There are no plans for accounts or cloud saves: Narraitor stays on your device unless a clear reason to change that turns up, and [the reasoning is written down](public_docs/architecture/ADR-014-browser-local-until-named-trigger.md). Further out, the ideas worth exploring are shared worlds, voice narration, and mobile apps.
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,37 @@ Releases get tagged manually from `develop` and fast-forwarded to `main`. Each e
 
 ---
 
+## v1.7.0 - 2026-09-10
+
+v1.7 closes the loop the [#1818](https://github.com/jerseycheese/Narraitor/issues/1818) playtest campaign left open. A world cost now lands on the decision that caused it, so losing something reads as a consequence of what the player chose instead of a fee charged on the next turn. The milestone closes 4 issues across 6 commits since [v1.6.0](https://github.com/jerseycheese/Narraitor/releases/tag/v1.6.0), two of which are docs.
+
+**What's in this release**
+
+The world answers back:
+
+- World costs are charged to the decisions that incur them. The cost extraction now sees the choice the player made and how it resolved, marks each cost that choice caused, and records the decision id on the segment, where later prompts and the journal can read it. In a live paired evaluation, risky choices had their cost attributed in 3 of 3 cases and safe choices drew no attributed cost in 3 of 3. It ships on by default, and `NEXT_PUBLIC_FEATURE_DECISION_ATTRIBUTED_WORLD_COSTS=false` is the kill switch ([#2020](https://github.com/jerseycheese/Narraitor/issues/2020)).
+- Choices without alignment metadata get a real category. They used to default to `neutral` and stay there. The decision is still recorded as `neutral` straight away so the turn never waits, then a background call classifies the choice text as diplomatic, aggressive, stealthy, helpful, selfish or neutral and updates the record ([#666](https://github.com/jerseycheese/Narraitor/issues/666)).
+
+Long sessions:
+
+- Once the story passes seven segments, older ones collapse behind a "Show earlier story" control. A milestone toast marks every five story beats, and a dismissible prompt offers a natural stopping point every 15 minutes ([#805](https://github.com/jerseycheese/Narraitor/issues/805)).
+
+Fixes and docs:
+
+- The world and character creation tours no longer undo a manual Next or Back click. The step-sync effect from [#2037](https://github.com/jerseycheese/Narraitor/issues/2037) now moves the wizard only when the tour's own step changes ([#2069](https://github.com/jerseycheese/Narraitor/issues/2069)).
+- README rewritten for a developer audience, with three current screenshots ([#2073](https://github.com/jerseycheese/Narraitor/pull/2073)).
+- PRODUCT.md rewritten against the tree, and seven pre-DS3 screenshots deleted ([#2074](https://github.com/jerseycheese/Narraitor/pull/2074)).
+
+**Known incomplete**
+
+The evaluation behind [#2020](https://github.com/jerseycheese/Narraitor/issues/2020) is thin: three paired cases, 12 calls, single turns in two worlds. That cleared the ship rule its eval log committed to up front, but it isn't a read across a whole session. A 30-turn playtest with the flag on is what would catch attribution drifting as a session wears on, and that hasn't run yet.
+
+**What's next**
+
+No v1.8 milestone is set yet. The top of the backlog is [#487](https://github.com/jerseycheese/Narraitor/issues/487), the long-deferred call on adopting the Vercel AI SDK or keeping the hand-rolled provider layer, which is answerable now that three providers run through it. Behind it is [#2000](https://github.com/jerseycheese/Narraitor/issues/2000): four stores carry a comment saying a version bump clears old saved data, while the code preserves it.
+
+---
+
 ## v1.6.0 - 2026-09-10
 
 v1.5 catalogued what the new-player path gets wrong. v1.6 fixes it. The milestone closes 12 issues from the [#2022](https://github.com/jerseycheese/Narraitor/issues/2022) discovery sweep across 14 commits since [v1.5.0](https://github.com/jerseycheese/Narraitor/releases/tag/v1.5.0), and picks up a production bug that turned out to break every dynamic route in the app.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "narraitor",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "narraitor",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "narraitor",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Description

Bumps `package.json` to 1.7.0 and adds the RELEASES.md entry for the tag.

v1.7 closes the loop the #1818 playtest campaign left open. World costs now land on the decision that caused them (#2020), choices without alignment metadata get a real category (#666), and long sessions get pacing (#805). The #2069 tutorial fix carried in from v1.6 rounds it out. The entry also covers the two docs PRs that landed after the v1.6.0 tag (#2073, #2074).

Known-incomplete names the thin #2020 evaluation: three paired cases and 12 calls, with no 30-turn read on the flag yet.

The README and PRODUCT.md status lines move to 1.7, per the docs-of-record sweep that goes with each release.

## Related Issue

Release prep for milestone v1.7 (4 of 4 closed). Nothing to close.

Closes #

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [ ] Test addition or improvement

## TDD Compliance

Not applicable. It's a version bump plus docs, with no source changes, so there's nothing to write a test against. The unit suite wasn't run locally, so these boxes stay unchecked.

- [ ] Tests written before implementation
- [ ] All new code is tested
- [ ] All tests pass locally
- [ ] Test coverage maintained or improved

## User Stories Addressed

Not applicable.

## Flow Diagrams

Not applicable.

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

Not applicable, no UI changes.

## Implementation Notes

| File | Change |
|---|---|
| `package.json`, `package-lock.json` | 1.6.0 -> 1.7.0 via `npm version 1.7.0 --no-git-tag-version` |
| `RELEASES.md` | New v1.7.0 section |
| `README.md` | Roadmap: current version 1.7, no next milestone yet |
| `PRODUCT.md` | Status sentence: v1.7 shipped |

PRODUCT.md's "verified against the tree at v1.6.0" line stays as it is. I only re-checked the claims the v1.7 work could have touched, and none of those changed, so re-dating the line would claim a full re-verification that didn't happen.

The 2020 facts in the release notes (3/3 risky attributed, 0/3 safe false positives, flag default on, kill-switch name) come from PR #2078 and the eval log. The pacing numbers (7 segments, every 5 beats, 15 minutes) come from `NarrativeHistory.tsx` and `useSessionPacing.ts`.

## Screenshots

Not applicable.

## Visual Baseline Changes

None

## Code Review Summary (if applicable)

Not applicable.

## Chrome DevTools MCP Verification Summary (if applicable)

Not applicable.

## Quality Checks (if applicable)
- [ ] Linting passed
- [ ] Type checking passed
- [ ] Security audit passed
- [ ] No console.log statements in production code
- [ ] No unhandled promises

No source changes, so these are left to CI. `docs:check-links` exits 1 locally on develop and on this branch alike. All 9 broken links are in the gitignored `playtest-log.md`, so CI never sees them.

## Testing Instructions

Read the new RELEASES.md section against the v1.6.0..develop log (`git log --oneline v1.6.0..origin/develop`), and check that `node -p "require('./package.json').version"` prints `1.7.0`.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed
