### PR TITLE
docs: update impeccable to 4.3.1 and refresh PRODUCT.md (#2081)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -2,7 +2,7 @@
 
 <!-- impeccable:product-schema 1 -->
 
-*Verified against the tree on 2026-09-10, at v1.6.0. Every claim below is checkable from a
+*Verified against the tree on 2026-09-11, at v1.7.0. Every claim below is checkable from a
 path in this file. When one stops matching the code, fix it here rather than working around
 it, and re-date this line.*
 
@@ -56,6 +56,10 @@ for a model.
 
 Sessions are resumable and long-lived. Players return to worlds and characters they made
 earlier, so the app is as much a library of your own stuff as it is a game.
+
+Long sessions pace themselves: past seven segments, older ones collapse behind a "Show
+earlier story" control, a milestone toast marks every five story beats, and a dismissible
+prompt offers a natural stopping point every 15 minutes.
 
 ## Capabilities and Constraints
 


### PR DESCRIPTION
## Description
Updated the `impeccable` design-review plugin from 4.0.4 to 4.3.1 (machine-local: `claude plugin marketplace update impeccable` + `claude plugin update impeccable@impeccable`), confirmed it healthy, and let it refresh project context. This is first of seven in the v1.8 milestone so every later foundation PR gets reviewed against the current tool, not a month-stale one.

## Related Issue
Closes #2081

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvements without changing functionality)
- [x] Documentation update
- [ ] Test addition or improvement

## TDD Compliance
Not applicable — this is a tooling version bump plus a docs-only PRODUCT.md refresh, no application logic to drive with tests.
- [ ] Tests written before implementation
- [ ] All new code is tested
- [x] All tests pass locally (unaffected; no code changed)
- [ ] Test coverage maintained or improved

## User Stories Addressed
Not applicable — internal tooling/docs maintenance, no user-facing story.

## Flow Diagrams
Not applicable.

## Component Development
Not applicable — no UI changed.
- [ ] Storybook stories created/updated
- [ ] Components developed in isolation first
- [ ] Visual consistency verified

## Implementation Notes
- `impeccable@impeccable` is now 4.3.1 (was 4.0.4), confirmed via `claude plugin list` after a session restart to load the new skill.
- `/impeccable doctor --json` came back with no `auto`-severity findings — nothing needed fixing. Two lower-severity notes, both deliberately not acted on: `design-md-drift` (just a commit count since DESIGN.md was last touched, not a contradiction — this issue explicitly leaves DESIGN.md to later foundation PRs and the closing `document` reconcile), and `config-build-path-unset` (only matters with image generation in the tool surface, which isn't available here — doctor's own instruction is to stay silent in that case).
- `/impeccable init` ran additively against the existing `PRODUCT.md` (already on the current schema, rewritten in #2074 the day before). Found two real gaps against `RELEASES.md`: the file's own freshness marker was one version behind (v1.6.0, corrected to v1.7.0), and the session-pacing/reading-milestone behavior that shipped in v1.7.0 (#805) wasn't captured under Operating Context. Added one sentence for it. No existing section was reopened or rewritten.

## Screenshots
Not applicable.

## Visual Baseline Changes
None.

## Code Review Summary (if applicable)
Not applicable.

## Chrome DevTools MCP Verification Summary (if applicable)
Not applicable.

## Quality Checks (if applicable)
- [x] Linting passed (docs-only change, not lint-scoped)
- [x] Type checking passed (unaffected)
- [ ] Security audit passed — not run; no dependency or code change
- [x] No console.log statements in production code
- [x] No unhandled promises

## Testing Instructions
1. `claude plugin list` — confirm `impeccable@impeccable` reports `4.3.1`.
2. `git diff PRODUCT.md` — confirm the only changes are the freshness-marker date/version and the new pacing sentence; no other section touched.

## Checklist
- [x] Code follows the project's coding standards
- [x] File size limits respected (max 300 lines per file)
- [x] Self-review of code performed
- [ ] Comments added for complex logic — not applicable, no code
- [x] Documentation updated (if required)
- [x] No new warnings generated
- [x] Accessibility considerations addressed — not applicable, no UI change
