### PR TITLE
fix(narrative): stop new segments from resetting the break timer

### DIFF
--- a/src/components/Narrative/hooks/__tests__/useSessionPacing.test.ts
+++ b/src/components/Narrative/hooks/__tests__/useSessionPacing.test.ts
@@ -85,6 +85,30 @@ describe('useSessionPacing', () => {
     expect(result.current.showBreakPrompt).toBe(true);
   });
 
+  it('keeps the break timer running while new segments arrive', () => {
+    const breakIntervalMs = 15 * 60 * 1000;
+    const { result, rerender } = renderHook(
+      ({ count }) => useSessionPacing({ segmentCount: count, breakIntervalMs }),
+      { initialProps: { count: 1 } }
+    );
+
+    // A player reading steadily: a new segment every five minutes.
+    act(() => {
+      jest.advanceTimersByTime(5 * 60 * 1000);
+      rerender({ count: 2 });
+    });
+    act(() => {
+      jest.advanceTimersByTime(5 * 60 * 1000);
+      rerender({ count: 3 });
+    });
+    expect(result.current.showBreakPrompt).toBe(false);
+
+    act(() => {
+      jest.advanceTimersByTime(5 * 60 * 1000);
+    });
+    expect(result.current.showBreakPrompt).toBe(true);
+  });
+
   it('dismissing break prompt keeps session going and schedules next break', () => {
     const breakIntervalMs = 15 * 60 * 1000;
     const { result } = renderHook(() =>

--- a/src/components/Narrative/hooks/useSessionPacing.ts
+++ b/src/components/Narrative/hooks/useSessionPacing.ts
@@ -63,16 +63,19 @@ export function useSessionPacing(options: UseSessionPacingOptions = {}): UseSess
     }
   }, [count, milestoneInterval, enabled, toast]);
 
-  // Schedule break prompts at regular intervals once reading begins
+  // Schedule break prompts at regular intervals once reading begins. Keyed on
+  // hasStartedReading, not count: a new segment must not restart the wait, or
+  // a player who keeps reading would never see the prompt.
+  const hasStartedReading = count > 0;
   useEffect(() => {
-    if (!enabled || count === 0 || showBreakPrompt || breakIntervalMs <= 0) return;
+    if (!enabled || !hasStartedReading || showBreakPrompt || breakIntervalMs <= 0) return;
 
     const timer = setTimeout(() => {
       setShowBreakPrompt(true);
     }, breakIntervalMs);
 
     return () => clearTimeout(timer);
-  }, [enabled, count, showBreakPrompt, breakIntervalMs]);
+  }, [enabled, hasStartedReading, showBreakPrompt, breakIntervalMs]);
 
   const dismissBreakPrompt = useCallback(() => {
     setShowBreakPrompt(false);


### PR DESCRIPTION
## Description

The session break prompt from #805 could never reach a player who kept reading. The timer effect in `useSessionPacing` listed the segment count in its dependencies, so every new segment cleared the pending timeout and started a fresh 15-minute wait. The prompt only fired after 15 minutes with no new segment, which means an idle player got it and an engaged one didn't.

The effect now keys on `hasStartedReading` (`count > 0`) instead of `count`. The wait runs from session start, or from the last dismissal, no matter how many segments land in between.

Codex caught this on the v1.7.0 release prep PR (#2079), where the release notes promise a prompt every 15 minutes. This fix lands first so the release ships what the notes say.

## Related Issue

Follow-up to #805 (closed). Nothing open to close.

Closes #

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [ ] Documentation update
- [x] Test addition or improvement

## TDD Compliance
- [x] Tests written before implementation
- [x] All new code is tested
- [x] All tests pass locally
- [x] Test coverage maintained or improved

The new case, "keeps the break timer running while new segments arrive", adds a segment every five minutes and expects the prompt at the 15-minute mark. It failed on the unfixed hook (`Expected: true, Received: false` at the final assertion) and passes with the fix. The existing break tests held `segmentCount` constant, which is why they never saw the reset.

## User Stories Addressed

As a player in a long session, I want the break prompt to appear while I'm actively reading, not only after I've already walked away.

## Flow Diagrams

Not applicable.

## Component Development
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

Not applicable. Hook logic only, no markup or styles changed.

## Implementation Notes

| File | Change |
|---|---|
| `src/components/Narrative/hooks/useSessionPacing.ts` | Timer effect depends on `hasStartedReading`, not `count` |
| `src/components/Narrative/hooks/__tests__/useSessionPacing.test.ts` | New case covering segments arriving mid-wait |

## Screenshots

Not applicable.

## Visual Baseline Changes

None

## Code Review Summary (if applicable)

Not applicable.

## Chrome DevTools MCP Verification Summary (if applicable)

Not run. The behavior only shows after a real 15-minute wait, and the fake-timer test covers the path directly.

## Quality Checks (if applicable)
- [x] Linting passed
- [x] Type checking passed
- [ ] Security audit passed
- [x] No console.log statements in production code
- [x] No unhandled promises

Security audit left to CI.

## Testing Instructions

`npm test -- src/components/Narrative/hooks/__tests__/useSessionPacing.test.ts`. To see the bug, revert the hook change and the new case fails.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [x] Comments added for complex logic
- [ ] Documentation updated (if required)
- [x] No new warnings generated
- [ ] Accessibility considerations addressed
